### PR TITLE
feat: Add AC Charge SOC Limit and SOC Cut-Off controls

### DIFF
--- a/const.py
+++ b/const.py
@@ -1681,6 +1681,7 @@ WORKING_MODES = {
 
 # SOC Limit Parameters
 # These parameters control battery state of charge thresholds for charging and discharging
+# Note: No entity_category set - these appear in Controls section like System Charge SOC Limit
 SOC_LIMIT_PARAMS = {
     'ac_charge_soc_limit': {
         'name': 'AC Charge SOC Limit',
@@ -1691,7 +1692,6 @@ SOC_LIMIT_PARAMS = {
         'max': 100,
         'step': 1,
         'unit': '%',
-        'entity_category': EntityCategory.CONFIG
     },
     'on_grid_soc_cutoff': {
         'name': 'On-Grid SOC Cut-Off',
@@ -1702,7 +1702,6 @@ SOC_LIMIT_PARAMS = {
         'max': 100,
         'step': 1,
         'unit': '%',
-        'entity_category': EntityCategory.CONFIG
     },
     'off_grid_soc_cutoff': {
         'name': 'Off-Grid SOC Cut-Off',
@@ -1713,7 +1712,6 @@ SOC_LIMIT_PARAMS = {
         'max': 100,
         'step': 1,
         'unit': '%',
-        'entity_category': EntityCategory.CONFIG
     },
 }
 

--- a/number.py
+++ b/number.py
@@ -1205,7 +1205,6 @@ class ACChargeSOCLimitNumber(CoordinatorEntity, NumberEntity):
         self._attr_mode = NumberMode.BOX
         self._attr_icon = "mdi:battery-charging-medium"
         self._attr_native_precision = 0
-        self._attr_entity_category = EntityCategory.CONFIG
 
         # Device info
         self._attr_device_info = coordinator.get_device_info(serial)
@@ -1452,7 +1451,6 @@ class OnGridSOCCutoffNumber(CoordinatorEntity, NumberEntity):
         self._attr_mode = NumberMode.BOX
         self._attr_icon = "mdi:battery-alert"
         self._attr_native_precision = 0
-        self._attr_entity_category = EntityCategory.CONFIG
 
         # Device info
         self._attr_device_info = coordinator.get_device_info(serial)
@@ -1699,7 +1697,6 @@ class OffGridSOCCutoffNumber(CoordinatorEntity, NumberEntity):
         self._attr_mode = NumberMode.BOX
         self._attr_icon = "mdi:battery-outline"
         self._attr_native_precision = 0
-        self._attr_entity_category = EntityCategory.CONFIG
 
         # Device info
         self._attr_device_info = coordinator.get_device_info(serial)


### PR DESCRIPTION
## Summary
Implements three new number entities for battery SOC management in the **Controls** section, enabling dynamic automation based on solar forecasting as requested by community user.

## New Controls
All three entities appear in the Controls section alongside System Charge SOC Limit, EPS Battery Backup, and Quick Charge:

### 1. AC Charge SOC Limit
- **Parameter**: `HOLD_AC_CHARGE_SOC_LIMIT`
- **Function**: Stop AC charging when battery reaches this SOC percentage
- **Range**: 0-100%
- **Icon**: `mdi:battery-charging-medium`

### 2. On-Grid SOC Cut-Off
- **Parameter**: `HOLD_DISCHG_CUT_OFF_SOC_EOD`
- **Function**: Minimum battery SOC when connected to grid (on-grid discharge cutoff)
- **Range**: 0-100%
- **Icon**: `mdi:battery-alert`

### 3. Off-Grid SOC Cut-Off
- **Parameter**: `HOLD_SOC_LOW_LIMIT_EPS_DISCHG`
- **Function**: Minimum battery SOC when off-grid (EPS mode discharge cutoff)
- **Range**: 0-100%
- **Icon**: `mdi:battery-outline`

## Implementation Details
- ✅ Full read/write support for all three parameters
- ✅ Automatic parameter reading from all register ranges
- ✅ Cross-inverter parameter synchronization (changes propagate to all inverters)
- ✅ Controls section placement (no entity_category set)
- ✅ Comprehensive error handling and logging
- ✅ Range validation (0-100%)
- ✅ Follows existing number entity patterns

## API Integration
- Uses existing `write_parameter` API method
- Matches exact curl commands from EG4 web interface
- Parameter names match EG4 API specification

## Use Case
Enables Home Assistant automations to dynamically adjust battery SOC thresholds based on:
- Solar forecasting data
- Time of day
- Energy pricing
- Weather predictions

## Testing Notes
- Entities will appear in Controls section of each inverter device
- Verify parameter writing by changing values in Home Assistant UI
- Confirm values update on physical device
- Test automation capabilities with solar forecasting

## Community Request
Addresses: https://community.home-assistant.io/t/integration-eg4-web-monitor-home-assistant-integration/929930/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)