### PR TITLE
fix: Force daily sensor reset to 0 at date boundary (v2.2.5)

### DIFF
--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "2.2.4"
+  "version": "2.2.5"
 }

--- a/tests/test_monotonic_state.py
+++ b/tests/test_monotonic_state.py
@@ -1,13 +1,16 @@
 """Test monotonic state tracking for total_increasing sensors."""
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from datetime import datetime, timezone, timedelta
 
 from custom_components.eg4_web_monitor.sensor import (
     EG4InverterSensor,
     EG4BatterySensor,
+    LIFETIME_SENSORS,
+    _get_current_date,
 )
 
 
@@ -16,6 +19,10 @@ def mock_coordinator():
     """Create a mock coordinator with test data."""
     coordinator = MagicMock(spec=DataUpdateCoordinator)
     coordinator.data = {
+        "station": {
+            "name": "Test Station",
+            "timezone": "GMT -8",
+        },
         "devices": {
             "1234567890": {
                 "type": "inverter",
@@ -23,6 +30,8 @@ def mock_coordinator():
                 "sensors": {
                     "consumption": 100.0,
                     "consumption_lifetime": 5000.0,
+                    "daily_energy": 10.0,
+                    "yield": 25.0,
                 },
                 "batteries": {
                     "battery_1": {
@@ -453,3 +462,311 @@ class TestMonotonicStateEdgeCases:
         value = sensor2.native_value
         assert value == 50.0
         assert sensor2._last_valid_state == 50.0
+
+
+class TestDateBoundaryReset:
+    """Test date boundary reset behavior for non-lifetime sensors."""
+
+    def test_get_current_date_with_timezone(self, mock_coordinator):
+        """Test _get_current_date function with timezone data."""
+        current_date = _get_current_date(mock_coordinator)
+        assert current_date is not None
+        assert len(current_date) == 10  # YYYY-MM-DD format
+        assert current_date.count("-") == 2
+
+    def test_get_current_date_without_timezone(self):
+        """Test _get_current_date function without timezone data."""
+        coordinator = MagicMock(spec=DataUpdateCoordinator)
+        coordinator.data = {"devices": {}}
+
+        current_date = _get_current_date(coordinator)
+        assert current_date is not None  # Should fallback to UTC
+
+    def test_lifetime_sensors_constant(self):
+        """Test that LIFETIME_SENSORS contains expected sensors."""
+        expected_lifetime = {
+            "total_energy",
+            "yield_lifetime",
+            "discharging_lifetime",
+            "charging_lifetime",
+            "consumption_lifetime",
+            "grid_export_lifetime",
+            "grid_import_lifetime",
+            "cycle_count",
+        }
+        assert LIFETIME_SENSORS == expected_lifetime
+
+    def test_daily_sensor_reset_at_date_boundary(self, mock_coordinator):
+        """Test that daily sensors force reset to 0 when date changes."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        # Initial value on day 1
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 10.0
+            assert sensor._last_valid_state == 10.0
+            assert sensor._last_update_date == "2025-01-19"
+
+            # Value increases during day 1
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 15.0
+            value = sensor.native_value
+            assert value == 15.0
+            assert sensor._last_valid_state == 15.0
+
+            # Date changes to day 2 - forces reset to 0 even if API returns old value
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 15.0  # API stale data
+            value = sensor.native_value
+            assert value == 0.0  # Should force reset to 0 at date boundary
+            assert sensor._last_valid_state == 0.0
+            assert sensor._last_update_date == "2025-01-20"
+
+    def test_daily_sensor_forced_reset_then_accumulates(self, mock_coordinator):
+        """Test that daily sensors force reset to 0, then accumulate from API values."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="yield",
+            device_type="inverter",
+        )
+
+        # Initial value on day 1
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 25.0
+            assert sensor._last_valid_state == 25.0
+
+            # Value increases during day 1
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["yield"] = 50.0
+            value = sensor.native_value
+            assert value == 50.0
+
+            # Date changes to day 2, forces reset to 0 (even if API says 50.0)
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["yield"] = 50.0  # API stale
+            value = sensor.native_value
+            assert value == 0.0  # Should force reset to 0 at date boundary
+            assert sensor._last_valid_state == 0.0
+
+            # Next update on day 2, API sends current value
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["yield"] = 2.5
+            value = sensor.native_value
+            assert value == 2.5  # Should accept new accumulation
+            assert sensor._last_valid_state == 2.5
+
+    def test_lifetime_sensor_never_resets_at_date_boundary(self, mock_coordinator):
+        """Test that lifetime sensors never reset, even at date boundary."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="consumption_lifetime",
+            device_type="inverter",
+        )
+
+        # Initial value on day 1
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 5000.0
+            assert sensor._last_valid_state == 5000.0
+
+            # Value increases during day 1
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["consumption_lifetime"] = 5100.0
+            value = sensor.native_value
+            assert value == 5100.0
+
+            # Date changes to day 2, but lifetime value tries to decrease
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["consumption_lifetime"] = 5050.0
+            value = sensor.native_value
+            assert value == 5100.0  # Should NOT allow reset for lifetime sensors
+            assert sensor._last_valid_state == 5100.0
+
+    def test_daily_sensor_manual_reset_to_zero(self, mock_coordinator):
+        """Test that daily sensors can reset to 0 manually (same day)."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        # Initial value
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 10.0
+            assert sensor._last_valid_state == 10.0
+
+            # Manual reset to 0 (same day)
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 0.0
+            value = sensor.native_value
+            assert value == 0.0  # Should allow reset to 0 for non-lifetime
+            assert sensor._last_valid_state == 0.0
+
+    def test_daily_sensor_prevents_non_zero_decrease_same_day(self, mock_coordinator):
+        """Test that daily sensors prevent non-zero decreases on same day."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        # Initial value
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 10.0
+            assert sensor._last_valid_state == 10.0
+
+            # Attempt non-zero decrease on same day (should be rejected)
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 8.5
+            value = sensor.native_value
+            assert value == 10.0  # Should maintain previous value
+            assert sensor._last_valid_state == 10.0
+
+    def test_battery_cycle_count_never_resets(self, mock_coordinator):
+        """Test that battery cycle count (lifetime) never resets."""
+        sensor = EG4BatterySensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            battery_key="battery_1",
+            sensor_key="cycle_count",
+        )
+
+        # Initial value on day 1
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            mock_date.return_value = "2025-01-19"
+            value = sensor.native_value
+            assert value == 50.0
+            assert sensor._last_valid_state == 50.0
+
+            # Increase during day 1
+            mock_coordinator.data["devices"]["1234567890"]["batteries"]["battery_1"]["cycle_count"] = 55.0
+            value = sensor.native_value
+            assert value == 55.0
+
+            # Date changes to day 2, cycle count tries to decrease
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["batteries"]["battery_1"]["cycle_count"] = 52.0
+            value = sensor.native_value
+            assert value == 55.0  # Should NOT allow reset for cycle count
+            assert sensor._last_valid_state == 55.0
+
+    def test_multiple_date_boundaries(self, mock_coordinator):
+        """Test sensor behavior across multiple date boundaries."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            # Day 1: Initial value
+            mock_date.return_value = "2025-01-19"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 10.0
+            assert sensor.native_value == 10.0
+
+            # Day 1: Increases
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 20.0
+            assert sensor.native_value == 20.0
+
+            # Day 2: Reset to 0
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 20.0
+            assert sensor.native_value == 0.0
+
+            # Day 2: New accumulation
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 5.0
+            assert sensor.native_value == 5.0
+
+            # Day 3: Reset to 0 again
+            mock_date.return_value = "2025-01-21"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 5.0
+            assert sensor.native_value == 0.0
+
+    def test_date_boundary_with_api_already_reset(self, mock_coordinator):
+        """Test that if API already reset to 0, we handle it correctly."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            # Day 1
+            mock_date.return_value = "2025-01-19"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 10.0
+            assert sensor.native_value == 10.0
+
+            # Day 2: API already sent 0
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 0.0
+            assert sensor.native_value == 0.0  # Should still work correctly
+
+    def test_first_reading_after_date_boundary(self, mock_coordinator):
+        """Test first reading after midnight is 0, subsequent readings accumulate."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            # Day 1: Build up value
+            mock_date.return_value = "2025-01-19"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 25.0
+            assert sensor.native_value == 25.0
+
+            # Day 2: First reading at 00:01 - forced to 0
+            mock_date.return_value = "2025-01-20"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 25.0
+            assert sensor.native_value == 0.0
+
+            # Day 2: Reading at 06:00 - API has accumulated 3.0
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 3.0
+            assert sensor.native_value == 3.0
+
+            # Day 2: Reading at 12:00 - API has accumulated 12.5
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 12.5
+            assert sensor.native_value == 12.5
+
+            # Day 2: Reading at 18:00 - API has accumulated 18.0
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 18.0
+            assert sensor.native_value == 18.0
+
+    def test_timezone_changes_dont_trigger_reset(self, mock_coordinator):
+        """Test that None timezone values don't cause spurious resets."""
+        sensor = EG4InverterSensor(
+            coordinator=mock_coordinator,
+            serial="1234567890",
+            sensor_key="daily_energy",
+            device_type="inverter",
+        )
+
+        with patch("custom_components.eg4_web_monitor.sensor._get_current_date") as mock_date:
+            # Normal operation with timezone
+            mock_date.return_value = "2025-01-19"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 10.0
+            assert sensor.native_value == 10.0
+
+            # Timezone info temporarily unavailable (returns None)
+            mock_date.return_value = None
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 15.0
+            assert sensor.native_value == 15.0  # Should still accept increases
+
+            # Timezone info back
+            mock_date.return_value = "2025-01-19"
+            mock_coordinator.data["devices"]["1234567890"]["sensors"]["daily_energy"] = 20.0
+            assert sensor.native_value == 20.0  # Should continue normally


### PR DESCRIPTION
## Problem
Daily energy sensors (daily_energy, yield, charging, discharging, etc.) were not resetting at midnight. The monotonic state tracking prevented legitimate resets, and when the API returned stale values after midnight, it caused data anomalies.

## Solution
- Differentiate lifetime sensors (never reset) from daily sensors (reset at midnight)
- Force daily sensors to 0.0 at date boundary regardless of API value
- Use station timezone for accurate date boundary detection
- Prevent stale API data from appearing as midnight spikes in graphs

## Changes
- **sensor.py**: Added LIFETIME_SENSORS set, _get_current_date() function
- **sensor.py**: Modified EG4InverterSensor and EG4BatterySensor to force 0.0 reset
- **test_monotonic_state.py**: Added 13 new tests for date boundary behavior
- **manifest.json**: Bumped version to 2.2.5

## Behavior

### Lifetime Sensors
`total_energy`, `*_lifetime` variants, `cycle_count`
- ❌ Never reset or decrease
- ✅ Always monotonically increasing

### Daily Sensors
`daily_energy`, `yield`, `charging`, `discharging`, `consumption`, `grid_export`, `grid_import`
- ✅ Force reset to 0.0 at midnight (date boundary)
- ✅ Accept API values normally during the day
- ✅ Allow manual reset to 0
- ❌ Prevent non-zero decreases on same day

## Real-World Example
```
Day 1, 11:59 PM: API returns 25.0 kWh → Sensor shows 25.0 kWh
Day 2, 12:01 AM: API returns 25.0 kWh (stale) → Sensor forces 0.0 kWh ✅
Day 2, 06:00 AM: API returns 3.5 kWh (fresh) → Sensor shows 3.5 kWh ✅
Day 2, 12:00 PM: API returns 12.8 kWh → Sensor shows 12.8 kWh ✅
```

This prevents data anomaly where stale API values would appear as midnight spikes!

## Test Coverage
- ✅ 332 tests passed (31 monotonic state tests)
- ✅ Ruff linting: All checks passed
- ✅ MyPy strict typing: No errors
- ✅ Platinum tier compliance: All requirements met

## Breaking Changes
None - this is a bug fix that improves data accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)