### PR TITLE
feat: Add Off Grid Mode switch

### DIFF
--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
   "requirements": ["pylxpweb>=0.4.0"],
-  "version": "3.0.0-rc.7"
+  "version": "3.0.0-rc.8"
 }

--- a/custom_components/eg4_web_monitor/strings.json
+++ b/custom_components/eg4_web_monitor/strings.json
@@ -168,6 +168,9 @@
       },
       "battery_backup_eps": {
         "name": "Battery Backup (EPS)"
+      },
+      "off_grid_mode": {
+        "name": "Off Grid Mode"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/en.json
+++ b/custom_components/eg4_web_monitor/translations/en.json
@@ -168,6 +168,9 @@
       },
       "battery_backup_eps": {
         "name": "Battery Backup (EPS)"
+      },
+      "off_grid_mode": {
+        "name": "Off Grid Mode"
       }
     },
     "number": {


### PR DESCRIPTION
## Summary

Adds a new switch entity to control Off-Grid Mode on inverters.

Closes #57

### Changes

- New `EG4OffGridModeSwitch` class that controls the `FUNC_GREEN_EN` parameter
- Uses `enable_green_mode()`/`disable_green_mode()` methods from pylxpweb
- Added translations for `off_grid_mode` switch
- Version bump to 3.0.0-rc.8

### Technical Details

Off-Grid Mode (called "Green Mode" in pylxpweb) controls the off-grid operating mode toggle visible in the EG4 web monitoring interface. When enabled, the inverter operates in an off-grid optimized configuration.

**Note**: This is `FUNC_GREEN_EN` in register 110, distinct from `FUNC_EPS_EN` (battery backup/EPS mode) in register 21.

## Test plan

- [x] All 124 tests pass
- [x] Ruff linting passes
- [ ] Manual test with real inverter

🤖 Generated with [Claude Code](https://claude.com/claude-code)