### PR TITLE
fix: Restore battery_status sensor lost in v3.0.0 refactoring (#60)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -281,9 +281,9 @@ class EG4DataUpdateCoordinator(
         # Process all inverters in the station
         for inverter in self.station.all_inverters:
             try:
-                processed["devices"][inverter.serial_number] = (
-                    await self._process_inverter_object(inverter)  # type: ignore[misc]
-                )
+                processed["devices"][
+                    inverter.serial_number
+                ] = await self._process_inverter_object(inverter)  # type: ignore[misc]
             except Exception as e:
                 _LOGGER.error(
                     "Error processing inverter %s: %s", inverter.serial_number, e

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -302,7 +302,8 @@ class DeviceProcessingMixin:
             "radiator2_temperature": "radiator2_temperature",
             # Battery sensors
             "battery_soc": "state_of_charge",
-            "battery_status": "battery_status",
+            # Note: battery_status is extracted from BatteryBank.status in
+            # _extract_battery_bank_from_object(), not from the inverter directly
             # Energy sensors - Generation
             "total_energy_today": "yield",
             "total_energy_lifetime": "yield_lifetime",
@@ -506,7 +507,15 @@ class DeviceProcessingMixin:
             Dictionary of sensor_key -> value mappings
         """
         property_map = self._get_battery_bank_property_map()
-        return _map_device_properties(battery_bank, property_map)
+        sensors = _map_device_properties(battery_bank, property_map)
+
+        # Add battery_status as alias for battery_bank_status for backwards compatibility
+        # In v2.2.x, the batStatus field was mapped to battery_status at the inverter level
+        # This maintains the sensor for users upgrading from v2.2.x
+        if "battery_bank_status" in sensors:
+            sensors["battery_status"] = sensors["battery_bank_status"]
+
+        return sensors
 
     @staticmethod
     def _get_battery_bank_property_map() -> dict[str, str]:

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
   "requirements": ["pylxpweb>=0.4.0"],
-  "version": "3.0.0-rc.8"
+  "version": "3.0.0-rc.9"
 }


### PR DESCRIPTION
## Summary

- Restores the `battery_status` sensor that was lost during v3.0.0 refactoring
- Adds backwards compatibility alias for users upgrading from v2.2.x
- Cleans up unused mypy type: ignore comments
- Bumps version to 3.0.0-rc.9

## Root Cause Analysis

In v2.2.x, the `battery_status` sensor was extracted from the `batStatus` field in the getBatteryInfo API response. During the v3.0.0 refactoring to use pylxpweb device objects, this sensor was inadvertently lost because:

1. The `BatteryBank.status` property was only mapped to `battery_bank_status` (new sensor name)
2. The inverter property map had a mapping for `battery_status`, but the inverter object doesn't have this property - it's on the `BatteryBank` object

## Changes

### Fix (`coordinator_mixins.py`)
- Added `battery_status` as an alias for `battery_bank_status` in `_extract_battery_bank_from_object()` 
- Added clarifying comment in inverter property map explaining where `battery_status` comes from

### Mypy Cleanup
- Removed unused `type: ignore` comments in `coordinator.py` and `select.py`
- Added necessary `type: ignore[call-arg]` for Home Assistant ConfigFlow metaclass pattern

## Test Plan

- [x] All 124 unit tests pass
- [x] mypy: no issues found
- [x] ruff: all checks passed
- [ ] Manual verification that `battery_status` sensor appears after upgrade

## Version

Bumps to `3.0.0-rc.9`

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)