### PR TITLE
Fix Quick Charge switch always showing OFF

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -277,6 +277,44 @@ class DeviceProcessingMixin:
                     e,
                 )
 
+        # Fetch quick charge status for switch entity
+        try:
+            if hasattr(inverter, "get_quick_charge_status"):
+                quick_charge_active = await inverter.get_quick_charge_status()
+                processed["quick_charge_status"] = {
+                    "hasUnclosedQuickChargeTask": quick_charge_active,
+                }
+                _LOGGER.debug(
+                    "Quick charge status for %s: %s",
+                    inverter.serial_number,
+                    quick_charge_active,
+                )
+        except Exception as e:
+            _LOGGER.debug(
+                "Could not fetch quick charge status for %s: %s",
+                inverter.serial_number,
+                e,
+            )
+
+        # Fetch battery backup (EPS) status for switch entity
+        try:
+            if hasattr(inverter, "get_battery_backup_status"):
+                battery_backup_enabled = await inverter.get_battery_backup_status()
+                processed["battery_backup_status"] = {
+                    "enabled": battery_backup_enabled,
+                }
+                _LOGGER.debug(
+                    "Battery backup status for %s: %s",
+                    inverter.serial_number,
+                    battery_backup_enabled,
+                )
+        except Exception as e:
+            _LOGGER.debug(
+                "Could not fetch battery backup status for %s: %s",
+                inverter.serial_number,
+                e,
+            )
+
         return processed
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Fixed Quick Charge switch always displaying OFF even when Quick Charge was active on the inverter
- Also fixed Battery Backup (EPS) switch to properly fetch status from the API

## Root Cause
The `EG4QuickChargeSwitch.is_on` property reads `quick_charge_status` from coordinator device data, but `_process_inverter_object()` never called `inverter.get_quick_charge_status()` to populate this data. The same issue affected the Battery Backup switch.

## Changes
Added API calls in `coordinator_mixins.py` → `_process_inverter_object()`:
- `inverter.get_quick_charge_status()` → stored as `{"hasUnclosedQuickChargeTask": bool}`
- `inverter.get_battery_backup_status()` → stored as `{"enabled": bool}`

Both are wrapped in try/except to gracefully handle devices that don't support these features.

## Testing
- Verified Quick Charge returns `True` when active via direct API test
- Verified Battery Backup returns `True` when enabled via direct API test
- All 124 existing tests pass
- Ruff check and format pass

## Test plan
- [ ] Verify Quick Charge switch shows correct state (ON when Quick Charge is active)
- [ ] Verify Battery Backup switch shows correct state
- [ ] Verify toggling switches still works correctly
- [ ] Verify no regressions on devices that don't support these features

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)