### PR TITLE
fix: Working mode switches now refresh parameters after actions

### DIFF
--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -504,7 +504,7 @@ class EG4WorkingModeSwitch(EG4BaseSwitch):
             enable_method=methods[0],
             disable_method=methods[1],
             turn_on=True,
-            refresh_params=False,
+            refresh_params=True,
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -520,7 +520,7 @@ class EG4WorkingModeSwitch(EG4BaseSwitch):
             enable_method=methods[0],
             disable_method=methods[1],
             turn_on=False,
-            refresh_params=False,
+            refresh_params=True,
         )
 
 


### PR DESCRIPTION
## Summary

- Fixed `EG4WorkingModeSwitch` not refreshing parameters after switch actions
- Changed `refresh_params=False` to `refresh_params=True` in both `async_turn_on()` and `async_turn_off()`
- Ensures working mode switches (battery_backup_mode, ac_charge, forced_chg_en, forced_dischg_en, grid_peak_shaving) fetch fresh parameter data after state changes

## Root Cause

`EG4WorkingModeSwitch` was using `refresh_params=False`, which meant:
1. After toggling the switch, only `async_request_refresh()` was called
2. The coordinator preserves existing parameter data during normal refreshes
3. Parameters were NOT re-fetched from the API
4. The switch read stale parameter values from the last hourly parameter sync

## Validation

- ✅ Code review passed - change is consistent with other parameter-based switches
- ✅ All 124 tests pass
- ✅ Ruff linting clean
- ✅ No race conditions - data is updated before optimistic state is cleared

## Test plan

- [ ] Toggle battery_backup_mode switch and verify state updates correctly
- [ ] Toggle other working mode switches (ac_charge, forced_chg_en, etc.)
- [ ] Verify switch state matches EG4 monitor website

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)