### PR TITLE
feat: Add CONF_LOCAL_TRANSPORTS for Station.attach_local_transports()

### DIFF
--- a/custom_components/eg4_web_monitor/const.py
+++ b/custom_components/eg4_web_monitor/const.py
@@ -140,6 +140,11 @@ HYBRID_LOCAL_MODBUS = "modbus"  # RS485 via Waveshare or similar adapter
 HYBRID_LOCAL_DONGLE = "dongle"  # WiFi dongle on port 8000
 HYBRID_LOCAL_NONE = "none"  # Cloud-only fallback (no local transport)
 
+# Multi-transport configuration for hybrid mode (list of transport configs)
+# Each item is a dict with: serial, type (modbus/dongle), and transport-specific fields
+# Example: [{"serial": "CE12345", "type": "modbus", "host": "192.168.1.100", ...}]
+CONF_LOCAL_TRANSPORTS = "local_transports"
+
 # Modbus configuration keys
 CONF_MODBUS_HOST = "modbus_host"
 CONF_MODBUS_PORT = "modbus_port"


### PR DESCRIPTION
## Summary

- Added `CONF_LOCAL_TRANSPORTS` constant for storing transport configs as a list suitable for `Station.attach_local_transports()`
- Updated `_create_hybrid_entry()` to store transport config in both legacy and new formats
- Updated `_update_hybrid_entry_from_reconfigure()` similarly
- Fixed mypy type errors in config flow

## Technical Details

The new `CONF_LOCAL_TRANSPORTS` format stores a list of transport configurations:

```python
{
    "local_transports": [
        {
            "serial": "CE12345678",
            "transport_type": "modbus_tcp",  # TransportType.MODBUS_TCP
            "host": "192.168.1.100",
            "port": 502,
            "unit_id": 1,
            "inverter_family": "PV_SERIES",
        }
    ]
}
```

This enables the coordinator (eg4-tp3.7) to use `Station.attach_local_transports()` for multi-transport hybrid mode polling.

## Backward Compatibility

Maintains dual storage format:
- Legacy flat keys (`CONF_MODBUS_HOST`, etc.) for existing coordinator code
- New `CONF_LOCAL_TRANSPORTS` list for future coordinator updates

## Test plan
- [x] All 124 existing tests pass
- [x] Ruff linting passes
- [x] mypy type checking passes
- [x] Code review completed (key naming aligned with TransportConfig)

## Related Issues
Part of: eg4-tp3 (Unified Data Access for Multi-Inverter Modbus Support)
Blocked by: eg4-tp3.15 (HybridStation) - ✅ Merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)