### PR TITLE
feat: Add onboarding mixins for all connection types

### DIFF
--- a/custom_components/eg4_web_monitor/config_flow/helpers.py
+++ b/custom_components/eg4_web_monitor/config_flow/helpers.py
@@ -56,13 +56,22 @@ def format_entry_title(mode: str, name: str) -> str:
     """Format the config entry title.
 
     Args:
-        mode: Connection mode (Web Monitor, Modbus, Dongle, Hybrid).
+        mode: Connection type (http, modbus, dongle, hybrid, local).
         name: Station/plant name or serial number.
 
     Returns:
         Formatted entry title.
     """
-    return f"{BRAND_NAME} {mode} - {name}"
+    # Map mode to display text
+    mode_display = {
+        "http": "Web Monitor",
+        "modbus": "Modbus",
+        "dongle": "Dongle",
+        "hybrid": "Hybrid",
+        "local": "Local",
+    }.get(mode, mode.title())
+
+    return f"{BRAND_NAME} {mode_display} - {name}"
 
 
 def build_unique_id(

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/__init__.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/__init__.py
@@ -1,3 +1,23 @@
-"""Onboarding mixins for config flow."""
+"""Onboarding mixins for EG4 Web Monitor config flow.
 
-# Mixins will be exported here once created
+This package contains mixins for initial setup flows, one for each connection type:
+- HttpOnboardingMixin: Cloud API (HTTP) only setup
+- ModbusOnboardingMixin: Local Modbus TCP setup
+- DongleOnboardingMixin: Local WiFi Dongle setup
+- HybridOnboardingMixin: Cloud + Local combined setup
+- LocalOnboardingMixin: Pure local multi-device setup (no cloud)
+"""
+
+from .dongle import DongleOnboardingMixin
+from .http import HttpOnboardingMixin
+from .hybrid import HybridOnboardingMixin
+from .local import LocalOnboardingMixin
+from .modbus import ModbusOnboardingMixin
+
+__all__ = [
+    "HttpOnboardingMixin",
+    "ModbusOnboardingMixin",
+    "DongleOnboardingMixin",
+    "HybridOnboardingMixin",
+    "LocalOnboardingMixin",
+]

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/dongle.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/dongle.py
@@ -1,0 +1,203 @@
+"""WiFi Dongle onboarding mixin for EG4 Web Monitor config flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_MODEL,
+    CONF_INVERTER_SERIAL,
+    CONNECTION_TYPE_DONGLE,
+    DEFAULT_DONGLE_PORT,
+    DEFAULT_INVERTER_FAMILY,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from ..helpers import build_unique_id, format_entry_title
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inverter family options for register map selection
+INVERTER_FAMILY_OPTIONS = {
+    INVERTER_FAMILY_PV_SERIES: "EG4 18kPV / FlexBOSS (PV Series)",
+    INVERTER_FAMILY_SNA: "EG4 12000XP / 6000XP (SNA Series)",
+    INVERTER_FAMILY_LXP_EU: "LXP-EU 12K (European)",
+}
+
+
+def _build_dongle_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Build the WiFi Dongle configuration schema.
+
+    Args:
+        defaults: Optional default values for reconfiguration.
+
+    Returns:
+        Voluptuous schema for dongle step.
+    """
+    defaults = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_DONGLE_HOST, default=defaults.get(CONF_DONGLE_HOST, "")
+            ): str,
+            vol.Optional(
+                CONF_DONGLE_PORT,
+                default=defaults.get(CONF_DONGLE_PORT, DEFAULT_DONGLE_PORT),
+            ): int,
+            vol.Required(
+                CONF_DONGLE_SERIAL, default=defaults.get(CONF_DONGLE_SERIAL, "")
+            ): str,
+            vol.Required(
+                CONF_INVERTER_SERIAL, default=defaults.get(CONF_INVERTER_SERIAL, "")
+            ): str,
+            vol.Optional(
+                CONF_INVERTER_MODEL, default=defaults.get(CONF_INVERTER_MODEL, "")
+            ): str,
+            vol.Optional(
+                CONF_INVERTER_FAMILY,
+                default=defaults.get(CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY),
+            ): vol.In(INVERTER_FAMILY_OPTIONS),
+        }
+    )
+
+
+class DongleOnboardingMixin:
+    """Mixin providing WiFi Dongle onboarding flow steps.
+
+    This mixin handles the initial setup for local WiFi Dongle connections:
+    1. Collect dongle connection details (host, port, dongle serial)
+    2. Collect inverter details (serial, model, family)
+    3. Test the connection
+    4. Create the config entry
+
+    Requires:
+        - ConfigFlowProtocol attributes (_dongle_host, _dongle_port, etc.)
+        - _test_dongle_connection() method from EG4ConfigFlowBase
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        _dongle_host: str | None
+        _dongle_port: int | None
+        _dongle_serial: str | None
+        _inverter_serial: str | None
+        _inverter_model: str | None
+        _inverter_family: str | None
+
+        async def _test_dongle_connection(self: ConfigFlowProtocol) -> None: ...
+        async def async_set_unique_id(
+            self: ConfigFlowProtocol, unique_id: str
+        ) -> None: ...
+        def _abort_if_unique_id_configured(self: ConfigFlowProtocol) -> None: ...
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+        def async_create_entry(
+            self: ConfigFlowProtocol,
+            *,
+            title: str,
+            data: dict[str, Any],
+        ) -> ConfigFlowResult: ...
+
+    async def async_step_dongle(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle WiFi Dongle TCP connection configuration step.
+
+        This is the main entry point for Dongle-only onboarding.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect dongle settings, or entry creation on success.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store dongle configuration in instance state
+            self._dongle_host = user_input[CONF_DONGLE_HOST]
+            self._dongle_port = user_input.get(CONF_DONGLE_PORT, DEFAULT_DONGLE_PORT)
+            self._dongle_serial = user_input[CONF_DONGLE_SERIAL]
+            self._inverter_serial = user_input[CONF_INVERTER_SERIAL]
+            self._inverter_model = user_input.get(CONF_INVERTER_MODEL, "")
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test dongle connection
+            try:
+                await self._test_dongle_connection()
+                return await self._create_dongle_entry()
+
+            except TimeoutError:
+                errors["base"] = "dongle_timeout"
+            except OSError as e:
+                _LOGGER.error("Dongle connection error: %s", e)
+                errors["base"] = "dongle_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected dongle error: %s", e)
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="dongle",
+            data_schema=_build_dongle_schema(),
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def _create_dongle_entry(self: ConfigFlowProtocol) -> ConfigFlowResult:
+        """Create config entry for WiFi dongle connection.
+
+        Returns:
+            Config entry creation result.
+        """
+        # Validate required state
+        assert self._dongle_host is not None
+        assert self._dongle_port is not None
+        assert self._dongle_serial is not None
+        assert self._inverter_serial is not None
+
+        # Set unique ID and check for duplicates
+        unique_id = build_unique_id("dongle", serial=self._inverter_serial)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # Create title with optional model suffix
+        title = format_entry_title("dongle", self._inverter_serial)
+        if self._inverter_model:
+            title = f"{title} ({self._inverter_model})"
+
+        data = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_DONGLE,
+            CONF_DONGLE_HOST: self._dongle_host,
+            CONF_DONGLE_PORT: self._dongle_port,
+            CONF_DONGLE_SERIAL: self._dongle_serial,
+            CONF_INVERTER_SERIAL: self._inverter_serial,
+            CONF_INVERTER_MODEL: self._inverter_model or "",
+            CONF_INVERTER_FAMILY: self._inverter_family or DEFAULT_INVERTER_FAMILY,
+        }
+
+        return self.async_create_entry(title=title, data=data)

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/http.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/http.py
@@ -1,0 +1,270 @@
+"""HTTP (Cloud API) onboarding mixin for EG4 Web Monitor config flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pylxpweb.exceptions import (
+    LuxpowerAPIError,
+    LuxpowerAuthError,
+    LuxpowerConnectionError,
+)
+
+from ...const import (
+    BRAND_NAME,
+    CONF_BASE_URL,
+    CONF_CONNECTION_TYPE,
+    CONF_DST_SYNC,
+    CONF_LIBRARY_DEBUG,
+    CONF_PLANT_ID,
+    CONF_PLANT_NAME,
+    CONF_VERIFY_SSL,
+    CONNECTION_TYPE_HTTP,
+    DEFAULT_BASE_URL,
+    DEFAULT_VERIFY_SSL,
+)
+from ..helpers import build_unique_id, format_entry_title, timezone_observes_dst
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _build_http_credentials_schema(dst_sync_default: bool = True) -> vol.Schema:
+    """Build the HTTP credentials schema with dynamic DST sync default.
+
+    Args:
+        dst_sync_default: Default value for DST sync checkbox.
+
+    Returns:
+        Voluptuous schema for HTTP credentials step.
+    """
+    return vol.Schema(
+        {
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_BASE_URL, default=DEFAULT_BASE_URL): str,
+            vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
+            vol.Optional(CONF_DST_SYNC, default=dst_sync_default): bool,
+            vol.Optional(CONF_LIBRARY_DEBUG, default=False): bool,
+        }
+    )
+
+
+class HttpOnboardingMixin:
+    """Mixin providing HTTP (Cloud API) onboarding flow steps.
+
+    This mixin handles the initial setup for cloud-only connections:
+    1. Collect HTTP credentials (username, password, base URL)
+    2. Test authentication and discover available plants
+    3. Allow user to select a plant (if multiple)
+    4. Create the config entry
+
+    Requires:
+        - ConfigFlowProtocol attributes (_username, _password, etc.)
+        - _test_credentials() method from EG4ConfigFlowBase
+        - hass attribute from ConfigFlow
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        _username: str | None
+        _password: str | None
+        _base_url: str | None
+        _verify_ssl: bool | None
+        _dst_sync: bool | None
+        _library_debug: bool | None
+        _plants: list[dict[str, Any]] | None
+
+        async def _test_credentials(self: ConfigFlowProtocol) -> None: ...
+        async def async_set_unique_id(
+            self: ConfigFlowProtocol, unique_id: str
+        ) -> None: ...
+        def _abort_if_unique_id_configured(self: ConfigFlowProtocol) -> None: ...
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+        def async_create_entry(
+            self: ConfigFlowProtocol,
+            *,
+            title: str,
+            data: dict[str, Any],
+        ) -> ConfigFlowResult: ...
+
+    async def async_step_http_credentials(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle HTTP cloud API credentials step.
+
+        This is the main entry point for HTTP-only onboarding.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect credentials, or next step/entry creation.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                # Store credentials in instance state
+                self._username = user_input[CONF_USERNAME]
+                self._password = user_input[CONF_PASSWORD]
+                self._base_url = user_input.get(CONF_BASE_URL, DEFAULT_BASE_URL)
+                self._verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
+                self._dst_sync = user_input.get(CONF_DST_SYNC, True)
+                self._library_debug = user_input.get(CONF_LIBRARY_DEBUG, False)
+
+                # Test authentication and discover plants
+                await self._test_credentials()
+
+                # If only one plant, auto-select and finish
+                if self._plants and len(self._plants) == 1:
+                    plant = self._plants[0]
+                    return await self._create_http_entry(
+                        plant_id=plant["plantId"], plant_name=plant["name"]
+                    )
+
+                # Multiple plants - show selection step
+                return await self.async_step_plant()
+
+            except LuxpowerAuthError:
+                errors["base"] = "invalid_auth"
+            except LuxpowerConnectionError:
+                errors["base"] = "cannot_connect"
+            except LuxpowerAPIError as e:
+                _LOGGER.error("API error during authentication: %s", e)
+                errors["base"] = "unknown"
+            except Exception as e:
+                _LOGGER.exception("Unexpected error: %s", e)
+                errors["base"] = "unknown"
+
+        # Determine DST sync default based on Home Assistant timezone
+        ha_timezone = self.hass.config.time_zone
+        dst_sync_default = timezone_observes_dst(ha_timezone)
+        _LOGGER.debug(
+            "HA timezone: %s, observes DST: %s", ha_timezone, dst_sync_default
+        )
+
+        return self.async_show_form(
+            step_id="http_credentials",
+            data_schema=_build_http_credentials_schema(dst_sync_default),
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "base_url": DEFAULT_BASE_URL,
+            },
+        )
+
+    async def async_step_plant(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle plant selection step when multiple plants exist.
+
+        Args:
+            user_input: Form data with selected plant_id, or None.
+
+        Returns:
+            Form to select plant, or entry creation on selection.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                plant_id = user_input[CONF_PLANT_ID]
+
+                # Find the selected plant
+                selected_plant = None
+                if self._plants:
+                    for plant in self._plants:
+                        if plant["plantId"] == plant_id:
+                            selected_plant = plant
+                            break
+
+                if not selected_plant:
+                    errors["base"] = "invalid_plant"
+                else:
+                    return await self._create_http_entry(
+                        plant_id=selected_plant["plantId"],
+                        plant_name=selected_plant["name"],
+                    )
+
+            except Exception as e:
+                _LOGGER.exception("Error during plant selection: %s", e)
+                errors["base"] = "unknown"
+
+        # Build plant selection schema
+        plant_options = {
+            plant["plantId"]: plant["name"] for plant in self._plants or []
+        }
+
+        plant_schema = vol.Schema(
+            {
+                vol.Required(CONF_PLANT_ID): vol.In(plant_options),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="plant",
+            data_schema=plant_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "plant_count": str(len(plant_options)),
+            },
+        )
+
+    async def _create_http_entry(
+        self: ConfigFlowProtocol, plant_id: str, plant_name: str
+    ) -> ConfigFlowResult:
+        """Create the config entry for HTTP cloud API connection.
+
+        Args:
+            plant_id: The selected plant/station ID.
+            plant_name: The plant name for display.
+
+        Returns:
+            Config entry creation result.
+        """
+        # Validate required state
+        assert self._username is not None
+        assert self._password is not None
+        assert self._base_url is not None
+        assert self._verify_ssl is not None
+        assert self._dst_sync is not None
+        assert self._library_debug is not None
+
+        # Set unique ID and check for duplicates
+        unique_id = build_unique_id("http", username=self._username, plant_id=plant_id)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # Create entry title
+        title = format_entry_title("http", plant_name)
+
+        # Create entry data
+        data = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP,
+            CONF_USERNAME: self._username,
+            CONF_PASSWORD: self._password,
+            CONF_BASE_URL: self._base_url,
+            CONF_VERIFY_SSL: self._verify_ssl,
+            CONF_DST_SYNC: self._dst_sync,
+            CONF_LIBRARY_DEBUG: self._library_debug,
+            CONF_PLANT_ID: plant_id,
+            CONF_PLANT_NAME: plant_name,
+        }
+
+        return self.async_create_entry(title=title, data=data)

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/hybrid.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/hybrid.py
@@ -1,0 +1,562 @@
+"""Hybrid (Cloud + Local) onboarding mixin for EG4 Web Monitor config flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import AbortFlow
+from pylxpweb.exceptions import (
+    LuxpowerAPIError,
+    LuxpowerAuthError,
+    LuxpowerConnectionError,
+)
+
+from ...const import (
+    BRAND_NAME,
+    CONF_BASE_URL,
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_DST_SYNC,
+    CONF_HYBRID_LOCAL_TYPE,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_SERIAL,
+    CONF_LIBRARY_DEBUG,
+    CONF_LOCAL_TRANSPORTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONF_PLANT_ID,
+    CONF_PLANT_NAME,
+    CONF_VERIFY_SSL,
+    CONNECTION_TYPE_HYBRID,
+    DEFAULT_BASE_URL,
+    DEFAULT_DONGLE_PORT,
+    DEFAULT_INVERTER_FAMILY,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT_ID,
+    DEFAULT_VERIFY_SSL,
+    HYBRID_LOCAL_DONGLE,
+    HYBRID_LOCAL_MODBUS,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from ..helpers import build_unique_id, format_entry_title, timezone_observes_dst
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inverter family options for register map selection
+INVERTER_FAMILY_OPTIONS = {
+    INVERTER_FAMILY_PV_SERIES: "EG4 18kPV / FlexBOSS (PV Series)",
+    INVERTER_FAMILY_SNA: "EG4 12000XP / 6000XP (SNA Series)",
+    INVERTER_FAMILY_LXP_EU: "LXP-EU 12K (European)",
+}
+
+# Local transport type options
+LOCAL_TYPE_OPTIONS = {
+    HYBRID_LOCAL_MODBUS: "Modbus TCP (RS485 adapter - fastest)",
+    HYBRID_LOCAL_DONGLE: "WiFi Dongle (no extra hardware)",
+}
+
+
+def _build_http_credentials_schema(dst_sync_default: bool = True) -> vol.Schema:
+    """Build the HTTP credentials schema for hybrid mode.
+
+    Args:
+        dst_sync_default: Default value for DST sync checkbox.
+
+    Returns:
+        Voluptuous schema for HTTP credentials step.
+    """
+    return vol.Schema(
+        {
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_BASE_URL, default=DEFAULT_BASE_URL): str,
+            vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
+            vol.Optional(CONF_DST_SYNC, default=dst_sync_default): bool,
+            vol.Optional(CONF_LIBRARY_DEBUG, default=False): bool,
+        }
+    )
+
+
+class HybridOnboardingMixin:
+    """Mixin providing Hybrid (Cloud + Local) onboarding flow steps.
+
+    This mixin handles the initial setup for hybrid connections that combine
+    cloud API access with local transport (Modbus or WiFi Dongle):
+    1. Collect HTTP credentials
+    2. Test authentication and discover plants
+    3. Allow user to select a plant (if multiple)
+    4. Select local transport type (Modbus or Dongle)
+    5. Configure the selected local transport
+    6. Create the config entry with both cloud and local settings
+
+    Requires:
+        - ConfigFlowProtocol attributes (all HTTP and local fields)
+        - _test_credentials() method from EG4ConfigFlowBase
+        - _test_modbus_connection() method from EG4ConfigFlowBase
+        - _test_dongle_connection() method from EG4ConfigFlowBase
+        - _get_inverter_serials_from_plant() method from EG4ConfigFlowBase
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        # HTTP fields
+        _username: str | None
+        _password: str | None
+        _base_url: str | None
+        _verify_ssl: bool | None
+        _dst_sync: bool | None
+        _library_debug: bool | None
+        _plant_id: str | None
+        _plants: list[dict[str, Any]] | None
+        # Modbus fields
+        _modbus_host: str | None
+        _modbus_port: int | None
+        _modbus_unit_id: int | None
+        # Dongle fields
+        _dongle_host: str | None
+        _dongle_port: int | None
+        _dongle_serial: str | None
+        # Shared local fields
+        _inverter_serial: str | None
+        _inverter_family: str | None
+        _hybrid_local_type: str | None
+
+        async def _test_credentials(self: ConfigFlowProtocol) -> None: ...
+        async def _test_modbus_connection(self: ConfigFlowProtocol) -> str: ...
+        async def _test_dongle_connection(self: ConfigFlowProtocol) -> None: ...
+        def _get_inverter_serials_from_plant(
+            self: ConfigFlowProtocol,
+        ) -> list[str]: ...
+        async def async_set_unique_id(
+            self: ConfigFlowProtocol, unique_id: str
+        ) -> None: ...
+        def _abort_if_unique_id_configured(self: ConfigFlowProtocol) -> None: ...
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+        def async_create_entry(
+            self: ConfigFlowProtocol,
+            *,
+            title: str,
+            data: dict[str, Any],
+        ) -> ConfigFlowResult: ...
+
+    async def async_step_hybrid_http(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle HTTP credentials step for hybrid mode.
+
+        This is the main entry point for Hybrid onboarding.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect credentials, or next step.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                # Store HTTP credentials
+                self._username = user_input[CONF_USERNAME]
+                self._password = user_input[CONF_PASSWORD]
+                self._base_url = user_input.get(CONF_BASE_URL, DEFAULT_BASE_URL)
+                self._verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
+                self._dst_sync = user_input.get(CONF_DST_SYNC, True)
+                self._library_debug = user_input.get(CONF_LIBRARY_DEBUG, False)
+
+                # Test authentication and get plants
+                await self._test_credentials()
+
+                # If only one plant, auto-select and move to local type selection
+                if self._plants and len(self._plants) == 1:
+                    plant = self._plants[0]
+                    self._plant_id = plant["plantId"]
+                    return await self.async_step_hybrid_local_type()
+
+                # Multiple plants - show selection step
+                return await self.async_step_hybrid_plant()
+
+            except LuxpowerAuthError:
+                errors["base"] = "invalid_auth"
+            except LuxpowerConnectionError:
+                errors["base"] = "cannot_connect"
+            except LuxpowerAPIError as e:
+                _LOGGER.error("API error during authentication: %s", e)
+                errors["base"] = "unknown"
+            except Exception as e:
+                _LOGGER.exception("Unexpected error: %s", e)
+                errors["base"] = "unknown"
+
+        # Determine DST sync default
+        ha_timezone = self.hass.config.time_zone
+        dst_sync_default = timezone_observes_dst(ha_timezone)
+
+        return self.async_show_form(
+            step_id="hybrid_http",
+            data_schema=_build_http_credentials_schema(dst_sync_default),
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "base_url": DEFAULT_BASE_URL,
+            },
+        )
+
+    async def async_step_hybrid_plant(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle plant selection for hybrid mode.
+
+        Args:
+            user_input: Form data with selected plant_id, or None.
+
+        Returns:
+            Form to select plant, or local type selection step.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                plant_id = user_input[CONF_PLANT_ID]
+
+                # Find the selected plant
+                selected_plant = None
+                if self._plants:
+                    for plant in self._plants:
+                        if plant["plantId"] == plant_id:
+                            selected_plant = plant
+                            break
+
+                if not selected_plant:
+                    errors["base"] = "invalid_plant"
+                else:
+                    self._plant_id = selected_plant["plantId"]
+                    return await self.async_step_hybrid_local_type()
+
+            except AbortFlow:
+                raise
+            except Exception as e:
+                _LOGGER.exception("Error during plant selection: %s", e)
+                errors["base"] = "unknown"
+
+        # Build plant selection schema
+        plant_options = {
+            plant["plantId"]: plant["name"] for plant in self._plants or []
+        }
+
+        plant_schema = vol.Schema(
+            {
+                vol.Required(CONF_PLANT_ID): vol.In(plant_options),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="hybrid_plant",
+            data_schema=plant_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "plant_count": str(len(plant_options)),
+            },
+        )
+
+    async def async_step_hybrid_local_type(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle local transport type selection for hybrid mode.
+
+        Allows user to choose between Modbus (RS485 adapter) or WiFi Dongle.
+
+        Args:
+            user_input: Form data with selected local type, or None.
+
+        Returns:
+            Form to select local type, or appropriate configuration step.
+        """
+        if user_input is not None:
+            local_type = user_input[CONF_HYBRID_LOCAL_TYPE]
+            self._hybrid_local_type = local_type
+
+            if local_type == HYBRID_LOCAL_MODBUS:
+                return await self.async_step_hybrid_modbus()
+            if local_type == HYBRID_LOCAL_DONGLE:
+                return await self.async_step_hybrid_dongle()
+            # Should not reach here, but default to modbus with warning
+            _LOGGER.warning(
+                "Unexpected hybrid_local_type value: %s, defaulting to Modbus",
+                local_type,
+            )
+            return await self.async_step_hybrid_modbus()
+
+        # Build local transport type selection schema
+        local_type_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_HYBRID_LOCAL_TYPE, default=HYBRID_LOCAL_MODBUS
+                ): vol.In(LOCAL_TYPE_OPTIONS),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="hybrid_local_type",
+            data_schema=local_type_schema,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_hybrid_modbus(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Modbus configuration for hybrid mode.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect Modbus settings, or entry creation on success.
+        """
+        errors: dict[str, str] = {}
+
+        # Ensure hybrid local type is set
+        if self._hybrid_local_type is None:
+            self._hybrid_local_type = HYBRID_LOCAL_MODBUS
+
+        if user_input is not None:
+            self._modbus_host = user_input[CONF_MODBUS_HOST]
+            self._modbus_port = user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
+            self._modbus_unit_id = user_input.get(
+                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+            )
+            # For hybrid, serial comes from plant discovery, but can be overridden
+            self._inverter_serial = user_input.get(
+                CONF_INVERTER_SERIAL, self._inverter_serial or ""
+            )
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test Modbus connection
+            try:
+                await self._test_modbus_connection()
+                return await self._create_hybrid_entry()
+
+            except ImportError:
+                errors["base"] = "modbus_not_installed"
+            except TimeoutError:
+                errors["base"] = "modbus_timeout"
+            except OSError as e:
+                _LOGGER.error("Modbus connection error: %s", e)
+                errors["base"] = "modbus_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected Modbus error: %s", e)
+                errors["base"] = "unknown"
+
+        # Try to get inverter serials from the discovered plant
+        inverter_serials = self._get_inverter_serials_from_plant()
+        default_serial = inverter_serials[0] if inverter_serials else ""
+
+        modbus_schema = vol.Schema(
+            {
+                vol.Required(CONF_MODBUS_HOST): str,
+                vol.Optional(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): int,
+                vol.Optional(CONF_MODBUS_UNIT_ID, default=DEFAULT_MODBUS_UNIT_ID): int,
+                vol.Required(CONF_INVERTER_SERIAL, default=default_serial): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="hybrid_modbus",
+            data_schema=modbus_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_hybrid_dongle(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle WiFi Dongle configuration for hybrid mode.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect dongle settings, or entry creation on success.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._dongle_host = user_input[CONF_DONGLE_HOST]
+            self._dongle_port = user_input.get(CONF_DONGLE_PORT, DEFAULT_DONGLE_PORT)
+            self._dongle_serial = user_input[CONF_DONGLE_SERIAL]
+            # For hybrid, inverter serial may come from plant discovery or be specified
+            self._inverter_serial = user_input.get(
+                CONF_INVERTER_SERIAL, self._inverter_serial or ""
+            )
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test dongle connection
+            try:
+                await self._test_dongle_connection()
+                return await self._create_hybrid_entry()
+
+            except TimeoutError:
+                errors["base"] = "dongle_timeout"
+            except OSError as e:
+                _LOGGER.error("Dongle connection error: %s", e)
+                errors["base"] = "dongle_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected dongle error: %s", e)
+                errors["base"] = "unknown"
+
+        # Try to get inverter serials from the discovered plant
+        inverter_serials = self._get_inverter_serials_from_plant()
+        default_serial = inverter_serials[0] if inverter_serials else ""
+
+        dongle_schema = vol.Schema(
+            {
+                vol.Required(CONF_DONGLE_HOST): str,
+                vol.Optional(CONF_DONGLE_PORT, default=DEFAULT_DONGLE_PORT): int,
+                vol.Required(CONF_DONGLE_SERIAL): str,
+                vol.Required(CONF_INVERTER_SERIAL, default=default_serial): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="hybrid_dongle",
+            data_schema=dongle_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def _create_hybrid_entry(self: ConfigFlowProtocol) -> ConfigFlowResult:
+        """Create config entry for hybrid (HTTP + local transport) connection.
+
+        Supports both Modbus and WiFi Dongle as local transport options.
+
+        Returns:
+            Config entry creation result.
+        """
+        # Validate required state
+        assert self._username is not None
+        assert self._password is not None
+        assert self._base_url is not None
+        assert self._verify_ssl is not None
+        assert self._dst_sync is not None
+        assert self._plant_id is not None
+        assert self._inverter_serial is not None
+        assert self._hybrid_local_type is not None
+
+        # Find plant name
+        plant_name = "Unknown"
+        if self._plants:
+            for plant in self._plants:
+                if plant["plantId"] == self._plant_id:
+                    plant_name = plant["name"]
+                    break
+
+        # Set unique ID and check for duplicates
+        unique_id = build_unique_id(
+            "hybrid", username=self._username, plant_id=self._plant_id
+        )
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        title = format_entry_title("hybrid", plant_name)
+
+        data: dict[str, Any] = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_HYBRID,
+            # HTTP configuration
+            CONF_USERNAME: self._username,
+            CONF_PASSWORD: self._password,
+            CONF_BASE_URL: self._base_url,
+            CONF_VERIFY_SSL: self._verify_ssl,
+            CONF_DST_SYNC: self._dst_sync,
+            CONF_LIBRARY_DEBUG: self._library_debug or False,
+            CONF_PLANT_ID: self._plant_id,
+            CONF_PLANT_NAME: plant_name,
+            # Local transport type (modbus or dongle)
+            CONF_HYBRID_LOCAL_TYPE: self._hybrid_local_type,
+            CONF_INVERTER_SERIAL: self._inverter_serial,
+            CONF_INVERTER_FAMILY: self._inverter_family or DEFAULT_INVERTER_FAMILY,
+        }
+
+        # Add transport-specific configuration (legacy format for backward compatibility)
+        # Also build the new CONF_LOCAL_TRANSPORTS list for Station.attach_local_transports()
+        local_transports: list[dict[str, Any]] = []
+
+        if self._hybrid_local_type == HYBRID_LOCAL_MODBUS:
+            assert self._modbus_host is not None
+            assert self._modbus_port is not None
+            assert self._modbus_unit_id is not None
+            # Legacy format (kept for backward compatibility)
+            data[CONF_MODBUS_HOST] = self._modbus_host
+            data[CONF_MODBUS_PORT] = self._modbus_port
+            data[CONF_MODBUS_UNIT_ID] = self._modbus_unit_id
+            # New format for Station.attach_local_transports()
+            local_transports.append(
+                {
+                    "serial": self._inverter_serial,
+                    "transport_type": "modbus_tcp",
+                    "host": self._modbus_host,
+                    "port": self._modbus_port,
+                    "unit_id": self._modbus_unit_id,
+                    "inverter_family": self._inverter_family or DEFAULT_INVERTER_FAMILY,
+                }
+            )
+        elif self._hybrid_local_type == HYBRID_LOCAL_DONGLE:
+            assert self._dongle_host is not None
+            assert self._dongle_port is not None
+            assert self._dongle_serial is not None
+            # Legacy format (kept for backward compatibility)
+            data[CONF_DONGLE_HOST] = self._dongle_host
+            data[CONF_DONGLE_PORT] = self._dongle_port
+            data[CONF_DONGLE_SERIAL] = self._dongle_serial
+            # New format for Station.attach_local_transports()
+            local_transports.append(
+                {
+                    "serial": self._inverter_serial,
+                    "transport_type": "wifi_dongle",
+                    "host": self._dongle_host,
+                    "port": self._dongle_port,
+                    "dongle_serial": self._dongle_serial,
+                    "inverter_family": self._inverter_family or DEFAULT_INVERTER_FAMILY,
+                }
+            )
+
+        # Store the new format for coordinator
+        if local_transports:
+            data[CONF_LOCAL_TRANSPORTS] = local_transports
+
+        return self.async_create_entry(title=title, data=data)

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/local.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/local.py
@@ -1,0 +1,465 @@
+"""Local-only (no cloud) onboarding mixin for EG4 Web Monitor config flow.
+
+This module provides the LOCAL connection type which allows users to configure
+multiple local devices (Modbus and/or WiFi Dongle) without any cloud credentials.
+This is useful for users who want purely local operation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_MODEL,
+    CONF_INVERTER_SERIAL,
+    CONF_LOCAL_TRANSPORTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONNECTION_TYPE_LOCAL,
+    DEFAULT_DONGLE_PORT,
+    DEFAULT_INVERTER_FAMILY,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT_ID,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from ..helpers import build_unique_id, format_entry_title
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inverter family options for register map selection
+INVERTER_FAMILY_OPTIONS = {
+    INVERTER_FAMILY_PV_SERIES: "EG4 18kPV / FlexBOSS (PV Series)",
+    INVERTER_FAMILY_SNA: "EG4 12000XP / 6000XP (SNA Series)",
+    INVERTER_FAMILY_LXP_EU: "LXP-EU 12K (European)",
+}
+
+# Local device type options
+LOCAL_DEVICE_TYPE_OPTIONS = {
+    "modbus": "Modbus TCP (RS485 adapter)",
+    "dongle": "WiFi Dongle",
+}
+
+
+class LocalOnboardingMixin:
+    """Mixin providing Local-only (no cloud) onboarding flow steps.
+
+    This mixin handles the initial setup for purely local connections without
+    any cloud credentials. Users can add multiple local devices (Modbus and/or
+    WiFi Dongle) to a single config entry:
+
+    1. Show local setup intro/information
+    2. Loop: Add local device (Modbus or Dongle)
+    3. After each device: Ask if user wants to add more
+    4. Create config entry with all local devices
+
+    The LOCAL mode differs from HYBRID in that:
+    - No cloud credentials required
+    - Can configure multiple inverters in one entry
+    - No plant/station concept - devices are purely local
+
+    Requires:
+        - ConfigFlowProtocol attributes
+        - _test_modbus_connection() method from EG4ConfigFlowBase
+        - _test_dongle_connection() method from EG4ConfigFlowBase
+        - _local_devices list to accumulate device configs
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        # Modbus fields
+        _modbus_host: str | None
+        _modbus_port: int | None
+        _modbus_unit_id: int | None
+        # Dongle fields
+        _dongle_host: str | None
+        _dongle_port: int | None
+        _dongle_serial: str | None
+        # Shared local fields
+        _inverter_serial: str | None
+        _inverter_model: str | None
+        _inverter_family: str | None
+        # Local devices accumulator
+        _local_devices: list[dict[str, Any]]
+        # Station name for display
+        _local_station_name: str | None
+
+        async def _test_modbus_connection(self: ConfigFlowProtocol) -> str: ...
+        async def _test_dongle_connection(self: ConfigFlowProtocol) -> None: ...
+        async def async_set_unique_id(
+            self: ConfigFlowProtocol, unique_id: str
+        ) -> None: ...
+        def _abort_if_unique_id_configured(self: ConfigFlowProtocol) -> None: ...
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+        def async_create_entry(
+            self: ConfigFlowProtocol,
+            *,
+            title: str,
+            data: dict[str, Any],
+        ) -> ConfigFlowResult: ...
+
+    async def async_step_local_setup(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial local setup step.
+
+        This is the main entry point for LOCAL onboarding. Shows information
+        about local-only mode and collects an optional station/installation name.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to start local setup, or next step.
+        """
+        if user_input is not None:
+            # Store optional station name for display purposes
+            self._local_station_name = (
+                user_input.get("station_name", "").strip() or None
+            )
+            # Initialize or clear the local devices list
+            self._local_devices = []
+            return await self.async_step_local_add_device()
+
+        # Build schema for local setup intro
+        setup_schema = vol.Schema(
+            {
+                vol.Optional("station_name", default=""): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="local_setup",
+            data_schema=setup_schema,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_local_add_device(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle adding a local device - select device type.
+
+        Args:
+            user_input: Form data with device type selection, or None.
+
+        Returns:
+            Form to select device type, or appropriate config step.
+        """
+        if user_input is not None:
+            device_type = user_input.get("device_type")
+
+            if device_type == "modbus":
+                return await self.async_step_local_modbus_device()
+            if device_type == "dongle":
+                return await self.async_step_local_dongle_device()
+            # Shouldn't happen but default to modbus
+            _LOGGER.warning(
+                "Unexpected device_type value: %s, defaulting to Modbus", device_type
+            )
+            return await self.async_step_local_modbus_device()
+
+        # Build device type selection schema
+        device_type_schema = vol.Schema(
+            {
+                vol.Required("device_type", default="modbus"): vol.In(
+                    LOCAL_DEVICE_TYPE_OPTIONS
+                ),
+            }
+        )
+
+        # Show how many devices have been added so far
+        device_count = len(self._local_devices) if self._local_devices else 0
+
+        return self.async_show_form(
+            step_id="local_add_device",
+            data_schema=device_type_schema,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "device_count": str(device_count),
+            },
+        )
+
+    async def async_step_local_modbus_device(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Modbus device configuration for local mode.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect Modbus settings, or device added confirmation.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store Modbus configuration temporarily
+            self._modbus_host = user_input[CONF_MODBUS_HOST]
+            self._modbus_port = user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
+            self._modbus_unit_id = user_input.get(
+                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+            )
+            self._inverter_serial = user_input.get(CONF_INVERTER_SERIAL, "")
+            self._inverter_model = user_input.get(CONF_INVERTER_MODEL, "")
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test Modbus connection
+            try:
+                detected_serial = await self._test_modbus_connection()
+                # Use detected serial if user didn't provide one
+                if not self._inverter_serial and detected_serial:
+                    self._inverter_serial = detected_serial
+                    _LOGGER.info(
+                        "Auto-detected inverter serial from Modbus: %s",
+                        detected_serial,
+                    )
+
+                # Check for duplicate serial in already-added devices
+                if self._local_devices:
+                    for device in self._local_devices:
+                        if device.get("serial") == self._inverter_serial:
+                            errors["base"] = "duplicate_serial"
+                            break
+
+                if not errors:
+                    # Add device to list
+                    device_config = {
+                        "serial": self._inverter_serial,
+                        "transport_type": "modbus_tcp",
+                        "host": self._modbus_host,
+                        "port": self._modbus_port,
+                        "unit_id": self._modbus_unit_id,
+                        "model": self._inverter_model or "",
+                        "inverter_family": self._inverter_family
+                        or DEFAULT_INVERTER_FAMILY,
+                    }
+                    self._local_devices.append(device_config)
+                    return await self.async_step_local_device_added()
+
+            except ImportError:
+                errors["base"] = "modbus_not_installed"
+            except TimeoutError:
+                errors["base"] = "modbus_timeout"
+            except OSError as e:
+                _LOGGER.error("Modbus connection error: %s", e)
+                errors["base"] = "modbus_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected Modbus error: %s", e)
+                errors["base"] = "unknown"
+
+        # Build Modbus configuration schema
+        modbus_schema = vol.Schema(
+            {
+                vol.Required(CONF_MODBUS_HOST): str,
+                vol.Optional(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): int,
+                vol.Optional(CONF_MODBUS_UNIT_ID, default=DEFAULT_MODBUS_UNIT_ID): int,
+                vol.Optional(CONF_INVERTER_SERIAL, default=""): str,
+                vol.Optional(CONF_INVERTER_MODEL, default=""): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="local_modbus_device",
+            data_schema=modbus_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_local_dongle_device(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle WiFi Dongle device configuration for local mode.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect dongle settings, or device added confirmation.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store dongle configuration temporarily
+            self._dongle_host = user_input[CONF_DONGLE_HOST]
+            self._dongle_port = user_input.get(CONF_DONGLE_PORT, DEFAULT_DONGLE_PORT)
+            self._dongle_serial = user_input[CONF_DONGLE_SERIAL]
+            self._inverter_serial = user_input[CONF_INVERTER_SERIAL]
+            self._inverter_model = user_input.get(CONF_INVERTER_MODEL, "")
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test dongle connection
+            try:
+                await self._test_dongle_connection()
+
+                # Check for duplicate serial in already-added devices
+                if self._local_devices:
+                    for device in self._local_devices:
+                        if device.get("serial") == self._inverter_serial:
+                            errors["base"] = "duplicate_serial"
+                            break
+
+                if not errors:
+                    # Add device to list
+                    device_config = {
+                        "serial": self._inverter_serial,
+                        "transport_type": "wifi_dongle",
+                        "host": self._dongle_host,
+                        "port": self._dongle_port,
+                        "dongle_serial": self._dongle_serial,
+                        "model": self._inverter_model or "",
+                        "inverter_family": self._inverter_family
+                        or DEFAULT_INVERTER_FAMILY,
+                    }
+                    self._local_devices.append(device_config)
+                    return await self.async_step_local_device_added()
+
+            except TimeoutError:
+                errors["base"] = "dongle_timeout"
+            except OSError as e:
+                _LOGGER.error("Dongle connection error: %s", e)
+                errors["base"] = "dongle_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected dongle error: %s", e)
+                errors["base"] = "unknown"
+
+        # Build dongle configuration schema
+        dongle_schema = vol.Schema(
+            {
+                vol.Required(CONF_DONGLE_HOST): str,
+                vol.Optional(CONF_DONGLE_PORT, default=DEFAULT_DONGLE_PORT): int,
+                vol.Required(CONF_DONGLE_SERIAL): str,
+                vol.Required(CONF_INVERTER_SERIAL): str,
+                vol.Optional(CONF_INVERTER_MODEL, default=""): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="local_dongle_device",
+            data_schema=dongle_schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_local_device_added(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle confirmation after a device is added.
+
+        Asks user if they want to add another device or finish setup.
+
+        Args:
+            user_input: Form data with add_another choice, or None.
+
+        Returns:
+            Add device step, or entry creation.
+        """
+        if user_input is not None:
+            add_another = user_input.get("add_another", False)
+
+            if add_another:
+                return await self.async_step_local_add_device()
+            # User is done - create the entry
+            return await self._create_local_entry()
+
+        # Build schema for add another choice
+        add_another_schema = vol.Schema(
+            {
+                vol.Required("add_another", default=False): bool,
+            }
+        )
+
+        # Get info about the last added device for display
+        last_device = self._local_devices[-1] if self._local_devices else {}
+        last_serial = last_device.get("serial", "Unknown")
+        last_type = last_device.get("transport_type", "unknown")
+        device_count = len(self._local_devices)
+
+        return self.async_show_form(
+            step_id="local_device_added",
+            data_schema=add_another_schema,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "device_serial": last_serial,
+                "device_type": last_type,
+                "device_count": str(device_count),
+            },
+        )
+
+    async def _create_local_entry(self: ConfigFlowProtocol) -> ConfigFlowResult:
+        """Create config entry for local-only (no cloud) connection.
+
+        Returns:
+            Config entry creation result.
+        """
+        # Validate that we have at least one device
+        assert self._local_devices, "At least one local device must be configured"
+
+        # Build unique ID from all device serials (sorted for consistency)
+        serials = sorted(device.get("serial", "") for device in self._local_devices)
+        unique_id = build_unique_id("local", station_name="_".join(serials))
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # Create title
+        if self._local_station_name:
+            title = format_entry_title("local", self._local_station_name)
+        else:
+            # Use first serial as name if no station name provided
+            first_serial = self._local_devices[0].get("serial", "Unknown")
+            device_count = len(self._local_devices)
+            if device_count == 1:
+                title = format_entry_title("local", first_serial)
+            else:
+                title = format_entry_title(
+                    "local", f"{first_serial} (+{device_count - 1})"
+                )
+
+        data: dict[str, Any] = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+            CONF_LOCAL_TRANSPORTS: self._local_devices,
+        }
+
+        # Store optional station name
+        if self._local_station_name:
+            data["station_name"] = self._local_station_name
+
+        return self.async_create_entry(title=title, data=data)

--- a/custom_components/eg4_web_monitor/config_flow/onboarding/modbus.py
+++ b/custom_components/eg4_web_monitor/config_flow/onboarding/modbus.py
@@ -1,0 +1,218 @@
+"""Modbus TCP onboarding mixin for EG4 Web Monitor config flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_MODEL,
+    CONF_INVERTER_SERIAL,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONNECTION_TYPE_MODBUS,
+    DEFAULT_INVERTER_FAMILY,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT_ID,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from ..helpers import build_unique_id, format_entry_title
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inverter family options for register map selection
+INVERTER_FAMILY_OPTIONS = {
+    INVERTER_FAMILY_PV_SERIES: "EG4 18kPV / FlexBOSS (PV Series)",
+    INVERTER_FAMILY_SNA: "EG4 12000XP / 6000XP (SNA Series)",
+    INVERTER_FAMILY_LXP_EU: "LXP-EU 12K (European)",
+}
+
+
+def _build_modbus_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Build the Modbus configuration schema.
+
+    Args:
+        defaults: Optional default values for reconfiguration.
+
+    Returns:
+        Voluptuous schema for Modbus step.
+    """
+    defaults = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_MODBUS_HOST, default=defaults.get(CONF_MODBUS_HOST, "")
+            ): str,
+            vol.Optional(
+                CONF_MODBUS_PORT,
+                default=defaults.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
+            ): int,
+            vol.Optional(
+                CONF_MODBUS_UNIT_ID,
+                default=defaults.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID),
+            ): int,
+            vol.Optional(
+                CONF_INVERTER_SERIAL, default=defaults.get(CONF_INVERTER_SERIAL, "")
+            ): str,
+            vol.Optional(
+                CONF_INVERTER_MODEL, default=defaults.get(CONF_INVERTER_MODEL, "")
+            ): str,
+            vol.Optional(
+                CONF_INVERTER_FAMILY,
+                default=defaults.get(CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY),
+            ): vol.In(INVERTER_FAMILY_OPTIONS),
+        }
+    )
+
+
+class ModbusOnboardingMixin:
+    """Mixin providing Modbus TCP onboarding flow steps.
+
+    This mixin handles the initial setup for local Modbus TCP connections:
+    1. Collect Modbus connection details (host, port, unit ID)
+    2. Optionally collect inverter details (serial, model, family)
+    3. Test the connection and auto-detect serial if not provided
+    4. Create the config entry
+
+    Requires:
+        - ConfigFlowProtocol attributes (_modbus_host, _modbus_port, etc.)
+        - _test_modbus_connection() method from EG4ConfigFlowBase
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        _modbus_host: str | None
+        _modbus_port: int | None
+        _modbus_unit_id: int | None
+        _inverter_serial: str | None
+        _inverter_model: str | None
+        _inverter_family: str | None
+
+        async def _test_modbus_connection(self: ConfigFlowProtocol) -> str: ...
+        async def async_set_unique_id(
+            self: ConfigFlowProtocol, unique_id: str
+        ) -> None: ...
+        def _abort_if_unique_id_configured(self: ConfigFlowProtocol) -> None: ...
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+        def async_create_entry(
+            self: ConfigFlowProtocol,
+            *,
+            title: str,
+            data: dict[str, Any],
+        ) -> ConfigFlowResult: ...
+
+    async def async_step_modbus(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Modbus TCP connection configuration step.
+
+        This is the main entry point for Modbus-only onboarding.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            Form to collect Modbus settings, or entry creation on success.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store Modbus configuration in instance state
+            self._modbus_host = user_input[CONF_MODBUS_HOST]
+            self._modbus_port = user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
+            self._modbus_unit_id = user_input.get(
+                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+            )
+            # Serial is optional - will be auto-detected if not provided
+            self._inverter_serial = user_input.get(CONF_INVERTER_SERIAL, "")
+            self._inverter_model = user_input.get(CONF_INVERTER_MODEL, "")
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Test Modbus connection and auto-detect serial if not provided
+            try:
+                detected_serial = await self._test_modbus_connection()
+                # Use detected serial if user didn't provide one
+                if not self._inverter_serial and detected_serial:
+                    self._inverter_serial = detected_serial
+                    _LOGGER.info(
+                        "Auto-detected inverter serial from Modbus: %s",
+                        detected_serial,
+                    )
+                return await self._create_modbus_entry()
+
+            except ImportError:
+                errors["base"] = "modbus_not_installed"
+            except TimeoutError:
+                errors["base"] = "modbus_timeout"
+            except OSError as e:
+                _LOGGER.error("Modbus connection error: %s", e)
+                errors["base"] = "modbus_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected Modbus error: %s", e)
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="modbus",
+            data_schema=_build_modbus_schema(),
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def _create_modbus_entry(self: ConfigFlowProtocol) -> ConfigFlowResult:
+        """Create config entry for Modbus connection.
+
+        Returns:
+            Config entry creation result.
+        """
+        # Validate required state
+        assert self._modbus_host is not None
+        assert self._modbus_port is not None
+        assert self._modbus_unit_id is not None
+        # Serial should have been auto-detected if not provided by user
+        assert self._inverter_serial, "Serial number must be provided or auto-detected"
+
+        # Set unique ID and check for duplicates
+        unique_id = build_unique_id("modbus", serial=self._inverter_serial)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # Create title with optional model suffix
+        title = format_entry_title("modbus", self._inverter_serial)
+        if self._inverter_model:
+            title = f"{title} ({self._inverter_model})"
+
+        data = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_MODBUS,
+            CONF_MODBUS_HOST: self._modbus_host,
+            CONF_MODBUS_PORT: self._modbus_port,
+            CONF_MODBUS_UNIT_ID: self._modbus_unit_id,
+            CONF_INVERTER_SERIAL: self._inverter_serial,
+            CONF_INVERTER_MODEL: self._inverter_model or "",
+            CONF_INVERTER_FAMILY: self._inverter_family or DEFAULT_INVERTER_FAMILY,
+        }
+
+        return self.async_create_entry(title=title, data=data)

--- a/custom_components/eg4_web_monitor/const.py
+++ b/custom_components/eg4_web_monitor/const.py
@@ -133,6 +133,9 @@ CONNECTION_TYPE_HTTP = "http"
 CONNECTION_TYPE_MODBUS = "modbus"
 CONNECTION_TYPE_DONGLE = "dongle"  # WiFi dongle local TCP (no additional hardware)
 CONNECTION_TYPE_HYBRID = "hybrid"  # Local (Modbus/Dongle) + Cloud HTTP for best of both
+CONNECTION_TYPE_LOCAL = (
+    "local"  # Pure local (Modbus/Dongle only) - no cloud credentials
+)
 
 # Hybrid mode local transport selection (priority: modbus > dongle > cloud-only)
 CONF_HYBRID_LOCAL_TYPE = "hybrid_local_type"

--- a/tests/test_onboarding_mixins.py
+++ b/tests/test_onboarding_mixins.py
@@ -1,0 +1,339 @@
+"""Tests for onboarding mixins."""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from custom_components.eg4_web_monitor.config_flow.onboarding import (
+    DongleOnboardingMixin,
+    HttpOnboardingMixin,
+    HybridOnboardingMixin,
+    LocalOnboardingMixin,
+    ModbusOnboardingMixin,
+)
+from custom_components.eg4_web_monitor.const import (
+    CONF_BASE_URL,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_DST_SYNC,
+    CONF_INVERTER_SERIAL,
+    CONF_LIBRARY_DEBUG,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONF_VERIFY_SSL,
+    DEFAULT_BASE_URL,
+    DEFAULT_DONGLE_PORT,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT_ID,
+    HYBRID_LOCAL_DONGLE,
+    HYBRID_LOCAL_MODBUS,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestHttpOnboardingMixin:
+    """Tests for HttpOnboardingMixin."""
+
+    def test_mixin_class_exists(self):
+        """Test that the mixin class exists and can be imported."""
+        assert HttpOnboardingMixin is not None
+
+    def test_mixin_has_required_methods(self):
+        """Test that the mixin has the required step methods."""
+        assert hasattr(HttpOnboardingMixin, "async_step_http_credentials")
+        assert hasattr(HttpOnboardingMixin, "async_step_plant")
+        assert hasattr(HttpOnboardingMixin, "_create_http_entry")
+
+    def test_step_methods_are_async(self):
+        """Test that step methods are coroutine functions."""
+        assert inspect.iscoroutinefunction(
+            HttpOnboardingMixin.async_step_http_credentials
+        )
+        assert inspect.iscoroutinefunction(HttpOnboardingMixin.async_step_plant)
+        assert inspect.iscoroutinefunction(HttpOnboardingMixin._create_http_entry)
+
+
+class TestModbusOnboardingMixin:
+    """Tests for ModbusOnboardingMixin."""
+
+    def test_mixin_class_exists(self):
+        """Test that the mixin class exists and can be imported."""
+        assert ModbusOnboardingMixin is not None
+
+    def test_mixin_has_required_methods(self):
+        """Test that the mixin has the required step methods."""
+        assert hasattr(ModbusOnboardingMixin, "async_step_modbus")
+        assert hasattr(ModbusOnboardingMixin, "_create_modbus_entry")
+
+    def test_step_methods_are_async(self):
+        """Test that step methods are coroutine functions."""
+        assert inspect.iscoroutinefunction(ModbusOnboardingMixin.async_step_modbus)
+        assert inspect.iscoroutinefunction(ModbusOnboardingMixin._create_modbus_entry)
+
+
+class TestDongleOnboardingMixin:
+    """Tests for DongleOnboardingMixin."""
+
+    def test_mixin_class_exists(self):
+        """Test that the mixin class exists and can be imported."""
+        assert DongleOnboardingMixin is not None
+
+    def test_mixin_has_required_methods(self):
+        """Test that the mixin has the required step methods."""
+        assert hasattr(DongleOnboardingMixin, "async_step_dongle")
+        assert hasattr(DongleOnboardingMixin, "_create_dongle_entry")
+
+    def test_step_methods_are_async(self):
+        """Test that step methods are coroutine functions."""
+        assert inspect.iscoroutinefunction(DongleOnboardingMixin.async_step_dongle)
+        assert inspect.iscoroutinefunction(DongleOnboardingMixin._create_dongle_entry)
+
+
+class TestHybridOnboardingMixin:
+    """Tests for HybridOnboardingMixin."""
+
+    def test_mixin_class_exists(self):
+        """Test that the mixin class exists and can be imported."""
+        assert HybridOnboardingMixin is not None
+
+    def test_mixin_has_required_methods(self):
+        """Test that the mixin has the required step methods."""
+        assert hasattr(HybridOnboardingMixin, "async_step_hybrid_http")
+        assert hasattr(HybridOnboardingMixin, "async_step_hybrid_plant")
+        assert hasattr(HybridOnboardingMixin, "async_step_hybrid_local_type")
+        assert hasattr(HybridOnboardingMixin, "async_step_hybrid_modbus")
+        assert hasattr(HybridOnboardingMixin, "async_step_hybrid_dongle")
+        assert hasattr(HybridOnboardingMixin, "_create_hybrid_entry")
+
+    def test_step_methods_are_async(self):
+        """Test that step methods are coroutine functions."""
+        assert inspect.iscoroutinefunction(HybridOnboardingMixin.async_step_hybrid_http)
+        assert inspect.iscoroutinefunction(
+            HybridOnboardingMixin.async_step_hybrid_plant
+        )
+        assert inspect.iscoroutinefunction(
+            HybridOnboardingMixin.async_step_hybrid_local_type
+        )
+        assert inspect.iscoroutinefunction(
+            HybridOnboardingMixin.async_step_hybrid_modbus
+        )
+        assert inspect.iscoroutinefunction(
+            HybridOnboardingMixin.async_step_hybrid_dongle
+        )
+        assert inspect.iscoroutinefunction(HybridOnboardingMixin._create_hybrid_entry)
+
+
+class TestLocalOnboardingMixin:
+    """Tests for LocalOnboardingMixin."""
+
+    def test_mixin_class_exists(self):
+        """Test that the mixin class exists and can be imported."""
+        assert LocalOnboardingMixin is not None
+
+    def test_mixin_has_required_methods(self):
+        """Test that the mixin has the required step methods."""
+        assert hasattr(LocalOnboardingMixin, "async_step_local_setup")
+        assert hasattr(LocalOnboardingMixin, "async_step_local_add_device")
+        assert hasattr(LocalOnboardingMixin, "async_step_local_modbus_device")
+        assert hasattr(LocalOnboardingMixin, "async_step_local_dongle_device")
+        assert hasattr(LocalOnboardingMixin, "async_step_local_device_added")
+        assert hasattr(LocalOnboardingMixin, "_create_local_entry")
+
+    def test_step_methods_are_async(self):
+        """Test that step methods are coroutine functions."""
+        assert inspect.iscoroutinefunction(LocalOnboardingMixin.async_step_local_setup)
+        assert inspect.iscoroutinefunction(
+            LocalOnboardingMixin.async_step_local_add_device
+        )
+        assert inspect.iscoroutinefunction(
+            LocalOnboardingMixin.async_step_local_modbus_device
+        )
+        assert inspect.iscoroutinefunction(
+            LocalOnboardingMixin.async_step_local_dongle_device
+        )
+        assert inspect.iscoroutinefunction(
+            LocalOnboardingMixin.async_step_local_device_added
+        )
+        assert inspect.iscoroutinefunction(LocalOnboardingMixin._create_local_entry)
+
+
+class TestOnboardingMixinSchemas:
+    """Tests for schema functions in onboarding mixins."""
+
+    def test_http_credentials_schema_builder(self):
+        """Test the HTTP credentials schema builder."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.http import (
+            _build_http_credentials_schema,
+        )
+
+        schema = _build_http_credentials_schema()
+        assert isinstance(schema, vol.Schema)
+
+        # Test validation with valid data
+        result = schema(
+            {
+                CONF_USERNAME: "test@example.com",
+                CONF_PASSWORD: "password123",
+            }
+        )
+        assert result[CONF_USERNAME] == "test@example.com"
+        assert result[CONF_PASSWORD] == "password123"
+        assert result[CONF_BASE_URL] == DEFAULT_BASE_URL
+        assert result[CONF_VERIFY_SSL] is True
+        assert result[CONF_DST_SYNC] is True
+        assert result[CONF_LIBRARY_DEBUG] is False
+
+    def test_http_credentials_schema_dst_default(self):
+        """Test DST sync default can be customized."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.http import (
+            _build_http_credentials_schema,
+        )
+
+        schema_true = _build_http_credentials_schema(dst_sync_default=True)
+        schema_false = _build_http_credentials_schema(dst_sync_default=False)
+
+        result_true = schema_true({CONF_USERNAME: "test", CONF_PASSWORD: "pass"})
+        result_false = schema_false({CONF_USERNAME: "test", CONF_PASSWORD: "pass"})
+
+        assert result_true[CONF_DST_SYNC] is True
+        assert result_false[CONF_DST_SYNC] is False
+
+    def test_modbus_schema_builder(self):
+        """Test the Modbus schema builder."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.modbus import (
+            _build_modbus_schema,
+        )
+
+        schema = _build_modbus_schema()
+        assert isinstance(schema, vol.Schema)
+
+        # Test validation with valid data
+        result = schema({CONF_MODBUS_HOST: "192.168.1.100"})
+        assert result[CONF_MODBUS_HOST] == "192.168.1.100"
+        assert result[CONF_MODBUS_PORT] == DEFAULT_MODBUS_PORT
+        assert result[CONF_MODBUS_UNIT_ID] == DEFAULT_MODBUS_UNIT_ID
+
+    def test_modbus_schema_builder_with_defaults(self):
+        """Test the Modbus schema builder with custom defaults."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.modbus import (
+            _build_modbus_schema,
+        )
+
+        defaults = {
+            CONF_MODBUS_HOST: "192.168.1.200",
+            CONF_MODBUS_PORT: 8502,
+            CONF_INVERTER_SERIAL: "1234567890",
+        }
+        schema = _build_modbus_schema(defaults)
+        result = schema({CONF_MODBUS_HOST: "192.168.1.200"})
+        assert result[CONF_MODBUS_PORT] == 8502
+
+    def test_dongle_schema_builder(self):
+        """Test the Dongle schema builder."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.dongle import (
+            _build_dongle_schema,
+        )
+
+        schema = _build_dongle_schema()
+        assert isinstance(schema, vol.Schema)
+
+        # Schema has defaults, so we can validate with minimal input
+        result = schema(
+            {
+                CONF_DONGLE_HOST: "192.168.1.100",
+                CONF_DONGLE_SERIAL: "dongle123",
+                CONF_INVERTER_SERIAL: "inverter456",
+            }
+        )
+        assert result[CONF_DONGLE_HOST] == "192.168.1.100"
+        assert result[CONF_DONGLE_PORT] == DEFAULT_DONGLE_PORT
+
+
+class TestOnboardingMixinInverterFamilyOptions:
+    """Tests for inverter family options constants."""
+
+    def test_modbus_inverter_family_options(self):
+        """Test that Modbus mixin has inverter family options."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.modbus import (
+            INVERTER_FAMILY_OPTIONS,
+        )
+
+        assert INVERTER_FAMILY_PV_SERIES in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_SNA in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_LXP_EU in INVERTER_FAMILY_OPTIONS
+
+    def test_dongle_inverter_family_options(self):
+        """Test that Dongle mixin has inverter family options."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.dongle import (
+            INVERTER_FAMILY_OPTIONS,
+        )
+
+        assert INVERTER_FAMILY_PV_SERIES in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_SNA in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_LXP_EU in INVERTER_FAMILY_OPTIONS
+
+    def test_hybrid_inverter_family_options(self):
+        """Test that Hybrid mixin has inverter family options."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.hybrid import (
+            INVERTER_FAMILY_OPTIONS,
+        )
+
+        assert INVERTER_FAMILY_PV_SERIES in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_SNA in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_LXP_EU in INVERTER_FAMILY_OPTIONS
+
+    def test_local_inverter_family_options(self):
+        """Test that Local mixin has inverter family options."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.local import (
+            INVERTER_FAMILY_OPTIONS,
+        )
+
+        assert INVERTER_FAMILY_PV_SERIES in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_SNA in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_LXP_EU in INVERTER_FAMILY_OPTIONS
+
+
+class TestHybridMixinLocalTypeOptions:
+    """Tests for hybrid mixin local type options."""
+
+    def test_local_type_options_exist(self):
+        """Test that local type options are defined."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.hybrid import (
+            LOCAL_TYPE_OPTIONS,
+        )
+
+        assert HYBRID_LOCAL_MODBUS in LOCAL_TYPE_OPTIONS
+        assert HYBRID_LOCAL_DONGLE in LOCAL_TYPE_OPTIONS
+
+    def test_local_type_options_descriptions(self):
+        """Test that local type options have descriptions."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.hybrid import (
+            LOCAL_TYPE_OPTIONS,
+        )
+
+        assert "Modbus" in LOCAL_TYPE_OPTIONS[HYBRID_LOCAL_MODBUS]
+        assert "Dongle" in LOCAL_TYPE_OPTIONS[HYBRID_LOCAL_DONGLE]
+
+
+class TestLocalMixinDeviceTypeOptions:
+    """Tests for local mixin device type options."""
+
+    def test_device_type_options_exist(self):
+        """Test that device type options are defined."""
+        from custom_components.eg4_web_monitor.config_flow.onboarding.local import (
+            LOCAL_DEVICE_TYPE_OPTIONS,
+        )
+
+        assert "modbus" in LOCAL_DEVICE_TYPE_OPTIONS
+        assert "dongle" in LOCAL_DEVICE_TYPE_OPTIONS


### PR DESCRIPTION
## Summary

- Add 5 onboarding mixins for config flow initialization:
  - `HttpOnboardingMixin`: Cloud-only onboarding (credentials + plant selection)
  - `ModbusOnboardingMixin`: Local Modbus TCP onboarding
  - `DongleOnboardingMixin`: WiFi Dongle onboarding
  - `HybridOnboardingMixin`: Cloud + Local combined onboarding
  - `LocalOnboardingMixin`: Pure local multi-device setup (NEW)

- Add `CONNECTION_TYPE_LOCAL` constant for pure local operation
- Update `format_entry_title` with mode display mapping
- Add 27 tests for onboarding mixins

## Test plan
- [x] All 242 tests pass
- [x] All 27 new onboarding mixin tests pass
- [x] Ruff linting passes
- [x] Schema builders properly create voluptuous schemas
- [x] Inverter family options match const.py values

🤖 Generated with [Claude Code](https://claude.ai/code)