### PR TITLE
feat: Add transitions module with builder pattern

### DIFF
--- a/custom_components/eg4_web_monitor/config_flow/transitions/__init__.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/__init__.py
@@ -1,3 +1,27 @@
-"""Transition mixins for config flow."""
+"""Transition builders for connection type switching.
 
-# Transition mixins will be exported here once created
+This package provides builders for transitioning between connection types:
+- HttpToHybridBuilder: Add local transport to HTTP-only setup
+- HybridToHttpBuilder: Remove local transport from Hybrid setup
+
+Each builder follows the builder pattern with validate(), collect_input(),
+and execute() methods for a consistent transition workflow.
+"""
+
+from .base import (
+    TransitionBuilder,
+    TransitionContext,
+    TransitionRequest,
+    TransitionType,
+)
+from .http_to_hybrid import HttpToHybridBuilder
+from .hybrid_to_http import HybridToHttpBuilder
+
+__all__ = [
+    "TransitionType",
+    "TransitionRequest",
+    "TransitionContext",
+    "TransitionBuilder",
+    "HttpToHybridBuilder",
+    "HybridToHttpBuilder",
+]

--- a/custom_components/eg4_web_monitor/config_flow/transitions/base.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/base.py
@@ -1,0 +1,194 @@
+"""Base classes for connection type transitions.
+
+This module provides the foundational abstractions for transitioning between
+connection types (e.g., HTTP to Hybrid, Hybrid to HTTP). The builder pattern
+ensures a consistent workflow: validate → collect_input → execute.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant import config_entries
+    from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.core import HomeAssistant
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TransitionType(Enum):
+    """Supported connection type transitions."""
+
+    HTTP_TO_HYBRID = "http_to_hybrid"
+    HYBRID_TO_HTTP = "hybrid_to_http"
+    MODBUS_TO_DONGLE = "modbus_to_dongle"
+    DONGLE_TO_MODBUS = "dongle_to_modbus"
+
+
+@dataclass
+class TransitionRequest:
+    """Request to transition between connection types.
+
+    Attributes:
+        source_type: Current connection type (e.g., "http", "hybrid").
+        target_type: Desired connection type.
+        entry: The config entry being transitioned.
+    """
+
+    source_type: str
+    target_type: str
+    entry: "config_entries.ConfigEntry[Any]"
+
+    @property
+    def transition_type(self) -> TransitionType | None:
+        """Get the transition type enum, if valid.
+
+        Returns:
+            TransitionType enum or None if not a supported transition.
+        """
+        key = f"{self.source_type}_to_{self.target_type}"
+        try:
+            return TransitionType(key)
+        except ValueError:
+            return None
+
+
+@dataclass
+class TransitionContext:
+    """Context accumulated during the transition workflow.
+
+    This dataclass holds validated data collected during the transition,
+    such as credentials, local transport configuration, and test results.
+
+    Attributes:
+        validated_credentials: HTTP credentials (username, password, etc.)
+            that have been validated against the cloud API.
+        local_transport_config: Local transport configuration (Modbus or Dongle)
+            if applicable to the target connection type.
+        test_results: Results from connection tests (connection latency, etc.).
+        warnings: List of warnings to show the user before completing.
+    """
+
+    validated_credentials: dict[str, Any] = field(default_factory=dict)
+    local_transport_config: dict[str, Any] | None = None
+    test_results: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+class TransitionBuilder(ABC):
+    """Abstract base class for connection type transition builders.
+
+    Builders follow a three-phase workflow:
+    1. validate() - Verify the transition is possible
+    2. collect_input() - Show forms and collect user input
+    3. execute() - Update the config entry and reload
+
+    Subclasses implement the abstract methods for specific transitions
+    (e.g., HttpToHybridBuilder, HybridToHttpBuilder).
+
+    Requires:
+        - hass: HomeAssistant instance
+        - flow: The ConfigFlow instance (for showing forms and updating entries)
+    """
+
+    def __init__(
+        self,
+        hass: "HomeAssistant",
+        flow: "ConfigFlowProtocol",
+        request: TransitionRequest,
+    ) -> None:
+        """Initialize the transition builder.
+
+        Args:
+            hass: Home Assistant instance.
+            flow: The config flow instance for showing forms.
+            request: The transition request with source/target types and entry.
+        """
+        self.hass = hass
+        self.flow = flow
+        self.request = request
+        self.context = TransitionContext()
+        self._current_step: str | None = None
+
+    @property
+    def entry(self) -> "config_entries.ConfigEntry[Any]":
+        """Get the config entry being transitioned."""
+        return self.request.entry
+
+    @abstractmethod
+    async def validate(self) -> bool:
+        """Validate that the transition can proceed.
+
+        Checks preconditions like:
+        - Entry is in a valid state for transition
+        - Required data exists in the current entry
+        - No conflicting entries exist
+
+        Returns:
+            True if transition can proceed, False otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def collect_input(
+        self, step_id: str, user_input: dict[str, Any] | None = None
+    ) -> "ConfigFlowResult":
+        """Collect user input for the transition.
+
+        This method may be called multiple times for multi-step flows.
+        Each call returns either a form to show or proceeds to the next step.
+
+        Args:
+            step_id: The current step identifier.
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult - either a form, abort, or success result.
+        """
+        ...
+
+    @abstractmethod
+    async def execute(self) -> "ConfigFlowResult":
+        """Execute the transition and update the config entry.
+
+        Called after all input has been collected and validated.
+        Updates the config entry with the new connection type and data,
+        then reloads the integration.
+
+        Returns:
+            ConfigFlowResult - abort with success reason.
+        """
+        ...
+
+    def add_warning(self, warning: str) -> None:
+        """Add a warning to show the user before completing.
+
+        Args:
+            warning: Warning message to display.
+        """
+        self.context.warnings.append(warning)
+
+    def _log_transition_start(self) -> None:
+        """Log the start of a transition."""
+        _LOGGER.info(
+            "Starting transition %s -> %s for entry %s",
+            self.request.source_type,
+            self.request.target_type,
+            self.request.entry.entry_id,
+        )
+
+    def _log_transition_complete(self) -> None:
+        """Log successful transition completion."""
+        _LOGGER.info(
+            "Transition %s -> %s completed for entry %s",
+            self.request.source_type,
+            self.request.target_type,
+            self.request.entry.entry_id,
+        )

--- a/custom_components/eg4_web_monitor/config_flow/transitions/http_to_hybrid.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/http_to_hybrid.py
@@ -1,0 +1,475 @@
+"""HTTP to Hybrid transition builder.
+
+This module provides the builder for transitioning from HTTP-only (cloud)
+to Hybrid (cloud + local) connection type. The transition preserves existing
+cloud credentials and adds local transport configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.const import CONF_USERNAME
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_HYBRID_LOCAL_TYPE,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_SERIAL,
+    CONF_LOCAL_TRANSPORTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONF_PLANT_ID,
+    CONF_PLANT_NAME,
+    CONNECTION_TYPE_HYBRID,
+    DEFAULT_DONGLE_PORT,
+    DEFAULT_INVERTER_FAMILY,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT_ID,
+    HYBRID_LOCAL_DONGLE,
+    HYBRID_LOCAL_MODBUS,
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+from ..helpers import format_entry_title
+from .base import TransitionBuilder, TransitionRequest
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.core import HomeAssistant
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inverter family options for register map selection
+INVERTER_FAMILY_OPTIONS = {
+    INVERTER_FAMILY_PV_SERIES: "EG4 18kPV / FlexBOSS (PV Series)",
+    INVERTER_FAMILY_SNA: "EG4 12000XP / 6000XP (SNA Series)",
+    INVERTER_FAMILY_LXP_EU: "LXP-EU 12K (European)",
+}
+
+# Local transport type options
+LOCAL_TYPE_OPTIONS = {
+    HYBRID_LOCAL_MODBUS: "Modbus TCP (RS485 adapter - fastest)",
+    HYBRID_LOCAL_DONGLE: "WiFi Dongle (no extra hardware)",
+}
+
+
+class HttpToHybridBuilder(TransitionBuilder):
+    """Builder for transitioning HTTP-only to Hybrid mode.
+
+    This transition:
+    1. Preserves existing HTTP credentials (username, password, plant)
+    2. Shows warning about new polling behavior with local transport
+    3. Collects local transport configuration (Modbus or Dongle)
+    4. Updates config entry to Hybrid type
+    5. Reloads the integration
+
+    Flow steps:
+    - transition_select_local_type: Choose Modbus or Dongle
+    - transition_modbus: Configure Modbus TCP settings
+    - transition_dongle: Configure WiFi Dongle settings
+    - transition_confirm: Show warnings and confirm
+    """
+
+    # Step identifiers
+    STEP_SELECT_LOCAL_TYPE = "transition_select_local_type"
+    STEP_MODBUS = "transition_modbus"
+    STEP_DONGLE = "transition_dongle"
+    STEP_CONFIRM = "transition_confirm"
+
+    def __init__(
+        self,
+        hass: "HomeAssistant",
+        flow: "ConfigFlowProtocol",
+        request: TransitionRequest,
+    ) -> None:
+        """Initialize the HTTP to Hybrid transition builder."""
+        super().__init__(hass, flow, request)
+
+        # Local transport configuration collected during flow
+        self._local_type: str | None = None
+        self._modbus_host: str | None = None
+        self._modbus_port: int = DEFAULT_MODBUS_PORT
+        self._modbus_unit_id: int = DEFAULT_MODBUS_UNIT_ID
+        self._dongle_host: str | None = None
+        self._dongle_port: int = DEFAULT_DONGLE_PORT
+        self._dongle_serial: str | None = None
+        self._inverter_serial: str | None = None
+        self._inverter_family: str = DEFAULT_INVERTER_FAMILY
+
+    async def validate(self) -> bool:
+        """Validate that the transition can proceed.
+
+        Checks:
+        - Entry is currently HTTP type
+        - Entry has valid cloud credentials (username, plant_id)
+
+        Returns:
+            True if transition can proceed.
+        """
+        entry_data = self.entry.data
+
+        # Must be HTTP type
+        if entry_data.get(CONF_CONNECTION_TYPE) != "http":
+            _LOGGER.warning(
+                "Cannot transition non-HTTP entry %s to Hybrid",
+                self.entry.entry_id,
+            )
+            return False
+
+        # Must have cloud credentials
+        if not entry_data.get(CONF_USERNAME) or not entry_data.get(CONF_PLANT_ID):
+            _LOGGER.warning(
+                "Entry %s missing required HTTP credentials for transition",
+                self.entry.entry_id,
+            )
+            return False
+
+        self._log_transition_start()
+        return True
+
+    async def collect_input(
+        self, step_id: str, user_input: dict[str, Any] | None = None
+    ) -> "ConfigFlowResult":
+        """Collect user input for the transition.
+
+        Args:
+            step_id: The current step identifier.
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult - form, next step, or completion.
+        """
+        self._current_step = step_id
+
+        if step_id == self.STEP_SELECT_LOCAL_TYPE:
+            return await self._handle_select_local_type(user_input)
+        if step_id == self.STEP_MODBUS:
+            return await self._handle_modbus(user_input)
+        if step_id == self.STEP_DONGLE:
+            return await self._handle_dongle(user_input)
+        if step_id == self.STEP_CONFIRM:
+            return await self._handle_confirm(user_input)
+
+        # Default to local type selection
+        return await self._handle_select_local_type(None)
+
+    async def _handle_select_local_type(
+        self, user_input: dict[str, Any] | None
+    ) -> "ConfigFlowResult":
+        """Handle local transport type selection step.
+
+        Args:
+            user_input: Form data with local type selection.
+
+        Returns:
+            Form or next step result.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._local_type = user_input[CONF_HYBRID_LOCAL_TYPE]
+
+            # Route to appropriate configuration step
+            if self._local_type == HYBRID_LOCAL_MODBUS:
+                return await self._handle_modbus(None)
+            if self._local_type == HYBRID_LOCAL_DONGLE:
+                return await self._handle_dongle(None)
+
+        # Build schema for local type selection
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HYBRID_LOCAL_TYPE): vol.In(LOCAL_TYPE_OPTIONS),
+            }
+        )
+
+        return self.flow.async_show_form(
+            step_id=self.STEP_SELECT_LOCAL_TYPE,
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "current_plant": self.entry.data.get(CONF_PLANT_NAME, "Unknown"),
+            },
+        )
+
+    async def _handle_modbus(
+        self, user_input: dict[str, Any] | None
+    ) -> "ConfigFlowResult":
+        """Handle Modbus TCP configuration step.
+
+        Args:
+            user_input: Form data with Modbus settings.
+
+        Returns:
+            Form or confirmation step result.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store Modbus configuration
+            self._modbus_host = user_input[CONF_MODBUS_HOST]
+            self._modbus_port = user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
+            self._modbus_unit_id = user_input.get(
+                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+            )
+            self._inverter_serial = user_input.get(CONF_INVERTER_SERIAL, "")
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Copy to flow for connection testing
+            self.flow._modbus_host = self._modbus_host
+            self.flow._modbus_port = self._modbus_port
+            self.flow._modbus_unit_id = self._modbus_unit_id
+            self.flow._inverter_serial = self._inverter_serial
+            self.flow._inverter_family = self._inverter_family
+
+            # Test Modbus connection
+            try:
+                detected_serial = await self.flow._test_modbus_connection()
+
+                # Auto-fill serial if not provided
+                if not self._inverter_serial and detected_serial:
+                    self._inverter_serial = detected_serial
+                    self.flow._inverter_serial = detected_serial
+
+                # Store local transport config
+                self.context.local_transport_config = {
+                    "serial": self._inverter_serial or "",
+                    "transport_type": "modbus_tcp",
+                    "host": self._modbus_host,
+                    "port": self._modbus_port,
+                    "unit_id": self._modbus_unit_id,
+                    "inverter_family": self._inverter_family,
+                }
+
+                # Add warning about polling behavior change
+                self.add_warning(
+                    "Local transport will enable 5-second polling (vs 30s for cloud-only). "
+                    "This provides faster updates but increases local network traffic."
+                )
+
+                # Proceed to confirmation
+                return await self._handle_confirm(None)
+
+            except ImportError:
+                errors["base"] = "modbus_not_installed"
+            except TimeoutError:
+                errors["base"] = "modbus_timeout"
+            except OSError as e:
+                _LOGGER.error("Modbus connection error: %s", e)
+                errors["base"] = "modbus_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected Modbus error: %s", e)
+                errors["base"] = "unknown"
+
+        # Build Modbus configuration schema
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_MODBUS_HOST): str,
+                vol.Optional(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): int,
+                vol.Optional(CONF_MODBUS_UNIT_ID, default=DEFAULT_MODBUS_UNIT_ID): int,
+                vol.Optional(CONF_INVERTER_SERIAL, default=""): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.flow.async_show_form(
+            step_id=self.STEP_MODBUS,
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def _handle_dongle(
+        self, user_input: dict[str, Any] | None
+    ) -> "ConfigFlowResult":
+        """Handle WiFi Dongle configuration step.
+
+        Args:
+            user_input: Form data with Dongle settings.
+
+        Returns:
+            Form or confirmation step result.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Store Dongle configuration
+            self._dongle_host = user_input[CONF_DONGLE_HOST]
+            self._dongle_port = user_input.get(CONF_DONGLE_PORT, DEFAULT_DONGLE_PORT)
+            self._dongle_serial = user_input[CONF_DONGLE_SERIAL]
+            self._inverter_serial = user_input[CONF_INVERTER_SERIAL]
+            self._inverter_family = user_input.get(
+                CONF_INVERTER_FAMILY, DEFAULT_INVERTER_FAMILY
+            )
+
+            # Copy to flow for connection testing
+            self.flow._dongle_host = self._dongle_host
+            self.flow._dongle_port = self._dongle_port
+            self.flow._dongle_serial = self._dongle_serial
+            self.flow._inverter_serial = self._inverter_serial
+            self.flow._inverter_family = self._inverter_family
+
+            # Test Dongle connection
+            try:
+                await self.flow._test_dongle_connection()
+
+                # Store local transport config
+                self.context.local_transport_config = {
+                    "serial": self._inverter_serial,
+                    "transport_type": "wifi_dongle",
+                    "host": self._dongle_host,
+                    "port": self._dongle_port,
+                    "dongle_serial": self._dongle_serial,
+                    "inverter_family": self._inverter_family,
+                }
+
+                # Add warning about polling behavior change
+                self.add_warning(
+                    "Local transport will enable 5-second polling (vs 30s for cloud-only). "
+                    "This provides faster updates but increases local network traffic."
+                )
+
+                # Proceed to confirmation
+                return await self._handle_confirm(None)
+
+            except TimeoutError:
+                errors["base"] = "dongle_timeout"
+            except OSError as e:
+                _LOGGER.error("Dongle connection error: %s", e)
+                errors["base"] = "dongle_connection_failed"
+            except Exception as e:
+                _LOGGER.exception("Unexpected Dongle error: %s", e)
+                errors["base"] = "unknown"
+
+        # Build Dongle configuration schema
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DONGLE_HOST): str,
+                vol.Optional(CONF_DONGLE_PORT, default=DEFAULT_DONGLE_PORT): int,
+                vol.Required(CONF_DONGLE_SERIAL): str,
+                vol.Required(CONF_INVERTER_SERIAL): str,
+                vol.Optional(
+                    CONF_INVERTER_FAMILY, default=DEFAULT_INVERTER_FAMILY
+                ): vol.In(INVERTER_FAMILY_OPTIONS),
+            }
+        )
+
+        return self.flow.async_show_form(
+            step_id=self.STEP_DONGLE,
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def _handle_confirm(
+        self, user_input: dict[str, Any] | None
+    ) -> "ConfigFlowResult":
+        """Handle transition confirmation step.
+
+        Shows warnings and allows user to confirm or cancel.
+
+        Args:
+            user_input: Form data (empty dict confirms, None shows form).
+
+        Returns:
+            Form, abort (cancel), or execute result.
+        """
+        if user_input is not None:
+            # User confirmed - execute the transition
+            return await self.execute()
+
+        # Build confirmation message with warnings
+        warnings_text = "\n".join(f"• {w}" for w in self.context.warnings)
+        local_type_display = LOCAL_TYPE_OPTIONS.get(self._local_type or "", "Unknown")
+
+        return self.flow.async_show_form(
+            step_id=self.STEP_CONFIRM,
+            data_schema=vol.Schema({}),  # Empty form, just confirm/cancel
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "current_plant": self.entry.data.get(CONF_PLANT_NAME, "Unknown"),
+                "local_type": local_type_display,
+                "warnings": warnings_text or "No warnings.",
+            },
+        )
+
+    async def execute(self) -> "ConfigFlowResult":
+        """Execute the transition and update the config entry.
+
+        Preserves HTTP credentials, adds local transport config,
+        and changes connection type to Hybrid.
+
+        Returns:
+            Abort result indicating success.
+        """
+        # Build updated config data
+        entry_data = dict(self.entry.data)
+
+        # Update connection type
+        entry_data[CONF_CONNECTION_TYPE] = CONNECTION_TYPE_HYBRID
+
+        # Set local transport type
+        entry_data[CONF_HYBRID_LOCAL_TYPE] = self._local_type
+
+        # Add local transport config to list
+        local_transports: list[dict[str, Any]] = []
+        if self.context.local_transport_config:
+            local_transports.append(self.context.local_transport_config)
+        entry_data[CONF_LOCAL_TRANSPORTS] = local_transports
+
+        # Add transport-specific fields based on type
+        if self._local_type == HYBRID_LOCAL_MODBUS:
+            entry_data[CONF_MODBUS_HOST] = self._modbus_host
+            entry_data[CONF_MODBUS_PORT] = self._modbus_port
+            entry_data[CONF_MODBUS_UNIT_ID] = self._modbus_unit_id
+        elif self._local_type == HYBRID_LOCAL_DONGLE:
+            entry_data[CONF_DONGLE_HOST] = self._dongle_host
+            entry_data[CONF_DONGLE_PORT] = self._dongle_port
+            entry_data[CONF_DONGLE_SERIAL] = self._dongle_serial
+
+        # Add common local fields
+        entry_data[CONF_INVERTER_SERIAL] = self._inverter_serial or ""
+        entry_data[CONF_INVERTER_FAMILY] = self._inverter_family
+
+        # Update entry title to reflect Hybrid mode
+        plant_name = entry_data.get(CONF_PLANT_NAME, "Unknown")
+        title = format_entry_title("hybrid", plant_name)
+
+        # Update the config entry
+        self.hass.config_entries.async_update_entry(
+            self.entry,
+            title=title,
+            data=entry_data,
+        )
+
+        # Reload the integration
+        await self.hass.config_entries.async_reload(self.entry.entry_id)
+
+        self._log_transition_complete()
+
+        return self.flow.async_abort(
+            reason="transition_successful",
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "new_type": "Hybrid (Cloud + Local)",
+            },
+        )

--- a/custom_components/eg4_web_monitor/config_flow/transitions/hybrid_to_http.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/hybrid_to_http.py
@@ -1,0 +1,237 @@
+"""Hybrid to HTTP transition builder.
+
+This module provides the builder for transitioning from Hybrid (cloud + local)
+to HTTP-only (cloud) connection type. The transition preserves cloud credentials
+and removes local transport configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_PORT,
+    CONF_DONGLE_SERIAL,
+    CONF_HYBRID_LOCAL_TYPE,
+    CONF_INVERTER_FAMILY,
+    CONF_INVERTER_SERIAL,
+    CONF_LOCAL_TRANSPORTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
+    CONF_PLANT_NAME,
+    CONNECTION_TYPE_HTTP,
+    HYBRID_LOCAL_DONGLE,
+    HYBRID_LOCAL_MODBUS,
+)
+from ..helpers import format_entry_title
+from .base import TransitionBuilder, TransitionRequest
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.core import HomeAssistant
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HybridToHttpBuilder(TransitionBuilder):
+    """Builder for transitioning Hybrid to HTTP-only mode.
+
+    This transition:
+    1. Preserves existing HTTP credentials (username, password, plant)
+    2. Shows warning about slower polling (30s vs 5s)
+    3. Removes local transport configuration
+    4. Updates config entry to HTTP type
+    5. Reloads the integration
+
+    Flow steps:
+    - transition_confirm_removal: Confirm removal and show warnings
+    """
+
+    # Step identifiers
+    STEP_CONFIRM_REMOVAL = "transition_confirm_removal"
+
+    def __init__(
+        self,
+        hass: "HomeAssistant",
+        flow: "ConfigFlowProtocol",
+        request: TransitionRequest,
+    ) -> None:
+        """Initialize the Hybrid to HTTP transition builder."""
+        super().__init__(hass, flow, request)
+
+    async def validate(self) -> bool:
+        """Validate that the transition can proceed.
+
+        Checks:
+        - Entry is currently Hybrid type
+        - Entry has valid cloud credentials (username, plant_id)
+
+        Returns:
+            True if transition can proceed.
+        """
+        entry_data = self.entry.data
+
+        # Must be Hybrid type
+        if entry_data.get(CONF_CONNECTION_TYPE) != "hybrid":
+            _LOGGER.warning(
+                "Cannot transition non-Hybrid entry %s to HTTP",
+                self.entry.entry_id,
+            )
+            return False
+
+        self._log_transition_start()
+
+        # Add warnings about the transition
+        local_type = entry_data.get(CONF_HYBRID_LOCAL_TYPE)
+        if local_type == HYBRID_LOCAL_MODBUS:
+            local_desc = "Modbus TCP"
+        elif local_type == HYBRID_LOCAL_DONGLE:
+            local_desc = "WiFi Dongle"
+        else:
+            local_desc = "local transport"
+
+        self.add_warning(
+            f"Removing {local_desc} will switch to cloud-only polling (30s intervals). "
+            "Local transport provides faster 5-second updates."
+        )
+        self.add_warning(
+            "You can re-add local transport later by transitioning back to Hybrid mode."
+        )
+
+        return True
+
+    async def collect_input(
+        self, step_id: str, user_input: dict[str, Any] | None = None
+    ) -> "ConfigFlowResult":
+        """Collect user input for the transition.
+
+        This transition only has a confirmation step.
+
+        Args:
+            step_id: The current step identifier.
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult - form or completion.
+        """
+        self._current_step = step_id
+
+        if step_id == self.STEP_CONFIRM_REMOVAL:
+            return await self._handle_confirm_removal(user_input)
+
+        # Default to confirmation step
+        return await self._handle_confirm_removal(None)
+
+    async def _handle_confirm_removal(
+        self, user_input: dict[str, Any] | None
+    ) -> "ConfigFlowResult":
+        """Handle transition confirmation step.
+
+        Shows warnings about losing local transport and allows user to confirm.
+
+        Args:
+            user_input: Form data (empty dict confirms, None shows form).
+
+        Returns:
+            Form or execute result.
+        """
+        if user_input is not None:
+            # User confirmed - execute the transition
+            return await self.execute()
+
+        # Get current local transport info for display
+        entry_data = self.entry.data
+        local_type = entry_data.get(CONF_HYBRID_LOCAL_TYPE)
+
+        if local_type == HYBRID_LOCAL_MODBUS:
+            local_type_display = "Modbus TCP"
+            local_host = entry_data.get(CONF_MODBUS_HOST, "Unknown")
+        elif local_type == HYBRID_LOCAL_DONGLE:
+            local_type_display = "WiFi Dongle"
+            local_host = entry_data.get(CONF_DONGLE_HOST, "Unknown")
+        else:
+            local_type_display = "Unknown"
+            local_host = "N/A"
+
+        # Build warnings text
+        warnings_text = "\n".join(f"• {w}" for w in self.context.warnings)
+
+        return self.flow.async_show_form(
+            step_id=self.STEP_CONFIRM_REMOVAL,
+            data_schema=vol.Schema({}),  # Empty form, just confirm/cancel
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "current_plant": entry_data.get(CONF_PLANT_NAME, "Unknown"),
+                "local_type": local_type_display,
+                "local_host": local_host,
+                "warnings": warnings_text or "No warnings.",
+            },
+        )
+
+    async def execute(self) -> "ConfigFlowResult":
+        """Execute the transition and update the config entry.
+
+        Preserves HTTP credentials, removes local transport config,
+        and changes connection type to HTTP.
+
+        Returns:
+            Abort result indicating success.
+        """
+        # Build updated config data by copying and filtering
+        entry_data = dict(self.entry.data)
+
+        # Update connection type
+        entry_data[CONF_CONNECTION_TYPE] = CONNECTION_TYPE_HTTP
+
+        # Remove local transport configuration keys
+        keys_to_remove = [
+            CONF_HYBRID_LOCAL_TYPE,
+            CONF_LOCAL_TRANSPORTS,
+            # Modbus keys
+            CONF_MODBUS_HOST,
+            CONF_MODBUS_PORT,
+            CONF_MODBUS_UNIT_ID,
+            # Dongle keys
+            CONF_DONGLE_HOST,
+            CONF_DONGLE_PORT,
+            CONF_DONGLE_SERIAL,
+            # Common local keys
+            CONF_INVERTER_SERIAL,
+            CONF_INVERTER_FAMILY,
+        ]
+
+        for key in keys_to_remove:
+            entry_data.pop(key, None)
+
+        # Update entry title to reflect HTTP mode
+        plant_name = entry_data.get(CONF_PLANT_NAME, "Unknown")
+        title = format_entry_title("http", plant_name)
+
+        # Update the config entry
+        self.hass.config_entries.async_update_entry(
+            self.entry,
+            title=title,
+            data=entry_data,
+        )
+
+        # Reload the integration
+        await self.hass.config_entries.async_reload(self.entry.entry_id)
+
+        self._log_transition_complete()
+
+        return self.flow.async_abort(
+            reason="transition_successful",
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "new_type": "Cloud API (HTTP)",
+            },
+        )

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,205 @@
+"""Tests for transition builders."""
+
+from __future__ import annotations
+
+import inspect
+
+from custom_components.eg4_web_monitor.config_flow.transitions import (
+    HttpToHybridBuilder,
+    HybridToHttpBuilder,
+    TransitionBuilder,
+    TransitionContext,
+    TransitionType,
+)
+from custom_components.eg4_web_monitor.const import (
+    INVERTER_FAMILY_LXP_EU,
+    INVERTER_FAMILY_PV_SERIES,
+    INVERTER_FAMILY_SNA,
+)
+
+
+class TestTransitionType:
+    """Tests for TransitionType enum."""
+
+    def test_http_to_hybrid_value(self):
+        """Test HTTP to Hybrid transition type value."""
+        assert TransitionType.HTTP_TO_HYBRID.value == "http_to_hybrid"
+
+    def test_hybrid_to_http_value(self):
+        """Test Hybrid to HTTP transition type value."""
+        assert TransitionType.HYBRID_TO_HTTP.value == "hybrid_to_http"
+
+    def test_modbus_to_dongle_value(self):
+        """Test Modbus to Dongle transition type value."""
+        assert TransitionType.MODBUS_TO_DONGLE.value == "modbus_to_dongle"
+
+    def test_dongle_to_modbus_value(self):
+        """Test Dongle to Modbus transition type value."""
+        assert TransitionType.DONGLE_TO_MODBUS.value == "dongle_to_modbus"
+
+
+class TestTransitionContext:
+    """Tests for TransitionContext dataclass."""
+
+    def test_default_values(self):
+        """Test TransitionContext default values."""
+        context = TransitionContext()
+
+        assert context.validated_credentials == {}
+        assert context.local_transport_config is None
+        assert context.test_results == {}
+        assert context.warnings == []
+
+    def test_with_credentials(self):
+        """Test TransitionContext with validated credentials."""
+        creds = {"username": "test", "password": "pass"}
+        context = TransitionContext(validated_credentials=creds)
+
+        assert context.validated_credentials == creds
+        assert context.validated_credentials["username"] == "test"
+
+    def test_with_local_transport(self):
+        """Test TransitionContext with local transport config."""
+        transport = {
+            "serial": "CE12345",
+            "transport_type": "modbus_tcp",
+            "host": "192.168.1.100",
+        }
+        context = TransitionContext(local_transport_config=transport)
+
+        assert context.local_transport_config is not None
+        assert context.local_transport_config["host"] == "192.168.1.100"
+
+    def test_with_warnings(self):
+        """Test TransitionContext with warnings."""
+        warnings = ["Warning 1", "Warning 2"]
+        context = TransitionContext(warnings=warnings)
+
+        assert len(context.warnings) == 2
+        assert "Warning 1" in context.warnings
+
+
+class TestTransitionBuilder:
+    """Tests for TransitionBuilder abstract base class."""
+
+    def test_is_abstract_class(self):
+        """Test that TransitionBuilder is an abstract class."""
+        assert inspect.isabstract(TransitionBuilder)
+
+    def test_has_validate_method(self):
+        """Test that TransitionBuilder has validate method."""
+        assert hasattr(TransitionBuilder, "validate")
+        assert inspect.iscoroutinefunction(TransitionBuilder.validate)
+
+    def test_has_collect_input_method(self):
+        """Test that TransitionBuilder has collect_input method."""
+        assert hasattr(TransitionBuilder, "collect_input")
+        assert inspect.iscoroutinefunction(TransitionBuilder.collect_input)
+
+    def test_has_execute_method(self):
+        """Test that TransitionBuilder has execute method."""
+        assert hasattr(TransitionBuilder, "execute")
+        assert inspect.iscoroutinefunction(TransitionBuilder.execute)
+
+    def test_has_add_warning_method(self):
+        """Test that TransitionBuilder has add_warning method."""
+        assert hasattr(TransitionBuilder, "add_warning")
+
+
+class TestHttpToHybridBuilder:
+    """Tests for HttpToHybridBuilder."""
+
+    def test_class_exists(self):
+        """Test that HttpToHybridBuilder class exists."""
+        assert HttpToHybridBuilder is not None
+
+    def test_inherits_from_transition_builder(self):
+        """Test that HttpToHybridBuilder inherits from TransitionBuilder."""
+        assert issubclass(HttpToHybridBuilder, TransitionBuilder)
+
+    def test_has_step_constants(self):
+        """Test that HttpToHybridBuilder has step constants."""
+        assert hasattr(HttpToHybridBuilder, "STEP_SELECT_LOCAL_TYPE")
+        assert hasattr(HttpToHybridBuilder, "STEP_MODBUS")
+        assert hasattr(HttpToHybridBuilder, "STEP_DONGLE")
+        assert hasattr(HttpToHybridBuilder, "STEP_CONFIRM")
+
+    def test_step_constant_values(self):
+        """Test step constant values are unique."""
+        steps = [
+            HttpToHybridBuilder.STEP_SELECT_LOCAL_TYPE,
+            HttpToHybridBuilder.STEP_MODBUS,
+            HttpToHybridBuilder.STEP_DONGLE,
+            HttpToHybridBuilder.STEP_CONFIRM,
+        ]
+        # All steps should be unique
+        assert len(steps) == len(set(steps))
+
+    def test_has_validate_method(self):
+        """Test that HttpToHybridBuilder has validate method."""
+        assert hasattr(HttpToHybridBuilder, "validate")
+        assert inspect.iscoroutinefunction(HttpToHybridBuilder.validate)
+
+    def test_has_collect_input_method(self):
+        """Test that HttpToHybridBuilder has collect_input method."""
+        assert hasattr(HttpToHybridBuilder, "collect_input")
+        assert inspect.iscoroutinefunction(HttpToHybridBuilder.collect_input)
+
+    def test_has_execute_method(self):
+        """Test that HttpToHybridBuilder has execute method."""
+        assert hasattr(HttpToHybridBuilder, "execute")
+        assert inspect.iscoroutinefunction(HttpToHybridBuilder.execute)
+
+
+class TestHybridToHttpBuilder:
+    """Tests for HybridToHttpBuilder."""
+
+    def test_class_exists(self):
+        """Test that HybridToHttpBuilder class exists."""
+        assert HybridToHttpBuilder is not None
+
+    def test_inherits_from_transition_builder(self):
+        """Test that HybridToHttpBuilder inherits from TransitionBuilder."""
+        assert issubclass(HybridToHttpBuilder, TransitionBuilder)
+
+    def test_has_step_constants(self):
+        """Test that HybridToHttpBuilder has step constants."""
+        assert hasattr(HybridToHttpBuilder, "STEP_CONFIRM_REMOVAL")
+
+    def test_has_validate_method(self):
+        """Test that HybridToHttpBuilder has validate method."""
+        assert hasattr(HybridToHttpBuilder, "validate")
+        assert inspect.iscoroutinefunction(HybridToHttpBuilder.validate)
+
+    def test_has_collect_input_method(self):
+        """Test that HybridToHttpBuilder has collect_input method."""
+        assert hasattr(HybridToHttpBuilder, "collect_input")
+        assert inspect.iscoroutinefunction(HybridToHttpBuilder.collect_input)
+
+    def test_has_execute_method(self):
+        """Test that HybridToHttpBuilder has execute method."""
+        assert hasattr(HybridToHttpBuilder, "execute")
+        assert inspect.iscoroutinefunction(HybridToHttpBuilder.execute)
+
+
+class TestInverterFamilyOptions:
+    """Tests for inverter family options in http_to_hybrid module."""
+
+    def test_inverter_family_options_exist(self):
+        """Test that inverter family options are defined."""
+        from custom_components.eg4_web_monitor.config_flow.transitions.http_to_hybrid import (
+            INVERTER_FAMILY_OPTIONS,
+        )
+
+        assert INVERTER_FAMILY_PV_SERIES in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_SNA in INVERTER_FAMILY_OPTIONS
+        assert INVERTER_FAMILY_LXP_EU in INVERTER_FAMILY_OPTIONS
+
+    def test_local_type_options_exist(self):
+        """Test that local type options are defined."""
+        from custom_components.eg4_web_monitor.config_flow.transitions.http_to_hybrid import (
+            LOCAL_TYPE_OPTIONS,
+        )
+
+        assert "modbus" in LOCAL_TYPE_OPTIONS
+        assert "dongle" in LOCAL_TYPE_OPTIONS


### PR DESCRIPTION
## Summary
- Creates TransitionBuilder abstract base class with builder pattern
- Implements HttpToHybridBuilder for adding local transport to HTTP-only setups
- Implements HybridToHttpBuilder for removing local transport from Hybrid setups
- Adds TransitionType enum, TransitionRequest, and TransitionContext dataclasses

## Test plan
- [x] All 289 tests pass
- [x] 28 new tests for transitions module
- [x] Ruff linting and formatting passes
- [x] Builder pattern with validate/collect_input/execute workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)