### PR TITLE
feat: Assemble main ConfigFlow class from mixins

### DIFF
--- a/custom_components/eg4_web_monitor/config_flow/__init__.py
+++ b/custom_components/eg4_web_monitor/config_flow/__init__.py
@@ -3,6 +3,21 @@
 This package provides a modular, mixin-based config flow architecture.
 The classes are assembled here and exported for use by the integration.
 
+Architecture:
+    EG4WebMonitorConfigFlow (final class)
+    ├── HttpOnboardingMixin      - Cloud API setup (async_step_http_credentials, async_step_plant)
+    ├── ModbusOnboardingMixin    - Local Modbus setup (async_step_modbus)
+    ├── DongleOnboardingMixin    - Local WiFi Dongle setup (async_step_dongle)
+    ├── HybridOnboardingMixin    - Cloud + Local setup (async_step_hybrid_*)
+    ├── LocalOnboardingMixin     - Pure local multi-device (async_step_local_*)
+    ├── HttpReconfigureMixin     - Reconfigure cloud (async_step_reconfigure_http)
+    ├── ModbusReconfigureMixin   - Reconfigure Modbus (async_step_reconfigure_modbus)
+    ├── HybridReconfigureMixin   - Reconfigure hybrid (async_step_reconfigure_hybrid)
+    ├── LocalReconfigureMixin    - Reconfigure local (async_step_reconfigure_local)
+    ├── ReauthMixin              - Reauthentication (async_step_reauth*)
+    ├── EG4ConfigFlowBase        - Shared state and connection testing
+    └── config_entries.ConfigFlow - Home Assistant ConfigFlow base
+
 Directory Structure:
     config_flow/
     ├── __init__.py      # This file - assembles & exports classes
@@ -12,55 +27,48 @@ Directory Structure:
     ├── options.py       # EG4OptionsFlow
     ├── onboarding/      # Onboarding mixins
     ├── reconfigure/     # Reconfigure mixins
-    └── transitions/     # Transition mixins
-
-BACKWARD COMPATIBILITY:
-During the transition to mixin-based architecture, the original config flow
-classes (EG4WebMonitorConfigFlow, EG4OptionsFlow) are imported from
-_config_flow_legacy.py and re-exported here to maintain API compatibility.
+    └── transitions/     # Transition builders
 """
 
-# =============================================================================
-# BACKWARD COMPATIBILITY - Re-export everything from legacy module
-# =============================================================================
-# The legacy module contains the full working config flow implementation.
-# All imports that previously targeted config_flow.py will now work through
-# this package's re-exports.
+from __future__ import annotations
 
-# Import everything from legacy module for backward compatibility
-# This ensures all existing imports continue to work
-from .._config_flow_legacy import (
-    # Module-level helpers (underscore prefix)
-    _timezone_observes_dst,
-    _build_user_data_schema,
-    # Main classes
-    EG4WebMonitorConfigFlow,
-    EG4OptionsFlow,
-    # Exception classes
-    CannotConnectError,
-    InvalidAuthError,
-    # Re-export imports that the legacy module exposes
-    LuxpowerClient,
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant import config_entries
+
+from ..const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONNECTION_TYPE_DONGLE,
+    CONNECTION_TYPE_HTTP,
+    CONNECTION_TYPE_HYBRID,
+    CONNECTION_TYPE_LOCAL,
+    CONNECTION_TYPE_MODBUS,
+    DOMAIN,
 )
-
-# =============================================================================
-# NEW MODULAR COMPONENTS
-# =============================================================================
-# These are the new refactored components that will eventually replace the
-# legacy implementation.
-
-# Import from helpers module (these replace module-level functions)
+from .base import ConfigFlowProtocol, EG4ConfigFlowBase
 from .helpers import (
     build_unique_id,
     format_entry_title,
     get_ha_timezone,
     timezone_observes_dst,
 )
-
-# Import base class and protocol
-from .base import ConfigFlowProtocol, EG4ConfigFlowBase
-
-# Import schemas
+from .onboarding import (
+    DongleOnboardingMixin,
+    HttpOnboardingMixin,
+    HybridOnboardingMixin,
+    LocalOnboardingMixin,
+    ModbusOnboardingMixin,
+)
+from .options import EG4OptionsFlow
+from .reconfigure import (
+    HttpReconfigureMixin,
+    HybridReconfigureMixin,
+    LocalReconfigureMixin,
+    ModbusReconfigureMixin,
+    ReauthMixin,
+)
 from .schemas import (
     INVERTER_FAMILY_OPTIONS,
     build_connection_type_schema,
@@ -76,25 +84,204 @@ from .schemas import (
     build_reauth_schema,
 )
 
+# Re-export exceptions from pylxpweb for backward compatibility
+from pylxpweb import LuxpowerClient
+from pylxpweb.exceptions import LuxpowerAuthError as InvalidAuthError
+from pylxpweb.exceptions import LuxpowerConnectionError as CannotConnectError
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+
+_LOGGER = logging.getLogger(__name__)
+
+# =============================================================================
+# LEGACY BACKWARD COMPATIBILITY
+# =============================================================================
+# Re-export private helper functions for any external code that may use them
+
+
+def _timezone_observes_dst(timezone_name: str | None) -> bool:
+    """Legacy wrapper for timezone_observes_dst.
+
+    This function is deprecated. Use timezone_observes_dst() from helpers module.
+
+    Args:
+        timezone_name: The timezone name to check (e.g., "America/New_York").
+
+    Returns:
+        True if the timezone observes DST, False otherwise.
+    """
+    return timezone_observes_dst(timezone_name)
+
+
+def _build_user_data_schema() -> None:
+    """Legacy placeholder - no longer used.
+
+    The original function built a voluptuous schema. Now use build_http_credentials_schema().
+    """
+    raise NotImplementedError(
+        "Use build_http_credentials_schema() from config_flow.schemas"
+    )
+
+
+# =============================================================================
+# ASSEMBLED CONFIG FLOW CLASS
+# =============================================================================
+
+
+class EG4WebMonitorConfigFlow(
+    # Onboarding mixins (provide async_step_* for initial setup)
+    HttpOnboardingMixin,
+    ModbusOnboardingMixin,
+    DongleOnboardingMixin,
+    HybridOnboardingMixin,
+    LocalOnboardingMixin,
+    # Reconfigure mixins (provide async_step_reconfigure_* methods)
+    HttpReconfigureMixin,
+    ModbusReconfigureMixin,
+    HybridReconfigureMixin,
+    LocalReconfigureMixin,
+    ReauthMixin,
+    # Base class (provides shared state and connection testing)
+    EG4ConfigFlowBase,
+    # Home Assistant ConfigFlow base (must be last for proper MRO)
+    config_entries.ConfigFlow,
+    domain=DOMAIN,  # type: ignore[call-arg]
+):
+    """Handle a config flow for EG4 Web Monitor.
+
+    This class assembles all mixins to provide a complete config flow for:
+    - Initial setup (onboarding) of HTTP, Modbus, Dongle, Hybrid, and Local modes
+    - Reconfiguration of existing entries
+    - Reauthentication when credentials expire
+
+    Mixins provide the step methods, while this class provides routing.
+
+    MRO Order Notes:
+        - Onboarding mixins come first (most specific step methods)
+        - Reconfigure mixins next
+        - ReauthMixin provides reauth steps
+        - EG4ConfigFlowBase provides shared state and _test_* methods
+        - ConfigFlow base must be last for proper method resolution
+    """
+
+    VERSION = 1
+
+    @staticmethod
+    @config_entries.HANDLERS.register(DOMAIN)
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> EG4OptionsFlow:
+        """Get the options flow for this handler."""
+        return EG4OptionsFlow(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> "ConfigFlowResult":
+        """Handle the initial step - connection type selection.
+
+        Routes to the appropriate onboarding flow based on connection type:
+        - HTTP → async_step_http_credentials (HttpOnboardingMixin)
+        - Modbus → async_step_modbus (ModbusOnboardingMixin)
+        - Dongle → async_step_dongle (DongleOnboardingMixin)
+        - Hybrid → async_step_hybrid_http (HybridOnboardingMixin)
+        - Local → async_step_local_setup (LocalOnboardingMixin)
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult - form or routing to next step.
+        """
+        if user_input is not None:
+            connection_type = user_input[CONF_CONNECTION_TYPE]
+            self._connection_type = connection_type
+
+            if connection_type == CONNECTION_TYPE_HTTP:
+                return await self.async_step_http_credentials()
+            if connection_type == CONNECTION_TYPE_MODBUS:
+                return await self.async_step_modbus()
+            if connection_type == CONNECTION_TYPE_DONGLE:
+                return await self.async_step_dongle()
+            if connection_type == CONNECTION_TYPE_LOCAL:
+                return await self.async_step_local_setup()
+            # CONNECTION_TYPE_HYBRID - start with HTTP credentials
+            return await self.async_step_hybrid_http()
+
+        # Show connection type selection form
+        return self.async_show_form(
+            step_id="user",
+            data_schema=build_connection_type_schema(),
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+            },
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> "ConfigFlowResult":
+        """Handle reconfiguration entry point.
+
+        Routes to the appropriate reconfigure flow based on the existing entry's
+        connection type:
+        - HTTP → async_step_reconfigure_http (HttpReconfigureMixin)
+        - Modbus → async_step_reconfigure_modbus (ModbusReconfigureMixin)
+        - Hybrid → async_step_reconfigure_hybrid (HybridReconfigureMixin)
+        - Local → async_step_reconfigure_local (LocalReconfigureMixin)
+
+        Note: Dongle mode reconfiguration uses the same flow as Modbus.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult - routing to appropriate reconfigure step.
+        """
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return self.async_abort(reason="entry_not_found")
+
+        connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_HTTP)
+
+        if connection_type == CONNECTION_TYPE_MODBUS:
+            return await self.async_step_reconfigure_modbus(user_input)
+        if connection_type == CONNECTION_TYPE_DONGLE:
+            # Dongle reconfigure is similar to Modbus
+            return await self.async_step_reconfigure_modbus(user_input)
+        if connection_type == CONNECTION_TYPE_HYBRID:
+            return await self.async_step_reconfigure_hybrid(user_input)
+        if connection_type == CONNECTION_TYPE_LOCAL:
+            return await self.async_step_reconfigure_local(user_input)
+
+        # Default to HTTP reconfigure
+        return await self.async_step_reconfigure_http(user_input)
+
+
+# =============================================================================
+# MODULE EXPORTS
+# =============================================================================
+
 __all__ = [
-    # Legacy classes (full backward compatibility)
+    # Main config flow classes
     "EG4WebMonitorConfigFlow",
     "EG4OptionsFlow",
+    # Exception classes (for backward compatibility)
     "CannotConnectError",
     "InvalidAuthError",
+    # Client (for backward compatibility)
     "LuxpowerClient",
     # Legacy helper functions (underscore prefix preserved)
     "_timezone_observes_dst",
     "_build_user_data_schema",
-    # New base components
+    # Base components
     "ConfigFlowProtocol",
     "EG4ConfigFlowBase",
-    # New helpers
+    # Helper functions
     "build_unique_id",
     "format_entry_title",
     "get_ha_timezone",
     "timezone_observes_dst",
-    # New schemas
+    # Schema builders
     "INVERTER_FAMILY_OPTIONS",
     "build_connection_type_schema",
     "build_dongle_schema",

--- a/tests/test_main_configflow.py
+++ b/tests/test_main_configflow.py
@@ -1,0 +1,262 @@
+"""Tests for the main EG4WebMonitorConfigFlow class assembly.
+
+This module tests that the ConfigFlow is properly assembled from all mixins
+and that routing works correctly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from custom_components.eg4_web_monitor.config_flow import (
+    CannotConnectError,
+    ConfigFlowProtocol,
+    EG4ConfigFlowBase,
+    EG4OptionsFlow,
+    EG4WebMonitorConfigFlow,
+    InvalidAuthError,
+    LuxpowerClient,
+    _build_user_data_schema,
+    _timezone_observes_dst,
+)
+
+
+class TestConfigFlowAssembly:
+    """Tests for ConfigFlow class assembly and MRO."""
+
+    def test_configflow_class_exists(self):
+        """Test that EG4WebMonitorConfigFlow class exists."""
+        assert EG4WebMonitorConfigFlow is not None
+
+    def test_configflow_inherits_all_onboarding_mixins(self):
+        """Test that ConfigFlow inherits from all onboarding mixins."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+
+        assert "HttpOnboardingMixin" in mro_names
+        assert "ModbusOnboardingMixin" in mro_names
+        assert "DongleOnboardingMixin" in mro_names
+        assert "HybridOnboardingMixin" in mro_names
+        assert "LocalOnboardingMixin" in mro_names
+
+    def test_configflow_inherits_all_reconfigure_mixins(self):
+        """Test that ConfigFlow inherits from all reconfigure mixins."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+
+        assert "HttpReconfigureMixin" in mro_names
+        assert "ModbusReconfigureMixin" in mro_names
+        assert "HybridReconfigureMixin" in mro_names
+        assert "LocalReconfigureMixin" in mro_names
+        assert "ReauthMixin" in mro_names
+
+    def test_configflow_inherits_base_class(self):
+        """Test that ConfigFlow inherits from EG4ConfigFlowBase."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+
+        assert "EG4ConfigFlowBase" in mro_names
+        assert "ConfigFlow" in mro_names
+
+    def test_configflow_mro_order(self):
+        """Test that MRO has correct order (mixins before base)."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+
+        # Base classes should come after all mixins
+        base_index = mro_names.index("EG4ConfigFlowBase")
+        configflow_index = mro_names.index("ConfigFlow")
+
+        # All onboarding mixins should come before base
+        assert mro_names.index("HttpOnboardingMixin") < base_index
+        assert mro_names.index("ModbusOnboardingMixin") < base_index
+        assert mro_names.index("DongleOnboardingMixin") < base_index
+
+        # All reconfigure mixins should come before base
+        assert mro_names.index("HttpReconfigureMixin") < base_index
+        assert mro_names.index("ReauthMixin") < base_index
+
+        # EG4ConfigFlowBase should come before ConfigFlow
+        assert base_index < configflow_index
+
+    def test_configflow_has_version(self):
+        """Test that ConfigFlow has VERSION attribute."""
+        assert hasattr(EG4WebMonitorConfigFlow, "VERSION")
+        assert EG4WebMonitorConfigFlow.VERSION == 1
+
+
+class TestConfigFlowRoutingMethods:
+    """Tests for ConfigFlow routing methods."""
+
+    def test_has_async_step_user(self):
+        """Test that ConfigFlow has async_step_user method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_user")
+        assert inspect.iscoroutinefunction(EG4WebMonitorConfigFlow.async_step_user)
+
+    def test_has_async_step_reconfigure(self):
+        """Test that ConfigFlow has async_step_reconfigure method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reconfigure")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reconfigure
+        )
+
+    def test_has_async_get_options_flow(self):
+        """Test that ConfigFlow has async_get_options_flow method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_get_options_flow")
+
+
+class TestOnboardingStepsFromMixins:
+    """Tests for onboarding step methods from mixins."""
+
+    def test_has_http_credentials_step(self):
+        """Test that ConfigFlow has async_step_http_credentials from HttpOnboardingMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_http_credentials")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_http_credentials
+        )
+
+    def test_has_modbus_step(self):
+        """Test that ConfigFlow has async_step_modbus from ModbusOnboardingMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_modbus")
+        assert inspect.iscoroutinefunction(EG4WebMonitorConfigFlow.async_step_modbus)
+
+    def test_has_dongle_step(self):
+        """Test that ConfigFlow has async_step_dongle from DongleOnboardingMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_dongle")
+        assert inspect.iscoroutinefunction(EG4WebMonitorConfigFlow.async_step_dongle)
+
+    def test_has_hybrid_steps(self):
+        """Test that ConfigFlow has hybrid steps from HybridOnboardingMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_hybrid_http")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_hybrid_local_type")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_hybrid_modbus")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_hybrid_dongle")
+
+    def test_has_local_steps(self):
+        """Test that ConfigFlow has local steps from LocalOnboardingMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_local_setup")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_local_add_device")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_local_modbus_device")
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_local_dongle_device")
+
+
+class TestReconfigureStepsFromMixins:
+    """Tests for reconfigure step methods from mixins."""
+
+    def test_has_reconfigure_http_step(self):
+        """Test that ConfigFlow has async_step_reconfigure_http from HttpReconfigureMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reconfigure_http")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reconfigure_http
+        )
+
+    def test_has_reconfigure_modbus_step(self):
+        """Test that ConfigFlow has async_step_reconfigure_modbus from ModbusReconfigureMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reconfigure_modbus")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reconfigure_modbus
+        )
+
+    def test_has_reconfigure_hybrid_step(self):
+        """Test that ConfigFlow has async_step_reconfigure_hybrid from HybridReconfigureMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reconfigure_hybrid")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reconfigure_hybrid
+        )
+
+    def test_has_reconfigure_local_step(self):
+        """Test that ConfigFlow has async_step_reconfigure_local from LocalReconfigureMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reconfigure_local")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reconfigure_local
+        )
+
+
+class TestReauthStepsFromMixin:
+    """Tests for reauth step methods from ReauthMixin."""
+
+    def test_has_reauth_step(self):
+        """Test that ConfigFlow has async_step_reauth from ReauthMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reauth")
+        assert inspect.iscoroutinefunction(EG4WebMonitorConfigFlow.async_step_reauth)
+
+    def test_has_reauth_confirm_step(self):
+        """Test that ConfigFlow has async_step_reauth_confirm from ReauthMixin."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_reauth_confirm")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_reauth_confirm
+        )
+
+
+class TestBaseClassMethods:
+    """Tests for base class methods from EG4ConfigFlowBase."""
+
+    def test_has_test_credentials_method(self):
+        """Test that ConfigFlow has _test_credentials from base class."""
+        assert hasattr(EG4WebMonitorConfigFlow, "_test_credentials")
+        assert inspect.iscoroutinefunction(EG4WebMonitorConfigFlow._test_credentials)
+
+    def test_has_test_modbus_connection_method(self):
+        """Test that ConfigFlow has _test_modbus_connection from base class."""
+        assert hasattr(EG4WebMonitorConfigFlow, "_test_modbus_connection")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow._test_modbus_connection
+        )
+
+    def test_has_test_dongle_connection_method(self):
+        """Test that ConfigFlow has _test_dongle_connection from base class."""
+        assert hasattr(EG4WebMonitorConfigFlow, "_test_dongle_connection")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow._test_dongle_connection
+        )
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility exports."""
+
+    def test_exceptions_exported(self):
+        """Test that exception classes are exported for backward compatibility."""
+        assert CannotConnectError is not None
+        assert InvalidAuthError is not None
+
+    def test_client_exported(self):
+        """Test that LuxpowerClient is exported for backward compatibility."""
+        assert LuxpowerClient is not None
+
+    def test_legacy_timezone_function_exported(self):
+        """Test that _timezone_observes_dst is exported."""
+        assert _timezone_observes_dst is not None
+
+    def test_legacy_timezone_function_works(self):
+        """Test that _timezone_observes_dst works with timezone argument."""
+        # Should accept a timezone name
+        result = _timezone_observes_dst("America/New_York")
+        assert isinstance(result, bool)
+
+    def test_legacy_schema_function_raises(self):
+        """Test that _build_user_data_schema raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            _build_user_data_schema()
+
+    def test_protocol_exported(self):
+        """Test that ConfigFlowProtocol is exported."""
+        assert ConfigFlowProtocol is not None
+
+    def test_base_class_exported(self):
+        """Test that EG4ConfigFlowBase is exported."""
+        assert EG4ConfigFlowBase is not None
+
+
+class TestOptionsFlow:
+    """Tests for EG4OptionsFlow integration."""
+
+    def test_options_flow_class_exists(self):
+        """Test that EG4OptionsFlow is exported."""
+        assert EG4OptionsFlow is not None
+
+    def test_options_flow_has_async_step_init(self):
+        """Test that EG4OptionsFlow has async_step_init method."""
+        assert hasattr(EG4OptionsFlow, "async_step_init")
+        assert inspect.iscoroutinefunction(EG4OptionsFlow.async_step_init)


### PR DESCRIPTION
## Summary
- Create the final EG4WebMonitorConfigFlow class by assembling all mixins into a complete config flow
- Add async_step_user() routing to appropriate onboarding flows
- Add async_step_reconfigure() routing based on connection type
- Maintain backward compatibility with legacy exports

## Changes
- **config_flow/__init__.py**: Assemble EG4WebMonitorConfigFlow from all mixins with proper MRO
- **tests/test_main_configflow.py**: 32 new tests for class assembly, MRO, and method availability

## MRO Order
```
EG4WebMonitorConfigFlow
├── HttpOnboardingMixin
├── ModbusOnboardingMixin
├── DongleOnboardingMixin
├── HybridOnboardingMixin
├── LocalOnboardingMixin
├── HttpReconfigureMixin
├── ModbusReconfigureMixin
├── HybridReconfigureMixin
├── LocalReconfigureMixin
├── ReauthMixin
├── EG4ConfigFlowBase
└── ConfigFlow
```

## Test plan
- [x] All 333 tests pass
- [x] MRO validation tests pass
- [x] Step method availability tests pass
- [x] Backward compatibility tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)