### PR TITLE
feat: Add transition flow mixin for connection type switching

### DIFF
--- a/custom_components/eg4_web_monitor/config_flow/__init__.py
+++ b/custom_components/eg4_web_monitor/config_flow/__init__.py
@@ -69,6 +69,7 @@ from .reconfigure import (
     ModbusReconfigureMixin,
     ReauthMixin,
 )
+from .transitions import TransitionMixin
 from .schemas import (
     INVERTER_FAMILY_OPTIONS,
     build_connection_type_schema,
@@ -142,6 +143,8 @@ class EG4WebMonitorConfigFlow(
     HybridReconfigureMixin,
     LocalReconfigureMixin,
     ReauthMixin,
+    # Transition mixin (provides async_step_transition_* methods)
+    TransitionMixin,
     # Base class (provides shared state and connection testing)
     EG4ConfigFlowBase,
     # Home Assistant ConfigFlow base (must be last for proper MRO)
@@ -154,6 +157,7 @@ class EG4WebMonitorConfigFlow(
     - Initial setup (onboarding) of HTTP, Modbus, Dongle, Hybrid, and Local modes
     - Reconfiguration of existing entries
     - Reauthentication when credentials expire
+    - Connection type transitions (HTTP ↔ Hybrid)
 
     Mixins provide the step methods, while this class provides routing.
 
@@ -161,6 +165,7 @@ class EG4WebMonitorConfigFlow(
         - Onboarding mixins come first (most specific step methods)
         - Reconfigure mixins next
         - ReauthMixin provides reauth steps
+        - TransitionMixin provides connection type transition steps
         - EG4ConfigFlowBase provides shared state and _test_* methods
         - ConfigFlow base must be last for proper method resolution
     """

--- a/custom_components/eg4_web_monitor/config_flow/transitions/__init__.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/__init__.py
@@ -3,6 +3,7 @@
 This package provides builders for transitioning between connection types:
 - HttpToHybridBuilder: Add local transport to HTTP-only setup
 - HybridToHttpBuilder: Remove local transport from Hybrid setup
+- TransitionMixin: Config flow mixin for integrating transitions
 
 Each builder follows the builder pattern with validate(), collect_input(),
 and execute() methods for a consistent transition workflow.
@@ -16,6 +17,7 @@ from .base import (
 )
 from .http_to_hybrid import HttpToHybridBuilder
 from .hybrid_to_http import HybridToHttpBuilder
+from .mixin import TransitionMixin
 
 __all__ = [
     "TransitionType",
@@ -24,4 +26,5 @@ __all__ = [
     "TransitionBuilder",
     "HttpToHybridBuilder",
     "HybridToHttpBuilder",
+    "TransitionMixin",
 ]

--- a/custom_components/eg4_web_monitor/config_flow/transitions/mixin.py
+++ b/custom_components/eg4_web_monitor/config_flow/transitions/mixin.py
@@ -1,0 +1,350 @@
+"""Transition mixin for connection type switching.
+
+This module provides the TransitionMixin class that integrates transition
+builders into the config flow, allowing users to switch between connection
+types (e.g., HTTP → Hybrid, Hybrid → HTTP) from the reconfigure flow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from ...const import (
+    BRAND_NAME,
+    CONF_CONNECTION_TYPE,
+    CONNECTION_TYPE_HTTP,
+    CONNECTION_TYPE_HYBRID,
+)
+from .base import TransitionRequest
+from .http_to_hybrid import HttpToHybridBuilder
+from .hybrid_to_http import HybridToHttpBuilder
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.core import HomeAssistant
+
+    from ..base import ConfigFlowProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Transition type options for user selection
+TRANSITION_OPTIONS_HTTP = {
+    "upgrade_to_hybrid": "Add Local Transport (Hybrid Mode)",
+    "no_change": "Keep Current Configuration",
+}
+
+TRANSITION_OPTIONS_HYBRID = {
+    "downgrade_to_http": "Remove Local Transport (Cloud Only)",
+    "no_change": "Keep Current Configuration",
+}
+
+
+class TransitionMixin:
+    """Mixin providing connection type transition flow steps.
+
+    This mixin integrates with reconfigure flows to offer users the ability
+    to switch between connection types:
+
+    - HTTP → Hybrid: Add local transport (Modbus or Dongle) to cloud connection
+    - Hybrid → HTTP: Remove local transport, keeping cloud credentials
+
+    Flow Steps:
+    - async_step_transition_select: Choose transition type
+    - async_step_transition_http_to_hybrid: Delegate to HttpToHybridBuilder
+    - async_step_transition_hybrid_to_http: Delegate to HybridToHttpBuilder
+
+    Usage:
+        Add this mixin to the ConfigFlow class and call async_step_transition_select()
+        from the appropriate reconfigure step when user requests a mode change.
+    """
+
+    # Type hints for mixin - these come from ConfigFlowProtocol
+    if TYPE_CHECKING:
+        hass: HomeAssistant
+        context: dict[str, Any]
+
+        def async_show_form(
+            self: ConfigFlowProtocol,
+            *,
+            step_id: str,
+            data_schema: vol.Schema | None = None,
+            errors: dict[str, str] | None = None,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+
+        def async_abort(
+            self: ConfigFlowProtocol,
+            *,
+            reason: str,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> ConfigFlowResult: ...
+
+    # Store active transition builder
+    _transition_builder: HttpToHybridBuilder | HybridToHttpBuilder | None = None
+
+    async def async_step_transition_select(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle transition type selection.
+
+        Presents options based on the current connection type:
+        - HTTP: Can upgrade to Hybrid
+        - Hybrid: Can downgrade to HTTP
+
+        Args:
+            user_input: Form data with transition selection.
+
+        Returns:
+            Form for selection, next step, or abort.
+        """
+        entry_id = self.context.get("entry_id")
+        if not entry_id:
+            return self.async_abort(reason="entry_not_found")
+
+        entry = self.hass.config_entries.async_get_entry(entry_id)
+        if not entry:
+            return self.async_abort(reason="entry_not_found")
+
+        current_type = entry.data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_HTTP)
+
+        if user_input is not None:
+            transition_choice = user_input.get("transition_type")
+
+            if transition_choice == "no_change":
+                # User wants to keep current config - return to reconfigure
+                if current_type == CONNECTION_TYPE_HTTP:
+                    return await self.async_step_reconfigure_http()
+                if current_type == CONNECTION_TYPE_HYBRID:
+                    return await self.async_step_reconfigure_hybrid()
+                return self.async_abort(reason="unknown_connection_type")
+
+            if transition_choice == "upgrade_to_hybrid":
+                return await self.async_step_transition_http_to_hybrid()
+
+            if transition_choice == "downgrade_to_http":
+                return await self.async_step_transition_hybrid_to_http()
+
+        # Build options based on current connection type
+        if current_type == CONNECTION_TYPE_HTTP:
+            options = TRANSITION_OPTIONS_HTTP
+        elif current_type == CONNECTION_TYPE_HYBRID:
+            options = TRANSITION_OPTIONS_HYBRID
+        else:
+            return self.async_abort(reason="transition_not_supported")
+
+        schema = vol.Schema(
+            {
+                vol.Required("transition_type", default="no_change"): vol.In(options),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="transition_select",
+            data_schema=schema,
+            description_placeholders={
+                "brand_name": BRAND_NAME,
+                "current_type": "Cloud API (HTTP)"
+                if current_type == CONNECTION_TYPE_HTTP
+                else "Hybrid (Cloud + Local)",
+            },
+        )
+
+    async def async_step_transition_http_to_hybrid(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle HTTP to Hybrid transition.
+
+        Creates and delegates to HttpToHybridBuilder for the multi-step
+        transition flow.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        entry_id = self.context.get("entry_id")
+        if not entry_id:
+            return self.async_abort(reason="entry_not_found")
+
+        entry = self.hass.config_entries.async_get_entry(entry_id)
+        if not entry:
+            return self.async_abort(reason="entry_not_found")
+
+        # Create or reuse builder
+        if self._transition_builder is None or not isinstance(
+            self._transition_builder, HttpToHybridBuilder
+        ):
+            request = TransitionRequest(
+                source_type=CONNECTION_TYPE_HTTP,
+                target_type=CONNECTION_TYPE_HYBRID,
+                entry=entry,
+            )
+            self._transition_builder = HttpToHybridBuilder(self.hass, self, request)
+
+            # Validate transition can proceed
+            if not await self._transition_builder.validate():
+                self._transition_builder = None
+                return self.async_abort(reason="transition_validation_failed")
+
+        # Determine which step to show based on builder state
+        builder = self._transition_builder
+        current_step = (
+            builder._current_step or HttpToHybridBuilder.STEP_SELECT_LOCAL_TYPE
+        )
+
+        # Delegate to builder's collect_input
+        return await builder.collect_input(current_step, user_input)
+
+    async def async_step_transition_select_local_type(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle local transport type selection for HTTP→Hybrid transition.
+
+        This is a pass-through step that delegates to the builder.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        if self._transition_builder is None:
+            return await self.async_step_transition_http_to_hybrid(user_input)
+
+        return await self._transition_builder.collect_input(
+            HttpToHybridBuilder.STEP_SELECT_LOCAL_TYPE, user_input
+        )
+
+    async def async_step_transition_modbus(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Modbus configuration for HTTP→Hybrid transition.
+
+        This is a pass-through step that delegates to the builder.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        if self._transition_builder is None:
+            return await self.async_step_transition_http_to_hybrid(user_input)
+
+        return await self._transition_builder.collect_input(
+            HttpToHybridBuilder.STEP_MODBUS, user_input
+        )
+
+    async def async_step_transition_dongle(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Dongle configuration for HTTP→Hybrid transition.
+
+        This is a pass-through step that delegates to the builder.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        if self._transition_builder is None:
+            return await self.async_step_transition_http_to_hybrid(user_input)
+
+        return await self._transition_builder.collect_input(
+            HttpToHybridBuilder.STEP_DONGLE, user_input
+        )
+
+    async def async_step_transition_confirm(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle transition confirmation step.
+
+        This is a pass-through step that delegates to the builder.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        if self._transition_builder is None:
+            return self.async_abort(reason="transition_not_started")
+
+        if isinstance(self._transition_builder, HttpToHybridBuilder):
+            return await self._transition_builder.collect_input(
+                HttpToHybridBuilder.STEP_CONFIRM, user_input
+            )
+        if isinstance(self._transition_builder, HybridToHttpBuilder):
+            return await self._transition_builder.collect_input(
+                HybridToHttpBuilder.STEP_CONFIRM_REMOVAL, user_input
+            )
+
+        return self.async_abort(reason="unknown_transition")
+
+    async def async_step_transition_hybrid_to_http(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Hybrid to HTTP transition.
+
+        Creates and delegates to HybridToHttpBuilder for the transition flow.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        entry_id = self.context.get("entry_id")
+        if not entry_id:
+            return self.async_abort(reason="entry_not_found")
+
+        entry = self.hass.config_entries.async_get_entry(entry_id)
+        if not entry:
+            return self.async_abort(reason="entry_not_found")
+
+        # Create or reuse builder
+        if self._transition_builder is None or not isinstance(
+            self._transition_builder, HybridToHttpBuilder
+        ):
+            request = TransitionRequest(
+                source_type=CONNECTION_TYPE_HYBRID,
+                target_type=CONNECTION_TYPE_HTTP,
+                entry=entry,
+            )
+            self._transition_builder = HybridToHttpBuilder(self.hass, self, request)
+
+            # Validate transition can proceed
+            if not await self._transition_builder.validate():
+                self._transition_builder = None
+                return self.async_abort(reason="transition_validation_failed")
+
+        # Delegate to builder's collect_input
+        return await self._transition_builder.collect_input(
+            HybridToHttpBuilder.STEP_CONFIRM_REMOVAL, user_input
+        )
+
+    async def async_step_transition_confirm_removal(
+        self: ConfigFlowProtocol, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle removal confirmation for Hybrid→HTTP transition.
+
+        This is a pass-through step that delegates to the builder.
+
+        Args:
+            user_input: Form data from user, or None for initial display.
+
+        Returns:
+            ConfigFlowResult from the builder.
+        """
+        if self._transition_builder is None:
+            return await self.async_step_transition_hybrid_to_http(user_input)
+
+        return await self._transition_builder.collect_input(
+            HybridToHttpBuilder.STEP_CONFIRM_REMOVAL, user_input
+        )

--- a/custom_components/eg4_web_monitor/strings.json
+++ b/custom_components/eg4_web_monitor/strings.json
@@ -274,6 +274,72 @@
         "data_description": {
           "plant_id": "Select the solar installation you want to monitor"
         }
+      },
+      "transition_select": {
+        "title": "Change Connection Mode",
+        "description": "You can change how this integration connects to your inverter. Current mode: {current_type}",
+        "data": {
+          "transition_type": "Connection Mode"
+        },
+        "data_description": {
+          "transition_type": "Select a new connection mode or keep the current configuration"
+        }
+      },
+      "transition_select_local_type": {
+        "title": "Select Local Transport Type",
+        "description": "Choose how to connect locally to your inverter. Modbus TCP provides the fastest updates using an RS485 adapter. WiFi Dongle uses the inverter's existing dongle (no extra hardware).",
+        "data": {
+          "hybrid_local_type": "Local Transport Type"
+        },
+        "data_description": {
+          "hybrid_local_type": "Select the local connection method for fast runtime data"
+        }
+      },
+      "transition_modbus": {
+        "title": "Configure Modbus Connection",
+        "description": "Enter your Modbus TCP gateway settings. This will enable fast 5-second polling for runtime data.",
+        "data": {
+          "modbus_host": "Modbus Gateway IP/Hostname",
+          "modbus_port": "Modbus TCP Port",
+          "modbus_unit_id": "Modbus Unit ID",
+          "inverter_serial": "Inverter Serial Number",
+          "inverter_family": "Inverter Family"
+        },
+        "data_description": {
+          "modbus_host": "IP address or hostname of your Modbus TCP gateway",
+          "modbus_port": "TCP port for Modbus communication (default: 502)",
+          "modbus_unit_id": "Modbus slave/unit ID of the inverter (default: 1)",
+          "inverter_serial": "Serial number of the inverter (leave blank to auto-detect)",
+          "inverter_family": "Select your inverter family for correct register mapping"
+        }
+      },
+      "transition_dongle": {
+        "title": "Configure WiFi Dongle Connection",
+        "description": "Enter your WiFi dongle connection settings. This enables fast 5-second polling using the inverter's existing dongle.",
+        "data": {
+          "dongle_host": "WiFi Dongle IP/Hostname",
+          "dongle_port": "Dongle TCP Port",
+          "dongle_serial": "Dongle Serial Number",
+          "inverter_serial": "Inverter Serial Number",
+          "inverter_family": "Inverter Family"
+        },
+        "data_description": {
+          "dongle_host": "IP address of your WiFi dongle on your local network",
+          "dongle_port": "TCP port for dongle communication (default: 8000)",
+          "dongle_serial": "10-character serial number of the WiFi dongle",
+          "inverter_serial": "Serial number of the inverter",
+          "inverter_family": "Select your inverter family for correct register mapping"
+        }
+      },
+      "transition_confirm": {
+        "title": "Confirm Connection Mode Change",
+        "description": "You are about to change from {current_type} to {target_type}. Station: {current_plant}\n\n{warnings}",
+        "submit": "Confirm Change"
+      },
+      "transition_confirm_removal": {
+        "title": "Confirm Local Transport Removal",
+        "description": "You are about to remove local transport from your Hybrid setup. Station: {current_plant}, Current local transport: {local_type} ({local_host})\n\n{warnings}",
+        "submit": "Remove Local Transport"
       }
     },
     "error": {

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -105,12 +105,16 @@ class TestBuildUniqueId:
 
     def test_http_mode_missing_username(self):
         """Test HTTP mode raises error without username."""
-        with pytest.raises(ValueError, match="HTTP mode requires username and plant_id"):
+        with pytest.raises(
+            ValueError, match="HTTP mode requires username and plant_id"
+        ):
             build_unique_id("http", plant_id="12345")
 
     def test_http_mode_missing_plant_id(self):
         """Test HTTP mode raises error without plant_id."""
-        with pytest.raises(ValueError, match="HTTP mode requires username and plant_id"):
+        with pytest.raises(
+            ValueError, match="HTTP mode requires username and plant_id"
+        ):
             build_unique_id("http", username="user@example.com")
 
     def test_hybrid_mode(self):

--- a/tests/test_config_flow_schemas.py
+++ b/tests/test_config_flow_schemas.py
@@ -37,7 +37,6 @@ from custom_components.eg4_web_monitor.const import (
     CONF_SENSOR_UPDATE_INTERVAL,
     CONF_VERIFY_SSL,
     CONNECTION_TYPE_HTTP,
-    DEFAULT_BASE_URL,
     DEFAULT_DONGLE_PORT,
     DEFAULT_INVERTER_FAMILY,
     DEFAULT_MODBUS_PORT,
@@ -127,12 +126,8 @@ class TestBuildHttpCredentialsSchema:
         schema_with_false = build_http_credentials_schema(dst_sync_default=False)
 
         # Both should work, just have different defaults
-        result_true = schema_with_true(
-            {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
-        )
-        result_false = schema_with_false(
-            {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
-        )
+        result_true = schema_with_true({CONF_USERNAME: "user", CONF_PASSWORD: "pass"})
+        result_false = schema_with_false({CONF_USERNAME: "user", CONF_PASSWORD: "pass"})
 
         assert result_true[CONF_DST_SYNC] is True
         assert result_false[CONF_DST_SYNC] is False
@@ -380,7 +375,9 @@ class TestBuildIntervalOptionsSchema:
 
         # Should reject values below minimum
         with pytest.raises(vol.MultipleInvalid):
-            schema({CONF_SENSOR_UPDATE_INTERVAL: 1, CONF_PARAMETER_REFRESH_INTERVAL: 60})
+            schema(
+                {CONF_SENSOR_UPDATE_INTERVAL: 1, CONF_PARAMETER_REFRESH_INTERVAL: 60}
+            )
 
     def test_validates_param_interval_range(self):
         """Test that parameter interval is validated against range."""
@@ -388,7 +385,9 @@ class TestBuildIntervalOptionsSchema:
 
         # Should reject values below minimum
         with pytest.raises(vol.MultipleInvalid):
-            schema({CONF_SENSOR_UPDATE_INTERVAL: 30, CONF_PARAMETER_REFRESH_INTERVAL: 1})
+            schema(
+                {CONF_SENSOR_UPDATE_INTERVAL: 30, CONF_PARAMETER_REFRESH_INTERVAL: 1}
+            )
 
     def test_accepts_valid_values(self):
         """Test that valid values are accepted."""

--- a/tests/test_transition_mixin.py
+++ b/tests/test_transition_mixin.py
@@ -1,0 +1,595 @@
+"""Tests for the TransitionMixin class.
+
+This module tests the transition flow steps provided by TransitionMixin,
+including HTTP → Hybrid and Hybrid → HTTP transitions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.eg4_web_monitor.config_flow import EG4WebMonitorConfigFlow
+from custom_components.eg4_web_monitor.config_flow.transitions import (
+    HttpToHybridBuilder,
+    HybridToHttpBuilder,
+    TransitionMixin,
+)
+from custom_components.eg4_web_monitor.config_flow.transitions.mixin import (
+    TRANSITION_OPTIONS_HTTP,
+    TRANSITION_OPTIONS_HYBRID,
+)
+from custom_components.eg4_web_monitor.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_DONGLE_HOST,
+    CONF_DONGLE_SERIAL,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONNECTION_TYPE_HTTP,
+    CONNECTION_TYPE_HYBRID,
+    CONNECTION_TYPE_MODBUS,
+)
+
+
+def _run_async(coro):
+    """Helper to run async code in sync tests."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# =============================================================================
+# Test Class Assembly
+# =============================================================================
+
+
+class TestTransitionMixinAssembly:
+    """Tests for TransitionMixin class assembly."""
+
+    def test_transition_mixin_exists(self):
+        """Test that TransitionMixin class exists."""
+        assert TransitionMixin is not None
+
+    def test_configflow_inherits_transition_mixin(self):
+        """Test that ConfigFlow inherits from TransitionMixin."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+        assert "TransitionMixin" in mro_names
+
+    def test_transition_mixin_before_base_in_mro(self):
+        """Test that TransitionMixin comes before base classes in MRO."""
+        mro = EG4WebMonitorConfigFlow.__mro__
+        mro_names = [c.__name__ for c in mro]
+
+        transition_index = mro_names.index("TransitionMixin")
+        base_index = mro_names.index("EG4ConfigFlowBase")
+        configflow_index = mro_names.index("ConfigFlow")
+
+        assert transition_index < base_index
+        assert transition_index < configflow_index
+
+
+# =============================================================================
+# Test Step Methods Availability
+# =============================================================================
+
+
+class TestTransitionStepMethods:
+    """Tests for TransitionMixin step methods availability."""
+
+    def test_has_async_step_transition_select(self):
+        """Test that ConfigFlow has async_step_transition_select method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_select")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_select
+        )
+
+    def test_has_async_step_transition_http_to_hybrid(self):
+        """Test that ConfigFlow has async_step_transition_http_to_hybrid method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_http_to_hybrid")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_http_to_hybrid
+        )
+
+    def test_has_async_step_transition_hybrid_to_http(self):
+        """Test that ConfigFlow has async_step_transition_hybrid_to_http method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_hybrid_to_http")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_hybrid_to_http
+        )
+
+    def test_has_async_step_transition_select_local_type(self):
+        """Test that ConfigFlow has async_step_transition_select_local_type method."""
+        assert hasattr(
+            EG4WebMonitorConfigFlow, "async_step_transition_select_local_type"
+        )
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_select_local_type
+        )
+
+    def test_has_async_step_transition_modbus(self):
+        """Test that ConfigFlow has async_step_transition_modbus method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_modbus")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_modbus
+        )
+
+    def test_has_async_step_transition_dongle(self):
+        """Test that ConfigFlow has async_step_transition_dongle method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_dongle")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_dongle
+        )
+
+    def test_has_async_step_transition_confirm(self):
+        """Test that ConfigFlow has async_step_transition_confirm method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_confirm")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_confirm
+        )
+
+    def test_has_async_step_transition_confirm_removal(self):
+        """Test that ConfigFlow has async_step_transition_confirm_removal method."""
+        assert hasattr(EG4WebMonitorConfigFlow, "async_step_transition_confirm_removal")
+        assert inspect.iscoroutinefunction(
+            EG4WebMonitorConfigFlow.async_step_transition_confirm_removal
+        )
+
+
+# =============================================================================
+# Test Transition Options
+# =============================================================================
+
+
+class TestTransitionOptions:
+    """Tests for transition options constants."""
+
+    def test_http_transition_options_contains_upgrade(self):
+        """Test that HTTP options contain upgrade to hybrid."""
+        assert "upgrade_to_hybrid" in TRANSITION_OPTIONS_HTTP
+        assert "no_change" in TRANSITION_OPTIONS_HTTP
+
+    def test_hybrid_transition_options_contains_downgrade(self):
+        """Test that Hybrid options contain downgrade to HTTP."""
+        assert "downgrade_to_http" in TRANSITION_OPTIONS_HYBRID
+        assert "no_change" in TRANSITION_OPTIONS_HYBRID
+
+    def test_transition_options_have_descriptions(self):
+        """Test that transition options have user-friendly descriptions."""
+        for key, value in TRANSITION_OPTIONS_HTTP.items():
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+        for key, value in TRANSITION_OPTIONS_HYBRID.items():
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+
+# =============================================================================
+# Test Transition Select Step (mocked hass)
+# =============================================================================
+
+
+class TestTransitionSelectStepMocked:
+    """Tests for async_step_transition_select behavior using mocks."""
+
+    def test_transition_select_aborts_without_entry_id(self):
+        """Test that transition select aborts when entry_id is missing."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {}  # No entry_id
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "entry_not_found"}
+        )
+
+        result = _run_async(TransitionMixin.async_step_transition_select(flow, None))
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "entry_not_found"
+
+    def test_transition_select_aborts_entry_not_found(self):
+        """Test that transition select aborts when entry doesn't exist."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "nonexistent_entry"}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = None
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "entry_not_found"}
+        )
+
+        result = _run_async(TransitionMixin.async_step_transition_select(flow, None))
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "entry_not_found"
+
+
+# =============================================================================
+# Test HTTP to Hybrid Builder Step (mocked)
+# =============================================================================
+
+
+class TestHttpToHybridStepMocked:
+    """Tests for HTTP to Hybrid transition step using mocks."""
+
+    def test_http_to_hybrid_aborts_without_entry(self):
+        """Test that HTTP to Hybrid aborts when entry is missing."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {}  # No entry_id
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "entry_not_found"}
+        )
+
+        result = _run_async(
+            TransitionMixin.async_step_transition_http_to_hybrid(flow, None)
+        )
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "entry_not_found"
+
+
+# =============================================================================
+# Test Hybrid to HTTP Builder Step (mocked)
+# =============================================================================
+
+
+class TestHybridToHttpStepMocked:
+    """Tests for Hybrid to HTTP transition step using mocks."""
+
+    def test_hybrid_to_http_aborts_without_entry(self):
+        """Test that Hybrid to HTTP aborts when entry is missing."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {}  # No entry_id
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "entry_not_found"}
+        )
+
+        result = _run_async(
+            TransitionMixin.async_step_transition_hybrid_to_http(flow, None)
+        )
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "entry_not_found"
+
+
+# =============================================================================
+# Test Pass-Through Step Methods (mocked)
+# =============================================================================
+
+
+class TestPassThroughStepMethodsMocked:
+    """Tests for pass-through step methods that delegate to builders."""
+
+    def test_transition_confirm_without_builder(self):
+        """Test that confirm step aborts without builder."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {}
+        flow._transition_builder = None
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "transition_not_started"}
+        )
+
+        result = _run_async(TransitionMixin.async_step_transition_confirm(flow, None))
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "transition_not_started"
+
+
+# =============================================================================
+# Test Builder Delegation (mocked)
+# =============================================================================
+
+
+class TestBuilderDelegationMocked:
+    """Tests for step methods delegating to builders using mocks."""
+
+    def test_select_local_type_delegates_to_builder(self):
+        """Test that select_local_type delegates to builder's collect_input."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HttpToHybridBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "form", "step_id": "test_step"}
+        )
+        flow._transition_builder = mock_builder
+
+        _run_async(
+            TransitionMixin.async_step_transition_select_local_type(
+                flow, {"test_input": "value"}
+            )
+        )
+
+        mock_builder.collect_input.assert_called_once_with(
+            HttpToHybridBuilder.STEP_SELECT_LOCAL_TYPE, {"test_input": "value"}
+        )
+
+    def test_modbus_delegates_to_builder(self):
+        """Test that modbus step delegates to builder's collect_input."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HttpToHybridBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "form", "step_id": "test_step"}
+        )
+        flow._transition_builder = mock_builder
+
+        modbus_input = {CONF_MODBUS_HOST: "192.168.1.100", CONF_MODBUS_PORT: 502}
+
+        _run_async(TransitionMixin.async_step_transition_modbus(flow, modbus_input))
+
+        mock_builder.collect_input.assert_called_once_with(
+            HttpToHybridBuilder.STEP_MODBUS, modbus_input
+        )
+
+    def test_dongle_delegates_to_builder(self):
+        """Test that dongle step delegates to builder's collect_input."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HttpToHybridBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "form", "step_id": "test_step"}
+        )
+        flow._transition_builder = mock_builder
+
+        dongle_input = {
+            CONF_DONGLE_HOST: "192.168.1.100",
+            CONF_DONGLE_SERIAL: "ABC123",
+        }
+
+        _run_async(TransitionMixin.async_step_transition_dongle(flow, dongle_input))
+
+        mock_builder.collect_input.assert_called_once_with(
+            HttpToHybridBuilder.STEP_DONGLE, dongle_input
+        )
+
+    def test_confirm_delegates_to_http_to_hybrid_builder(self):
+        """Test that confirm delegates to HttpToHybridBuilder."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HttpToHybridBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "abort", "reason": "success"}
+        )
+        flow._transition_builder = mock_builder
+
+        _run_async(TransitionMixin.async_step_transition_confirm(flow, {}))
+
+        mock_builder.collect_input.assert_called_once_with(
+            HttpToHybridBuilder.STEP_CONFIRM, {}
+        )
+
+    def test_confirm_delegates_to_hybrid_to_http_builder(self):
+        """Test that confirm delegates to HybridToHttpBuilder."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HybridToHttpBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "abort", "reason": "success"}
+        )
+        flow._transition_builder = mock_builder
+
+        _run_async(TransitionMixin.async_step_transition_confirm(flow, {}))
+
+        mock_builder.collect_input.assert_called_once_with(
+            HybridToHttpBuilder.STEP_CONFIRM_REMOVAL, {}
+        )
+
+    def test_confirm_removal_delegates_to_builder(self):
+        """Test that confirm_removal delegates to HybridToHttpBuilder."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_entry"}
+
+        mock_builder = MagicMock(spec=HybridToHttpBuilder)
+        mock_builder.collect_input = AsyncMock(
+            return_value={"type": "form", "step_id": "test_step"}
+        )
+        flow._transition_builder = mock_builder
+
+        _run_async(TransitionMixin.async_step_transition_confirm_removal(flow, {}))
+
+        mock_builder.collect_input.assert_called_once_with(
+            HybridToHttpBuilder.STEP_CONFIRM_REMOVAL, {}
+        )
+
+
+# =============================================================================
+# Test Builder State Management
+# =============================================================================
+
+
+class TestBuilderStateManagement:
+    """Tests for builder state management in TransitionMixin."""
+
+    def test_builder_is_none_initially(self):
+        """Test that _transition_builder is None initially."""
+        flow = EG4WebMonitorConfigFlow()
+        assert flow._transition_builder is None
+
+    def test_transition_builder_attribute_on_mixin(self):
+        """Test that TransitionMixin has _transition_builder attribute."""
+        assert hasattr(TransitionMixin, "_transition_builder")
+
+
+# =============================================================================
+# Test Builder Constants
+# =============================================================================
+
+
+class TestBuilderConstants:
+    """Tests for builder step constants."""
+
+    def test_http_to_hybrid_builder_has_step_constants(self):
+        """Test that HttpToHybridBuilder has step constants."""
+        assert hasattr(HttpToHybridBuilder, "STEP_SELECT_LOCAL_TYPE")
+        assert hasattr(HttpToHybridBuilder, "STEP_MODBUS")
+        assert hasattr(HttpToHybridBuilder, "STEP_DONGLE")
+        assert hasattr(HttpToHybridBuilder, "STEP_CONFIRM")
+
+        assert (
+            HttpToHybridBuilder.STEP_SELECT_LOCAL_TYPE == "transition_select_local_type"
+        )
+        assert HttpToHybridBuilder.STEP_MODBUS == "transition_modbus"
+        assert HttpToHybridBuilder.STEP_DONGLE == "transition_dongle"
+        assert HttpToHybridBuilder.STEP_CONFIRM == "transition_confirm"
+
+    def test_hybrid_to_http_builder_has_step_constants(self):
+        """Test that HybridToHttpBuilder has step constants."""
+        assert hasattr(HybridToHttpBuilder, "STEP_CONFIRM_REMOVAL")
+        assert HybridToHttpBuilder.STEP_CONFIRM_REMOVAL == "transition_confirm_removal"
+
+
+# =============================================================================
+# Test Transition Type Flow (integration-style with mocks)
+# =============================================================================
+
+
+class TestTransitionTypeSelection:
+    """Tests for transition type selection routing."""
+
+    def test_transition_routes_upgrade_to_http_to_hybrid(self):
+        """Test that 'upgrade_to_hybrid' routes to http_to_hybrid step."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_http_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+
+        flow.async_step_transition_http_to_hybrid = AsyncMock(
+            return_value={"type": "form", "step_id": "transition_select_local_type"}
+        )
+
+        _run_async(
+            TransitionMixin.async_step_transition_select(
+                flow, {"transition_type": "upgrade_to_hybrid"}
+            )
+        )
+
+        flow.async_step_transition_http_to_hybrid.assert_called_once()
+
+    def test_transition_routes_downgrade_to_hybrid_to_http(self):
+        """Test that 'downgrade_to_http' routes to hybrid_to_http step."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_hybrid_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HYBRID}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+
+        flow.async_step_transition_hybrid_to_http = AsyncMock(
+            return_value={"type": "form", "step_id": "transition_confirm_removal"}
+        )
+
+        _run_async(
+            TransitionMixin.async_step_transition_select(
+                flow, {"transition_type": "downgrade_to_http"}
+            )
+        )
+
+        flow.async_step_transition_hybrid_to_http.assert_called_once()
+
+    def test_transition_routes_no_change_to_http_reconfigure(self):
+        """Test that 'no_change' routes to reconfigure_http for HTTP entry."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_http_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+
+        flow.async_step_reconfigure_http = AsyncMock(
+            return_value={"type": "form", "step_id": "reconfigure_http"}
+        )
+
+        _run_async(
+            TransitionMixin.async_step_transition_select(
+                flow, {"transition_type": "no_change"}
+            )
+        )
+
+        flow.async_step_reconfigure_http.assert_called_once()
+
+    def test_transition_routes_no_change_to_hybrid_reconfigure(self):
+        """Test that 'no_change' routes to reconfigure_hybrid for Hybrid entry."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_hybrid_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HYBRID}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+
+        flow.async_step_reconfigure_hybrid = AsyncMock(
+            return_value={"type": "form", "step_id": "reconfigure_hybrid"}
+        )
+
+        _run_async(
+            TransitionMixin.async_step_transition_select(
+                flow, {"transition_type": "no_change"}
+            )
+        )
+
+        flow.async_step_reconfigure_hybrid.assert_called_once()
+
+    def test_transition_aborts_for_unsupported_type(self):
+        """Test that transition aborts for unsupported connection type."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_modbus_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_MODBUS}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "transition_not_supported"}
+        )
+
+        result = _run_async(TransitionMixin.async_step_transition_select(flow, None))
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "transition_not_supported"
+
+    def test_transition_shows_form_for_http_entry(self):
+        """Test that transition shows form with HTTP options."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_http_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+        flow.async_show_form = MagicMock(
+            return_value={"type": "form", "step_id": "transition_select"}
+        )
+
+        _run_async(TransitionMixin.async_step_transition_select(flow, None))
+
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "transition_select"
+        assert "Cloud API" in call_kwargs["description_placeholders"]["current_type"]
+
+    def test_transition_shows_form_for_hybrid_entry(self):
+        """Test that transition shows form with Hybrid options."""
+        flow = MagicMock(spec=EG4WebMonitorConfigFlow)
+        flow.context = {"entry_id": "test_hybrid_entry"}
+
+        mock_entry = MagicMock()
+        mock_entry.data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_HYBRID}
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_get_entry.return_value = mock_entry
+        flow.async_show_form = MagicMock(
+            return_value={"type": "form", "step_id": "transition_select"}
+        )
+
+        _run_async(TransitionMixin.async_step_transition_select(flow, None))
+
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "transition_select"
+        assert "Hybrid" in call_kwargs["description_placeholders"]["current_type"]


### PR DESCRIPTION
## Summary

- Create TransitionMixin class that integrates transition builders into the ConfigFlow
- Add transition flow step methods that delegate to HttpToHybridBuilder and HybridToHttpBuilder
- Enable users to switch between HTTP and Hybrid connection types during reconfiguration
- Add translation strings for all transition UI steps

## Key Changes

### TransitionMixin (`config_flow/transitions/mixin.py`)
- `async_step_transition_select`: Entry point for mode selection (shows HTTP or Hybrid options based on current type)
- `async_step_transition_http_to_hybrid`: Creates and delegates to HttpToHybridBuilder
- `async_step_transition_hybrid_to_http`: Creates and delegates to HybridToHttpBuilder
- Pass-through steps for local type selection, Modbus, Dongle, and confirmation

### ConfigFlow Integration
- Added TransitionMixin to EG4WebMonitorConfigFlow class hierarchy
- Updated MRO documentation

### Translation Strings
- Added step descriptions for: `transition_select`, `transition_select_local_type`, `transition_modbus`, `transition_dongle`, `transition_confirm`, `transition_confirm_removal`

## Test plan
- [x] All 369 tests pass
- [x] 36 new tests for TransitionMixin
- [x] Tests cover MRO validation, method availability, builder delegation, state management
- [x] Tests cover routing for both HTTP and Hybrid entries
- [x] Ruff linting clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)