### PR TITLE
refactor: Extract config keys to const/config_keys.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -38,11 +38,8 @@ from .brand import (
     MANUFACTURER,
 )
 
-# Re-export everything from legacy module for backward compatibility
-# As modules are extracted, imports will be updated to pull from submodules
-from .._const_legacy import (
-    # Classes
-    SensorConfig,
+# Configuration keys - extracted to config_keys.py
+from .config_keys import (
     # Configuration keys
     CONF_BASE_URL,
     CONF_CONNECTION_TYPE,
@@ -90,6 +87,13 @@ from .._const_legacy import (
     MIN_PARAMETER_REFRESH_INTERVAL,
     MIN_SENSOR_UPDATE_INTERVAL,
     MODBUS_UPDATE_INTERVAL,
+)
+
+# Re-export everything from legacy module for backward compatibility
+# As modules are extracted, imports will be updated to pull from submodules
+from .._const_legacy import (
+    # Classes
+    SensorConfig,
     # Modbus registers
     MODBUS_BIT_AC_CHARGE_EN,
     MODBUS_BIT_BAT_SHARED,

--- a/custom_components/eg4_web_monitor/const/config_keys.py
+++ b/custom_components/eg4_web_monitor/const/config_keys.py
@@ -1,0 +1,96 @@
+"""Configuration key constants for the EG4 Web Monitor integration.
+
+This module contains all configuration-related constants including:
+- Configuration keys (CONF_*)
+- Connection type constants
+- Default values for various settings
+- Options flow limits
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# Configuration Keys
+# =============================================================================
+
+# Basic configuration keys
+CONF_BASE_URL = "base_url"
+CONF_VERIFY_SSL = "verify_ssl"
+CONF_PLANT_ID = "plant_id"
+CONF_PLANT_NAME = "plant_name"
+CONF_DST_SYNC = "dst_sync"
+CONF_LIBRARY_DEBUG = "library_debug"
+
+# Options flow configuration keys (configurable via UI after setup)
+CONF_SENSOR_UPDATE_INTERVAL = "sensor_update_interval"
+CONF_PARAMETER_REFRESH_INTERVAL = "parameter_refresh_interval"
+
+# Connection type configuration
+CONF_CONNECTION_TYPE = "connection_type"
+
+# Hybrid mode local transport selection
+CONF_HYBRID_LOCAL_TYPE = "hybrid_local_type"
+
+# Multi-transport configuration for hybrid mode (list of transport configs)
+# Each item is a dict with: serial, transport_type (modbus_tcp/wifi_dongle),
+# and transport-specific fields
+CONF_LOCAL_TRANSPORTS = "local_transports"
+
+# Modbus configuration keys
+CONF_MODBUS_HOST = "modbus_host"
+CONF_MODBUS_PORT = "modbus_port"
+CONF_MODBUS_UNIT_ID = "modbus_unit_id"
+CONF_INVERTER_SERIAL = "inverter_serial"
+CONF_INVERTER_MODEL = "inverter_model"
+CONF_INVERTER_FAMILY = "inverter_family"  # pylxpweb 0.5.12+ for register map selection
+
+# WiFi Dongle configuration keys (pylxpweb 0.5.15+)
+CONF_DONGLE_HOST = "dongle_host"
+CONF_DONGLE_PORT = "dongle_port"
+CONF_DONGLE_SERIAL = "dongle_serial"
+
+# =============================================================================
+# Connection Types
+# =============================================================================
+
+CONNECTION_TYPE_HTTP = "http"
+CONNECTION_TYPE_MODBUS = "modbus"
+CONNECTION_TYPE_DONGLE = "dongle"  # WiFi dongle local TCP (no additional hardware)
+CONNECTION_TYPE_HYBRID = "hybrid"  # Local (Modbus/Dongle) + Cloud HTTP for best of both
+CONNECTION_TYPE_LOCAL = (
+    "local"  # Pure local (Modbus/Dongle only) - no cloud credentials
+)
+
+# Hybrid mode local transport options (priority: modbus > dongle > cloud-only)
+HYBRID_LOCAL_MODBUS = "modbus"  # RS485 via Waveshare or similar adapter
+HYBRID_LOCAL_DONGLE = "dongle"  # WiFi dongle on port 8000
+HYBRID_LOCAL_NONE = "none"  # Cloud-only fallback (no local transport)
+
+# =============================================================================
+# Default Values
+# =============================================================================
+
+# Options flow default values
+DEFAULT_SENSOR_UPDATE_INTERVAL_HTTP = 30  # seconds for HTTP mode
+DEFAULT_SENSOR_UPDATE_INTERVAL_LOCAL = 5  # seconds for Modbus/Dongle modes
+DEFAULT_PARAMETER_REFRESH_INTERVAL = 60  # minutes (1 hour)
+
+# Options flow limits
+MIN_SENSOR_UPDATE_INTERVAL = 5  # seconds
+MAX_SENSOR_UPDATE_INTERVAL = 300  # seconds (5 minutes)
+MIN_PARAMETER_REFRESH_INTERVAL = 5  # minutes
+MAX_PARAMETER_REFRESH_INTERVAL = 1440  # minutes (24 hours)
+
+# Modbus default values
+DEFAULT_MODBUS_PORT = 502
+DEFAULT_MODBUS_UNIT_ID = 1
+DEFAULT_MODBUS_TIMEOUT = 10.0  # seconds
+DEFAULT_INVERTER_FAMILY = "PV_SERIES"  # Default to EG4-18KPV register map
+
+# WiFi Dongle default values (pylxpweb 0.5.15+)
+DEFAULT_DONGLE_PORT = 8000
+DEFAULT_DONGLE_TIMEOUT = 10.0  # seconds
+
+# Update intervals for local connections (faster than HTTP due to local network)
+MODBUS_UPDATE_INTERVAL = 5  # seconds (vs 30 for HTTP)
+DONGLE_UPDATE_INTERVAL = 5  # seconds (same as Modbus - local network)


### PR DESCRIPTION
## Summary

Extracts configuration-related constants from `_const_legacy.py` to dedicated `const/config_keys.py` module.

**Extracted constants:**
- All `CONF_*` configuration keys
- Connection type constants (`CONNECTION_TYPE_*`, `HYBRID_LOCAL_*`)
- Default values (`DEFAULT_MODBUS_PORT`, `DEFAULT_DONGLE_PORT`, etc.)
- Options flow limits (`MIN/MAX` intervals)
- Update intervals (`MODBUS_UPDATE_INTERVAL`, `DONGLE_UPDATE_INTERVAL`)

## Test plan
- [x] All 377 tests pass
- [x] ruff check passes

Part of epic #eg4-38a (task eg4-1n5)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)