### PR TITLE
refactor: Extract device types to const/device_types.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -116,28 +116,29 @@ from .modbus import (
     MODBUS_REG_SYS_FUNC,
 )
 
-# Re-export everything from legacy module for backward compatibility
-# As modules are extracted, imports will be updated to pull from submodules
-from .._const_legacy import (
-    # Classes
-    SensorConfig,
-    # Device types
+# Device types and inverter families - extracted to device_types.py
+from .device_types import (
     DEVICE_TYPE_BATTERY,
     DEVICE_TYPE_GRIDBOSS,
     DEVICE_TYPE_INVERTER,
     DEVICE_TYPE_STATION,
-    # Inverter families
+    DISCHARGE_RECOVERY_SENSORS,
     INVERTER_FAMILY_DEFAULT_MODELS,
     INVERTER_FAMILY_LXP_EU,
     INVERTER_FAMILY_LXP_LV,
     INVERTER_FAMILY_PV_SERIES,
     INVERTER_FAMILY_SNA,
     INVERTER_FAMILY_UNKNOWN,
-    # Feature-based sensor sets
-    DISCHARGE_RECOVERY_SENSORS,
     SPLIT_PHASE_ONLY_SENSORS,
     THREE_PHASE_ONLY_SENSORS,
     VOLT_WATT_SENSORS,
+)
+
+# Re-export everything from legacy module for backward compatibility
+# As modules are extracted, imports will be updated to pull from submodules
+from .._const_legacy import (
+    # Classes
+    SensorConfig,
     # Number entity limits
     AC_CHARGE_POWER_MAX,
     AC_CHARGE_POWER_MIN,

--- a/custom_components/eg4_web_monitor/const/device_types.py
+++ b/custom_components/eg4_web_monitor/const/device_types.py
@@ -1,0 +1,88 @@
+"""Device type constants for the EG4 Web Monitor integration.
+
+This module contains all device type and inverter family constants including:
+- Device type identifiers
+- Inverter family constants
+- Feature-based sensor classification sets
+- Inverter family to default model mapping
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# Device Types
+# =============================================================================
+
+DEVICE_TYPE_INVERTER = "inverter"
+DEVICE_TYPE_GRIDBOSS = "gridboss"
+DEVICE_TYPE_BATTERY = "battery"
+DEVICE_TYPE_STATION = "station"
+
+# =============================================================================
+# Inverter Family Constants
+# =============================================================================
+# From pylxpweb InverterFamily enum - used for feature-based sensor filtering
+
+INVERTER_FAMILY_SNA = "SNA"  # Split-phase, North America (12000XP, 6000XP)
+INVERTER_FAMILY_PV_SERIES = "PV_SERIES"  # High-voltage DC (18KPV, etc.)
+INVERTER_FAMILY_LXP_EU = "LXP_EU"  # European market
+INVERTER_FAMILY_LXP_LV = "LXP_LV"  # Low-voltage DC
+INVERTER_FAMILY_UNKNOWN = "UNKNOWN"
+
+# Mapping from inverter family to default model for entity compatibility checks
+# Used when inverter_model is not provided in config entry (Modbus/Dongle modes)
+INVERTER_FAMILY_DEFAULT_MODELS: dict[str, str] = {
+    "PV_SERIES": "18kPV",  # Matches "18kpv" in SUPPORTED_INVERTER_MODELS
+    "SNA": "12000XP",  # Matches "xp" in SUPPORTED_INVERTER_MODELS
+    "LXP_EU": "LXP-EU",  # LuxPower EU models - matches "lxp" in SUPPORTED_INVERTER_MODELS
+}
+
+# =============================================================================
+# Feature-based Sensor Classification
+# =============================================================================
+# These sets define which sensors are only available on specific device families
+
+# Sensors only available on split-phase (SNA) inverters (12000XP, 6000XP)
+# These inverters use L1/L2 phase naming convention
+SPLIT_PHASE_ONLY_SENSORS: frozenset[str] = frozenset(
+    {
+        "eps_power_l1",
+        "eps_power_l2",
+    }
+)
+
+# Sensors only available on three-phase capable inverters (PV Series, LXP-EU)
+# These inverters use R/S/T phase naming convention
+THREE_PHASE_ONLY_SENSORS: frozenset[str] = frozenset(
+    {
+        "grid_voltage_r",
+        "grid_voltage_s",
+        "grid_voltage_t",
+        "eps_voltage_r",
+        "eps_voltage_s",
+        "eps_voltage_t",
+    }
+)
+
+# Sensors related to discharge recovery hysteresis (SNA series only)
+# These parameters prevent oscillation when SOC is near the cutoff threshold
+DISCHARGE_RECOVERY_SENSORS: frozenset[str] = frozenset(
+    {
+        "discharge_recovery_lag_soc",
+        "discharge_recovery_lag_volt",
+    }
+)
+
+# Sensors related to Volt-Watt curve (PV Series, LXP-EU only)
+VOLT_WATT_SENSORS: frozenset[str] = frozenset(
+    {
+        "volt_watt_v1",
+        "volt_watt_v2",
+        "volt_watt_v3",
+        "volt_watt_v4",
+        "volt_watt_p1",
+        "volt_watt_p2",
+        "volt_watt_p3",
+        "volt_watt_p4",
+    }
+)


### PR DESCRIPTION
## Summary

Extracts device type and inverter family constants from `_const_legacy.py` to dedicated `const/device_types.py` module.

**Extracted constants:**
- Device type identifiers (`DEVICE_TYPE_*`)
- Inverter family constants (`INVERTER_FAMILY_*`)
- `INVERTER_FAMILY_DEFAULT_MODELS` mapping
- Feature-based sensor sets (`SPLIT_PHASE_ONLY_SENSORS`, `THREE_PHASE_ONLY_SENSORS`, etc.)

## Test plan
- [x] All 377 tests pass
- [x] ruff check passes

Part of epic #eg4-38a (task eg4-joi)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)