### PR TITLE
refactor: Extract number entity limits to const/limits.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -134,12 +134,8 @@ from .device_types import (
     VOLT_WATT_SENSORS,
 )
 
-# Re-export everything from legacy module for backward compatibility
-# As modules are extracted, imports will be updated to pull from submodules
-from .._const_legacy import (
-    # Classes
-    SensorConfig,
-    # Number entity limits
+# Number entity limits - extracted to limits.py
+from .limits import (
     AC_CHARGE_POWER_MAX,
     AC_CHARGE_POWER_MIN,
     AC_CHARGE_POWER_STEP,
@@ -158,6 +154,13 @@ from .._const_legacy import (
     SYSTEM_CHARGE_SOC_LIMIT_MAX,
     SYSTEM_CHARGE_SOC_LIMIT_MIN,
     SYSTEM_CHARGE_SOC_LIMIT_STEP,
+)
+
+# Re-export everything from legacy module for backward compatibility
+# As modules are extracted, imports will be updated to pull from submodules
+from .._const_legacy import (
+    # Classes
+    SensorConfig,
     # Sensor types
     SENSOR_TYPES,
     STATION_SENSOR_TYPES,

--- a/custom_components/eg4_web_monitor/const/limits.py
+++ b/custom_components/eg4_web_monitor/const/limits.py
@@ -1,0 +1,55 @@
+"""Number entity limit constants for the EG4 Web Monitor integration.
+
+This module contains min/max/step values for number entities that control
+inverter parameters like charge power, current limits, and SOC thresholds.
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# AC Charge Power (kW)
+# =============================================================================
+
+AC_CHARGE_POWER_MIN = 0.0
+AC_CHARGE_POWER_MAX = 15.0
+AC_CHARGE_POWER_STEP = 0.1
+
+# =============================================================================
+# PV Charge Power (kW)
+# =============================================================================
+
+PV_CHARGE_POWER_MIN = 0
+PV_CHARGE_POWER_MAX = 15
+PV_CHARGE_POWER_STEP = 1
+
+# =============================================================================
+# Grid Peak Shaving Power (kW)
+# =============================================================================
+
+GRID_PEAK_SHAVING_POWER_MIN = 0.0
+GRID_PEAK_SHAVING_POWER_MAX = 25.5
+GRID_PEAK_SHAVING_POWER_STEP = 0.1
+
+# =============================================================================
+# Battery Charge/Discharge Current (A)
+# =============================================================================
+
+BATTERY_CURRENT_MIN = 0
+BATTERY_CURRENT_MAX = 250
+BATTERY_CURRENT_STEP = 1
+
+# =============================================================================
+# SOC Limits (%)
+# =============================================================================
+
+SOC_LIMIT_MIN = 0
+SOC_LIMIT_MAX = 100
+SOC_LIMIT_STEP = 1
+
+# =============================================================================
+# System Charge SOC Limit (%)
+# =============================================================================
+
+SYSTEM_CHARGE_SOC_LIMIT_MIN = 10
+SYSTEM_CHARGE_SOC_LIMIT_MAX = 101
+SYSTEM_CHARGE_SOC_LIMIT_STEP = 1


### PR DESCRIPTION
## Summary

Extracts number entity limit constants from `_const_legacy.py` to dedicated `const/limits.py` module.

**Extracted constants:**
- AC Charge Power limits (min, max, step)
- PV Charge Power limits
- Grid Peak Shaving Power limits
- Battery Charge/Discharge Current limits
- SOC Limits and System Charge SOC limits

## Test plan
- [x] All 377 tests pass
- [x] ruff check passes

Part of epic #eg4-38a (task eg4-dxv)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)