### PR TITLE
refactor: Extract working modes to const/working_modes.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -156,6 +156,13 @@ from .limits import (
     SYSTEM_CHARGE_SOC_LIMIT_STEP,
 )
 
+# Working modes - extracted to working_modes.py
+from .working_modes import (
+    FUNCTION_PARAM_MAPPING,
+    SOC_LIMIT_PARAMS,
+    WORKING_MODES,
+)
+
 # Re-export everything from legacy module for backward compatibility
 # As modules are extracted, imports will be updated to pull from submodules
 from .._const_legacy import (
@@ -175,10 +182,6 @@ from .._const_legacy import (
     DIVIDE_BY_100_SENSORS,
     GRIDBOSS_ENERGY_SENSORS,
     VOLTAGE_SENSORS,
-    # Working modes
-    FUNCTION_PARAM_MAPPING,
-    SOC_LIMIT_PARAMS,
-    WORKING_MODES,
     # Battery constants
     BATTERY_KEY_PREFIX,
     BATTERY_KEY_SEPARATOR,

--- a/custom_components/eg4_web_monitor/const/working_modes.py
+++ b/custom_components/eg4_web_monitor/const/working_modes.py
@@ -1,0 +1,115 @@
+"""Working mode configuration constants for the EG4 Web Monitor integration.
+
+This module contains configurations for inverter working modes and SOC limit
+parameters used by switch and number entities.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import EntityCategory
+
+# =============================================================================
+# Working Mode Configurations
+# =============================================================================
+# These define switch entities for various inverter operational modes
+
+WORKING_MODES = {
+    "ac_charge_mode": {
+        "name": "AC Charge Mode",
+        "param": "FUNC_AC_CHARGE",
+        "description": "Allow battery charging from AC grid power",
+        "icon": "mdi:battery-charging-medium",
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "pv_charge_priority_mode": {
+        "name": "PV Charge Priority Mode",
+        "param": "FUNC_FORCED_CHG_EN",
+        "description": "Prioritize PV charging during specified hours",
+        "icon": "mdi:solar-power",
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "forced_discharge_mode": {
+        "name": "Forced Discharge Mode",
+        "param": "FUNC_FORCED_DISCHG_EN",
+        "description": "Force battery discharge for grid export",
+        "icon": "mdi:battery-arrow-down",
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "peak_shaving_mode": {
+        "name": "Grid Peak Shaving Mode",
+        "param": "FUNC_GRID_PEAK_SHAVING",
+        "description": "Grid peak shaving to reduce demand charges",
+        "icon": "mdi:chart-bell-curve-cumulative",
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "battery_backup_mode": {
+        "name": "Battery Backup Mode",
+        "param": "FUNC_BATTERY_BACKUP_CTRL",
+        "description": "Emergency Power Supply (EPS) backup functionality",
+        "icon": "mdi:home-battery",
+        "entity_category": EntityCategory.CONFIG,
+    },
+}
+
+# =============================================================================
+# SOC Limit Parameters
+# =============================================================================
+# These parameters control battery state of charge thresholds
+# Note: No entity_category set - these appear in Controls section
+
+SOC_LIMIT_PARAMS = {
+    "system_charge_soc_limit": {
+        "name": "System Charge SOC Limit",
+        "param": "HOLD_SYSTEM_CHARGE_SOC_LIMIT",
+        "description": "Maximum battery SOC during normal charging (10-100%, or 101% for top balancing)",
+        "icon": "mdi:battery-charging",
+        "min": 10,
+        "max": 101,
+        "step": 1,
+        "unit": "%",
+    },
+    "ac_charge_soc_limit": {
+        "name": "AC Charge SOC Limit",
+        "param": "HOLD_AC_CHARGE_SOC_LIMIT",
+        "description": "Stop AC charging when battery reaches this SOC percentage",
+        "icon": "mdi:battery-charging-medium",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "unit": "%",
+    },
+    "on_grid_soc_cutoff": {
+        "name": "On-Grid SOC Cut-Off",
+        "param": "HOLD_DISCHG_CUT_OFF_SOC_EOD",
+        "description": "Minimum battery SOC when connected to grid (on-grid discharge cutoff)",
+        "icon": "mdi:battery-alert",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "unit": "%",
+    },
+    "off_grid_soc_cutoff": {
+        "name": "Off-Grid SOC Cut-Off",
+        "param": "HOLD_SOC_LOW_LIMIT_EPS_DISCHG",
+        "description": "Minimum battery SOC when off-grid (EPS mode discharge cutoff)",
+        "icon": "mdi:battery-outline",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "unit": "%",
+    },
+}
+
+# =============================================================================
+# Function Parameter Mapping
+# =============================================================================
+# Maps function control parameters to their corresponding status parameters
+
+FUNCTION_PARAM_MAPPING = {
+    "FUNC_BATTERY_BACKUP_CTRL": "FUNC_BATTERY_BACKUP_CTRL",
+    "FUNC_GRID_PEAK_SHAVING": "FUNC_GRID_PEAK_SHAVING",
+    "FUNC_AC_CHARGE": "FUNC_AC_CHARGE",
+    "FUNC_FORCED_CHG_EN": "FUNC_FORCED_CHG_EN",
+    "FUNC_FORCED_DISCHG_EN": "FUNC_FORCED_DISCHG_EN",
+    "FUNC_SET_TO_STANDBY": "FUNC_SET_TO_STANDBY",
+}


### PR DESCRIPTION
## Summary

Extracts working mode configuration constants from `_const_legacy.py` to dedicated `const/working_modes.py` module.

**Extracted constants:**
- `WORKING_MODES` dictionary for switch entity configurations
- `SOC_LIMIT_PARAMS` for number entity configurations  
- `FUNCTION_PARAM_MAPPING` for parameter lookups

## Test plan
- [x] All 377 tests pass
- [x] ruff check passes

Part of epic #eg4-38a (task eg4-mfb)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)