### PR TITLE
refactor: Extract diagnostics constants to const/diagnostics.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -163,6 +163,26 @@ from .working_modes import (
     WORKING_MODES,
 )
 
+# Diagnostics - extracted to diagnostics.py
+from .diagnostics import (
+    # Battery constants
+    BATTERY_KEY_PREFIX,
+    BATTERY_KEY_SEPARATOR,
+    BATTERY_KEY_SHORT_PREFIX,
+    # Diagnostic keys
+    DIAGNOSTIC_BATTERY_SENSOR_KEYS,
+    DIAGNOSTIC_DEVICE_SENSOR_KEYS,
+    # Supported models
+    SUPPORTED_INVERTER_MODELS,
+    # Scaling factors
+    BATTERY_CURRENT_SCALE_DECIAMPS,
+    BATTERY_TEMPERATURE_SCALE_DECIDEGREES,
+    BATTERY_VOLTAGE_SCALE_CENTIVOLTS,
+    BATTERY_VOLTAGE_SCALE_MILLIVOLTS,
+    # Task cleanup
+    BACKGROUND_TASK_CLEANUP_TIMEOUT,
+)
+
 # Re-export everything from legacy module for backward compatibility
 # As modules are extracted, imports will be updated to pull from submodules
 from .._const_legacy import (
@@ -182,22 +202,6 @@ from .._const_legacy import (
     DIVIDE_BY_100_SENSORS,
     GRIDBOSS_ENERGY_SENSORS,
     VOLTAGE_SENSORS,
-    # Battery constants
-    BATTERY_KEY_PREFIX,
-    BATTERY_KEY_SEPARATOR,
-    BATTERY_KEY_SHORT_PREFIX,
-    # Diagnostic keys
-    DIAGNOSTIC_BATTERY_SENSOR_KEYS,
-    DIAGNOSTIC_DEVICE_SENSOR_KEYS,
-    # Supported models
-    SUPPORTED_INVERTER_MODELS,
-    # Scaling factors
-    BATTERY_CURRENT_SCALE_DECIAMPS,
-    BATTERY_TEMPERATURE_SCALE_DECIDEGREES,
-    BATTERY_VOLTAGE_SCALE_CENTIVOLTS,
-    BATTERY_VOLTAGE_SCALE_MILLIVOLTS,
-    # Task cleanup
-    BACKGROUND_TASK_CLEANUP_TIMEOUT,
 )
 
 __all__ = [

--- a/custom_components/eg4_web_monitor/const/diagnostics.py
+++ b/custom_components/eg4_web_monitor/const/diagnostics.py
@@ -1,0 +1,90 @@
+"""Diagnostic and utility constants for the EG4 Web Monitor integration.
+
+This module contains diagnostic sensor keys, battery data parsing constants,
+scaling factors, supported model identifiers, and task management constants.
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# Battery Data Parsing Constants
+# =============================================================================
+# These constants define the separators and formats used in battery identification
+
+BATTERY_KEY_SEPARATOR = "_Battery_ID_"
+BATTERY_KEY_PREFIX = "Battery_ID_"
+BATTERY_KEY_SHORT_PREFIX = "BAT"
+
+# =============================================================================
+# Diagnostic Sensor Keys
+# =============================================================================
+# Centralized for consistency across platforms - these sensor keys are assigned
+# EntityCategory.DIAGNOSTIC
+
+DIAGNOSTIC_DEVICE_SENSOR_KEYS = frozenset(
+    {
+        "temperature",
+        "cycle_count",
+        "state_of_health",
+        "status_code",
+        "status_text",
+        "internal_temperature",
+        "radiator1_temperature",
+        "radiator2_temperature",
+        "firmware_version",
+        "has_data",
+    }
+)
+
+# Diagnostic battery sensor keys - additional sensors specific to batteries
+DIAGNOSTIC_BATTERY_SENSOR_KEYS = frozenset(
+    {
+        "temperature",
+        "cycle_count",
+        "state_of_health",
+        "battery_firmware_version",
+        "battery_max_cell_temp_num",
+        "battery_min_cell_temp_num",
+        "battery_max_cell_voltage_num",
+        "battery_min_cell_voltage_num",
+        "battery_serial_number",
+        "battery_type",
+        "battery_type_text",
+        "battery_bms_model",
+        "battery_index",
+        "battery_discharge_capacity",
+    }
+)
+
+# =============================================================================
+# Supported Inverter Models
+# =============================================================================
+# Model identifiers for number/switch entities that require model-specific logic
+
+SUPPORTED_INVERTER_MODELS = frozenset(
+    {
+        "flexboss",
+        "18kpv",
+        "18k",
+        "12kpv",
+        "12k",
+        "xp",
+        "lxp",
+    }
+)
+
+# =============================================================================
+# Battery Data Scaling Factors
+# =============================================================================
+# Raw API values are scaled by these factors and need division for proper units
+
+BATTERY_VOLTAGE_SCALE_MILLIVOLTS = 1000  # Battery cell voltage in mV (÷1000 for V)
+BATTERY_VOLTAGE_SCALE_CENTIVOLTS = 100  # Total battery voltage in cV (÷100 for V)
+BATTERY_CURRENT_SCALE_DECIAMPS = 10  # Battery current in dA (÷10 for A)
+BATTERY_TEMPERATURE_SCALE_DECIDEGREES = 10  # Battery temperature in dC (÷10 for °C)
+
+# =============================================================================
+# Task Management Constants
+# =============================================================================
+
+BACKGROUND_TASK_CLEANUP_TIMEOUT = 5  # Seconds to wait for background task cancellation


### PR DESCRIPTION
## Summary
- Extract battery parsing constants, diagnostic sensor keys, supported models, scaling factors, and task cleanup constants to `const/diagnostics.py`
- Update `const/__init__.py` to import from new module

## Test plan
- [x] All 377 tests pass
- [x] Backward compatibility maintained via re-exports

Part of const.py modularization epic (eg4-38a).
Closes: eg4-j44

🤖 Generated with [Claude Code](https://claude.com/claude-code)