### PR TITLE
refactor: Create const/sensors/ subpackage structure

### DIFF
--- a/custom_components/eg4_web_monitor/const/sensors/__init__.py
+++ b/custom_components/eg4_web_monitor/const/sensors/__init__.py
@@ -1,17 +1,19 @@
-"""Sensor type definitions for the EG4 Web Monitor integration.
+"""Sensor definitions for the EG4 Web Monitor integration.
 
-This subpackage contains all sensor-related constants:
-- types: SensorConfig TypedDict
+This subpackage contains sensor type definitions and configurations for
+all entity types in the integration.
+
+Submodules (to be populated during refactoring):
+- types: SensorConfig TypedDict definition
 - inverter: Main SENSOR_TYPES dictionary
 - mappings: Field mappings and sensor lists
 - gridboss: GridBOSS sensor definitions
 - station: Station/plant sensor definitions
-
-During refactoring, sensor constants are re-exported from the parent
-const package for backward compatibility.
 """
 
 from __future__ import annotations
 
-# Placeholder - will be populated as sensor modules are extracted
-# For now, sensor constants are imported via const/__init__.py from _const_legacy.py
+# Submodules will be imported here as they are created
+# For now, the parent const/__init__.py re-exports from _const_legacy.py
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- Create const/sensors/ subpackage for organizing sensor type definitions
- Prepares for extracting SENSOR_TYPES (~1,575 lines) and related definitions

## Test plan
- [x] All 377 tests pass
- [x] Package structure created

Part of const.py modularization epic (eg4-38a).
Closes: eg4-cwx

🤖 Generated with [Claude Code](https://claude.com/claude-code)