### PR TITLE
refactor: Extract SensorConfig TypedDict to const/sensors/types.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -183,11 +183,12 @@ from .diagnostics import (
     BACKGROUND_TASK_CLEANUP_TIMEOUT,
 )
 
+# Sensor types - extracted to sensors/ subpackage
+from .sensors import SensorConfig
+
 # Re-export everything from legacy module for backward compatibility
 # As modules are extracted, imports will be updated to pull from submodules
 from .._const_legacy import (
-    # Classes
-    SensorConfig,
     # Sensor types
     SENSOR_TYPES,
     STATION_SENSOR_TYPES,

--- a/custom_components/eg4_web_monitor/const/sensors/__init__.py
+++ b/custom_components/eg4_web_monitor/const/sensors/__init__.py
@@ -13,7 +13,9 @@ Submodules (to be populated during refactoring):
 
 from __future__ import annotations
 
-# Submodules will be imported here as they are created
-# For now, the parent const/__init__.py re-exports from _const_legacy.py
+# Type definitions - extracted to types.py
+from .types import SensorConfig
 
-__all__: list[str] = []
+__all__ = [
+    "SensorConfig",
+]

--- a/custom_components/eg4_web_monitor/const/sensors/types.py
+++ b/custom_components/eg4_web_monitor/const/sensors/types.py
@@ -1,0 +1,35 @@
+"""Sensor type definitions for the EG4 Web Monitor integration.
+
+This module contains TypedDict definitions for sensor configurations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from homeassistant.const import EntityCategory
+
+
+class SensorConfig(TypedDict, total=False):
+    """TypedDict for sensor configuration.
+
+    Attributes:
+        name: Display name for the sensor
+        unit: Unit of measurement (e.g., UnitOfPower.WATT)
+        device_class: Home Assistant device class (power, energy, voltage, etc.)
+        state_class: Home Assistant state class (measurement, total, total_increasing)
+        icon: MDI icon string (e.g., "mdi:solar-power")
+        entity_category: Entity category (diagnostic, config, etc.)
+        suggested_display_precision: Number of decimal places to display
+    """
+
+    name: str
+    unit: str | None
+    device_class: str | None
+    state_class: str | None
+    icon: str
+    entity_category: EntityCategory | None
+    suggested_display_precision: int


### PR DESCRIPTION
## Summary
- Extract SensorConfig TypedDict to `const/sensors/types.py`
- Update sensors/__init__.py to export SensorConfig
- Update const/__init__.py to import from sensors subpackage

## Test plan
- [x] All 377 tests pass
- [x] Backward compatibility maintained via re-exports

Part of const.py modularization epic (eg4-38a).
Closes: eg4-c6c

🤖 Generated with [Claude Code](https://claude.com/claude-code)