### PR TITLE
refactor: Extract station sensors to const/sensors/station.py

### DIFF
--- a/custom_components/eg4_web_monitor/const/__init__.py
+++ b/custom_components/eg4_web_monitor/const/__init__.py
@@ -195,14 +195,8 @@ from .sensors import (
     PARALLEL_GROUP_FIELD_MAPPING,
     SENSOR_TYPES,
     SensorConfig,
-    VOLTAGE_SENSORS,
-)
-
-# Re-export everything from legacy module for backward compatibility
-# As modules are extracted, imports will be updated to pull from submodules
-from .._const_legacy import (
-    # Sensor types
     STATION_SENSOR_TYPES,
+    VOLTAGE_SENSORS,
 )
 
 __all__ = [

--- a/custom_components/eg4_web_monitor/const/sensors/__init__.py
+++ b/custom_components/eg4_web_monitor/const/sensors/__init__.py
@@ -32,9 +32,13 @@ from .mappings import (
     VOLTAGE_SENSORS,
 )
 
+# Station sensor definitions - extracted to station.py
+from .station import STATION_SENSOR_TYPES
+
 __all__ = [
     "SensorConfig",
     "SENSOR_TYPES",
+    "STATION_SENSOR_TYPES",
     # Field mappings
     "GRIDBOSS_FIELD_MAPPING",
     "INVERTER_ENERGY_FIELD_MAPPING",

--- a/custom_components/eg4_web_monitor/const/sensors/station.py
+++ b/custom_components/eg4_web_monitor/const/sensors/station.py
@@ -1,0 +1,37 @@
+"""Station sensor type definitions for the EG4 Web Monitor integration.
+
+This module contains sensor configurations for station/plant-level entities.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import EntityCategory
+
+# Station sensor types - read-only display sensors
+STATION_SENSOR_TYPES = {
+    "station_name": {
+        "name": "Station Name",
+        "icon": "mdi:home-lightning-bolt-outline",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "station_country": {
+        "name": "Country",
+        "icon": "mdi:map-marker",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "station_timezone": {
+        "name": "Timezone",
+        "icon": "mdi:clock-outline",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "station_create_date": {
+        "name": "Created",
+        "icon": "mdi:calendar",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "station_address": {
+        "name": "Address",
+        "icon": "mdi:map-marker-outline",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+}


### PR DESCRIPTION
## Summary
- Extract STATION_SENSOR_TYPES to `const/sensors/station.py`
- Remove last legacy import - const/__init__.py now fully modular!

## Test plan
- [x] All 377 tests pass
- [x] Backward compatibility maintained via re-exports

Part of const.py modularization epic (eg4-38a).
Closes: eg4-97s

🤖 Generated with [Claude Code](https://claude.com/claude-code)