### PR TITLE
fix: lower WiFi dongle minimum polling interval to 5s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - 2026-03-08
+## [3.2.0] - 2026-03-09
 
 The biggest release in the integration's history: 279 commits, 43 beta/RC releases, and contributions from the community. Local polling is no longer experimental — it's production-ready across all four connection modes with full entity parity validated in Docker.
+
+### Changed
+
+- **WiFi dongle minimum polling interval** ([#185](https://github.com/joyfulhouse/eg4_web_monitor/issues/185)): Lowered from 15s to 5s, allowing users who need faster reaction times to opt in via the options flow. Default remains 30s.
 
 ### Breaking Changes
 

--- a/custom_components/eg4_web_monitor/const/config_keys.py
+++ b/custom_components/eg4_web_monitor/const/config_keys.py
@@ -113,7 +113,7 @@ DEFAULT_DONGLE_UPDATE_INTERVAL = 30  # seconds (WiFi dongle reads take ~8-10s)
 # Per-transport polling limits
 MIN_MODBUS_UPDATE_INTERVAL = 3  # seconds
 MAX_MODBUS_UPDATE_INTERVAL = 300  # seconds (5 minutes)
-MIN_DONGLE_UPDATE_INTERVAL = 15  # seconds (reads take ~7-10s, need recovery gap)
+MIN_DONGLE_UPDATE_INTERVAL = 5  # seconds (user-configurable; reads take ~7-10s)
 MAX_DONGLE_UPDATE_INTERVAL = 300  # seconds (5 minutes)
 
 # HTTP/Cloud polling interval limits (rate limit protection)


### PR DESCRIPTION
## Summary

- Lowers `MIN_DONGLE_UPDATE_INTERVAL` from 15s to 5s, allowing users who need faster reaction times to opt in via the options flow
- Default interval remains 30s — no change for existing users

Closes #185

## Test plan

- [x] All 793 tests pass (4 pre-existing serial discovery failures unrelated)
- [x] Ruff lint + format clean
- [x] mypy strict passes
- [ ] Verify options flow shows updated 5-300s range

🤖 Generated with [Claude Code](https://claude.com/claude-code)