### PR TITLE
fix: lower HACS minimum HA version to 2026.1.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": false,
   "zip_release": true,
   "filename": "eg4_web_monitor.zip",
-  "homeassistant": "2026.2.0"
+  "homeassistant": "2026.1.0"
 }


### PR DESCRIPTION
## Summary

- Lowers `homeassistant` in `hacs.json` from `2026.2.0` to `2026.1.0`
- The binding constraint is `aiohttp>=3.13.2` (from pylxpweb), which is satisfied by HA 2025.12.0+
- Setting to `2026.1.0` as a safe minimum

Closes #187

## Test plan

- [ ] User on HA 2026.1.x can install v3.2.0 via HACS without version error

🤖 Generated with [Claude Code](https://claude.com/claude-code)