### PR TITLE
fix: off-grid mode state change fails due to smart port enum conversion (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Off-grid mode state change fails on fresh LOCAL-only install** ([#194](https://github.com/joyfulhouse/eg4_web_monitor/issues/194)): Smart port status sensors received raw integer `0` instead of enum string `"unused"` when all ports were unused and no cache existed, causing HA to reject entity state writes and block switch toggles.
+- **Firmware cache sentinel inconsistency**: `_resolve_local_firmware()` now caches a sentinel when `read_firmware_version()` returns empty string (avoids unnecessary Modbus reads every poll cycle) and treats `"Unknown"` entries from the LOCAL path as sentinels in HYBRID mode.
+
 ## [3.2.0] - 2026-03-09
 
 The biggest release in the integration's history: 279 commits, 43 beta/RC releases, and contributions from the community. Local polling is no longer experimental — it's production-ready across all four connection modes with full entity parity validated in Docker.

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -400,11 +400,20 @@ class DeviceProcessingMixin(_MixinBase):
         """Return firmware version, preferring local register over cloud API.
 
         The cloud API can report incorrect firmware values.  When a local
-        transport is attached, read holding registers 7-10 and cache the
-        result.  If the transport lacks ``read_firmware_version`` entirely,
-        a sentinel is cached so we never re-check.  If the read raises an
-        exception (e.g. Waveshare bus stall on first refresh), no sentinel
-        is cached so the read is retried on the next poll cycle.
+        transport is attached, delegate to ``transport.read_firmware_version``
+        (which reads holding registers 7-10) and cache the result.
+
+        Sentinel values (``""`` or ``"Unknown"``) in the cache mean "local
+        firmware is unavailable" and trigger a cloud fallback.  The LOCAL
+        path in ``coordinator_local.py`` may pre-populate the cache with
+        ``"Unknown"``; this method treats that identically to its own ``""``
+        sentinel.
+
+        Caching strategy:
+        - Real firmware string → cached, returned on subsequent calls.
+        - No ``read_firmware_version`` method → ``""`` sentinel cached.
+        - Method returns empty/falsy → ``""`` sentinel cached (permanent).
+        - Exception (e.g. Waveshare bus stall) → **not** cached (retry).
 
         Args:
             device: BaseInverter or MIDDevice with optional ``_transport``.
@@ -420,7 +429,10 @@ class DeviceProcessingMixin(_MixinBase):
         serial: str = device.serial_number
         cached = self._firmware_cache.get(serial)
         if cached is not None:
-            return cached if cached else cloud_version
+            # Real firmware → return it.  Sentinel ("" or "Unknown") → cloud.
+            if cached and cached != "Unknown":
+                return cached
+            return cloud_version
 
         # First encounter — read from local transport and cache.
         read_fw = getattr(transport, "read_firmware_version", None)
@@ -434,6 +446,9 @@ class DeviceProcessingMixin(_MixinBase):
             if local_fw:
                 self._firmware_cache[serial] = local_fw
                 return local_fw
+            # Transport responded but returned empty — permanent condition.
+            # Cache sentinel so we don't re-read every poll cycle.
+            self._firmware_cache[serial] = ""
         except Exception as exc:
             # Transient failure (e.g. Waveshare bus stall on first refresh).
             # Do NOT cache sentinel — allow retry on the next poll cycle

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -1565,11 +1565,18 @@ class DeviceProcessingMixin(_MixinBase):
             }
         else:
             # No cache yet and current read is suspect -- skip filtering
-            # to avoid removing sensors that may be in use.
+            # to avoid removing sensors that may be in use.  Still convert
+            # any valid raw integers to enum strings so HA doesn't reject
+            # them (e.g. 0 → "unused").  See issue #194.
             _LOGGER.debug(
                 "Smart Port statuses all zero/invalid with no cache — "
                 "skipping sensor filtering on initial poll"
             )
+            for port, status in smart_port_statuses.items():
+                if status is not None and status in _SMART_PORT_STATUS_LABELS:
+                    sensors[f"smart_port{port}_status"] = _SMART_PORT_STATUS_LABELS[
+                        status
+                    ]
             return
 
         # Convert raw status integers to enum string labels

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3943,6 +3943,38 @@ class TestSmartPortFiltering:
         assert sensors["smart_load1_power_l1"] == 50.0
         assert sensors["ac_couple1_power_l1"] == 100.0
 
+    def test_all_zeros_no_cache_converts_to_enum_strings(self):
+        """Issue #194: raw integer 0 must be converted to 'unused' even on early return.
+
+        When all smart port statuses are zero and there is no cache,
+        the function skips sensor filtering but must still convert the raw
+        integer status values to enum string labels.  Otherwise HA rejects
+        the value because 0 is not in the sensor's options list.
+        """
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+            _last_good_smart_port_statuses,
+        )
+
+        serial = "TEST_MID_ISSUE194"
+        _last_good_smart_port_statuses.pop(serial, None)
+
+        mid = self._make_mid_device({1: 0, 2: 0, 3: 0, 4: 0}, serial=serial)
+        sensors: dict = {
+            "smart_port1_status": 0,
+            "smart_port2_status": 0,
+            "smart_port3_status": 0,
+            "smart_port4_status": 0,
+        }
+
+        DeviceProcessingMixin._filter_unused_smart_port_sensors(sensors, mid)
+
+        # All raw integers converted to enum string labels
+        assert sensors["smart_port1_status"] == "unused"
+        assert sensors["smart_port2_status"] == "unused"
+        assert sensors["smart_port3_status"] == "unused"
+        assert sensors["smart_port4_status"] == "unused"
+
     def test_all_zeros_with_cache_uses_cached_statuses(self):
         """When all statuses are 0 but cache exists, cached statuses are used."""
         from custom_components.eg4_web_monitor.coordinator_mixins import (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5685,8 +5685,10 @@ class TestResolveLocalFirmware:
         assert result2 == "FAAB-2525"
         assert coordinator._firmware_cache["INV001"] == "FAAB-2525"
 
-    async def test_empty_read_returns_cloud_version(self, hass, mock_config_entry):
-        """Empty string from transport read falls back to cloud version."""
+    async def test_empty_read_caches_sentinel_and_returns_cloud(
+        self, hass, mock_config_entry
+    ):
+        """Empty string from transport read caches sentinel and falls back to cloud."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
@@ -5694,6 +5696,28 @@ class TestResolveLocalFirmware:
         device.serial_number = "INV001"
         device._transport = MagicMock()
         device._transport.read_firmware_version = AsyncMock(return_value="")
+
+        result = await coordinator._resolve_local_firmware(device, "CLOUD-1.0")
+        assert result == "CLOUD-1.0"
+        # Sentinel cached — no re-read on subsequent polls
+        assert coordinator._firmware_cache["INV001"] == ""
+
+    async def test_unknown_cache_hit_returns_cloud_version(
+        self, hass, mock_config_entry
+    ):
+        """'Unknown' cached by coordinator_local.py is treated as sentinel.
+
+        In HYBRID mode, coordinator_local.py may pre-populate _firmware_cache
+        with 'Unknown' when the transport can't read firmware.  This method
+        should fall back to cloud_version rather than returning 'Unknown'.
+        """
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator._firmware_cache["INV001"] = "Unknown"
+
+        device = MagicMock()
+        device.serial_number = "INV001"
+        device._transport = MagicMock()
 
         result = await coordinator._resolve_local_firmware(device, "CLOUD-1.0")
         assert result == "CLOUD-1.0"


### PR DESCRIPTION
## Summary

- **Bug**: Toggling the Off Grid Mode switch on a FlexBOSS 21 (local WiFi Dongle) fails with error: `Sensor sensor.grid_boss_*_smart_port_1_status provides state value '0', which is not in the list of options provided`
- **Root cause**: `_filter_unused_smart_port_sensors()` in `coordinator_mixins.py` has an early-return path when all smart port statuses are zero and no cache exists. This path skipped converting raw integer status values (0) to enum string labels ("unused"), causing HA to reject the sensor state during entity validation.
- **Fix**: Added integer-to-string conversion before the early return, so raw `0` → `"unused"`, `1` → `"smart_load"`, `2` → `"ac_couple"` regardless of the code path taken.

Closes #194

## Test plan

- [x] New regression test `test_all_zeros_no_cache_converts_to_enum_strings` verifies all four port statuses are converted from integer 0 to "unused" in the exact scenario from the bug report
- [x] All 11 SmartPortFiltering tests pass
- [x] Full test suite passes (802 tests, 4 pre-existing failures in unrelated `TestDiscoverSerialDeviceWithErrors`)
- [x] Ruff lint + mypy strict pass
- [ ] Manual testing: toggle Off Grid Mode switch on local-only WiFi Dongle setup with FlexBOSS 21

🤖 Generated with [Claude Code](https://claude.com/claude-code)