### PR TITLE
fix: resolve smart port mode write failure for GridBOSS devices (#182)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -475,6 +475,31 @@ class EG4DataUpdateCoordinator(
         """Get inverter device object by serial number (O(1) cached lookup)."""
         return self._inverter_cache.get(serial)
 
+    def get_mid_device_object(self, serial: str) -> Any | None:
+        """Get MID device (GridBOSS) object by serial number.
+
+        Checks the LOCAL mode cache first, then the Station's MID devices
+        for HYBRID mode support.
+
+        Args:
+            serial: MID device serial number.
+
+        Returns:
+            MIDDevice instance or None if not found.
+        """
+        # Check LOCAL mode cache first
+        mid_device = self._mid_device_cache.get(serial)
+        if mid_device is not None:
+            return mid_device
+
+        # Check Station MID devices (HYBRID mode)
+        if self.station:
+            for mid in self.station.all_mid_devices:
+                if mid.serial_number == serial:
+                    return mid
+
+        return None
+
     def get_battery_object(self, serial: str, battery_index: int) -> Battery | None:
         """Get battery object by inverter serial and battery index."""
         inverter = self.get_inverter_object(serial)
@@ -630,6 +655,84 @@ class EG4DataUpdateCoordinator(
             raise HomeAssistantError(
                 f"Failed to write parameter {parameter}: {err}"
             ) from err
+
+    async def write_smart_port_mode(
+        self,
+        serial: str,
+        port: int,
+        value: int,
+    ) -> bool:
+        """Write a GridBOSS smart port mode via local transport or cloud API.
+
+        Smart port modes are stored in GridBOSS holding register 20 as
+        2-bit fields (per port).  This method resolves the correct transport
+        for the MID device and falls back to the cloud API when no local
+        transport is available.
+
+        Args:
+            serial: GridBOSS/MID device serial number.
+            port: Smart port number (1-4).
+            value: Port mode (0=Off, 1=Smart Load, 2=AC Couple).
+
+        Returns:
+            True if write succeeded.
+
+        Raises:
+            HomeAssistantError: If neither local transport nor cloud API
+                is available, or if the write fails.
+        """
+        param_name = f"BIT_MIDBOX_SP_MODE_{port}"
+
+        # Try local transport first
+        transport = self.get_local_transport(serial)
+        if transport:
+            try:
+                if not transport.is_connected:
+                    _LOGGER.debug(
+                        "Reconnecting transport for %s before writing %s",
+                        serial,
+                        param_name,
+                    )
+                    await transport.connect()
+
+                await transport.write_named_parameters({param_name: value})
+                _LOGGER.debug(
+                    "Wrote smart port %d mode = %d for %s via local transport",
+                    port,
+                    value,
+                    serial,
+                )
+                return True
+
+            except Exception as err:
+                _LOGGER.warning(
+                    "Local transport write failed for %s, trying cloud API: %s",
+                    param_name,
+                    err,
+                )
+                # Fall through to cloud API
+
+        # Fallback to cloud API
+        if self.client is not None:
+            result = await self.client.api.control.set_smart_port_mode(
+                serial, port, value
+            )
+            if result.success:
+                _LOGGER.debug(
+                    "Wrote smart port %d mode = %d for %s via cloud API",
+                    port,
+                    value,
+                    serial,
+                )
+                return True
+            raise HomeAssistantError(
+                f"Cloud API failed to set smart port {port} mode for {serial}"
+            )
+
+        raise HomeAssistantError(
+            f"No local transport or cloud API available to write smart port mode "
+            f"for {serial}"
+        )
 
     def _get_device_object(self, serial: str) -> BaseInverter | Any | None:
         """Get device object (inverter or MID device) by serial number.

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -1975,6 +1975,13 @@ class LocalTransportMixin(_MixinBase):
             if transport:
                 return transport
 
+            # Check Station MID devices (GridBOSS in HYBRID mode)
+            for station_mid in self.station.all_mid_devices:
+                if station_mid.serial_number == serial:
+                    transport = getattr(station_mid, "_transport", None)
+                    if transport:
+                        return transport
+
         # Check LOCAL mode inverter cache
         if serial and self.connection_type == CONNECTION_TYPE_LOCAL:
             inverter = self._inverter_cache.get(serial)

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -488,7 +488,12 @@ class EG4SmartPortModeSelect(CoordinatorEntity, SelectEntity):
         return False
 
     async def async_select_option(self, option: str) -> None:
-        """Change the smart port mode via local Modbus or cloud API."""
+        """Change the smart port mode via local Modbus or cloud API.
+
+        Uses the coordinator's write_smart_port_mode() which tries local
+        transport first (with automatic cloud fallback) for robust
+        GridBOSS register writes across all connection modes.
+        """
         if option not in SMART_PORT_MODE_TO_VALUE:
             raise HomeAssistantError(f"Invalid smart port mode: {option}")
 
@@ -506,24 +511,9 @@ class EG4SmartPortModeSelect(CoordinatorEntity, SelectEntity):
             self._optimistic_state = option
             self.async_write_ha_state()
 
-            if self.coordinator.has_local_transport(self._serial):
-                await self.coordinator.write_named_parameter(
-                    f"BIT_MIDBOX_SP_MODE_{self._port}",
-                    int_value,
-                    serial=self._serial,
-                )
-            elif self.coordinator.client is not None:
-                result = await self.coordinator.client.api.control.set_smart_port_mode(
-                    self._serial, self._port, int_value
-                )
-                if not result.success:
-                    raise HomeAssistantError(
-                        f"Failed to set smart port {self._port} mode to {option}"
-                    )
-            else:
-                raise HomeAssistantError(
-                    "No local transport or cloud API available for parameter write."
-                )
+            await self.coordinator.write_smart_port_mode(
+                self._serial, self._port, int_value
+            )
 
             _LOGGER.info(
                 "Successfully set smart port %d mode to %s for device %s",

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -417,6 +418,52 @@ class TestTransportAccessors:
         result = coordinator.get_local_transport("GRIDBOSS001")
         assert result is None
 
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    def test_get_local_transport_from_station_mid_device(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ):
+        """HYBRID mode: get_local_transport finds MID device via station (#182)."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+
+        mock_transport = MagicMock()
+        mock_mid = MagicMock()
+        mock_mid.serial_number = "GRIDBOSS001"
+        mock_mid._transport = mock_transport
+
+        mock_station = MagicMock()
+        mock_station.all_inverters = []
+        mock_station.all_mid_devices = [mock_mid]
+        coordinator.station = mock_station
+
+        # Inverter lookup returns None (GridBOSS is not an inverter)
+        coordinator.get_inverter_object = MagicMock(return_value=None)
+
+        result = coordinator.get_local_transport("GRIDBOSS001")
+        assert result is mock_transport
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    def test_get_local_transport_station_mid_no_transport(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ):
+        """HYBRID mode: station MID device without transport returns None."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+
+        mock_mid = MagicMock(spec=[])  # No _transport attribute
+        mock_mid.serial_number = "GRIDBOSS001"
+
+        mock_station = MagicMock()
+        mock_station.all_inverters = []
+        mock_station.all_mid_devices = [mock_mid]
+        coordinator.station = mock_station
+        coordinator.get_inverter_object = MagicMock(return_value=None)
+
+        result = coordinator.get_local_transport("GRIDBOSS001")
+        assert result is None
+
     def test_is_local_only_local_mode(self, hass, local_config_entry):
         """LOCAL mode → is_local_only returns True."""
         local_config_entry.add_to_hass(hass)
@@ -442,6 +489,204 @@ class TestTransportAccessors:
         hybrid_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
         assert coordinator.is_local_only() is False
+
+
+# ── write_smart_port_mode ──────────────────────────────────────────────
+
+
+class TestWriteSmartPortMode:
+    """Tests for coordinator.write_smart_port_mode() (#182)."""
+
+    @pytest.mark.asyncio
+    async def test_write_via_local_transport(self, hass, local_config_entry):
+        """Local transport path: writes via transport.write_named_parameters."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        mock_transport = AsyncMock()
+        mock_transport.is_connected = True
+        mock_transport.write_named_parameters = AsyncMock(return_value=True)
+
+        mock_mid = MagicMock()
+        mock_mid._transport = mock_transport
+        coordinator._mid_device_cache["GB001"] = mock_mid
+
+        result = await coordinator.write_smart_port_mode("GB001", 2, 1)
+
+        assert result is True
+        mock_transport.write_named_parameters.assert_called_once_with(
+            {"BIT_MIDBOX_SP_MODE_2": 1}
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_reconnects_transport(self, hass, local_config_entry):
+        """Reconnects transport if not connected before writing."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        mock_transport = AsyncMock()
+        mock_transport.is_connected = False
+        mock_transport.connect = AsyncMock()
+        mock_transport.write_named_parameters = AsyncMock(return_value=True)
+
+        mock_mid = MagicMock()
+        mock_mid._transport = mock_transport
+        coordinator._mid_device_cache["GB001"] = mock_mid
+
+        await coordinator.write_smart_port_mode("GB001", 1, 2)
+
+        mock_transport.connect.assert_called_once()
+        mock_transport.write_named_parameters.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_write_via_cloud_api(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Cloud API path: writes via client.api.control.set_smart_port_mode."""
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+
+        result_mock = MagicMock()
+        result_mock.success = True
+        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
+            return_value=result_mock
+        )
+
+        result = await coordinator.write_smart_port_mode("GB001", 3, 0)
+
+        assert result is True
+        coordinator.client.api.control.set_smart_port_mode.assert_called_once_with(
+            "GB001", 3, 0
+        )
+
+    @pytest.mark.asyncio
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_local_failure_falls_back_to_cloud(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ):
+        """Local transport failure falls back to cloud API."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+
+        mock_transport = AsyncMock()
+        mock_transport.is_connected = True
+        mock_transport.write_named_parameters = AsyncMock(
+            side_effect=Exception("Modbus timeout")
+        )
+        mock_mid = MagicMock()
+        mock_mid._transport = mock_transport
+        coordinator._mid_device_cache["GB001"] = mock_mid
+
+        result_mock = MagicMock()
+        result_mock.success = True
+        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
+            return_value=result_mock
+        )
+
+        result = await coordinator.write_smart_port_mode("GB001", 4, 2)
+
+        assert result is True
+        coordinator.client.api.control.set_smart_port_mode.assert_called_once_with(
+            "GB001", 4, 2
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_transport_no_client_raises(self, hass, local_config_entry):
+        """No local transport and no cloud API raises HomeAssistantError."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        with pytest.raises(HomeAssistantError, match="No local transport or cloud API"):
+            await coordinator.write_smart_port_mode("GB001", 1, 1)
+
+    @pytest.mark.asyncio
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_cloud_failure_raises(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Cloud API returning failure raises HomeAssistantError."""
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+
+        result_mock = MagicMock()
+        result_mock.success = False
+        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
+            return_value=result_mock
+        )
+
+        with pytest.raises(HomeAssistantError, match="Cloud API failed"):
+            await coordinator.write_smart_port_mode("GB001", 2, 1)
+
+
+# ── get_mid_device_object ──────────────────────────────────────────────
+
+
+class TestGetMidDeviceObject:
+    """Tests for coordinator.get_mid_device_object() (#182)."""
+
+    def test_from_mid_device_cache(self, hass, local_config_entry):
+        """Finds MID device in LOCAL mode cache."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        mock_mid = MagicMock()
+        coordinator._mid_device_cache["GB001"] = mock_mid
+
+        result = coordinator.get_mid_device_object("GB001")
+        assert result is mock_mid
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    def test_from_station_mid_devices(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ):
+        """Finds MID device via station in HYBRID mode."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+
+        mock_mid = MagicMock()
+        mock_mid.serial_number = "GB001"
+
+        mock_station = MagicMock()
+        mock_station.all_mid_devices = [mock_mid]
+        coordinator.station = mock_station
+
+        result = coordinator.get_mid_device_object("GB001")
+        assert result is mock_mid
+
+    def test_not_found_returns_none(self, hass, local_config_entry):
+        """Returns None when MID device not found anywhere."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        result = coordinator.get_mid_device_object("UNKNOWN")
+        assert result is None
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    def test_cache_takes_precedence_over_station(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ):
+        """LOCAL cache is checked before station (for performance)."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+
+        cached_mid = MagicMock()
+        coordinator._mid_device_cache["GB001"] = cached_mid
+
+        station_mid = MagicMock()
+        station_mid.serial_number = "GB001"
+        mock_station = MagicMock()
+        mock_station.all_mid_devices = [station_mid]
+        coordinator.station = mock_station
+
+        # Cache should win
+        result = coordinator.get_mid_device_object("GB001")
+        assert result is cached_mid
 
 
 # ── _attach_local_transports_to_station ──────────────────────────────

--- a/tests/test_select_entities.py
+++ b/tests/test_select_entities.py
@@ -214,7 +214,7 @@ def _mock_gridboss_coordinator(
     coordinator.last_update_success = True
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.async_request_refresh = AsyncMock()
-    coordinator.write_named_parameter = AsyncMock()
+    coordinator.write_smart_port_mode = AsyncMock(return_value=True)
 
     coordinator.data = {
         "devices": {
@@ -311,10 +311,9 @@ class TestSmartPortModeSelect:
         assert select.name == "Smart Port 3 Mode"
 
     @pytest.mark.asyncio
-    async def test_select_option_local(self):
-        """Local path writes via write_named_parameter."""
+    async def test_select_option_delegates_to_coordinator(self):
+        """Select delegates to coordinator.write_smart_port_mode()."""
         coordinator = _mock_gridboss_coordinator()
-        coordinator.has_local_transport = MagicMock(return_value=True)
         device_data = coordinator.data["devices"]["gb123"]
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=2)
         select.hass = MagicMock()
@@ -323,21 +322,13 @@ class TestSmartPortModeSelect:
 
         await select.async_select_option("AC Couple")
 
-        coordinator.write_named_parameter.assert_called_once_with(
-            "BIT_MIDBOX_SP_MODE_2", 2, serial="gb123"
-        )
+        coordinator.write_smart_port_mode.assert_called_once_with("gb123", 2, 2)
         coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_select_option_cloud(self):
-        """Cloud path writes via set_smart_port_mode."""
+    async def test_select_option_smart_load(self):
+        """Smart Load maps to value 1."""
         coordinator = _mock_gridboss_coordinator()
-        coordinator.has_local_transport = MagicMock(return_value=False)
-        result_mock = MagicMock()
-        result_mock.success = True
-        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
-            return_value=result_mock
-        )
         device_data = coordinator.data["devices"]["gb123"]
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
         select.hass = MagicMock()
@@ -346,20 +337,29 @@ class TestSmartPortModeSelect:
 
         await select.async_select_option("Smart Load")
 
-        coordinator.client.api.control.set_smart_port_mode.assert_called_once_with(
-            "gb123", 1, 1
-        )
+        coordinator.write_smart_port_mode.assert_called_once_with("gb123", 1, 1)
         coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_select_option_cloud_failure(self):
-        """Cloud API failure raises HomeAssistantError."""
+    async def test_select_option_unused(self):
+        """Unused maps to value 0."""
         coordinator = _mock_gridboss_coordinator()
-        coordinator.has_local_transport = MagicMock(return_value=False)
-        result_mock = MagicMock()
-        result_mock.success = False
-        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
-            return_value=result_mock
+        device_data = coordinator.data["devices"]["gb123"]
+        select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=3)
+        select.hass = MagicMock()
+        select.entity_id = "select.test_smart_port_3_mode"
+        select.async_write_ha_state = MagicMock()
+
+        await select.async_select_option("Unused")
+
+        coordinator.write_smart_port_mode.assert_called_once_with("gb123", 3, 0)
+
+    @pytest.mark.asyncio
+    async def test_select_option_failure_raises(self):
+        """Coordinator write failure raises HomeAssistantError."""
+        coordinator = _mock_gridboss_coordinator()
+        coordinator.write_smart_port_mode = AsyncMock(
+            side_effect=HomeAssistantError("No local transport or cloud API available")
         )
         device_data = coordinator.data["devices"]["gb123"]
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
@@ -367,8 +367,8 @@ class TestSmartPortModeSelect:
         select.entity_id = "select.test_smart_port_1_mode"
         select.async_write_ha_state = MagicMock()
 
-        with pytest.raises(HomeAssistantError, match="Failed to set smart port"):
-            await select.async_select_option("Unused")
+        with pytest.raises(HomeAssistantError, match="No local transport"):
+            await select.async_select_option("Smart Load")
 
     @pytest.mark.asyncio
     async def test_select_invalid_option(self):
@@ -384,16 +384,20 @@ class TestSmartPortModeSelect:
             await select.async_select_option("Invalid")
 
     @pytest.mark.asyncio
-    async def test_select_no_transport(self):
-        """No transport raises HomeAssistantError."""
+    async def test_select_clears_optimistic_state_on_failure(self):
+        """Optimistic state is cleared on write failure."""
         coordinator = _mock_gridboss_coordinator()
-        coordinator.has_local_transport = MagicMock(return_value=False)
-        coordinator.client = None
+        coordinator.write_smart_port_mode = AsyncMock(
+            side_effect=HomeAssistantError("Write failed")
+        )
         device_data = coordinator.data["devices"]["gb123"]
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
         select.hass = MagicMock()
         select.entity_id = "select.test_smart_port_1_mode"
         select.async_write_ha_state = MagicMock()
 
-        with pytest.raises(HomeAssistantError, match="No local transport"):
+        with pytest.raises(HomeAssistantError):
             await select.async_select_option("Smart Load")
+
+        # Optimistic state should be cleared after failure
+        assert select._optimistic_state is None


### PR DESCRIPTION
## Summary

- Fix GridBOSS Smart Port Mode select entities failing to write via local transport in HYBRID mode
- Add `get_mid_device_object()` and `write_smart_port_mode()` methods to coordinator
- Fix `get_local_transport()` to find MID device transports via Station object

## Root Cause

In HYBRID mode, `get_local_transport()` could not find the GridBOSS MID device's local transport. It checked `_mid_device_cache` (only populated in LOCAL mode) and the inverter cache (GridBOSS is not an inverter), but missed Station's MID devices that have transports attached via `station.attach_local_transports()`.

## Fix

1. **`coordinator_local.py`**: Extended `get_local_transport()` to iterate `station.all_mid_devices` when a Station exists (HYBRID mode)
2. **`coordinator.py`**: Added `get_mid_device_object()` for MID device lookup from both LOCAL cache and Station objects
3. **`coordinator.py`**: Added `write_smart_port_mode()` — dedicated method that tries local transport (via inverter), then cloud API, with proper MID device handling

## Test plan

- [x] Tests for `get_local_transport` finding MID device via Station
- [x] Tests for `write_smart_port_mode` (local + cloud paths)
- [x] Tests for `get_mid_device_object`
- [x] Full test suite passing
- [x] ruff check/format clean
- [x] mypy strict clean

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)