### PR TITLE
docs: update example dashboards to match v3.2.0 entity names (#209)

### DIFF
--- a/examples/dashboards/battery_details.yaml
+++ b/examples/dashboards/battery_details.yaml
@@ -16,7 +16,7 @@ cards:
   - type: horizontal-stack
     cards:
       - type: gauge
-        entity: sensor.eg4_flexboss21_1234567890_battery_soc
+        entity: sensor.eg4_flexboss21_1234567890_state_of_charge
         name: State of Charge
         min: 0
         max: 100
@@ -154,7 +154,7 @@ cards:
       - entity: sensor.eg4_flexboss21_1234567890_battery_power
         name: Power (W)
         yaxis_id: power
-      - entity: sensor.eg4_flexboss21_1234567890_battery_soc
+      - entity: sensor.eg4_flexboss21_1234567890_state_of_charge
         name: SOC (%)
         yaxis_id: soc
     yaxis:

--- a/examples/dashboards/eg4_solar_monitor.yaml
+++ b/examples/dashboards/eg4_solar_monitor.yaml
@@ -16,9 +16,7 @@ views:
           - type: custom:power-flow-card-plus
             entities:
               battery:
-                entity:
-                  consumption: sensor.18kpv_1234567890_battery_discharge_power
-                  production: sensor.18kpv_1234567890_battery_charge_power
+                entity: sensor.18kpv_1234567890_battery_power
                 state_of_charge: sensor.18kpv_1234567890_state_of_charge
                 name: Battery Bank
                 icon: mdi:battery-high

--- a/examples/dashboards/energy_overview.yaml
+++ b/examples/dashboards/energy_overview.yaml
@@ -16,21 +16,21 @@ cards:
         entity: sensor.eg4_flexboss21_1234567890_grid_power
         name: Grid
       solar:
-        entity: sensor.eg4_flexboss21_1234567890_pv_power
+        entity: sensor.eg4_flexboss21_1234567890_pv_total_power
         name: Solar
       battery:
         entity: sensor.eg4_flexboss21_1234567890_battery_power
-        state_of_charge: sensor.eg4_flexboss21_1234567890_battery_soc
+        state_of_charge: sensor.eg4_flexboss21_1234567890_state_of_charge
         name: Battery
       home:
-        entity: sensor.eg4_flexboss21_1234567890_load_power
+        entity: sensor.eg4_flexboss21_1234567890_consumption_power
         name: Home
 
   # Real-Time Power Metrics
   - type: horizontal-stack
     cards:
       - type: entity
-        entity: sensor.eg4_flexboss21_1234567890_pv_power
+        entity: sensor.eg4_flexboss21_1234567890_pv_total_power
         name: Solar Production
         icon: mdi:solar-power
       - type: entity
@@ -38,7 +38,7 @@ cards:
         name: Grid Power
         icon: mdi:transmission-tower
       - type: entity
-        entity: sensor.eg4_flexboss21_1234567890_load_power
+        entity: sensor.eg4_flexboss21_1234567890_consumption_power
         name: Load Consumption
         icon: mdi:home-lightning-bolt
 
@@ -46,7 +46,7 @@ cards:
   - type: horizontal-stack
     cards:
       - type: gauge
-        entity: sensor.eg4_flexboss21_1234567890_battery_soc
+        entity: sensor.eg4_flexboss21_1234567890_state_of_charge
         name: Battery SOC
         min: 0
         max: 100
@@ -67,17 +67,17 @@ cards:
   - type: horizontal-stack
     cards:
       - type: statistic
-        entity: sensor.eg4_flexboss21_1234567890_daily_pv_generation
+        entity: sensor.eg4_flexboss21_1234567890_yield
         name: Solar Generated Today
         icon: mdi:solar-power
         stat_type: change
       - type: statistic
-        entity: sensor.eg4_flexboss21_1234567890_daily_load_consumption
+        entity: sensor.eg4_flexboss21_1234567890_consumption
         name: Consumed Today
         icon: mdi:home-import-outline
         stat_type: change
       - type: statistic
-        entity: sensor.eg4_flexboss21_1234567890_daily_grid_import
+        entity: sensor.eg4_flexboss21_1234567890_grid_import
         name: Grid Import Today
         icon: mdi:transmission-tower-import
         stat_type: change
@@ -89,13 +89,13 @@ cards:
       title: Power Flow (24h)
     graph_span: 24h
     series:
-      - entity: sensor.eg4_flexboss21_1234567890_pv_power
+      - entity: sensor.eg4_flexboss21_1234567890_pv_total_power
         name: Solar
         color: orange
       - entity: sensor.eg4_flexboss21_1234567890_grid_power
         name: Grid
         color: blue
-      - entity: sensor.eg4_flexboss21_1234567890_load_power
+      - entity: sensor.eg4_flexboss21_1234567890_consumption_power
         name: Load
         color: red
       - entity: sensor.eg4_flexboss21_1234567890_battery_power
@@ -109,7 +109,7 @@ cards:
       title: Battery SOC (7 days)
     graph_span: 7d
     series:
-      - entity: sensor.eg4_flexboss21_1234567890_battery_soc
+      - entity: sensor.eg4_flexboss21_1234567890_state_of_charge
         name: Battery %
         color: green
 


### PR DESCRIPTION
## Summary

Closes #209. Restores and extends the previous PR #212 fix that was removed during a force-push/reset on `main`.

Updates the three example Lovelace dashboards under `examples/dashboards/` so the sensor keys match the entity names emitted by the current 3.x integration. The mapping changes were:

- `battery_soc` → `state_of_charge`
- `pv_power` → `pv_total_power`
- `load_power` → `consumption_power` (the inverter `load_power` sensor was removed because register 27 / `pToUser` is grid import, not consumption)
- `daily_pv_generation` → `yield`
- `daily_load_consumption` → `consumption`
- `daily_grid_import` → `grid_import`
- `battery_charge_power` / `battery_discharge_power` → signed `battery_power`

## Test plan

- [x] `yaml.safe_load` parses each updated dashboard without error
- [x] No remaining references to the renamed sensor keys: `battery_soc`, `pv_power`, `daily_pv_generation`, `daily_load_consumption`, `daily_grid_import`, `battery_charge_power`, `battery_discharge_power`, or `_load_power` on inverter entities
- [ ] User installs `examples/dashboards/energy_overview.yaml`, runs find-and-replace on serial/model, and verifies all power-flow card tiles populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)