### PR TITLE
feat: per-model PV string count + pv4-6, cloud battery-bank parity, AC-couple parity

### DIFF
--- a/custom_components/eg4_web_monitor/const/sensors/inverter.py
+++ b/custom_components/eg4_web_monitor/const/sensors/inverter.py
@@ -1182,6 +1182,52 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "icon": "mdi:solar-panel",
     },
+    # PV strings 4-6 (MPPT 4-6) — only created for inverter models whose
+    # pv_string_count >= 4 (see _should_create_sensor in sensor.py).  Most
+    # residential models (18kPV, FlexBOSS21) are 3-string, so these are unused
+    # there; the definitions exist for any future >3-string model.
+    "pv4_voltage": {
+        "name": "PV4 Voltage",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
+    "pv5_voltage": {
+        "name": "PV5 Voltage",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
+    "pv6_voltage": {
+        "name": "PV6 Voltage",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
+    "pv4_power": {
+        "name": "PV4 Power",
+        "unit": UnitOfPower.WATT,
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
+    "pv5_power": {
+        "name": "PV5 Power",
+        "unit": UnitOfPower.WATT,
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
+    "pv6_power": {
+        "name": "PV6 Power",
+        "unit": UnitOfPower.WATT,
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:solar-panel",
+    },
     # GridBOSS MidBox specific sensors
     "grid_voltage_l1": {
         "name": "Grid Voltage L1",

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -31,6 +31,7 @@ from pylxpweb.exceptions import (
 )
 
 from .const import (
+    CONF_INCLUDE_AC_COUPLE_PV,
     CONNECTION_TYPE_HTTP,
     CONNECTION_TYPE_HYBRID,
     DOMAIN,
@@ -42,6 +43,7 @@ from .coordinator_mappings import (
 )
 from .coordinator_mixins import (
     _MixinBase,
+    apply_ac_couple_pv_adjustment,
     apply_gridboss_overlay,
     compute_total_inverter_power_kw,
 )
@@ -633,6 +635,21 @@ class HTTPUpdateMixin(_MixinBase):
                                 group_data.get("sensors", {}),
                                 mid_data.get("sensors", {}),
                                 group.name,
+                            )
+
+                            # Add AC-coupled smart-port power into
+                            # pv_total_power (parity with LOCAL path).  Without
+                            # this, HYBRID AC-coupled users see a low
+                            # pv_total_power.  Configurable via options.
+                            include_ac_couple = self.entry.options.get(
+                                CONF_INCLUDE_AC_COUPLE_PV,
+                                self.entry.data.get(CONF_INCLUDE_AC_COUPLE_PV, False),
+                            )
+                            apply_ac_couple_pv_adjustment(
+                                group_data.get("sensors", {}),
+                                mid_data.get("sensors", {}),
+                                group.name,
+                                include_ac_couple=include_ac_couple,
                             )
 
                         except Exception as e:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -34,6 +34,7 @@ from .const import (
 )
 from .coordinator_mixins import (
     _MixinBase,
+    apply_ac_couple_pv_adjustment,
     apply_gridboss_overlay,
     compute_total_inverter_power_kw,
 )
@@ -1736,45 +1737,20 @@ class LocalTransportMixin(_MixinBase):
                     consumption,
                 )
 
-                # Add AC couple power to pv_total_power for smart ports in AC couple mode
-                # Smart port status 2 = AC Couple (solar inverter connected)
-                # This is configurable via options (default: disabled)
+                # Add AC couple power to pv_total_power for smart ports in AC
+                # couple mode.  Shared with the HTTP/HYBRID path so both modes
+                # report total solar production consistently.  Configurable via
+                # options (default: disabled).
                 include_ac_couple = self.entry.options.get(
                     CONF_INCLUDE_AC_COUPLE_PV,
                     self.entry.data.get(CONF_INCLUDE_AC_COUPLE_PV, False),
                 )
-                if include_ac_couple:
-                    ac_couple_total = 0.0
-                    for port_num in range(1, 5):  # Ports 1-4
-                        status_key = f"smart_port{port_num}_status"
-                        status = gb_sensors.get(status_key)
-                        if status == "ac_couple":  # AC Couple mode
-                            l1_power = (
-                                gb_sensors.get(f"ac_couple{port_num}_power_l1") or 0
-                            )
-                            l2_power = (
-                                gb_sensors.get(f"ac_couple{port_num}_power_l2") or 0
-                            )
-                            port_power = float(l1_power) + float(l2_power)
-                            ac_couple_total += port_power
-                            _LOGGER.debug(
-                                "LOCAL: Parallel group %s: AC couple port %d power=%sW",
-                                group_name,
-                                port_num,
-                                port_power,
-                            )
-
-                    if ac_couple_total > 0:
-                        current_pv = group_sensors.get("pv_total_power", 0.0)
-                        group_sensors["pv_total_power"] = current_pv + ac_couple_total
-                        _LOGGER.debug(
-                            "LOCAL: Parallel group %s: pv_total_power=%sW "
-                            "(inverters=%sW + AC couple=%sW)",
-                            group_name,
-                            group_sensors["pv_total_power"],
-                            current_pv,
-                            ac_couple_total,
-                        )
+                apply_ac_couple_pv_adjustment(
+                    group_sensors,
+                    gb_sensors,
+                    group_name,
+                    include_ac_couple=include_ac_couple,
+                )
 
                 break  # Only one MID device per system
 

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -142,6 +142,16 @@ INVERTER_RUNTIME_KEYS: frozenset[str] = frozenset(
         "pv2_power",
         "pv3_voltage",
         "pv3_power",
+        # PV strings 4-6 (MPPT 4-6) — only materialized for models whose
+        # pv_string_count >= 4/5/6 (gated by _should_create_sensor).  Present
+        # in the static set so the count-driven entities and parity checks see
+        # them; 3-string models simply never create or populate them.
+        "pv4_voltage",
+        "pv4_power",
+        "pv5_voltage",
+        "pv5_power",
+        "pv6_voltage",
+        "pv6_power",
         "pv_total_power",
         "battery_voltage",
         "battery_current",
@@ -500,6 +510,14 @@ def _build_runtime_sensor_mapping(runtime_data: Any) -> dict[str, Any]:
         "pv2_power": runtime_data.pv2_power,
         "pv3_voltage": runtime_data.pv3_voltage,
         "pv3_power": runtime_data.pv3_power,
+        # PV strings 4-6 (V23 extended) — only populated for >3-string models;
+        # RuntimeData leaves these None for residential 3-string inverters.
+        "pv4_voltage": runtime_data.pv4_voltage,
+        "pv4_power": runtime_data.pv4_power,
+        "pv5_voltage": runtime_data.pv5_voltage,
+        "pv5_power": runtime_data.pv5_power,
+        "pv6_voltage": runtime_data.pv6_voltage,
+        "pv6_power": runtime_data.pv6_power,
         "pv_total_power": runtime_data.pv_total_power,
         # Battery
         "battery_voltage": runtime_data.battery_voltage,

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -143,6 +143,60 @@ def apply_gridboss_overlay(
             )
 
 
+def apply_ac_couple_pv_adjustment(
+    pg_sensors: dict[str, Any],
+    gb_sensors: dict[str, Any],
+    group_name: str,
+    *,
+    include_ac_couple: bool,
+) -> None:
+    """Add AC-coupled smart-port power into the parallel group's pv_total_power.
+
+    AC-coupled solar inverters feed through GridBOSS smart ports, so their
+    production is invisible to the EG4 inverters' own PV registers.  When the
+    user opts in (CONF_INCLUDE_AC_COUPLE_PV), add the AC-couple smart-port
+    power to pv_total_power so total solar production is represented.
+
+    Called from both the LOCAL path and the HTTP path (hybrid mode) so that
+    pv_total_power is consistent regardless of connection mode.
+
+    Args:
+        pg_sensors: Parallel group sensor dict (modified in place).
+        gb_sensors: GridBOSS/MID device sensor dict.
+        group_name: Parallel group name for debug logging.
+        include_ac_couple: Whether AC-couple inclusion is enabled.
+    """
+    if not include_ac_couple:
+        return
+
+    ac_couple_total = 0.0
+    for port_num in range(1, 5):  # Ports 1-4
+        # Smart port status 2 = AC Couple (solar inverter connected)
+        if gb_sensors.get(f"smart_port{port_num}_status") != "ac_couple":
+            continue
+        l1_power = gb_sensors.get(f"ac_couple{port_num}_power_l1") or 0
+        l2_power = gb_sensors.get(f"ac_couple{port_num}_power_l2") or 0
+        port_power = float(l1_power) + float(l2_power)
+        ac_couple_total += port_power
+        _LOGGER.debug(
+            "Parallel group %s: AC couple port %d power=%sW",
+            group_name,
+            port_num,
+            port_power,
+        )
+
+    if ac_couple_total > 0:
+        current_pv = float(pg_sensors.get("pv_total_power", 0.0) or 0.0)
+        pg_sensors["pv_total_power"] = current_pv + ac_couple_total
+        _LOGGER.debug(
+            "Parallel group %s: pv_total_power=%sW (inverters=%sW + AC couple=%sW)",
+            group_name,
+            pg_sensors["pv_total_power"],
+            current_pv,
+            ac_couple_total,
+        )
+
+
 def compute_total_inverter_power_kw(
     inverters: Any,
 ) -> float:
@@ -788,6 +842,11 @@ class DeviceProcessingMixin(_MixinBase):
             "pv1_power": "pv1_power",
             "pv2_power": "pv2_power",
             "pv3_power": "pv3_power",
+            # PV strings 4-6 (only present on >3-string models; absent on
+            # residential inverters where the inverter property returns None)
+            "pv4_power": "pv4_power",
+            "pv5_power": "pv5_power",
+            "pv6_power": "pv6_power",
             "battery_power": "battery_power",
             "consumption_power": "consumption_power",
             "inverter_power": "ac_power",
@@ -812,6 +871,10 @@ class DeviceProcessingMixin(_MixinBase):
             "pv1_voltage": "pv1_voltage",
             "pv2_voltage": "pv2_voltage",
             "pv3_voltage": "pv3_voltage",
+            # PV strings 4-6 (only present on >3-string models)
+            "pv4_voltage": "pv4_voltage",
+            "pv5_voltage": "pv5_voltage",
+            "pv6_voltage": "pv6_voltage",
             "battery_voltage": "battery_voltage",
             "grid_voltage_r": "grid_voltage_r",
             "grid_voltage_s": "grid_voltage_s",
@@ -929,6 +992,15 @@ class DeviceProcessingMixin(_MixinBase):
             elif hasattr(inverter_features, attr_name):
                 # Fallback to features object attribute using correct mapping
                 features[prop] = getattr(inverter_features, attr_name, False)
+
+        # PV (MPPT) string count (0..n) drives per-string PV sensor creation.
+        # Explicit per-model value declared in pylxpweb
+        # (DEVICE_TYPE_CODE_PV_STRING_COUNT).  A 3-string model -> pv1-3 only.
+        pv_string_count = getattr(inverter, "pv_string_count", None)
+        if pv_string_count is None:
+            pv_string_count = getattr(inverter_features, "pv_string_count", None)
+        if pv_string_count is not None:
+            features["pv_string_count"] = int(pv_string_count)
 
         return features
 
@@ -1051,6 +1123,30 @@ class DeviceProcessingMixin(_MixinBase):
         """
         property_map = self._get_battery_bank_property_map()
         sensors = _map_device_properties(battery_bank, property_map)
+
+        # Last polled timestamp for battery bank device (parity with LOCAL,
+        # which sets battery_bank_last_polled in _build_battery_bank_sensor_mapping).
+        sensors["battery_bank_last_polled"] = dt_util.utcnow()
+
+        # Derive bank-level minimum cell temperature/voltage from per-battery
+        # data.  The cloud BatteryBank object does NOT expose
+        # min_cell_temperature/min_cell_voltage (those come from Modbus bank
+        # registers in LOCAL mode), but each per-battery Battery object does.
+        # Mirror LOCAL's battery_bank_min_cell_* sensors when CAN/per-battery
+        # data is available; otherwise omit (never fabricate).
+        batteries = getattr(battery_bank, "batteries", None) or []
+        min_cell_temps = [
+            t for b in batteries if (t := getattr(b, "min_cell_temp", None)) is not None
+        ]
+        if min_cell_temps:
+            sensors["battery_bank_min_cell_temp"] = min(min_cell_temps)
+        min_cell_voltages = [
+            v
+            for b in batteries
+            if (v := getattr(b, "min_cell_voltage", None)) is not None
+        ]
+        if min_cell_voltages:
+            sensors["battery_bank_min_cell_voltage"] = min(min_cell_voltages)
 
         # Add battery_status as alias for battery_bank_status for backwards compatibility
         # In v2.2.x, the batStatus field was mapped to battery_status at the inverter level

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.26", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.28", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.2.0"
 }

--- a/custom_components/eg4_web_monitor/sensor.py
+++ b/custom_components/eg4_web_monitor/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform for EG4 Web Monitor integration."""
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
@@ -34,6 +35,15 @@ from .coordinator_mappings import GRIDBOSS_SMART_PORT_DYNAMIC_KEYS
 
 _LOGGER = logging.getLogger(__name__)
 
+# Matches per-string PV sensor keys: pv1_voltage, pv2_power, pv3_current, ...
+# Sensor creation for these is driven by the inverter model's pv_string_count
+# (0..n): a key pvN_* is created only when N <= pv_string_count.
+_PV_STRING_SENSOR = re.compile(r"^pv(\d+)_(?:voltage|power|current)$")
+
+# Default PV string count when the inverter model did not report one
+# (conservative residential norm — keeps the canonical pv1-3 set).
+_DEFAULT_PV_STRING_COUNT = 3
+
 
 def _should_create_sensor(sensor_key: str, features: dict[str, Any] | None) -> bool:
     """Determine if a sensor should be created based on device features.
@@ -51,6 +61,17 @@ def _should_create_sensor(sensor_key: str, features: dict[str, Any] | None) -> b
     # If no features detected, create all sensors (conservative fallback)
     if not features:
         return True
+
+    # Per-string PV sensors are created based on the model's pv_string_count
+    # (0..n).  A 3-string model (18kPV, FlexBOSS21) creates pv1-3 only; a
+    # 0-string model (battery-only / AC-coupled-only) creates none; a 5-string
+    # model would create pv1-5.  The count comes from the inverter model in
+    # pylxpweb (DEVICE_TYPE_CODE_PV_STRING_COUNT) via feature detection.
+    pv_match = _PV_STRING_SENSOR.match(sensor_key)
+    if pv_match:
+        string_index = int(pv_match.group(1))
+        pv_string_count = features.get("pv_string_count", _DEFAULT_PV_STRING_COUNT)
+        return string_index <= int(pv_string_count)
 
     # Check split-phase sensors (only for EG4_OFFGRID series)
     if sensor_key in SPLIT_PHASE_ONLY_SENSORS:

--- a/scripts/bd_seed_maintainability.sh
+++ b/scripts/bd_seed_maintainability.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Seed the bd backlog for the maintainability / contract-hardening initiative.
+#
+# Source of findings: docs/claude/MAINTAINABILITY_FINDINGS.md (Claude + Codex peer review, 2026-05-29)
+#
+# Prereq: a HEALTHY bd workspace. As of 2026-05-29 the local bd DB had a
+# schema-migration block (bd v1.0.5 vs older cloned remote schema, "dirty tables").
+# Resolve that first (match the team's bd version / repair the Dolt working set),
+# verify with `bd status` showing the 127 issues + a configured prefix, THEN run:
+#
+#     ./scripts/bd_seed_maintainability.sh
+#
+# Idempotency: NOT idempotent — running twice creates duplicate epics. Run once.
+# Dry preview: pass --dry-run to echo the bd commands without executing.
+set -euo pipefail
+
+DRY="${1:-}"
+run() {
+  if [[ "$DRY" == "--dry-run" ]]; then
+    printf 'bd %s\n' "$*"
+    # emit a fake id so dependent commands echo coherently in dry-run
+    echo "eg4-DRY"
+  else
+    bd "$@"
+  fi
+}
+
+# ---- Standing policy embedded in every epic's acceptance criteria ----
+SHIP_GATE="SHIP GATE (mandatory before any PR/merge of work under this epic): \
+run a Codex ADVERSARIAL review on the diff via /codex:adversarial-review \
+(or the codex:codex-rescue subagent). Resolve or explicitly justify EVERY Codex \
+finding; do not ship without a clean or acknowledged Codex pass. Pre-gate checks \
+must also pass in each affected repo: \
+'uv run ruff check --fix && uv run ruff format && uv run mypy --strict . && uv run pytest'."
+
+echo "==> Creating epics"
+E1=$(run create "Live bug hotfixes (scaling + mapping)" --type epic -p P0 -l live-bug --silent \
+  -d "Fix concrete LOCAL/CLOUD data bugs surfaced by the maintainability review (docs/claude/MAINTAINABILITY_FINDINGS.md). User-facing; prove the root-cause thesis." \
+  --acceptance "$SHIP_GATE")
+
+E2=$(run create "Register-derived contract-validation harness" --type epic -p P1 -l contract,ci --silent \
+  -d "Make the register table the single source of truth and assert it in CI. Highest-leverage change (both reviewers ranked #1): closes the innermost seam; would have caught genuine #172-style mismatches and PV-string-count gaps. MUST compare resulting physical values against real payloads, not scale symbols (the maxChgCurr false positive proved symbol-comparison is insufficient)." \
+  --acceptance "$SHIP_GATE")
+
+E3=$(run create "Real-object test fixtures (eliminate MagicMock shape-blindness)" --type epic -p P1 -l tests --silent \
+  -d "Replace MagicMock with real pylxpweb objects / create_autospec(spec_set=True). MagicMock fabricates any attribute, so the suite cannot catch F1/F7 shape drift today." \
+  --acceptance "$SHIP_GATE")
+
+E4=$(run create "Typed contract at the pylxpweb<->integration seam" --type epic -p P2 -l contract,typing --silent \
+  -d "pylxpweb publishes Protocol/DTOs for consumed shapes + a public cache-TTL API; integration drops Any and stops poking private attrs. Makes mypy --strict enforce the seam (F1/F6/F7 become build failures)." \
+  --acceptance "$SHIP_GATE")
+
+E5=$(run create "Consolidate duplicated cloud/local/hybrid paths" --type epic -p P2 -l refactor --silent \
+  -d "Collapse duplicated battery-bank extractors and the triple parallel-group/GridBOSS-overlay implementations into single canonical workflows. Structural cure for F4/M2/M3 (fix-one-miss-the-other)." \
+  --acceptance "$SHIP_GATE")
+
+E6=$(run create "Unify feature detection on pylxpweb" --type epic -p P3 -l refactor --silent \
+  -d "Integration consumes pylxpweb detect_features/InverterFeatures instead of re-deriving under different key names; keep only the user grid-type override. Kills F6." \
+  --acceptance "$SHIP_GATE")
+
+E7=$(run create "Dead code cleanup" --type epic -p P3 -l cleanup --silent \
+  -d "Remove shadowed/unreachable code and document authoritative sources. Reduces surface area; stops misleading greps (F2)." \
+  --acceptance "$SHIP_GATE")
+
+echo "    E1=$E1 E2=$E2 E3=$E3 E4=$E4 E5=$E5 E6=$E6 E7=$E7"
+
+mk() { # mk <parent> <priority> <labels> <title> <description>
+  run create "$4" --type task -p "$2" --parent "$1" -l "$3" --silent -d "$5"
+}
+
+echo "==> E1 tasks (live bugs)"
+mk "$E1" P3 chore,pylxpweb "maxChgCurr scaling: VALIDATED not-a-bug (keep guard test)" \
+  "RESOLVED 2026-05-29: cloud maxChgCurr raw=6000 (0.01A, /100 -> 60A) and modbus reg81 raw=600 (0.1A, /10 -> 60A) yield the same physical amps; scaling.py SCALE_100 is correct. A prior blind flip to SCALE_10 was reverted; guard test test_bms_current_limit_cloud_local_same_physical_amps added. No code change needed — task exists for the audit trail." >/dev/null
+mk "$E1" P2 feature,pylxpweb,integration "PV strings: explicit declarative per-model pv_string_count (0-n)" \
+  "Add an EXPLICIT, declarative per-inverter-MODEL pv_string_count (0..n) that the model sets directly — single obvious source of truth, easy to maintain. Create exactly pv1..pvN sensors (0 => none, for battery-only/AC-coupled inverters; generalizes downward too). 3 is NOT a default (our 18kPV/FlexBOSS21 coincidentally have 3). Known: 18kPV=3, FlexBOSS21=3. Unmapped models fall back to the register-set-implied count (registers_for_model) so pv1-3 never regresses, with TODO(confirm) markers. Relates to E6 (feature detection). TDD, per-count tests." >/dev/null
+mk "$E1" P1 live-bug,integration "Fix cloud battery-bank sensor omission (M2)" \
+  "_extract_battery_bank_from_object() (coordinator_mixins.py:1121-1130) emits only cycle/SoH/max-cell-temp/temp-delta; LOCAL emits min-cell-temp, min-cell-voltage, BMS limits, BMS type (coordinator_mappings.py:731-741). Align cloud extractor to LOCAL sensor set; add parity test." >/dev/null
+mk "$E1" P1 live-bug,integration "Fix AC-couple PV adjustment missing in HYBRID/HTTP (M3)" \
+  "LOCAL adds AC-couple smart-port power into pv_total_power post-overlay (coordinator_local.py:1739-1769); HTTP has no equivalent (coordinator_http.py:626-636). HYBRID AC-coupled users show low pv_total_power. Mirror the adjustment; add test." >/dev/null
+
+mk "$E1" P3 feature,pylxpweb "Follow-up: PV4-6 per-string energy register coverage (>3-string only)" \
+  "Codex MED (not a blocker): PV4-6 energy registers (223-231) are not in the combined input-register read group (only pv1-3 energy / 217-222). For >3-string inverters, LOCAL energy accounting would miss pv4-6 string energy. No user-facing per-string energy sensor exists today, so this is internal-only. Extend the read group + ENERGY_FIELD mapping if/when per-string energy is needed for >3-string models." >/dev/null
+
+echo "==> E2 tasks (contract harness)"
+mk "$E2" P1 contract,pylxpweb "Scale-parity test: register cloud_api_field scale == scaling.py" \
+  "For every register with cloud_api_field, assert the cloud and modbus paths yield the SAME PHYSICAL VALUE when fed real sample payloads (NOT just matching scale symbols — maxChgCurr has different raw units per path yet is correct). Fails CI on drift. Catches genuine #172-style mismatches." >/dev/null
+mk "$E2" P1 contract,pylxpweb "Field-mapping completeness test" \
+  "Assert every dataclass field populated by from_modbus_registers() has a RUNTIME_FIELD/ENERGY_FIELD/BATTERY_FIELD/GRIDBOSS_FIELD mapping. Catches PV4-6 and all future silent-None gaps." >/dev/null
+mk "$E2" P2 contract,pylxpweb "ha_sensor_key reachability test" \
+  "Assert every register with non-None ha_sensor_key is reachable end-to-end (register -> field mapping -> dataclass -> property)." >/dev/null
+mk "$E2" P1 ci "Wire contract harness into CI (both repos)" \
+  "Add the parity/completeness/reachability tests to CI for pylxpweb and the integration so drift fails per-commit." >/dev/null
+
+echo "==> E3 tasks (real-object fixtures)"
+mk "$E3" P1 tests "Build real pylxpweb object fixtures per path" \
+  "Fixtures using real BatteryBankData (LOCAL), BatteryBank (CLOUD), runtime/midbox objects, both for HYBRID. Replace MagicMock device objects." >/dev/null
+mk "$E3" P1 tests "Replace MagicMock with real objects / autospec(spec_set=True)" \
+  "Swap MagicMock in mapping/coordinator tests for real objects or create_autospec(..., spec_set=True). Surfaces F1/F7 attribute drift in CI." >/dev/null
+mk "$E3" P2 tests "Cross-path sensor-set parity assertions" \
+  "Assert LOCAL and CLOUD produce the expected (and reconciled) sensor key sets per device type; encode known/intended divergences explicitly." >/dev/null
+
+echo "==> E4 tasks (typed contract)"
+mk "$E4" P2 contract,typing,pylxpweb "Export Protocol/DTOs for consumed shapes" \
+  "pylxpweb publishes typed Protocols/frozen DTOs for InverterRuntime, BatteryBankData, BatteryModuleData, MidboxData, InverterFeatures — the integration's consumed surface." >/dev/null
+mk "$E4" P2 contract,pylxpweb "Public cache-TTL API (stop private-attr poking)" \
+  "Add set_cache_ttls(runtime=, energy=, battery=) to pylxpweb so the integration stops writing inverter._runtime_cache_ttl/_energy/_battery (coordinator.py:552-554)." >/dev/null
+mk "$E4" P2 typing,integration "Drop Any; annotate mapping helpers; stop reading _transport_*" \
+  "Type coordinator_mappings helpers against the new DTOs (remove Any at lines 9/483/668/830); replace inverter._transport_* reads with public accessors." >/dev/null
+mk "$E4" P2 ci,typing "Enforce mypy --strict across the seam in CI" \
+  "With DTOs in place, mypy --strict must catch renamed/removed properties at build time. Add/verify in CI for both repos." >/dev/null
+
+echo "==> E5 tasks (consolidate paths)"
+mk "$E5" P2 refactor,integration "Unify battery-bank extraction" \
+  "Merge _build_battery_bank_sensor_mapping (LOCAL) and _extract_battery_bank_from_object (cloud) into one adapter producing a canonical dict for LOCAL/CLOUD/HYBRID. Makes parity visible in one place; resolves M2." >/dev/null
+mk "$E5" P2 refactor,integration "Unify parallel-group + GridBOSS overlay workflow" \
+  "One _process_parallel_group_data(pg_data, gridboss_data, source) called by both coordinators; fold the LOCAL AC-couple post-step (M3) behind a flag. Removes triple parallel-group impl + divergent overlay call sites (F4)." >/dev/null
+mk "$E5" P2 ci,tests "CI parity test across config/config-local/config-hybrid" \
+  "Wire the existing capture dirs + scripts into a CI parity check so cloud/local/hybrid entity sets are compared automatically." >/dev/null
+
+echo "==> E6 task (feature detection)"
+mk "$E6" P3 refactor,integration "Consume pylxpweb detect_features; drop duplicate" \
+  "Integration uses pylxpweb detect_features/InverterFeatures; keep only the user grid-type override layered on top; delete _features_from_family duplicate logic (coordinator_mappings.py:1011-1097). Add a test asserting both agree per known device." >/dev/null
+
+echo "==> E7 tasks (dead code)"
+mk "$E7" P3 cleanup,pylxpweb "Delete shadowed registers.py" \
+  "src/pylxpweb/registers.py (module, 511 lines) is shadowed/unreachable by the registers/ package. Confirm no external consumers, then delete." >/dev/null
+mk "$E7" P3 cleanup,pylxpweb "Resolve dead scheduling.py SCHEDULE_TYPES/SCHEDULE_REGISTERS" \
+  "registers/scheduling.py exports an unused 7-day schedule system (regs 500-723) that contradicts the live 3-period system (constants/registers.py, regs 68-84). Remove or wire it up; document which schedule register range is authoritative." >/dev/null
+
+echo "==> Done. Review with: bd list --type epic   and   bd ready"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2914,6 +2914,176 @@ class TestGridBOSSOverlay:
         assert pg_sensors["load_power"] == pytest.approx(1800.0)
 
 
+class TestACCouplePVAdjustment:
+    """Tests for the shared AC-couple PV adjustment helper (bug M3).
+
+    AC-coupled solar feeds through GridBOSS smart ports, so its production
+    is not visible in inverter PV registers.  When enabled, the helper adds
+    AC-couple smart-port power into pv_total_power.  This must run in BOTH
+    LOCAL and HTTP/HYBRID paths via one shared function.
+    """
+
+    def test_adds_ac_couple_power_when_enabled(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            apply_ac_couple_pv_adjustment,
+        )
+
+        pg = {"pv_total_power": 5500.0}
+        gb = {
+            "smart_port1_status": "ac_couple",
+            "ac_couple1_power_l1": 1500.0,
+            "ac_couple1_power_l2": 1200.0,
+            "smart_port2_status": "unused",
+            "smart_port3_status": "unused",
+            "smart_port4_status": "unused",
+        }
+
+        apply_ac_couple_pv_adjustment(pg, gb, "A", include_ac_couple=True)
+
+        assert pg["pv_total_power"] == pytest.approx(8200.0)
+
+    def test_disabled_leaves_pv_unchanged(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            apply_ac_couple_pv_adjustment,
+        )
+
+        pg = {"pv_total_power": 5500.0}
+        gb = {
+            "smart_port1_status": "ac_couple",
+            "ac_couple1_power_l1": 1500.0,
+            "ac_couple1_power_l2": 1200.0,
+        }
+
+        apply_ac_couple_pv_adjustment(pg, gb, "A", include_ac_couple=False)
+
+        assert pg["pv_total_power"] == pytest.approx(5500.0)
+
+    def test_no_ac_couple_ports_leaves_pv_unchanged(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            apply_ac_couple_pv_adjustment,
+        )
+
+        pg = {"pv_total_power": 5500.0}
+        gb = {
+            "smart_port1_status": "smart_load",
+            "smart_port2_status": "unused",
+        }
+
+        apply_ac_couple_pv_adjustment(pg, gb, "A", include_ac_couple=True)
+
+        assert pg["pv_total_power"] == pytest.approx(5500.0)
+
+    def test_sums_multiple_ac_couple_ports(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            apply_ac_couple_pv_adjustment,
+        )
+
+        pg = {"pv_total_power": 1000.0}
+        gb = {
+            "smart_port1_status": "ac_couple",
+            "ac_couple1_power_l1": 500.0,
+            "ac_couple1_power_l2": 500.0,
+            "smart_port3_status": "ac_couple",
+            "ac_couple3_power_l1": 300.0,
+            "ac_couple3_power_l2": 200.0,
+        }
+
+        apply_ac_couple_pv_adjustment(pg, gb, "A", include_ac_couple=True)
+
+        # 1000 + (500+500) + (300+200) = 2500
+        assert pg["pv_total_power"] == pytest.approx(2500.0)
+
+    @pytest.mark.asyncio
+    async def test_http_path_applies_ac_couple_adjustment(self, hass):
+        """HYBRID mode adds AC-couple power to pv_total_power in HTTP path.
+
+        Regression test for bug M3: before the fix, the HTTP path applied the
+        GridBOSS overlay but never added AC-coupled smart-port power, so
+        HYBRID AC-coupled users saw a low pv_total_power vs LOCAL.
+        """
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EG4 - Hybrid AC Couple",
+            data={
+                CONF_USERNAME: "test",
+                CONF_PASSWORD: "test",
+                CONF_PLANT_ID: "999",
+                CONF_PLANT_NAME: "Hybrid AC Couple",
+                CONF_BASE_URL: "https://test.example.com",
+                CONF_CONNECTION_TYPE: CONNECTION_TYPE_HYBRID,
+                CONF_VERIFY_SSL: True,
+                CONF_HTTP_POLLING_INTERVAL: DEFAULT_HTTP_POLLING_INTERVAL,
+                CONF_DST_SYNC: False,
+                CONF_LIBRARY_DEBUG: False,
+                CONF_LOCAL_TRANSPORTS: [],
+            },
+            options={CONF_INCLUDE_AC_COUPLE_PV: True},
+        )
+        entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator.client = MagicMock()
+        coordinator.station = MagicMock()
+
+        mock_group = MagicMock()
+        mock_group.name = "A"
+        mock_group._has_local_energy.return_value = False
+        mock_group._fetch_energy_data = AsyncMock()
+        mock_mid = MagicMock()
+        mock_mid.serial_number = "GB001"
+        mock_mid.refresh = AsyncMock()
+        mock_group.mid_device = mock_mid
+        mock_group.inverters = [MagicMock(serial_number="INV001")]
+        coordinator.station.parallel_groups = [mock_group]
+        coordinator.station.standalone_mid_devices = []
+
+        async def mock_pg_process(group):
+            return {
+                "name": "Parallel Group A",
+                "type": "parallel_group",
+                "first_device_serial": "INV001",
+                "member_serials": ["INV001"],
+                "member_count": 1,
+                "sensors": {
+                    "pv_total_power": 5500.0,
+                    "parallel_group_last_polled": dt_util.utcnow(),
+                },
+                "binary_sensors": {},
+            }
+
+        async def mock_mid_process(mid):
+            return {
+                "name": "GridBOSS",
+                "type": "gridboss",
+                "sensors": {
+                    "smart_port1_status": "ac_couple",
+                    "ac_couple1_power_l1": 1500.0,
+                    "ac_couple1_power_l2": 1200.0,
+                    "smart_port2_status": "unused",
+                    "smart_port3_status": "unused",
+                    "smart_port4_status": "unused",
+                },
+            }
+
+        with (
+            patch.object(
+                coordinator,
+                "_process_parallel_group_object",
+                side_effect=mock_pg_process,
+            ),
+            patch.object(
+                coordinator,
+                "_process_mid_device_object",
+                side_effect=mock_mid_process,
+            ),
+            patch.object(coordinator, "_rebuild_inverter_cache"),
+        ):
+            processed = await coordinator._process_station_data()
+
+        pg_sensors = processed["devices"]["parallel_group_a"]["sensors"]
+        # pv_total_power = inverter sum (5500) + AC couple (1500 + 1200)
+        assert pg_sensors["pv_total_power"] == pytest.approx(8200.0)
+
+
 class TestCoordinatorIntervalLogic:
     """Tests for coordinator interval selection based on connection type."""
 
@@ -4243,6 +4413,137 @@ class TestBatteryBankCurrentKey:
         assert prop_map["current"] == "battery_bank_current"
 
 
+class _FakeCloudBattery:
+    """Minimal stand-in for a pylxpweb Battery object (cloud path).
+
+    Defines ONLY the per-battery attributes the cloud Battery object
+    genuinely exposes, so accessing anything else raises AttributeError
+    (catching shape bugs that MagicMock would silently hide).
+    """
+
+    def __init__(self, min_cell_temp: float, min_cell_voltage: float) -> None:
+        self.min_cell_temp = min_cell_temp
+        self.min_cell_voltage = min_cell_voltage
+
+
+class _FakeCloudBatteryBank:
+    """Minimal stand-in for the pylxpweb cloud BatteryBank object.
+
+    Defines ONLY the properties the cloud BatteryBank genuinely exposes
+    (verified against devices/battery_bank.py).  Notably it does NOT
+    define min_cell_temperature / min_cell_voltage / BMS register fields,
+    so any attempt to read those via getattr() must fall back gracefully
+    rather than raising AttributeError.
+    """
+
+    def __init__(self, batteries: list[_FakeCloudBattery] | None = None) -> None:
+        # Core metrics (always present on cloud BatteryBank)
+        self.voltage = 52.0
+        self.current = 15.5
+        self.soc = 85
+        self.charge_power = 800
+        self.discharge_power = 0
+        self.battery_power = 800
+        self.max_capacity = 200
+        self.current_capacity = 170.0
+        self.remain_capacity = 170
+        self.full_capacity = 200
+        self.capacity_percent = 85
+        self.battery_count = 4
+        self.status = "charging"
+        # Cross-battery diagnostics (computed from self.batteries)
+        self.min_soh = 98
+        self.max_cell_temp = 28.0
+        self.temp_delta = 3.0
+        self.cell_voltage_delta_max = 0.02
+        self.soc_delta = 2
+        self.soh_delta = 1
+        self.voltage_delta = 0.1
+        self.cycle_count_delta = 5
+        # Individual battery modules (used to derive min-cell values)
+        self.batteries = batteries if batteries is not None else []
+
+
+class TestCloudBatteryBankParity:
+    """CLOUD battery-bank extractor reaches LOCAL sensor parity (bug M2).
+
+    The cloud _extract_battery_bank_from_object() must emit every additional
+    sensor the cloud BatteryBank object can actually provide, matching the
+    set LOCAL emits.  Fields the cloud object genuinely lacks (BMS register
+    data) are simply absent; min-cell values are derived from per-battery
+    data when available.
+    """
+
+    def _extract(self, bank: object) -> dict:
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        return DeviceProcessingMixin._extract_battery_bank_from_object(
+            DeviceProcessingMixin(), bank
+        )
+
+    def test_cross_battery_diagnostics_emitted(self):
+        """min_soh, max_cell_temp, temp_delta, cell_voltage_delta_max emitted."""
+        bank = _FakeCloudBatteryBank()
+        result = self._extract(bank)
+        assert result["battery_bank_min_soh"] == 98
+        assert result["battery_bank_max_cell_temp"] == 28.0
+        assert result["battery_bank_temp_delta"] == 3.0
+        assert result["battery_bank_cell_voltage_delta_max"] == 0.02
+
+    def test_min_cell_values_derived_from_per_battery_data(self):
+        """min cell temp/voltage derived from per-battery data when available."""
+        bank = _FakeCloudBatteryBank(
+            batteries=[
+                _FakeCloudBattery(min_cell_temp=21.0, min_cell_voltage=3.250),
+                _FakeCloudBattery(min_cell_temp=19.5, min_cell_voltage=3.211),
+            ]
+        )
+        result = self._extract(bank)
+        # Min across batteries
+        assert result["battery_bank_min_cell_temp"] == pytest.approx(19.5)
+        assert result["battery_bank_min_cell_voltage"] == pytest.approx(3.211)
+
+    def test_min_cell_values_absent_without_per_battery_data(self):
+        """min cell temp/voltage omitted (not AttributeError) when no batteries."""
+        bank = _FakeCloudBatteryBank(batteries=[])
+        result = self._extract(bank)
+        # Cloud BatteryBank has no min_cell_temperature/min_cell_voltage
+        # property and no per-battery data to derive from -> omit.
+        assert "battery_bank_min_cell_temp" not in result
+        assert "battery_bank_min_cell_voltage" not in result
+
+    def test_no_attribute_error_on_missing_bms_fields(self):
+        """Extractor never raises even though cloud bank lacks BMS register fields."""
+        bank = _FakeCloudBatteryBank()
+        # Must not raise AttributeError for bms_* / voltage_inv_sample fields.
+        result = self._extract(bank)
+        # BMS register fields are genuinely unavailable on cloud -> absent.
+        assert "battery_bank_bms_charge_current_limit" not in result
+        assert "battery_bank_bms_discharge_current_limit" not in result
+        assert "battery_bank_bms_charge_voltage_ref" not in result
+        assert "battery_bank_bms_discharge_cutoff" not in result
+        assert "battery_bank_bms_battery_type" not in result
+        assert "battery_bank_voltage_inv_sample" not in result
+
+    def test_cloud_property_map_covers_local_diagnostic_keys(self):
+        """Property map includes all cross-battery diagnostic keys LOCAL emits."""
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        emitted = set(DeviceProcessingMixin._get_battery_bank_property_map().values())
+        # These are derivable on cloud and were previously missing.
+        for key in (
+            "battery_bank_min_soh",
+            "battery_bank_max_cell_temp",
+            "battery_bank_temp_delta",
+            "battery_bank_cell_voltage_delta_max",
+        ):
+            assert key in emitted, f"{key} missing from cloud property map"
+
+
 class TestBatteryBankBMSCoreKeys:
     """Test BMS CORE keys always present in mapping from bank-level registers."""
 
@@ -5530,3 +5831,291 @@ class TestRoundRobinTruncatedSerialGuard:
             batteries = [self._make_battery("Batter", index=0)]
             result = coordinator._merge_round_robin_batteries(serial, batteries)
             assert len(result) == 1  # only the original real battery
+
+
+class TestPVStringCountFeatureExtraction:
+    """_extract_inverter_features surfaces the model's pv_string_count.
+
+    Uses real pylxpweb InverterFeatures objects (not bare MagicMock) so the
+    feature shape and the downstream _should_create_sensor gating are exercised
+    end-to-end.
+    """
+
+    @staticmethod
+    def _make_inverter(pv_string_count: int):
+        """Build a real-shaped inverter stand-in.
+
+        Mirrors BaseInverter's relevant surface: a real ``_features`` dataclass
+        plus the ``pv_string_count`` property the extractor reads.
+        """
+        from pylxpweb.devices.inverters._features import InverterFeatures
+
+        class _Inverter:
+            def __init__(self, count: int) -> None:
+                self._features = InverterFeatures(pv_string_count=count)
+
+            @property
+            def pv_string_count(self) -> int:
+                return self._features.pv_string_count
+
+        return _Inverter(pv_string_count)
+
+    def test_three_string_model_extracts_count_3(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        inverter = self._make_inverter(3)
+        features = DeviceProcessingMixin._extract_inverter_features(inverter)
+        assert features["pv_string_count"] == 3
+
+    def test_zero_string_model_extracts_count_0(self):
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        inverter = self._make_inverter(0)
+        features = DeviceProcessingMixin._extract_inverter_features(inverter)
+        assert features["pv_string_count"] == 0
+
+    def test_extracted_count_drives_sensor_creation(self):
+        """The extracted count gates per-string PV sensor creation."""
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+        from custom_components.eg4_web_monitor.sensor import _should_create_sensor
+
+        # 3-string model: pv1-3 created, pv4-6 not.
+        features3 = DeviceProcessingMixin._extract_inverter_features(
+            self._make_inverter(3)
+        )
+        created3 = {
+            f"pv{n}_voltage"
+            for n in range(1, 7)
+            if _should_create_sensor(f"pv{n}_voltage", features3)
+        }
+        assert created3 == {"pv1_voltage", "pv2_voltage", "pv3_voltage"}
+
+        # 0-string model: no PV sensors.
+        features0 = DeviceProcessingMixin._extract_inverter_features(
+            self._make_inverter(0)
+        )
+        created0 = {
+            f"pv{n}_voltage"
+            for n in range(1, 7)
+            if _should_create_sensor(f"pv{n}_voltage", features0)
+        }
+        assert created0 == set()
+
+        # 5-string model: pv1-5 created, pv6 not.
+        features5 = DeviceProcessingMixin._extract_inverter_features(
+            self._make_inverter(5)
+        )
+        created5 = {
+            f"pv{n}_voltage"
+            for n in range(1, 7)
+            if _should_create_sensor(f"pv{n}_voltage", features5)
+        }
+        assert created5 == {
+            "pv1_voltage",
+            "pv2_voltage",
+            "pv3_voltage",
+            "pv4_voltage",
+            "pv5_voltage",
+        }
+
+
+class TestPV456DataPath:
+    """pv4-6 values must actually flow into coordinator sensor data.
+
+    Count-driven creation (TestPVStringCountFeatureExtraction) makes pv4-6
+    sensor *entities* exist for >3-string models, but they are useless if the
+    coordinator never maps pv4-6 *values*.  These tests assert the DATA, not
+    just _should_create_sensor, using real/spec'd objects (never bare
+    MagicMock, which masks missing attributes).
+    """
+
+    def test_local_runtime_mapping_includes_pv4_6(self):
+        """LOCAL _build_runtime_sensor_mapping maps pv4-6 from RuntimeData."""
+        from pylxpweb.transports.data import InverterRuntimeData
+
+        runtime = InverterRuntimeData(
+            pv1_voltage=350.0,
+            pv1_power=3000,
+            pv4_voltage=361.0,
+            pv4_power=3100.0,
+            pv5_voltage=362.0,
+            pv5_power=3200.0,
+            pv6_voltage=363.0,
+            pv6_power=3300.0,
+        )
+        mapping = _build_runtime_sensor_mapping(runtime)
+
+        assert mapping["pv4_voltage"] == 361.0
+        assert mapping["pv4_power"] == 3100.0
+        assert mapping["pv5_voltage"] == 362.0
+        assert mapping["pv5_power"] == 3200.0
+        assert mapping["pv6_voltage"] == 363.0
+        assert mapping["pv6_power"] == 3300.0
+
+    def test_runtime_keys_include_pv4_6(self):
+        """Static key set must include pv4-6 so they survive parity checks."""
+        for key in (
+            "pv4_voltage",
+            "pv4_power",
+            "pv5_voltage",
+            "pv5_power",
+            "pv6_voltage",
+            "pv6_power",
+        ):
+            assert key in INVERTER_RUNTIME_KEYS
+
+    def test_http_property_map_includes_pv4_6(self):
+        """HTTP property map must map inverter pv4-6 properties to sensor keys."""
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        property_map = DeviceProcessingMixin._get_inverter_property_map()
+        for key in (
+            "pv4_voltage",
+            "pv4_power",
+            "pv5_voltage",
+            "pv5_power",
+            "pv6_voltage",
+            "pv6_power",
+        ):
+            assert property_map.get(key) == key
+
+    def test_http_map_device_properties_emits_pv4_5_from_inverter(self):
+        """HTTP path emits pv4/pv5 values from a real-shaped inverter object.
+
+        Uses a spec'd stand-in exposing pv4_voltage/pv4_power/pv5_* exactly as
+        the pylxpweb BaseInverter does (NOT a bare MagicMock, which would
+        fabricate any attribute and hide a missing-property bug).
+        """
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+            _map_device_properties,
+        )
+
+        class _Inverter:
+            """Real-shaped inverter: only the pv properties under test exist."""
+
+            pv1_voltage = 350.0
+            pv1_power = 3000
+            pv4_voltage = 361.0
+            pv4_power = 3100
+            pv5_voltage = 362.0
+            pv5_power = 3200
+            pv6_voltage = 363.0
+            pv6_power = 3300
+
+        property_map = DeviceProcessingMixin._get_inverter_property_map()
+        sensors = _map_device_properties(_Inverter(), property_map)
+
+        assert sensors["pv4_voltage"] == 361.0
+        assert sensors["pv4_power"] == 3100
+        assert sensors["pv5_voltage"] == 362.0
+        assert sensors["pv5_power"] == 3200
+        assert sensors["pv6_voltage"] == 363.0
+        assert sensors["pv6_power"] == 3300
+
+    def test_pylxpweb_inverter_exposes_pv4_6_properties(self):
+        """pylxpweb BaseInverter must expose pv4-6 voltage/power properties.
+
+        This is the cross-repo contract the HTTP path relies on: the property
+        map reads inverter.pv4_voltage etc. via getattr.
+        """
+        from pylxpweb.devices.inverters._runtime_properties import (
+            InverterRuntimePropertiesMixin,
+        )
+
+        for prop in (
+            "pv4_voltage",
+            "pv4_power",
+            "pv5_voltage",
+            "pv5_power",
+            "pv6_voltage",
+            "pv6_power",
+        ):
+            assert isinstance(
+                getattr(InverterRuntimePropertiesMixin, prop, None), property
+            ), f"BaseInverter missing property {prop}"
+
+    async def test_process_inverter_object_emits_pv4_5_full_path(
+        self, hass, mock_config_entry
+    ):
+        """Full coordinator path: _process_inverter_object emits pv4/pv5 data.
+
+        The other pv4-6 tests stop at _build_runtime_sensor_mapping /
+        _map_device_properties.  This drives the REAL coordinator method
+        (_process_inverter_object) on a real/spec'd inverter whose pv4/pv5
+        runtime properties come from a genuine InverterRuntimeData via the
+        actual pylxpweb InverterRuntimePropertiesMixin (NOT a bare MagicMock,
+        which would fabricate any attribute and hide a regression).  An
+        inverter with pv_string_count=5 must yield device_data["sensors"]
+        containing pv4 and pv5 voltage/power values.
+        """
+        from pylxpweb.devices.inverters._features import InverterFeatures
+        from pylxpweb.devices.inverters._runtime_properties import (
+            InverterRuntimePropertiesMixin,
+        )
+        from pylxpweb.transports.data import InverterRuntimeData
+
+        # Real runtime data with pv4/pv5 (and pv6) populated.
+        runtime = InverterRuntimeData(
+            pv1_voltage=350.0,
+            pv1_power=3000,
+            pv4_voltage=361.0,
+            pv4_power=3100,
+            pv5_voltage=362.0,
+            pv5_power=3200,
+            pv6_voltage=363.0,
+            pv6_power=3300,
+        )
+
+        class _SpecInverter(InverterRuntimePropertiesMixin):
+            """Real-shaped inverter exposing genuine pv4-6 runtime properties.
+
+            pv4_voltage/pv4_power/etc. resolve through the real mixin reading
+            ``_transport_runtime`` — exactly as a local-transport BaseInverter
+            does — so the values under test are not fabricated.
+            """
+
+            # firmware_version is a read-only property on the real mixin —
+            # override with a plain class attribute for the stand-in.
+            serial_number = "5555555555"
+            model = "18kPV"
+            firmware_version = "1.0.0"
+            has_data = True
+
+            def __init__(self, rt: InverterRuntimeData) -> None:
+                self._runtime = None
+                self._transport_runtime = rt
+                # 5-string model drives pv4/pv5 creation.
+                self._features = InverterFeatures(pv_string_count=5)
+
+            @property
+            def pv_string_count(self) -> int:
+                return self._features.pv_string_count
+
+            async def refresh(self) -> None:
+                return None
+
+            async def detect_features(self) -> None:
+                return None
+
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        inverter = _SpecInverter(runtime)
+        result = await coordinator._process_inverter_object(inverter)
+        sensors = result["sensors"]
+
+        assert sensors["pv4_voltage"] == 361.0
+        assert sensors["pv4_power"] == 3100
+        assert sensors["pv5_voltage"] == 362.0
+        assert sensors["pv5_power"] == 3200
+        # pv_string_count surfaced through feature extraction.
+        assert result["features"]["pv_string_count"] == 5

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -117,6 +117,34 @@ class TestShouldCreateSensor:
         for key in THREE_PHASE_ONLY_SENSORS:
             assert _should_create_sensor(key, features) is False
 
+    def test_pv_three_string_model_creates_pv1_3_only(self):
+        """A 3-string model (18kPV, FlexBOSS21) -> pv1-3, no pv4-6."""
+        features = {"pv_string_count": 3}
+        for key in ("pv1_voltage", "pv2_power", "pv3_current"):
+            assert _should_create_sensor(key, features) is True
+        for key in ("pv4_voltage", "pv5_power", "pv6_voltage"):
+            assert _should_create_sensor(key, features) is False
+
+    def test_pv_zero_string_model_creates_none(self):
+        """A 0-string model (battery-only / AC-coupled-only) -> no PV sensors."""
+        features = {"pv_string_count": 0}
+        for key in ("pv1_voltage", "pv2_power", "pv3_current", "pv4_voltage"):
+            assert _should_create_sensor(key, features) is False
+
+    def test_pv_five_string_model_creates_pv1_5(self):
+        """A hypothetical 5-string model -> pv1-5, not pv6."""
+        features = {"pv_string_count": 5}
+        for key in ("pv1_voltage", "pv4_power", "pv5_voltage"):
+            assert _should_create_sensor(key, features) is True
+        assert _should_create_sensor("pv6_voltage", features) is False
+
+    def test_pv_count_missing_defaults_to_three(self):
+        """Absent pv_string_count falls back to the residential pv1-3 set."""
+        features = {"supports_split_phase": True}
+        for key in ("pv1_voltage", "pv3_power"):
+            assert _should_create_sensor(key, features) is True
+        assert _should_create_sensor("pv4_voltage", features) is False
+
     def test_discharge_recovery_with_support(self):
         """Discharge recovery sensor created when device supports it."""
         features = {"supports_discharge_recovery_hysteresis": True}


### PR DESCRIPTION
Requires **pylxpweb>=0.9.28** (released alongside; PR joyfulhouse/pylxpweb#143).

## What
- **PV strings**: per-model `pv_string_count` (0-n) drives `pvN_{voltage,power}` sensor creation; pv4-6 mapped end-to-end (LOCAL + HTTP). 3-string models (18kPV/FlexBOSS) unchanged.
- **M2**: cloud battery-bank extractor now emits `min_cell_temp`/`min_cell_voltage`/`last_polled` (LOCAL parity); cloud-absent BMS fields omitted, not faked.
- **M3**: shared `apply_ac_couple_pv_adjustment()` called by LOCAL + HTTP so HYBRID `pv_total_power` matches LOCAL.

## Validation
- Codex adversarial review: **SHIP** (5 rounds)
- Full suite: **821 passed**; `mypy --strict` clean
- Live dev vs prod: parity clean (398 sensors; 219/223 batteries identical); M2 sensors populated; #201 dongle reconnect recovered from a live "Connection lost"

🤖 Generated with [Claude Code](https://claude.com/claude-code)