### PR TITLE
test: cross-repo seam contract integration↔pylxpweb (eg4-1ch)

### DIFF
--- a/tests/test_register_contract.py
+++ b/tests/test_register_contract.py
@@ -1,0 +1,107 @@
+"""Cross-repo seam contract: integration ↔ pylxpweb.
+
+The coordinator reads pylxpweb device/dataclass attributes by NAME through the
+``_get_*_property_map()`` tables in ``coordinator_mixins`` (consumed via
+``getattr`` in ``_map_device_properties``).  When pylxpweb renames or removes an
+attribute, ``getattr`` silently returns ``None`` and the corresponding Home
+Assistant sensor goes permanently unavailable — a silent regression that no
+existing test catches because the coordinator tests feed ``MagicMock`` objects
+that answer to ANY attribute name.
+
+This test asserts every attribute the property maps read actually exists on the
+real pylxpweb class it is applied to, so a future pylxpweb bump that drops or
+renames a consumed attribute fails CI here instead of in production.
+
+It is the integration half of the register-derived contract harness (the
+pylxpweb half lives in ``pylxpweb/tests/unit/test_register_contract.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pylxpweb.devices import (
+    BaseInverter,
+    Battery,
+    BatteryBank,
+    MIDDevice,
+    ParallelGroup,
+)
+
+from custom_components.eg4_web_monitor.coordinator_mixins import DeviceProcessingMixin
+
+# -------------------------------------------------------------------------
+# Pre-existing seam gaps: attributes a property map reads that the pylxpweb
+# class does NOT expose, so the sensor is only populated via a different
+# (cloud/camelCase) path or not at all.  Each entry is DEBT, not design —
+# keep this set SHRINKING.  Tracked in beads (see issue refs).
+# -------------------------------------------------------------------------
+KNOWN_SEAM_GAPS: dict[tuple[str, str], str] = {
+    # Cloud-only metadata: the EG4 cloud returns powerRatingText / hasRuntimeData
+    # (wired via const/sensors/mappings.py), but the pylxpweb inverter DEVICE
+    # exposes no such property, so the device-object path yields None.  Tracked
+    # for seam consolidation (eg4-2iw).
+    ("inverter", "power_rating_text"): "cloud-only metadata; not a device property",
+    (
+        "inverter",
+        "has_runtime_data",
+    ): "cloud-only flag; not an inverter device property",
+    # BatteryBank exposes cycle_count_delta but not a bank-level cycle_count;
+    # the battery_bank_cycle_count sensor is populated from the local reg-106
+    # path instead.  Tracked for seam consolidation (eg4-2iw).
+    (
+        "battery_bank",
+        "cycle_count",
+    ): "BatteryBank has no cycle_count property (only _delta)",
+}
+
+# (label, property_map, target pylxpweb class the map is applied to)
+_PROPERTY_MAP_TARGETS = [
+    ("inverter", DeviceProcessingMixin._get_inverter_property_map(), BaseInverter),
+    ("battery", DeviceProcessingMixin._get_battery_property_map(), Battery),
+    (
+        "battery_bank",
+        DeviceProcessingMixin._get_battery_bank_property_map(),
+        BatteryBank,
+    ),
+    (
+        "parallel_group",
+        DeviceProcessingMixin._get_parallel_group_property_map(),
+        ParallelGroup,
+    ),
+    ("mid_device", DeviceProcessingMixin._get_mid_device_property_map(), MIDDevice),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "property_map", "cls"),
+    _PROPERTY_MAP_TARGETS,
+    ids=[t[0] for t in _PROPERTY_MAP_TARGETS],
+)
+def test_property_map_sources_exist_on_pylxpweb_class(
+    label: str, property_map: dict[str, str], cls: type
+) -> None:
+    """Every property-map source attribute resolves on its pylxpweb class."""
+    offenders = [
+        src
+        for src in property_map
+        if not hasattr(cls, src) and (label, src) not in KNOWN_SEAM_GAPS
+    ]
+    assert not offenders, (
+        f"{label} property map reads attributes missing from "
+        f"pylxpweb {cls.__name__} (silent None / seam drift):\n  "
+        + "\n  ".join(sorted(offenders))
+    )
+
+
+def test_known_seam_gaps_are_still_gaps() -> None:
+    """Keep the debt list honest: a KNOWN_SEAM_GAP that pylxpweb now provides
+    must be removed so the real contract takes over."""
+    target_by_label = {label: cls for label, _, cls in _PROPERTY_MAP_TARGETS}
+    resolved: list[str] = []
+    for (label, attr), _reason in KNOWN_SEAM_GAPS.items():
+        cls = target_by_label[label]
+        if hasattr(cls, attr):
+            resolved.append(
+                f"{label}.{attr} now exists on {cls.__name__}; drop it from KNOWN_SEAM_GAPS"
+            )
+    assert not resolved, "Stale KNOWN_SEAM_GAPS entries:\n  " + "\n  ".join(resolved)


### PR DESCRIPTION
## Summary
Integration half of the register-derived contract harness (epic eg4-1ch). Pairs with pylxpweb PR joyfulhouse/pylxpweb#166.

New: `tests/test_register_contract.py`
- Asserts every pylxpweb attribute the coordinator property maps read via `getattr` (`_get_*_property_map` in `coordinator_mixins`) actually exists on the real pylxpweb device class it is applied to (`BaseInverter`/`Battery`/`BatteryBank`/`ParallelGroup`/`MIDDevice`).
- This catches **silent seam drift**: when pylxpweb renames or removes a consumed attribute, `getattr` returns `None` and the sensor goes permanently unavailable — a regression the existing `MagicMock`-based coordinator tests are blind to (a mock answers to any attribute name).

## Gaps found (pre-existing, tracked)
3 seam gaps surfaced and captured in a **shrinking** `KNOWN_SEAM_GAPS` debt list with an honesty guard (`test_known_seam_gaps_are_still_gaps`):
- `inverter.power_rating_text`, `inverter.has_runtime_data` — cloud-only metadata, populated via the camelCase cloud path, not the device-object path.
- `BatteryBank.cycle_count` — only `cycle_count_delta` exists; the bank cycle-count comes from the local reg-106 path.

Filed as `eg4-ohz`. Per "fix as I go", these will be resolved within the typed-seam epic (eg4-2iw).

## Validation
`6 passed`, ruff clean. CI runs `pytest tests/` so the contract is enforced per-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)