### PR TITLE
test: real-object fixtures, kill MagicMock shape-blindness (eg4-uqs)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,87 @@
 """Fixtures for EG4 Web Monitor integration tests."""
 
 import threading
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pylxpweb.devices import HybridInverter, MIDDevice
+from pylxpweb.transports.data import (
+    InverterEnergyData,
+    InverterRuntimeData,
+    MidboxRuntimeData,
+)
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+# =========================================================================
+# Shape-faithful pylxpweb device builders (epic eg4-uqs)
+# =========================================================================
+# A plain MagicMock answers to ANY attribute, so a coordinator test passes even
+# when the real pylxpweb object lacks the attribute the code reads — the exact
+# blindness that let seam drift (e.g. eg4-ohz) ship undetected.
+#
+# These builders return REAL pylxpweb device objects (mock client — the client
+# is only used for API calls, never by the property accessors) with REAL
+# transport dataclasses injected.  The device's @property accessors compute for
+# real, and reading an attribute the class does not define raises AttributeError
+# — so a test fails the moment the integration relies on a non-existent
+# pylxpweb attribute.  ``_map_device_properties`` then gets ``None`` for a
+# missing property (its getattr default), exactly as in production.
+#
+# For pure transport dataclasses (InverterRuntimeData, InverterEnergyData,
+# BatteryData, BatteryBankData, MidboxRuntimeData) construct the REAL dataclass
+# directly in the test — they are trivial to instantiate and carry real field
+# semantics; no helper is needed.
+
+
+def make_real_inverter(
+    serial_number: str = "1234567890",
+    model: str = "FlexBOSS21",
+    *,
+    runtime: InverterRuntimeData | None = None,
+    energy: InverterEnergyData | None = None,
+    client: Any = None,
+) -> HybridInverter:
+    """Build a REAL HybridInverter with injected transport data.
+
+    The client is mocked (only API methods use it); the property accessors read
+    the injected ``InverterRuntimeData`` / ``InverterEnergyData``.  Reading an
+    attribute the real class does not define raises AttributeError.
+    """
+    inverter = HybridInverter(client or MagicMock(), serial_number, model)
+    if runtime is not None:
+        inverter._transport_runtime = runtime
+    if energy is not None:
+        inverter._transport_energy = energy
+    return inverter
+
+
+def make_real_mid(
+    serial_number: str = "0987654321",
+    model: str = "GridBOSS",
+    *,
+    runtime: MidboxRuntimeData | None = None,
+    client: Any = None,
+) -> MIDDevice:
+    """Build a REAL MIDDevice (GridBOSS) with injected runtime data."""
+    mid = MIDDevice(client or MagicMock(), serial_number, model)
+    if runtime is not None:
+        mid._transport_runtime = runtime
+    return mid
+
+
+@pytest.fixture
+def make_real_inverter_factory():
+    """Fixture returning the ``make_real_inverter`` builder."""
+    return make_real_inverter
+
+
+@pytest.fixture
+def make_real_mid_factory():
+    """Fixture returning the ``make_real_mid`` builder."""
+    return make_real_mid
 
 
 def create_mock_station(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@
 
 import threading
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 from pylxpweb.devices import HybridInverter, MIDDevice
+from pylxpweb.transports import ModbusTransport
 from pylxpweb.transports.data import (
     InverterEnergyData,
     InverterRuntimeData,
@@ -82,6 +83,30 @@ def make_real_inverter_factory():
 def make_real_mid_factory():
     """Fixture returning the ``make_real_mid`` builder."""
     return make_real_mid
+
+
+def make_transport_spec(**attrs: Any) -> Any:
+    """Build a shape-faithful stand-in for a pylxpweb network transport.
+
+    The transport is the network CONNECTION object (Modbus/Dongle socket); a
+    real connected one needs a live socket, so tests cannot use it directly.
+    Unlike the device classes, ModbusTransport exposes ``host`` / ``is_connected``
+    / ``split_phase`` and the read/connect coroutines at the CLASS level, so
+    ``create_autospec(spec_set=True)`` gives a stand-in that is BOTH controllable
+    (set host/is_connected/...) AND shape-faithful (reading or setting an
+    attribute the real transport does not define raises AttributeError).  Use
+    this instead of a bare MagicMock so a renamed transport attribute fails CI.
+    """
+    spec = create_autospec(ModbusTransport, spec_set=True, instance=True)
+    if attrs:
+        spec.configure_mock(**attrs)
+    return spec
+
+
+@pytest.fixture
+def make_transport_spec_factory():
+    """Fixture returning the ``make_transport_spec`` helper."""
+    return make_transport_spec
 
 
 def create_mock_station(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -77,7 +77,7 @@ from pylxpweb.transports.data import (
     MidboxRuntimeData,
 )
 
-from tests.conftest import make_real_inverter, make_real_mid
+from tests.conftest import make_real_inverter, make_real_mid, make_transport_spec
 
 
 @pytest.fixture
@@ -1191,8 +1191,7 @@ class TestDeferredLocalParameters:
             ),
         )
         mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
+        mock_inverter._transport = make_transport_spec(is_connected=True)
 
         coordinator._inverter_cache["1234567890"] = mock_inverter
         coordinator._firmware_cache["1234567890"] = "TEST-FW"
@@ -1233,8 +1232,7 @@ class TestDeferredLocalParameters:
         )
         mock_inverter.refresh = AsyncMock()
         mock_inverter.detect_features = AsyncMock()
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
+        mock_inverter._transport = make_transport_spec(is_connected=True)
 
         coordinator._inverter_cache["1234567890"] = mock_inverter
         coordinator._firmware_cache["1234567890"] = "TEST-FW"
@@ -1423,8 +1421,7 @@ class TestCacheTTLAdherence:
             ),
         )
         mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
+        mock_inverter._transport = make_transport_spec(is_connected=True)
 
         coordinator._inverter_cache["INV001"] = mock_inverter
         coordinator._firmware_cache["INV001"] = "TEST-FW"
@@ -4252,8 +4249,7 @@ class TestParameterPreComputation:
             mock_inv = make_real_inverter(serial, "FlexBOSS21", runtime=runtime)
             mock_inv.refresh = AsyncMock()
             mock_inv.detect_features = AsyncMock()
-            mock_inv._transport = MagicMock()
-            mock_inv._transport.is_connected = True
+            mock_inv._transport = make_transport_spec(is_connected=True)
             mock_inv._transport_energy = None
             mock_inv._transport_battery = None
             coordinator._inverter_cache[serial] = mock_inv
@@ -4333,8 +4329,7 @@ class TestParameterPreComputation:
         mock_inv = make_real_inverter("1111111111", "FlexBOSS21", runtime=runtime)
         mock_inv.refresh = AsyncMock()
         mock_inv.detect_features = AsyncMock()
-        mock_inv._transport = MagicMock()
-        mock_inv._transport.is_connected = True
+        mock_inv._transport = make_transport_spec(is_connected=True)
         mock_inv._transport_energy = None
         mock_inv._transport_battery = None
         coordinator._inverter_cache["1111111111"] = mock_inv
@@ -4942,7 +4937,7 @@ class TestHybridTransportExclusiveSensors:
         mock_inverter = make_real_inverter("1111111111", "LXP-12K", runtime=runtime)
         mock_inverter.refresh = AsyncMock()
         mock_inverter.detect_features = AsyncMock()
-        mock_inverter._transport = MagicMock()
+        mock_inverter._transport = make_transport_spec()
 
         result = await coordinator._process_inverter_object(mock_inverter)
         sensors = result["sensors"]
@@ -4992,7 +4987,7 @@ class TestHybridTransportExclusiveSensors:
         mock_inverter = make_real_inverter("1111111111", "LXP-12K", runtime=runtime)
         mock_inverter.refresh = AsyncMock()
         mock_inverter.detect_features = AsyncMock()
-        mock_inverter._transport = MagicMock()
+        mock_inverter._transport = make_transport_spec()
 
         result = await coordinator._process_inverter_object(mock_inverter)
         sensors = result["sensors"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4959,15 +4959,12 @@ class TestHybridTransportExclusiveSensors:
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter.serial_number = "1111111111"
-        mock_inverter.model = "LXP-12K"
-        mock_inverter.firmware_version = "1.0.0"
+        # REAL inverter with NO runtime/transport injected: the real class
+        # defaults _transport_runtime and _transport to None, so the overlay
+        # path is naturally skipped (no MagicMock del-attr gymnastics needed).
+        mock_inverter = make_real_inverter("1111111111", "LXP-12K")
         mock_inverter.refresh = AsyncMock()
         mock_inverter.detect_features = AsyncMock()
-        # No _transport_runtime at all
-        del mock_inverter._transport_runtime
-        del mock_inverter._transport
 
         result = await coordinator._process_inverter_object(mock_inverter)
         sensors = result["sensors"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4237,27 +4237,25 @@ class TestParameterPreComputation:
         coordinator = EG4DataUpdateCoordinator(hass, two_device_config_entry)
         coordinator._local_parameters_loaded = True
 
-        # Set up two mock inverters
+        # Set up two REAL inverters (real transport runtime; the computed power
+        # properties resolve for real). refresh/detect_features/_transport stay
+        # control-flow mocks — this test is about parameter-refresh gating.
         for serial in ["1111111111", "2222222222"]:
-            mock_inv = MagicMock()
+            runtime = InverterRuntimeData(
+                pv_total_power=0,
+                battery_soc=50,
+                grid_power=0,
+                parallel_number=0,
+                parallel_master_slave=0,
+                parallel_phase=0,
+            )
+            mock_inv = make_real_inverter(serial, "FlexBOSS21", runtime=runtime)
             mock_inv.refresh = AsyncMock()
             mock_inv.detect_features = AsyncMock()
             mock_inv._transport = MagicMock()
             mock_inv._transport.is_connected = True
-            mock_inv._transport_runtime = MagicMock()
-            mock_inv._transport_runtime.pv_total_power = 0
-            mock_inv._transport_runtime.battery_soc = 50
-            mock_inv._transport_runtime.grid_power = 0
-            mock_inv._transport_runtime.parallel_number = 0
-            mock_inv._transport_runtime.parallel_master_slave = 0
-            mock_inv._transport_runtime.parallel_phase = 0
             mock_inv._transport_energy = None
             mock_inv._transport_battery = None
-            mock_inv.consumption_power = None
-            mock_inv.total_load_power = None
-            mock_inv.battery_power = None
-            mock_inv.rectifier_power = None
-            mock_inv.power_to_user = None
             coordinator._inverter_cache[serial] = mock_inv
             coordinator._firmware_cache[serial] = "TEST-FW"
 
@@ -4324,24 +4322,21 @@ class TestParameterPreComputation:
         coordinator = EG4DataUpdateCoordinator(hass, config_entry)
         # _local_parameters_loaded defaults to False
 
-        mock_inv = MagicMock()
+        runtime = InverterRuntimeData(
+            pv_total_power=0,
+            battery_soc=50,
+            grid_power=0,
+            parallel_number=0,
+            parallel_master_slave=0,
+            parallel_phase=0,
+        )
+        mock_inv = make_real_inverter("1111111111", "FlexBOSS21", runtime=runtime)
         mock_inv.refresh = AsyncMock()
+        mock_inv.detect_features = AsyncMock()
         mock_inv._transport = MagicMock()
         mock_inv._transport.is_connected = True
-        mock_inv._transport_runtime = MagicMock()
-        mock_inv._transport_runtime.pv_total_power = 0
-        mock_inv._transport_runtime.battery_soc = 50
-        mock_inv._transport_runtime.grid_power = 0
-        mock_inv._transport_runtime.parallel_number = 0
-        mock_inv._transport_runtime.parallel_master_slave = 0
-        mock_inv._transport_runtime.parallel_phase = 0
         mock_inv._transport_energy = None
         mock_inv._transport_battery = None
-        mock_inv.consumption_power = None
-        mock_inv.total_load_power = None
-        mock_inv.battery_power = None
-        mock_inv.rectifier_power = None
-        mock_inv.power_to_user = None
         coordinator._inverter_cache["1111111111"] = mock_inv
         coordinator._firmware_cache["1111111111"] = "TEST-FW"
 
@@ -4784,9 +4779,11 @@ class TestParallelGroupConsumptionEnergyBalance:
         mock_group.battery_count = 6
         mock_group.first_device_serial = "INV001"
 
-        # Mark inverters as having local transport
+        # Mark inverters as having local transport (real empty energy object is
+        # the truthiness sentinel _has_local_energy() checks; the energy values
+        # themselves come from the parallel-group aggregate above).
         for inv in mock_group.inverters:
-            inv._transport_energy = MagicMock()
+            inv._transport_energy = InverterEnergyData()
 
         result = await coordinator._process_parallel_group_object(mock_group)
         sensors = result["sensors"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4930,24 +4930,22 @@ class TestHybridTransportExclusiveSensors:
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter.serial_number = "1111111111"
-        mock_inverter.model = "LXP-12K"
-        mock_inverter.firmware_version = "1.0.0"
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter.detect_features = AsyncMock()
-        mock_inverter._transport = MagicMock()
-
-        # Real transport runtime with Modbus-only data, so the overlay attrs
-        # resolve against the genuine InverterRuntimeData shape.
-        mock_inverter._transport_runtime = InverterRuntimeData(
+        # REAL inverter so the FULL base property surface mapped by
+        # _process_inverter_object is exercised against the genuine class shape,
+        # not fabricated by MagicMock.  pv_total_power=2500 makes the real
+        # consumption_power (== total_load_power) compute to 2500.
+        runtime = InverterRuntimeData(
             temperature_t1=35.0,
             inverter_rms_current_r=4.5,
             inverter_rms_current_s=4.3,
             inverter_rms_current_t=4.1,
             battery_current=12.5,
+            pv_total_power=2500,
         )
-        mock_inverter.total_load_power = 2500.0
+        mock_inverter = make_real_inverter("1111111111", "LXP-12K", runtime=runtime)
+        mock_inverter.refresh = AsyncMock()
+        mock_inverter.detect_features = AsyncMock()
+        mock_inverter._transport = MagicMock()
 
         result = await coordinator._process_inverter_object(mock_inverter)
         sensors = result["sensors"]
@@ -4957,7 +4955,7 @@ class TestHybridTransportExclusiveSensors:
         assert sensors["grid_current_l2"] == 4.3
         assert sensors["grid_current_l3"] == 4.1
         assert sensors["battery_current"] == 12.5
-        assert sensors["total_load_power"] == 2500.0
+        assert sensors["total_load_power"] == 2500
 
     async def test_no_transport_runtime_skips_overlay(self, hass, mock_config_entry):
         """Without _transport_runtime, overlay is skipped entirely."""
@@ -4987,23 +4985,20 @@ class TestHybridTransportExclusiveSensors:
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter.serial_number = "1111111111"
-        mock_inverter.model = "LXP-12K"
-        mock_inverter.firmware_version = "1.0.0"
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter.detect_features = AsyncMock()
-        mock_inverter._transport = MagicMock()
-
-        # Real transport runtime with some None values (defaults are None).
-        mock_inverter._transport_runtime = InverterRuntimeData(
+        # REAL inverter with a sparse runtime: only inverter_rms_current_r is
+        # set, and NO pv/grid/battery power, so the real consumption_power
+        # (== total_load_power) computes to None and must not be overlaid.
+        runtime = InverterRuntimeData(
             temperature_t1=None,
             inverter_rms_current_r=4.5,
             inverter_rms_current_s=None,
             inverter_rms_current_t=None,
             battery_current=None,
         )
-        mock_inverter.total_load_power = None
+        mock_inverter = make_real_inverter("1111111111", "LXP-12K", runtime=runtime)
+        mock_inverter.refresh = AsyncMock()
+        mock_inverter.detect_features = AsyncMock()
+        mock_inverter._transport = MagicMock()
 
         result = await coordinator._process_inverter_object(mock_inverter)
         sensors = result["sensors"]
@@ -5716,37 +5711,40 @@ class TestRoundRobinTruncatedSerialGuard:
         voltage: float = 53.0,
         soc: int = 96,
         index: int = 0,
-    ) -> MagicMock:
-        """Build a mock BatteryData with all attributes for mapping."""
-        batt = MagicMock()
-        batt.serial_number = serial
-        batt.voltage = voltage
-        batt.soc = soc
-        batt.battery_index = index
-        batt.current = -5.0
-        batt.power = -260.0
-        batt.soh = 100
-        batt.max_cell_temperature = 26.0
-        batt.min_cell_temperature = 24.0
-        batt.max_cell_num_temp = 1
-        batt.min_cell_num_temp = 3
-        batt.max_cell_voltage = 3.35
-        batt.min_cell_voltage = 3.30
-        batt.max_cell_num_voltage = 2
-        batt.min_cell_num_voltage = 8
-        batt.cell_voltage_delta = 0.05
-        batt.cell_temp_delta = 2.0
-        batt.remaining_capacity = 96.0
-        batt.max_capacity = 100.0
-        batt.capacity_percent = 96.0
-        batt.charge_current_limit = 50.0
-        batt.charge_voltage_ref = 56.0
-        batt.cycle_count = 50
-        batt.firmware_version = "1.0"
-        batt.battery_type = None
-        batt.battery_type_text = None
-        batt.model = "EG4-LL"
-        return batt
+    ) -> BatteryData:
+        """Build a REAL BatteryData for the round-robin merge mapping.
+
+        Only real dataclass FIELDS are set; the computed properties (power,
+        cell_voltage_delta, cell_temp_delta, remaining_capacity,
+        capacity_percent) resolve for real from those fields — so the
+        individual-battery mapping is exercised against the genuine shape
+        instead of a MagicMock fabricating every attribute.
+        """
+        return BatteryData(
+            serial_number=serial,
+            voltage=voltage,
+            soc=soc,
+            battery_index=index,
+            current=-5.0,
+            soh=100,
+            max_cell_temperature=26.0,
+            min_cell_temperature=24.0,
+            max_cell_num_temp=1,
+            min_cell_num_temp=3,
+            max_cell_voltage=3.35,
+            min_cell_voltage=3.30,
+            max_cell_num_voltage=2,
+            min_cell_num_voltage=8,
+            current_capacity=96.0,
+            max_capacity=100.0,
+            charge_current_limit=50.0,
+            charge_voltage_ref=56.0,
+            cycle_count=50,
+            firmware_version="1.0",
+            battery_type=None,
+            battery_type_text=None,
+            model="EG4-LL",
+        )
 
     async def test_truncated_serial_skipped(self, hass, mock_config_entry):
         """A truncated serial is skipped, not cached as a phantom entry."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -69,6 +69,15 @@ from pylxpweb.exceptions import (
     LuxpowerAuthError,
     LuxpowerConnectionError,
 )
+from pylxpweb.transports.data import (
+    BatteryBankData,
+    BatteryData,
+    InverterEnergyData,
+    InverterRuntimeData,
+    MidboxRuntimeData,
+)
+
+from tests.conftest import make_real_inverter, make_real_mid
 
 
 @pytest.fixture
@@ -1166,24 +1175,24 @@ class TestDeferredLocalParameters:
         """Verify include_parameters=False on first local refresh."""
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_inverter = MagicMock()
+        # Real inverter so _build_runtime_sensor_mapping + computed power
+        # properties resolve against the genuine pylxpweb shape; only refresh
+        # (control flow) is mocked.
+        mock_inverter = make_real_inverter(
+            "1234567890",
+            "FlexBOSS21",
+            runtime=InverterRuntimeData(
+                pv_total_power=0,
+                battery_soc=50,
+                grid_power=0,
+                parallel_number=0,
+                parallel_master_slave=0,
+                parallel_phase=0,
+            ),
+        )
         mock_inverter.refresh = AsyncMock()
         mock_inverter._transport = MagicMock()
         mock_inverter._transport.is_connected = True
-        mock_inverter._transport_runtime = MagicMock()
-        mock_inverter._transport_runtime.pv_total_power = 0
-        mock_inverter._transport_runtime.battery_soc = 50
-        mock_inverter._transport_runtime.grid_power = 0
-        mock_inverter._transport_runtime.parallel_number = 0
-        mock_inverter._transport_runtime.parallel_master_slave = 0
-        mock_inverter._transport_runtime.parallel_phase = 0
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = None
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
 
         coordinator._inverter_cache["1234567890"] = mock_inverter
         coordinator._firmware_cache["1234567890"] = "TEST-FW"
@@ -1209,25 +1218,23 @@ class TestDeferredLocalParameters:
         coordinator._local_parameters_loaded = True  # Simulate post-first-refresh
         coordinator._include_params_this_cycle = True  # Simulate poll-cycle decision
 
-        mock_inverter = MagicMock()
+        # Real inverter; refresh/detect_features mocked for control-flow asserts.
+        mock_inverter = make_real_inverter(
+            "1234567890",
+            "FlexBOSS21",
+            runtime=InverterRuntimeData(
+                pv_total_power=0,
+                battery_soc=50,
+                grid_power=0,
+                parallel_number=0,
+                parallel_master_slave=0,
+                parallel_phase=0,
+            ),
+        )
         mock_inverter.refresh = AsyncMock()
         mock_inverter.detect_features = AsyncMock()
         mock_inverter._transport = MagicMock()
         mock_inverter._transport.is_connected = True
-        mock_inverter._transport_runtime = MagicMock()
-        mock_inverter._transport_runtime.pv_total_power = 0
-        mock_inverter._transport_runtime.battery_soc = 50
-        mock_inverter._transport_runtime.grid_power = 0
-        mock_inverter._transport_runtime.parallel_number = 0
-        mock_inverter._transport_runtime.parallel_master_slave = 0
-        mock_inverter._transport_runtime.parallel_phase = 0
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = None
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
 
         coordinator._inverter_cache["1234567890"] = mock_inverter
         coordinator._firmware_cache["1234567890"] = "TEST-FW"
@@ -1402,24 +1409,22 @@ class TestCacheTTLAdherence:
         modbus_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, modbus_config_entry)
 
-        mock_inverter = MagicMock()
+        # Real inverter; refresh mocked for the force=False control-flow assert.
+        mock_inverter = make_real_inverter(
+            "INV001",
+            "FlexBOSS21",
+            runtime=InverterRuntimeData(
+                pv_total_power=0,
+                battery_soc=50,
+                grid_power=0,
+                parallel_number=0,
+                parallel_master_slave=0,
+                parallel_phase=0,
+            ),
+        )
         mock_inverter.refresh = AsyncMock()
         mock_inverter._transport = MagicMock()
         mock_inverter._transport.is_connected = True
-        mock_inverter._transport_runtime = MagicMock()
-        mock_inverter._transport_runtime.pv_total_power = 0
-        mock_inverter._transport_runtime.battery_soc = 50
-        mock_inverter._transport_runtime.grid_power = 0
-        mock_inverter._transport_runtime.parallel_number = 0
-        mock_inverter._transport_runtime.parallel_master_slave = 0
-        mock_inverter._transport_runtime.parallel_phase = 0
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = None
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
 
         coordinator._inverter_cache["INV001"] = mock_inverter
         coordinator._firmware_cache["INV001"] = "TEST-FW"
@@ -1702,32 +1707,29 @@ class TestStaticLocalData:
 
     def test_static_keys_match_runtime_mapping(self):
         """INVERTER_RUNTIME_KEYS matches _build_runtime_sensor_mapping keys."""
-        mock_runtime = MagicMock()
-        mapping = _build_runtime_sensor_mapping(mock_runtime)
+        mapping = _build_runtime_sensor_mapping(InverterRuntimeData())
         assert set(mapping.keys()) == INVERTER_RUNTIME_KEYS
 
     def test_static_keys_match_energy_mapping(self):
         """INVERTER_ENERGY_KEYS matches _build_energy_sensor_mapping keys."""
-        mock_energy = MagicMock()
-        mapping = _build_energy_sensor_mapping(mock_energy)
+        mapping = _build_energy_sensor_mapping(InverterEnergyData())
         assert set(mapping.keys()) == INVERTER_ENERGY_KEYS
 
     def test_static_keys_match_battery_bank_mapping(self):
         """BATTERY_BANK_KEYS matches _build_battery_bank_sensor_mapping keys."""
-        mock_battery = MagicMock()
-        # Ensure diagnostic values are non-None so all keys are present
-        mock_battery.min_soh = 95.0
-        mock_battery.max_cell_temp = 30.0
-        mock_battery.temp_delta = 2.0
-        mock_battery.cell_voltage_delta_max = 0.05
-        mock_battery.soc_delta = 1.0
-        mock_battery.soh_delta = 2.0
-        mock_battery.voltage_delta = 0.1
-        mock_battery.cycle_count_delta = 5
-        mock_battery.charge_power = 500
-        mock_battery.discharge_power = 0
-        mock_battery.battery_power = 500
-        mapping = _build_battery_bank_sensor_mapping(mock_battery)
+        # Real BatteryBankData; two batteries with differing soc/soh/voltage/
+        # cycle_count so the CAN-derived delta properties resolve non-None and
+        # every BATTERY_BANK key is emitted (the diagnostics keys are otherwise
+        # omitted when None).
+        battery_data = BatteryBankData(
+            charge_power=500,
+            discharge_power=0,
+            batteries=[
+                BatteryData(soc=95, soh=98, voltage=53.2, cycle_count=10),
+                BatteryData(soc=94, soh=96, voltage=53.1, cycle_count=5),
+            ],
+        )
+        mapping = _build_battery_bank_sensor_mapping(battery_data)
         # Charge rate key is computed by compute_bank_charge_rate()
         # after the raw mapping, so it appears in the frozenset but not here.
         computed_keys = {
@@ -1737,7 +1739,7 @@ class TestStaticLocalData:
 
     def test_static_keys_match_gridboss_mapping(self):
         """GRIDBOSS_SENSOR_KEYS covers _build_gridboss_sensor_mapping keys + metadata."""
-        mock_mid = MagicMock()
+        mock_mid = make_real_mid("0987654321", "GridBOSS", runtime=MidboxRuntimeData())
         mapping = _build_gridboss_sensor_mapping(mock_mid)
         mapping_keys = set(mapping.keys())
 
@@ -3718,8 +3720,9 @@ class TestMappingKeyConsistency:
 
     def test_gridboss_local_keys_subset_of_static(self):
         """LOCAL _build_gridboss_sensor_mapping() keys ⊆ static + dynamic sets."""
-        # Create a mock MID device where every attribute returns a sentinel
-        mock_mid = MagicMock()
+        # Real MID device so the mapping resolves against the genuine GridBOSS
+        # property surface (a missing property would raise, not be fabricated).
+        mock_mid = make_real_mid("0987654321", "GridBOSS", runtime=MidboxRuntimeData())
         sensors = _build_gridboss_sensor_mapping(mock_mid)
         local_keys = set(sensors.keys())
         allowed = (
@@ -3785,7 +3788,7 @@ class TestMappingKeyConsistency:
             DeviceProcessingMixin,
         )
 
-        mock_mid = MagicMock()
+        mock_mid = make_real_mid("0987654321", "GridBOSS", runtime=MidboxRuntimeData())
         local_keys = set(_build_gridboss_sensor_mapping(mock_mid).keys())
         http_keys = set(DeviceProcessingMixin._get_mid_device_property_map().values())
 
@@ -3798,8 +3801,7 @@ class TestMappingKeyConsistency:
 
     def test_inverter_local_runtime_keys_subset_of_static(self):
         """LOCAL _build_runtime_sensor_mapping() keys ⊆ INVERTER_RUNTIME_KEYS."""
-        mock_runtime = MagicMock()
-        sensors = _build_runtime_sensor_mapping(mock_runtime)
+        sensors = _build_runtime_sensor_mapping(InverterRuntimeData())
         local_keys = set(sensors.keys())
         unknown = local_keys - INVERTER_RUNTIME_KEYS
         assert not unknown, (
@@ -4375,30 +4377,19 @@ class TestBatteryBankCurrentKey:
 
     def test_battery_bank_current_in_build_mapping(self):
         """_build_battery_bank_sensor_mapping includes battery_bank_current."""
-        mock_battery = MagicMock()
-        mock_battery.soc = 85
-        mock_battery.voltage = 52.0
-        mock_battery.current = 15.5
-        mock_battery.charge_power = 800.0
-        mock_battery.discharge_power = 0.0
-        mock_battery.battery_power = 800.0
-        mock_battery.max_capacity = 200
-        mock_battery.current_capacity = 170
-        mock_battery.remain_capacity = 170
-        mock_battery.full_capacity = 200
-        mock_battery.capacity_percent = 85
-        mock_battery.battery_count = 4
-        mock_battery.status = "charging"
-        mock_battery.soc_delta = 2.0
-        mock_battery.min_soh = 98
-        mock_battery.soh_delta = 1
-        mock_battery.voltage_delta = 0.1
-        mock_battery.cell_voltage_delta_max = 0.02
-        mock_battery.cycle_count_delta = 5
-        mock_battery.max_cell_temp = 28.0
-        mock_battery.temp_delta = 3.0
+        battery_data = BatteryBankData(
+            soc=85,
+            voltage=52.0,
+            current=15.5,
+            charge_power=800.0,
+            discharge_power=0.0,
+            max_capacity=200,
+            current_capacity=170,
+            battery_count=4,
+            status="charging",
+        )
 
-        result = _build_battery_bank_sensor_mapping(mock_battery)
+        result = _build_battery_bank_sensor_mapping(battery_data)
         assert "battery_bank_current" in result
         assert result["battery_bank_current"] == 15.5
 
@@ -4549,33 +4540,29 @@ class TestBatteryBankBMSCoreKeys:
 
     def test_build_mapping_includes_bms_core_sensors(self):
         """BMS CORE keys present in mapping even without CAN bus data."""
-        mock_battery = MagicMock()
-        mock_battery.soc = 85
-        mock_battery.voltage = 52.0
-        mock_battery.current = 15.5
-        mock_battery.charge_power = 800.0
-        mock_battery.discharge_power = 0.0
-        mock_battery.battery_power = 800.0
-        mock_battery.max_capacity = 200
-        mock_battery.current_capacity = 170
-        mock_battery.remain_capacity = 170
-        mock_battery.full_capacity = 200
-        mock_battery.capacity_percent = 85
-        mock_battery.battery_count = 4
-        mock_battery.status = "charging"
-        # CAN-dependent diagnostics return None (need individual batteries)
-        mock_battery.soc_delta = None
-        mock_battery.soh_delta = None
-        mock_battery.voltage_delta = None
-        mock_battery.cycle_count_delta = None
-        # Bank-level BMS registers (always available, CORE keys)
-        mock_battery.min_soh = 100
-        mock_battery.max_cell_temp = 35.0
-        mock_battery.temp_delta = 5.5
-        mock_battery.cell_voltage_delta_max = 0.050
-        mock_battery.cycle_count = 53
+        # Real BatteryBankData with no per-battery list: the bank-level BMS
+        # register fields drive the CORE diagnostics (min_soh←soh, max_cell_temp
+        # ←max_cell_temperature, temp_delta←max-min cell temp, etc.) while the
+        # CAN-derived deltas stay None (no batteries).
+        battery_data = BatteryBankData(
+            soc=85,
+            voltage=52.0,
+            current=15.5,
+            charge_power=800.0,
+            discharge_power=0.0,
+            max_capacity=200,
+            current_capacity=170,
+            battery_count=4,
+            status="charging",
+            soh=100,
+            max_cell_temperature=35.0,
+            min_cell_temperature=29.5,
+            max_cell_voltage=3.350,
+            min_cell_voltage=3.300,
+            cycle_count=53,
+        )
 
-        result = _build_battery_bank_sensor_mapping(mock_battery)
+        result = _build_battery_bank_sensor_mapping(battery_data)
         # BMS CORE keys always present
         assert "battery_bank_min_soh" in result
         assert result["battery_bank_min_soh"] == 100
@@ -4635,64 +4622,69 @@ class TestBatteryBankCANDiagnosticSuppression:
 
     def test_can_keys_added_dynamically_when_data_present(self):
         """CAN diagnostic keys appear in mapping when individual battery data exists."""
-        mock_battery = MagicMock()
-        mock_battery.soc = 85
-        mock_battery.voltage = 52.0
-        mock_battery.current = 15.5
-        mock_battery.charge_power = 800.0
-        mock_battery.discharge_power = 0.0
-        mock_battery.battery_power = 800.0
-        mock_battery.max_capacity = 200
-        mock_battery.current_capacity = 170
-        mock_battery.remain_capacity = 170
-        mock_battery.full_capacity = 200
-        mock_battery.capacity_percent = 85
-        mock_battery.battery_count = 3
-        mock_battery.status = "charging"
-        # CAN-dependent diagnostics return values
-        mock_battery.soc_delta = 2
-        mock_battery.min_soh = 95
-        mock_battery.soh_delta = 3
-        mock_battery.voltage_delta = 0.15
-        mock_battery.cycle_count_delta = 10
-        # BMS fallbacks also present
-        mock_battery.max_cell_temp = 30.0
-        mock_battery.temp_delta = 2.0
-        mock_battery.cell_voltage_delta_max = 0.03
+        # Real BatteryBankData with two differing batteries so every CAN-derived
+        # delta (soc/soh/voltage/cycle_count) resolves non-None.
+        battery_data = BatteryBankData(
+            soc=85,
+            voltage=52.0,
+            current=15.5,
+            charge_power=800.0,
+            discharge_power=0.0,
+            max_capacity=200,
+            current_capacity=170,
+            battery_count=3,
+            status="charging",
+            batteries=[
+                BatteryData(
+                    soc=85,
+                    soh=95,
+                    voltage=52.05,
+                    cycle_count=20,
+                    max_cell_temperature=30.0,
+                    min_cell_temperature=28.0,
+                    max_cell_voltage=3.34,
+                    min_cell_voltage=3.31,
+                ),
+                BatteryData(
+                    soc=83,
+                    soh=92,
+                    voltage=51.90,
+                    cycle_count=10,
+                    max_cell_temperature=29.5,
+                    min_cell_temperature=28.5,
+                    max_cell_voltage=3.33,
+                    min_cell_voltage=3.32,
+                ),
+            ],
+        )
 
-        result = _build_battery_bank_sensor_mapping(mock_battery)
+        result = _build_battery_bank_sensor_mapping(battery_data)
         for key in BATTERY_BANK_CAN_DIAGNOSTIC_KEYS:
             assert key in result, f"{key} should be in mapping when CAN data present"
 
     def test_can_keys_absent_when_no_individual_batteries(self):
         """CAN diagnostic keys absent from mapping when no CAN bus data."""
-        mock_battery = MagicMock()
-        mock_battery.soc = 85
-        mock_battery.voltage = 52.0
-        mock_battery.current = 15.5
-        mock_battery.charge_power = 800.0
-        mock_battery.discharge_power = 0.0
-        mock_battery.battery_power = 800.0
-        mock_battery.max_capacity = 200
-        mock_battery.current_capacity = 170
-        mock_battery.remain_capacity = 170
-        mock_battery.full_capacity = 200
-        mock_battery.capacity_percent = 85
-        mock_battery.battery_count = 3
-        mock_battery.status = "Idle"
-        # No CAN data — all cross-battery diagnostics return None
-        mock_battery.soc_delta = None
-        mock_battery.soh_delta = None
-        mock_battery.voltage_delta = None
-        mock_battery.cycle_count_delta = None
-        # Bank-level BMS sensors still available (CORE keys)
-        mock_battery.min_soh = 100
-        mock_battery.max_cell_temp = 28.0
-        mock_battery.temp_delta = 1.5
-        mock_battery.cell_voltage_delta_max = 0.01
-        mock_battery.cycle_count = 53
+        # Real BatteryBankData with no per-battery list: bank-level BMS register
+        # fields supply the CORE keys; CAN-derived deltas resolve to None.
+        battery_data = BatteryBankData(
+            soc=85,
+            voltage=52.0,
+            current=15.5,
+            charge_power=800.0,
+            discharge_power=0.0,
+            max_capacity=200,
+            current_capacity=170,
+            battery_count=3,
+            status="Idle",
+            soh=100,
+            max_cell_temperature=28.0,
+            min_cell_temperature=26.5,
+            max_cell_voltage=3.32,
+            min_cell_voltage=3.31,
+            cycle_count=53,
+        )
 
-        result = _build_battery_bank_sensor_mapping(mock_battery)
+        result = _build_battery_bank_sensor_mapping(battery_data)
         for key in BATTERY_BANK_CAN_DIAGNOSTIC_KEYS:
             assert key not in result, f"{key} should NOT be in mapping without CAN data"
         # Bank-level BMS sensors (CORE keys) should always be present
@@ -4946,14 +4938,15 @@ class TestHybridTransportExclusiveSensors:
         mock_inverter.detect_features = AsyncMock()
         mock_inverter._transport = MagicMock()
 
-        # Transport runtime with Modbus-only data
-        mock_runtime = MagicMock()
-        mock_runtime.temperature_t1 = 35.0
-        mock_runtime.inverter_rms_current_r = 4.5
-        mock_runtime.inverter_rms_current_s = 4.3
-        mock_runtime.inverter_rms_current_t = 4.1
-        mock_runtime.battery_current = 12.5
-        mock_inverter._transport_runtime = mock_runtime
+        # Real transport runtime with Modbus-only data, so the overlay attrs
+        # resolve against the genuine InverterRuntimeData shape.
+        mock_inverter._transport_runtime = InverterRuntimeData(
+            temperature_t1=35.0,
+            inverter_rms_current_r=4.5,
+            inverter_rms_current_s=4.3,
+            inverter_rms_current_t=4.1,
+            battery_current=12.5,
+        )
         mock_inverter.total_load_power = 2500.0
 
         result = await coordinator._process_inverter_object(mock_inverter)
@@ -5002,14 +4995,14 @@ class TestHybridTransportExclusiveSensors:
         mock_inverter.detect_features = AsyncMock()
         mock_inverter._transport = MagicMock()
 
-        # Transport runtime with some None values
-        mock_runtime = MagicMock()
-        mock_runtime.temperature_t1 = None
-        mock_runtime.inverter_rms_current_r = 4.5
-        mock_runtime.inverter_rms_current_s = None
-        mock_runtime.inverter_rms_current_t = None
-        mock_runtime.battery_current = None
-        mock_inverter._transport_runtime = mock_runtime
+        # Real transport runtime with some None values (defaults are None).
+        mock_inverter._transport_runtime = InverterRuntimeData(
+            temperature_t1=None,
+            inverter_rms_current_r=4.5,
+            inverter_rms_current_s=None,
+            inverter_rms_current_t=None,
+            battery_current=None,
+        )
         mock_inverter.total_load_power = None
 
         result = await coordinator._process_inverter_object(mock_inverter)
@@ -5518,18 +5511,21 @@ class TestChargeRates:
         *,
         current: float = 0.0,
         max_capacity: float = 280.0,
-    ) -> MagicMock:
-        """Create a minimal mock battery for ``_build_individual_battery_mapping``."""
-        battery = MagicMock()
-        battery.voltage = 50.0
-        battery.current = current
-        battery.power = battery.voltage * current
-        battery.soc = 80
-        battery.soh = 99
-        battery.max_capacity = max_capacity
-        battery.charge_current_limit = 20.0
-        battery.discharge_current_limit = 20.0
-        return battery
+    ) -> BatteryData:
+        """Build a real BatteryData for ``_build_individual_battery_mapping``.
+
+        ``power`` resolves through the real voltage*current property, and the
+        mapping reads every other field against the genuine BatteryData shape.
+        """
+        return BatteryData(
+            voltage=50.0,
+            current=current,
+            soc=80,
+            soh=99,
+            max_capacity=max_capacity,
+            charge_current_limit=20.0,
+            discharge_current_limit=20.0,
+        )
 
     def test_individual_battery_charge_rate(self):
         """Individual battery mapping includes signed charge rate."""

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -33,7 +33,7 @@ from pylxpweb.exceptions import (
 )
 from pylxpweb.transports.data import BatteryBankData, BatteryData, MidboxRuntimeData
 
-from tests.conftest import make_real_mid
+from tests.conftest import make_real_mid, make_transport_spec
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────
@@ -486,9 +486,9 @@ class TestHybridMode:
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
 
         inv = _mock_inverter(serial="INV001")
-        mock_transport = MagicMock()
-        mock_transport.transport_type = "modbus"
-        mock_transport.host = "192.168.1.100"
+        mock_transport = make_transport_spec(
+            transport_type="modbus", host="192.168.1.100"
+        )
         inv._transport = mock_transport
 
         coordinator.station = _mock_station([inv])

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -31,7 +31,7 @@ from pylxpweb.exceptions import (
     LuxpowerAuthError,
     LuxpowerConnectionError,
 )
-from pylxpweb.transports.data import MidboxRuntimeData
+from pylxpweb.transports.data import BatteryBankData, BatteryData, MidboxRuntimeData
 
 from tests.conftest import make_real_mid
 
@@ -926,15 +926,19 @@ class TestBatteryExtraction:
         inv = _mock_inverter(serial="INV001")
         inv._battery_bank = None  # No cloud batteries
 
-        # Transport batteries
-        mock_transport_battery = MagicMock()
-        mock_batt = MagicMock()
-        mock_batt.battery_index = 0
-        mock_batt.voltage = 52.0
-        mock_batt.current = 10.0
-        mock_batt.soc = 85
-        mock_batt.serial_number = "BAT_SN_001"
-        mock_transport_battery.batteries = [mock_batt]
+        # Transport batteries — real BatteryData/BatteryBankData so the
+        # individual-battery read path is exercised against the genuine shape.
+        mock_transport_battery = BatteryBankData(
+            batteries=[
+                BatteryData(
+                    battery_index=0,
+                    voltage=52.0,
+                    current=10.0,
+                    soc=85,
+                    serial_number="BAT_SN_001",
+                )
+            ]
+        )
         inv._transport_battery = mock_transport_battery
 
         coordinator.station = _mock_station([inv])

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -31,6 +31,9 @@ from pylxpweb.exceptions import (
     LuxpowerAuthError,
     LuxpowerConnectionError,
 )
+from pylxpweb.transports.data import MidboxRuntimeData
+
+from tests.conftest import make_real_mid
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────
@@ -806,14 +809,18 @@ class TestHybridTransportGating:
         hybrid_dongle_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_dongle_config_entry)
 
-        mid_device = MagicMock()
-        mid_device.serial_number = "MID001"
-        mid_device.model = "GridBOSS"
-        mid_device.firmware_version = "1.0.0"
+        mid_device = make_real_mid(
+            serial_number="MID001",
+            model="GridBOSS",
+            runtime=MidboxRuntimeData(
+                grid_l1_voltage=122.5,
+                grid_l2_voltage=122.4,
+                grid_frequency=60.0,
+            ),
+        )
+        # refresh() is the call under test — wrap it so we can assert it is
+        # NOT invoked (control-flow mock, not data-producing).
         mid_device.refresh = AsyncMock()
-        # Give it basic properties so processing doesn't error
-        mid_device.grid_voltage = 240.0
-        mid_device.grid_frequency = 60.0
 
         await coordinator._process_mid_device_object(mid_device)
 

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -14,6 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pylxpweb.transports.data import (
+    BatteryBankData,
+    BatteryData,
+    InverterEnergyData,
+    InverterRuntimeData,
+)
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.eg4_web_monitor.const import (
@@ -201,7 +207,7 @@ class TestBuildLocalDeviceData:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = MagicMock()
+        mock_inverter._transport_runtime = InverterRuntimeData()
         mock_inverter._transport_energy = None
         mock_inverter._transport_battery = None
         mock_inverter._transport = MagicMock()
@@ -238,8 +244,8 @@ class TestBuildLocalDeviceData:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = MagicMock()
-        mock_inverter._transport_energy = MagicMock()
+        mock_inverter._transport_runtime = InverterRuntimeData()
+        mock_inverter._transport_energy = InverterEnergyData()
         mock_inverter._transport_battery = None
         mock_inverter._transport = None
         mock_inverter.consumption_power = None
@@ -274,7 +280,7 @@ class TestBuildLocalDeviceData:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = MagicMock()
+        mock_inverter._transport_runtime = InverterRuntimeData()
         mock_inverter._transport_energy = None
         mock_inverter._transport_battery = None
         mock_inverter._transport = None
@@ -963,20 +969,22 @@ class TestSharedBatterySecondary:
         coordinator = EG4DataUpdateCoordinator(hass, parallel_config_entry)
         coordinator._local_static_phase_done = True
 
-        # Mock secondary inverter: role=2, battery_count=0 (shared battery)
-        mock_runtime = MagicMock()
-        mock_runtime.parallel_number = 2
-        mock_runtime.parallel_master_slave = 2
-        mock_runtime.parallel_phase = 0
-        mock_runtime.pv_total_power = 5000
-        mock_runtime.battery_soc = 93
-        mock_runtime.grid_power = 0
-        mock_runtime.battery_current = 15.0
-        mock_runtime.battery_voltage = 53.7
+        # Secondary inverter: role=2, battery_count=0 (shared battery)
+        mock_runtime = InverterRuntimeData(
+            parallel_number=2,
+            parallel_master_slave=2,
+            parallel_phase=0,
+            pv_total_power=5000,
+            battery_soc=93,
+            grid_power=0,
+            battery_current=15.0,
+            battery_voltage=53.7,
+        )
 
-        mock_battery_data = MagicMock()
-        mock_battery_data.battery_count = None  # CAN bus not connected
-        mock_battery_data.batteries = []
+        mock_battery_data = BatteryBankData(
+            battery_count=None,  # CAN bus not connected
+            batteries=[],
+        )
 
         mock_inverter = MagicMock()
         mock_inverter.refresh = AsyncMock()
@@ -1038,37 +1046,30 @@ class TestSharedBatterySecondary:
         coordinator = EG4DataUpdateCoordinator(hass, parallel_config_entry)
         coordinator._local_static_phase_done = True
 
-        mock_runtime = MagicMock()
-        mock_runtime.parallel_number = 2
-        mock_runtime.parallel_master_slave = 1
-        mock_runtime.parallel_phase = 0
-        mock_runtime.pv_total_power = 8000
-        mock_runtime.battery_soc = 93
-        mock_runtime.grid_power = 0
+        mock_runtime = InverterRuntimeData(
+            parallel_number=2,
+            parallel_master_slave=1,
+            parallel_phase=0,
+            pv_total_power=8000,
+            battery_soc=93,
+            grid_power=0,
+        )
 
-        mock_battery_data = MagicMock()
-        mock_battery_data.battery_count = 4  # CAN bus connected
-        mock_battery_data.voltage = 53.7
-        mock_battery_data.current = 30.0
-        mock_battery_data.soc = 93
-        mock_battery_data.charge_power = 825.0
-        mock_battery_data.discharge_power = 0
-        mock_battery_data.battery_power = 1611.0
-        mock_battery_data.max_capacity = 280.0
-        mock_battery_data.current_capacity = 260.0
-        mock_battery_data.remain_capacity = 260.0
-        mock_battery_data.full_capacity = 280.0
-        mock_battery_data.capacity_percent = 92.9
-        mock_battery_data.status = "Charging"
-        mock_battery_data.min_soh = None
-        mock_battery_data.max_cell_temp = None
-        mock_battery_data.temp_delta = None
-        mock_battery_data.cell_voltage_delta_max = None
-        mock_battery_data.soc_delta = None
-        mock_battery_data.soh_delta = None
-        mock_battery_data.voltage_delta = None
-        mock_battery_data.cycle_count_delta = None
-        mock_battery_data.batteries = [MagicMock(), MagicMock()]
+        mock_battery_data = BatteryBankData(
+            battery_count=4,  # CAN bus connected
+            voltage=53.7,
+            current=30.0,
+            soc=93,
+            charge_power=825.0,
+            discharge_power=0,
+            max_capacity=280.0,
+            current_capacity=260.0,
+            status="Charging",
+            batteries=[
+                BatteryData(battery_index=0, serial_number="BAT0"),
+                BatteryData(battery_index=1, serial_number="BAT1"),
+            ],
+        )
 
         mock_inverter = MagicMock()
         mock_inverter.refresh = AsyncMock()
@@ -1158,34 +1159,24 @@ class TestSharedBatterySecondary:
         coordinator = EG4DataUpdateCoordinator(hass, entry)
         coordinator._local_static_phase_done = True
 
-        mock_runtime = MagicMock()
-        mock_runtime.parallel_number = 0  # No parallel group
-        mock_runtime.parallel_master_slave = 0  # Not a secondary
-        mock_runtime.parallel_phase = 0
+        mock_runtime = InverterRuntimeData(
+            parallel_number=0,  # No parallel group
+            parallel_master_slave=0,  # Not a secondary
+            parallel_phase=0,
+        )
 
-        mock_battery_data = MagicMock()
-        mock_battery_data.battery_count = None  # Temporarily 0
-        mock_battery_data.voltage = 53.7
-        mock_battery_data.current = 0.0
-        mock_battery_data.soc = 50
-        mock_battery_data.charge_power = 0
-        mock_battery_data.discharge_power = 0
-        mock_battery_data.battery_power = 0
-        mock_battery_data.max_capacity = None
-        mock_battery_data.current_capacity = None
-        mock_battery_data.remain_capacity = None
-        mock_battery_data.full_capacity = None
-        mock_battery_data.capacity_percent = None
-        mock_battery_data.status = "Idle"
-        mock_battery_data.min_soh = None
-        mock_battery_data.max_cell_temp = None
-        mock_battery_data.temp_delta = None
-        mock_battery_data.cell_voltage_delta_max = None
-        mock_battery_data.soc_delta = None
-        mock_battery_data.soh_delta = None
-        mock_battery_data.voltage_delta = None
-        mock_battery_data.cycle_count_delta = None
-        mock_battery_data.batteries = []
+        mock_battery_data = BatteryBankData(
+            battery_count=None,  # Temporarily 0
+            voltage=53.7,
+            current=0.0,
+            soc=50,
+            charge_power=0,
+            discharge_power=0,
+            max_capacity=None,
+            current_capacity=None,
+            status="Idle",
+            batteries=[],
+        )
 
         mock_inverter = MagicMock()
         mock_inverter.refresh = AsyncMock()
@@ -1265,14 +1256,16 @@ class TestBatteryBankCountSuppression:
     @staticmethod
     def _make_mock_inverter(*, battery_count: int | None = None) -> MagicMock:
         """Build a mock inverter with shared-battery secondary defaults."""
-        mock_runtime = MagicMock()
-        mock_runtime.parallel_number = 2
-        mock_runtime.parallel_master_slave = 2
-        mock_runtime.parallel_phase = 0
+        mock_runtime = InverterRuntimeData(
+            parallel_number=2,
+            parallel_master_slave=2,
+            parallel_phase=0,
+        )
 
-        mock_battery_data = MagicMock()
-        mock_battery_data.battery_count = battery_count
-        mock_battery_data.batteries = []
+        mock_battery_data = BatteryBankData(
+            battery_count=battery_count,
+            batteries=[],
+        )
 
         mock_inverter = MagicMock()
         mock_inverter.refresh = AsyncMock()
@@ -1474,14 +1467,16 @@ class TestBatteryRRCacheFallback:
 
     @staticmethod
     def _make_mock_inverter(*, battery_count: int, batteries: list[Any]) -> MagicMock:
-        mock_runtime = MagicMock()
-        mock_runtime.parallel_number = 0
-        mock_runtime.parallel_master_slave = 0
-        mock_runtime.parallel_phase = 0
+        mock_runtime = InverterRuntimeData(
+            parallel_number=0,
+            parallel_master_slave=0,
+            parallel_phase=0,
+        )
 
-        mock_battery_data = MagicMock()
-        mock_battery_data.battery_count = battery_count
-        mock_battery_data.batteries = batteries
+        mock_battery_data = BatteryBankData(
+            battery_count=battery_count,
+            batteries=batteries,
+        )
 
         mock_inverter = MagicMock()
         mock_inverter.refresh = AsyncMock()

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -283,16 +283,20 @@ class TestBuildLocalDeviceData:
 
         # REAL inverter: the computed power properties are exercised for real
         # from injected transport data, instead of a MagicMock fabricating them.
-        # Energy balance: consumption = pv + (discharge - charge) + import - export
-        #   = 3000 + (0 - 1500) + 1500 - 0 = 3000
+        # Physically coherent fixture — grid import is one quantity, so
+        # power_from_grid (consumption energy-balance) == load_power (Ptouser,
+        # the grid_import_power sensor source), both 500, mirroring real modbus
+        # where both derive from the same Ptouser register.
+        #   consumption = pv + (discharge - charge) + import - export
+        #               = 3000 + (0 - 1500) + 500 - 0 = 2000
         runtime = InverterRuntimeData(
             pv_total_power=3000,
             battery_charge_power=1500,
             battery_discharge_power=0,
-            power_from_grid=1500,
+            power_from_grid=500,
             power_to_grid=0,
             grid_power=200,  # rectifier_power (Prec) source
-            load_power=500,  # power_to_user (Ptouser) source
+            load_power=500,  # power_to_user (Ptouser) -> grid_import_power sensor
         )
         inverter = make_real_inverter("INV001", "FlexBOSS21", runtime=runtime)
 
@@ -308,13 +312,14 @@ class TestBuildLocalDeviceData:
                 connection_type="modbus",
             )
 
-        assert result["sensors"]["consumption_power"] == 3000
+        assert result["sensors"]["consumption_power"] == 2000
         # total_load_power is a documented ALIAS of consumption_power (a real
         # pylxpweb semantic the old MagicMock hid by asserting a distinct 4000).
-        assert result["sensors"]["total_load_power"] == 3000
+        assert result["sensors"]["total_load_power"] == 2000
         assert result["sensors"]["total_load_power"] == result["sensors"]["consumption_power"]
         assert result["sensors"]["battery_power"] == 1500
         assert result["sensors"]["rectifier_power"] == 200
+        # grid_import_power sensor is sourced from inverter.power_to_user (load_power)
         assert result["sensors"]["grid_import_power"] == 500
 
 

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -213,6 +213,9 @@ class TestBuildLocalDeviceData:
         # real (all derive to 0 from the empty transport data).
         inverter = make_real_inverter("INV001", "FlexBOSS21", runtime=InverterRuntimeData())
         inverter._transport_battery = None
+        # _transport is the network CONNECTION object (Modbus/Dongle socket), not
+        # a pylxpweb data model — a real one needs a live socket.  It is an infra
+        # mock by design; transport_host is connection metadata, not device data.
         inverter._transport = MagicMock()
         inverter._transport.host = "192.168.1.100"
 

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -211,7 +211,9 @@ class TestBuildLocalDeviceData:
 
         # REAL inverter with an empty runtime — computed power properties run for
         # real (all derive to 0 from the empty transport data).
-        inverter = make_real_inverter("INV001", "FlexBOSS21", runtime=InverterRuntimeData())
+        inverter = make_real_inverter(
+            "INV001", "FlexBOSS21", runtime=InverterRuntimeData()
+        )
         inverter._transport_battery = None
         # _transport is the network CONNECTION object (Modbus/Dongle socket), not
         # a pylxpweb data model — a real one needs a live socket.  It is an infra
@@ -314,7 +316,10 @@ class TestBuildLocalDeviceData:
         # total_load_power is a documented ALIAS of consumption_power (a real
         # pylxpweb semantic the old MagicMock hid by asserting a distinct 4000).
         assert result["sensors"]["total_load_power"] == 2000
-        assert result["sensors"]["total_load_power"] == result["sensors"]["consumption_power"]
+        assert (
+            result["sensors"]["total_load_power"]
+            == result["sensors"]["consumption_power"]
+        )
         assert result["sensors"]["battery_power"] == 1500
         assert result["sensors"]["rectifier_power"] == 200
         # grid_import_power sensor is sourced from inverter.power_to_user (load_power)
@@ -1442,7 +1447,9 @@ class TestBatteryRRCacheFallback:
         return entry
 
     @staticmethod
-    def _make_mock_inverter(*, battery_count: int, batteries: list[Any]) -> HybridInverter:
+    def _make_mock_inverter(
+        *, battery_count: int, batteries: list[Any]
+    ) -> HybridInverter:
         mock_runtime = InverterRuntimeData(
             parallel_number=0,
             parallel_master_slave=0,

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -23,7 +23,7 @@ from pylxpweb.transports.data import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from tests.conftest import make_real_inverter
+from tests.conftest import make_real_inverter, make_transport_spec
 
 from custom_components.eg4_web_monitor.const import (
     CONF_BASE_URL,
@@ -138,8 +138,8 @@ class TestReadModbusParameters:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_transport = MagicMock()
-        mock_transport.read_named_parameters = AsyncMock(return_value={"PARAM_A": True})
+        mock_transport = make_transport_spec()
+        mock_transport.read_named_parameters.return_value = {"PARAM_A": True}
 
         result = await coordinator._read_modbus_parameters(mock_transport)
 
@@ -161,8 +161,8 @@ class TestReadModbusParameters:
                 raise RuntimeError("range 20 failed")
             return {f"param_{start}": start}
 
-        mock_transport = MagicMock()
-        mock_transport.read_named_parameters = AsyncMock(side_effect=mock_read)
+        mock_transport = make_transport_spec()
+        mock_transport.read_named_parameters.side_effect = mock_read
 
         result = await coordinator._read_modbus_parameters(mock_transport)
 
@@ -176,10 +176,8 @@ class TestReadModbusParameters:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_transport = MagicMock()
-        mock_transport.read_named_parameters = AsyncMock(
-            side_effect=RuntimeError("all fail")
-        )
+        mock_transport = make_transport_spec()
+        mock_transport.read_named_parameters.side_effect = RuntimeError("all fail")
 
         result = await coordinator._read_modbus_parameters(mock_transport)
 
@@ -218,8 +216,7 @@ class TestBuildLocalDeviceData:
         # _transport is the network CONNECTION object (Modbus/Dongle socket), not
         # a pylxpweb data model — a real one needs a live socket.  It is an infra
         # mock by design; transport_host is connection metadata, not device data.
-        inverter._transport = MagicMock()
-        inverter._transport.host = "192.168.1.100"
+        inverter._transport = make_transport_spec(host="192.168.1.100")
 
         with patch(
             "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
@@ -337,7 +334,7 @@ class TestTransportAccessors:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_transport = MagicMock()
+        mock_transport = make_transport_spec()
         mock_inverter = MagicMock()
         mock_inverter._transport = mock_transport
         coordinator._inverter_cache["INV001"] = mock_inverter
@@ -354,7 +351,7 @@ class TestTransportAccessors:
         hybrid_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
 
-        mock_transport = MagicMock()
+        mock_transport = make_transport_spec()
         mock_inverter = MagicMock()
         mock_inverter._transport = mock_transport
         mock_inverter.serial_number = "INV001"
@@ -387,7 +384,7 @@ class TestTransportAccessors:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_inverter = MagicMock()
-        mock_inverter._transport = MagicMock()
+        mock_inverter._transport = make_transport_spec()
         coordinator._inverter_cache["INV001"] = mock_inverter
 
         assert coordinator.has_local_transport("INV001") is True
@@ -412,7 +409,7 @@ class TestTransportAccessors:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_transport = MagicMock()
+        mock_transport = make_transport_spec()
         mock_mid = MagicMock()
         mock_mid._transport = mock_transport
         coordinator._mid_device_cache["GRIDBOSS001"] = mock_mid
@@ -426,7 +423,7 @@ class TestTransportAccessors:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_mid = MagicMock()
-        mock_mid._transport = MagicMock()
+        mock_mid._transport = make_transport_spec()
         coordinator._mid_device_cache["GRIDBOSS001"] = mock_mid
 
         assert coordinator.has_local_transport("GRIDBOSS001") is True
@@ -592,7 +589,7 @@ class TestAttachForcedTransportRead:
         mock_result.failed_serials = []
 
         mock_inverter = MagicMock()
-        mock_inverter._transport = MagicMock()
+        mock_inverter._transport = make_transport_spec()
         mock_inverter.serial_number = "1234567890"
         mock_inverter.refresh = AsyncMock()
 
@@ -768,9 +765,8 @@ class TestGridBOSSFirmwareCache:
         coordinator._local_static_phase_done = True
 
         # Build a mock MIDDevice with a transport that returns firmware
-        mock_transport = MagicMock()
-        mock_transport.is_connected = True
-        mock_transport.read_firmware_version = AsyncMock(return_value="IAAB-1600")
+        mock_transport = make_transport_spec(is_connected=True)
+        mock_transport.read_firmware_version.return_value = "IAAB-1600"
 
         mock_mid = MagicMock()
         mock_mid._transport = mock_transport
@@ -839,11 +835,8 @@ class TestGridBOSSFirmwareCache:
         # Pre-populate firmware cache (simulates first refresh already done)
         coordinator._firmware_cache["GB002"] = "IAAB-1600"
 
-        mock_transport = MagicMock()
-        mock_transport.is_connected = True
-        mock_transport.read_firmware_version = AsyncMock(
-            return_value="SHOULD-NOT-BE-CALLED"
-        )
+        mock_transport = make_transport_spec(is_connected=True)
+        mock_transport.read_firmware_version.return_value = "SHOULD-NOT-BE-CALLED"
 
         mock_mid = MagicMock()
         mock_mid._transport = mock_transport
@@ -1006,10 +999,9 @@ class TestSharedBatterySecondary:
         inverter = make_real_inverter("SECONDARY01", "FlexBOSS21", runtime=mock_runtime)
         inverter.refresh = AsyncMock()
         inverter._transport_battery = mock_battery_data
-        inverter._transport = MagicMock()
-        inverter._transport.is_connected = True
-        inverter._transport.host = "192.168.1.101"
-        inverter._transport.disconnect = AsyncMock()
+        inverter._transport = make_transport_spec(
+            is_connected=True, host="192.168.1.101"
+        )
 
         # Pre-populate caches
         coordinator._inverter_cache["SECONDARY01"] = inverter
@@ -1082,10 +1074,9 @@ class TestSharedBatterySecondary:
         inverter = make_real_inverter("PRIMARY001", "FlexBOSS21", runtime=mock_runtime)
         inverter.refresh = AsyncMock()
         inverter._transport_battery = mock_battery_data
-        inverter._transport = MagicMock()
-        inverter._transport.is_connected = True
-        inverter._transport.host = "192.168.1.100"
-        inverter._transport.disconnect = AsyncMock()
+        inverter._transport = make_transport_spec(
+            is_connected=True, host="192.168.1.100"
+        )
 
         coordinator._inverter_cache["PRIMARY001"] = inverter
         coordinator._firmware_cache["PRIMARY001"] = "FAAB-2525"
@@ -1180,10 +1171,9 @@ class TestSharedBatterySecondary:
         inverter = make_real_inverter("STANDALONE1", "FlexBOSS21", runtime=mock_runtime)
         inverter.refresh = AsyncMock()
         inverter._transport_battery = mock_battery_data
-        inverter._transport = MagicMock()
-        inverter._transport.is_connected = True
-        inverter._transport.host = "192.168.1.100"
-        inverter._transport.disconnect = AsyncMock()
+        inverter._transport = make_transport_spec(
+            is_connected=True, host="192.168.1.100"
+        )
 
         coordinator._inverter_cache["STANDALONE1"] = inverter
         coordinator._firmware_cache["STANDALONE1"] = "FAAB-2525"
@@ -1260,10 +1250,9 @@ class TestBatteryBankCountSuppression:
         inverter = make_real_inverter("SECONDARY01", "FlexBOSS21", runtime=mock_runtime)
         inverter.refresh = AsyncMock()
         inverter._transport_battery = mock_battery_data
-        inverter._transport = MagicMock()
-        inverter._transport.is_connected = True
-        inverter._transport.host = "192.168.1.100"
-        inverter._transport.disconnect = AsyncMock()
+        inverter._transport = make_transport_spec(
+            is_connected=True, host="192.168.1.100"
+        )
         return inverter
 
     async def test_secondary_no_battery_bank_sensors(self, hass):
@@ -1464,10 +1453,9 @@ class TestBatteryRRCacheFallback:
         inverter = make_real_inverter("DONGLE001", "FlexBOSS21", runtime=mock_runtime)
         inverter.refresh = AsyncMock()
         inverter._transport_battery = mock_battery_data
-        inverter._transport = MagicMock()
-        inverter._transport.is_connected = True
-        inverter._transport.host = "192.168.1.100"
-        inverter._transport.disconnect = AsyncMock()
+        inverter._transport = make_transport_spec(
+            is_connected=True, host="192.168.1.100"
+        )
         return inverter
 
     async def test_cache_fallback_when_batteries_empty_this_poll(

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pylxpweb.devices import HybridInverter
 from pylxpweb.transports.data import (
     BatteryBankData,
     BatteryData,
@@ -208,24 +209,19 @@ class TestBuildLocalDeviceData:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = InverterRuntimeData()
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = None
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.host = "192.168.1.100"
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
+        # REAL inverter with an empty runtime — computed power properties run for
+        # real (all derive to 0 from the empty transport data).
+        inverter = make_real_inverter("INV001", "FlexBOSS21", runtime=InverterRuntimeData())
+        inverter._transport_battery = None
+        inverter._transport = MagicMock()
+        inverter._transport.host = "192.168.1.100"
 
         with patch(
             "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
             return_value={"pv_total_power": 5000},
         ):
             result = coordinator._build_local_device_data(
-                inverter=mock_inverter,
+                inverter=inverter,
                 serial="INV001",
                 model="FlexBOSS21",
                 firmware_version="ARM-1.0",
@@ -245,16 +241,15 @@ class TestBuildLocalDeviceData:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = InverterRuntimeData()
-        mock_inverter._transport_energy = InverterEnergyData()
-        mock_inverter._transport_battery = None
-        mock_inverter._transport = None
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
+        # REAL inverter with empty runtime + energy transport data.
+        inverter = make_real_inverter(
+            "INV001",
+            "FlexBOSS21",
+            runtime=InverterRuntimeData(),
+            energy=InverterEnergyData(),
+        )
+        inverter._transport_battery = None
+        inverter._transport = None
 
         with (
             patch(
@@ -267,7 +262,7 @@ class TestBuildLocalDeviceData:
             ),
         ):
             result = coordinator._build_local_device_data(
-                inverter=mock_inverter,
+                inverter=inverter,
                 serial="INV001",
                 model="FlexBOSS21",
                 firmware_version="ARM-1.0",
@@ -1000,25 +995,16 @@ class TestSharedBatterySecondary:
             batteries=[],
         )
 
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport_runtime = mock_runtime
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = mock_battery_data
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
-        mock_inverter._transport.host = "192.168.1.101"
-        mock_inverter._transport.disconnect = AsyncMock()
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
-        mock_inverter.eps_power_l1 = None
-        mock_inverter.eps_power_l2 = None
+        inverter = make_real_inverter("SECONDARY01", "FlexBOSS21", runtime=mock_runtime)
+        inverter.refresh = AsyncMock()
+        inverter._transport_battery = mock_battery_data
+        inverter._transport = MagicMock()
+        inverter._transport.is_connected = True
+        inverter._transport.host = "192.168.1.101"
+        inverter._transport.disconnect = AsyncMock()
 
         # Pre-populate caches
-        coordinator._inverter_cache["SECONDARY01"] = mock_inverter
+        coordinator._inverter_cache["SECONDARY01"] = inverter
         coordinator._firmware_cache["SECONDARY01"] = "fAAB-2525"
 
         with patch(
@@ -1085,24 +1071,15 @@ class TestSharedBatterySecondary:
             ],
         )
 
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport_runtime = mock_runtime
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = mock_battery_data
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
-        mock_inverter._transport.host = "192.168.1.100"
-        mock_inverter._transport.disconnect = AsyncMock()
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
-        mock_inverter.eps_power_l1 = None
-        mock_inverter.eps_power_l2 = None
+        inverter = make_real_inverter("PRIMARY001", "FlexBOSS21", runtime=mock_runtime)
+        inverter.refresh = AsyncMock()
+        inverter._transport_battery = mock_battery_data
+        inverter._transport = MagicMock()
+        inverter._transport.is_connected = True
+        inverter._transport.host = "192.168.1.100"
+        inverter._transport.disconnect = AsyncMock()
 
-        coordinator._inverter_cache["PRIMARY001"] = mock_inverter
+        coordinator._inverter_cache["PRIMARY001"] = inverter
         coordinator._firmware_cache["PRIMARY001"] = "FAAB-2525"
 
         with patch(
@@ -1192,24 +1169,15 @@ class TestSharedBatterySecondary:
             batteries=[],
         )
 
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport_runtime = mock_runtime
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = mock_battery_data
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
-        mock_inverter._transport.host = "192.168.1.100"
-        mock_inverter._transport.disconnect = AsyncMock()
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
-        mock_inverter.eps_power_l1 = None
-        mock_inverter.eps_power_l2 = None
+        inverter = make_real_inverter("STANDALONE1", "FlexBOSS21", runtime=mock_runtime)
+        inverter.refresh = AsyncMock()
+        inverter._transport_battery = mock_battery_data
+        inverter._transport = MagicMock()
+        inverter._transport.is_connected = True
+        inverter._transport.host = "192.168.1.100"
+        inverter._transport.disconnect = AsyncMock()
 
-        coordinator._inverter_cache["STANDALONE1"] = mock_inverter
+        coordinator._inverter_cache["STANDALONE1"] = inverter
         coordinator._firmware_cache["STANDALONE1"] = "FAAB-2525"
 
         with patch(
@@ -1268,8 +1236,8 @@ class TestBatteryBankCountSuppression:
         return entry
 
     @staticmethod
-    def _make_mock_inverter(*, battery_count: int | None = None) -> MagicMock:
-        """Build a mock inverter with shared-battery secondary defaults."""
+    def _make_mock_inverter(*, battery_count: int | None = None) -> HybridInverter:
+        """Build a REAL inverter with shared-battery secondary defaults."""
         mock_runtime = InverterRuntimeData(
             parallel_number=2,
             parallel_master_slave=2,
@@ -1281,23 +1249,14 @@ class TestBatteryBankCountSuppression:
             batteries=[],
         )
 
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport_runtime = mock_runtime
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = mock_battery_data
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
-        mock_inverter._transport.host = "192.168.1.100"
-        mock_inverter._transport.disconnect = AsyncMock()
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
-        mock_inverter.eps_power_l1 = None
-        mock_inverter.eps_power_l2 = None
-        return mock_inverter
+        inverter = make_real_inverter("SECONDARY01", "FlexBOSS21", runtime=mock_runtime)
+        inverter.refresh = AsyncMock()
+        inverter._transport_battery = mock_battery_data
+        inverter._transport = MagicMock()
+        inverter._transport.is_connected = True
+        inverter._transport.host = "192.168.1.100"
+        inverter._transport.disconnect = AsyncMock()
+        return inverter
 
     async def test_secondary_no_battery_bank_sensors(self, hass):
         """Secondary with battery_count=0 gets no battery_bank_* sensors."""
@@ -1480,7 +1439,7 @@ class TestBatteryRRCacheFallback:
         return entry
 
     @staticmethod
-    def _make_mock_inverter(*, battery_count: int, batteries: list[Any]) -> MagicMock:
+    def _make_mock_inverter(*, battery_count: int, batteries: list[Any]) -> HybridInverter:
         mock_runtime = InverterRuntimeData(
             parallel_number=0,
             parallel_master_slave=0,
@@ -1492,23 +1451,14 @@ class TestBatteryRRCacheFallback:
             batteries=batteries,
         )
 
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        mock_inverter._transport_runtime = mock_runtime
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = mock_battery_data
-        mock_inverter._transport = MagicMock()
-        mock_inverter._transport.is_connected = True
-        mock_inverter._transport.host = "192.168.1.100"
-        mock_inverter._transport.disconnect = AsyncMock()
-        mock_inverter.consumption_power = None
-        mock_inverter.total_load_power = None
-        mock_inverter.battery_power = None
-        mock_inverter.rectifier_power = None
-        mock_inverter.power_to_user = None
-        mock_inverter.eps_power_l1 = None
-        mock_inverter.eps_power_l2 = None
-        return mock_inverter
+        inverter = make_real_inverter("DONGLE001", "FlexBOSS21", runtime=mock_runtime)
+        inverter.refresh = AsyncMock()
+        inverter._transport_battery = mock_battery_data
+        inverter._transport = MagicMock()
+        inverter._transport.is_connected = True
+        inverter._transport.host = "192.168.1.100"
+        inverter._transport.disconnect = AsyncMock()
+        return inverter
 
     async def test_cache_fallback_when_batteries_empty_this_poll(
         self, hass: Any

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -22,6 +22,8 @@ from pylxpweb.transports.data import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from tests.conftest import make_real_inverter
+
 from custom_components.eg4_web_monitor.const import (
     CONF_BASE_URL,
     CONF_CONNECTION_TYPE,
@@ -279,23 +281,27 @@ class TestBuildLocalDeviceData:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_inverter = MagicMock()
-        mock_inverter._transport_runtime = InverterRuntimeData()
-        mock_inverter._transport_energy = None
-        mock_inverter._transport_battery = None
-        mock_inverter._transport = None
-        mock_inverter.consumption_power = 3000
-        mock_inverter.total_load_power = 4000
-        mock_inverter.battery_power = 1500
-        mock_inverter.rectifier_power = 200
-        mock_inverter.power_to_user = 500
+        # REAL inverter: the computed power properties are exercised for real
+        # from injected transport data, instead of a MagicMock fabricating them.
+        # Energy balance: consumption = pv + (discharge - charge) + import - export
+        #   = 3000 + (0 - 1500) + 1500 - 0 = 3000
+        runtime = InverterRuntimeData(
+            pv_total_power=3000,
+            battery_charge_power=1500,
+            battery_discharge_power=0,
+            power_from_grid=1500,
+            power_to_grid=0,
+            grid_power=200,  # rectifier_power (Prec) source
+            load_power=500,  # power_to_user (Ptouser) source
+        )
+        inverter = make_real_inverter("INV001", "FlexBOSS21", runtime=runtime)
 
         with patch(
             "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
             return_value={},
         ):
             result = coordinator._build_local_device_data(
-                inverter=mock_inverter,
+                inverter=inverter,
                 serial="INV001",
                 model="FlexBOSS21",
                 firmware_version="ARM-1.0",
@@ -303,7 +309,10 @@ class TestBuildLocalDeviceData:
             )
 
         assert result["sensors"]["consumption_power"] == 3000
-        assert result["sensors"]["total_load_power"] == 4000
+        # total_load_power is a documented ALIAS of consumption_power (a real
+        # pylxpweb semantic the old MagicMock hid by asserting a distinct 4000).
+        assert result["sensors"]["total_load_power"] == 3000
+        assert result["sensors"]["total_load_power"] == result["sensors"]["consumption_power"]
         assert result["sensors"]["battery_power"] == 1500
         assert result["sensors"]["rectifier_power"] == 200
         assert result["sensors"]["grid_import_power"] == 500


### PR DESCRIPTION
## Summary
Epic eg4-uqs — eliminate **MagicMock shape-blindness** in the coordinator tests. A plain `MagicMock` answers to ANY attribute, so a test passes even when the real pylxpweb object lacks the attribute the coordinator reads — the exact blindness that lets cross-repo seam drift ship undetected (complements the static contract harness in #235 / pylxpweb #166).

### eg4-uqs.1 — real-object builders (`tests/conftest.py`)
`make_real_inverter` / `make_real_mid` return **real** pylxpweb `HybridInverter`/`MIDDevice` (mock client — only used for API calls) with **real** `InverterRuntimeData`/`MidboxRuntimeData` injected, so the device's `@property` accessors compute for real. (Note: `autospec(spec_set=True)` was tried and rejected — instance attributes set in `__init__` are invisible to autospec, so real construction is required.)

### eg4-uqs.2 — conversions
Converted the **data-producing** device/transport mocks across `test_coordinator.py`, `test_coordinator_local.py`, `test_coordinator_http.py` to real objects/dataclasses, targeting the sensor-building surface (`_process_*`, `_extract_*`, `_map_device_properties`, `_build_local_device_data`, `_build_*_mapping`). Zero `_transport_* = MagicMock()` data mocks remain.

**Intentionally left as MagicMock** (control-flow / no-builder, per "data-mocks only"): `refresh`/`detect_features`/polling mocks, the network `_transport` connection object, the LuxpowerClient/HA-core/config-entry mocks, and the `ParallelGroup`/`Station` cascades (no builder).

### Notable finding
Converting `test_includes_computed_sensors` to a real inverter surfaced that **`total_load_power` is a documented alias of `consumption_power`** — the old mock had asserted an impossible distinct value (4000). Fixed to the real coupled value with an explicit alias assertion.

## Validation
- **0 assertions weakened** (only corrected-to-real values).
- Full suite **827 passed**, ruff clean.
- Codex adversarial review across multiple rounds drove every conversion (caught half-cosmetic wrapper conversions, an incoherent fixture, and missed data mocks — all fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)