### PR TITLE
refactor: consume pylxpweb typed seam, enforce mypy --strict across it

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -528,7 +528,9 @@ class EG4DataUpdateCoordinator(
             intervals.append(self._dongle_interval)
         return intervals
 
-    def _align_inverter_cache_ttls(self, inverter: Any, transport_type: str) -> None:
+    def _align_inverter_cache_ttls(
+        self, inverter: BaseInverter, transport_type: str
+    ) -> None:
         """Set inverter cache TTLs to match coordinator's configured intervals.
 
         pylxpweb's ``set_transport_cache_ttls()`` uses hardcoded values, but the
@@ -549,9 +551,7 @@ class EG4DataUpdateCoordinator(
         if interval is None:
             return
         ttl = timedelta(seconds=interval)
-        inverter._runtime_cache_ttl = ttl
-        inverter._energy_cache_ttl = ttl
-        inverter._battery_cache_ttl = ttl
+        inverter.set_cache_ttls(runtime=ttl, energy=ttl, battery=ttl)
 
     def _should_poll_transport(self, transport_type: str) -> bool:
         """Check whether enough time has elapsed to poll this transport type.

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -146,12 +146,19 @@ class HTTPUpdateMixin(_MixinBase):
             all_devices.extend(self.station.all_mid_devices)
 
         for device in all_devices:
-            transport = getattr(device, "_transport", None)
+            transport = device.transport
             if transport is None:
                 no_transport.append(device)
                 continue
-            host = getattr(transport, "_host", "")
-            port = getattr(transport, "_port", 0)
+            # Group by the PUBLIC host/port (network transports — TCP dongle).
+            # A transport without a network endpoint (e.g. serial) can't share
+            # one, so it refreshes on its own rather than collapsing into a
+            # bogus ":0" group (the eg4-xi7 silent-default bug).
+            host = getattr(transport, "host", None)
+            port = getattr(transport, "port", None)
+            if host is None or port is None:
+                no_transport.append(device)
+                continue
             endpoint = f"{host}:{port}"
             endpoint_groups.setdefault(endpoint, []).append(device)
 
@@ -230,7 +237,7 @@ class HTTPUpdateMixin(_MixinBase):
                 device = self._inverter_cache.get(serial) or self._mid_device_cache.get(
                     serial
                 )
-            transport = getattr(device, "_transport", None) if device else None
+            transport = device.transport if device else None
             if transport is not None:
                 transport_type = getattr(transport, "transport_type", "local")
                 label = _get_transport_label(transport_type)
@@ -698,7 +705,7 @@ class HTTPUpdateMixin(_MixinBase):
             )
 
             # Get transport battery data (local Modbus real-time values)
-            transport_battery = getattr(inverter, "_transport_battery", None)
+            transport_battery = inverter.transport_battery
             transport_batteries = (
                 transport_battery.batteries
                 if transport_battery and hasattr(transport_battery, "batteries")
@@ -737,7 +744,11 @@ class HTTPUpdateMixin(_MixinBase):
                 # Overlay transport real-time data matched by serial
                 transport_matched = 0
                 for batt in transport_batteries:
-                    if batt.voltage is None and batt.soc is None:
+                    # Skip ghost batteries (no real data) — matches pylxpweb's
+                    # canonical ghost definition (BatteryData voltage/soc are
+                    # non-optional, defaulting to 0, so an empty 5002+ slot reads
+                    # 0/0 rather than None).
+                    if batt.voltage == 0 and batt.soc == 0:
                         continue
                     bat_serial: str = getattr(batt, "serial_number", "") or ""
                     if not bat_serial or bat_serial not in cloud_by_serial:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -7,7 +7,7 @@ aggregation, and static entity creation.
 
 import asyncio
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -15,6 +15,11 @@ from homeassistant.util import dt as dt_util
 
 from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.exceptions import LuxpowerDeviceError
+from pylxpweb.transports import (
+    DongleTransport,
+    ModbusSerialTransport,
+    ModbusTransport,
+)
 
 from .const import (
     CONF_GRID_TYPE,
@@ -59,6 +64,15 @@ from .coordinator_mappings import (
 
 _LOGGER = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from pylxpweb.transports.data import BatteryData
+
+# Local network transports that carry the split-phase per-leg-fallback flag.
+# inverter.transport is typed as the generic InverterTransport protocol (which
+# HTTP transports also satisfy and which has no split_phase); narrowing to these
+# concrete local types lets the typed seam verify the split_phase write.
+_LOCAL_REGISTER_TRANSPORTS = (ModbusTransport, ModbusSerialTransport, DongleTransport)
+
 # Derived from energy balance arithmetic; small decreases are normal
 # timing artifacts (not corruption).  Clamped to prevent HA
 # total_increasing warnings.
@@ -76,7 +90,7 @@ class LocalTransportMixin(_MixinBase):
     def _merge_round_robin_batteries(
         self,
         inverter_serial: str,
-        transport_batteries: list[Any],
+        transport_batteries: list["BatteryData"],
     ) -> dict[str, dict[str, Any]]:
         """Merge transport battery slot data into the round-robin cache.
 
@@ -106,8 +120,9 @@ class LocalTransportMixin(_MixinBase):
         new_serials: list[str] = []
 
         for batt in transport_batteries:
-            # Skip batteries with no CAN bus data
-            if batt.voltage is None and batt.soc is None:
+            # Skip ghost batteries with no CAN bus data — BatteryData voltage/soc
+            # are non-optional (default 0), so an empty slot reads 0/0 not None.
+            if batt.voltage == 0 and batt.soc == 0:
                 poll_slots_skipped += 1
                 _LOGGER.debug(
                     "RR [%s] slot %d: skipped (no CAN data, voltage=%s soc=%s)",
@@ -278,19 +293,24 @@ class LocalTransportMixin(_MixinBase):
         Returns:
             Dictionary with device data, sensors, and features
         """
+        runtime = inverter.transport_runtime
+        if runtime is None:
+            from pylxpweb.transports.exceptions import TransportReadError
+
+            raise TransportReadError(f"No transport runtime data for {serial}")
         device_data: dict[str, Any] = {
             "type": "inverter",
             "model": model,
             "serial": serial,
             "firmware_version": firmware_version,
-            "sensors": _build_runtime_sensor_mapping(inverter._transport_runtime),
+            "sensors": _build_runtime_sensor_mapping(runtime),
             "batteries": {},
         }
 
-        if energy_data := inverter._transport_energy:
+        if energy_data := inverter.transport_energy:
             device_data["sensors"].update(_build_energy_sensor_mapping(energy_data))
 
-        if battery_data := inverter._transport_battery:
+        if battery_data := inverter.transport_battery:
             device_data["sensors"].update(
                 _build_battery_bank_sensor_mapping(battery_data)
             )
@@ -314,7 +334,7 @@ class LocalTransportMixin(_MixinBase):
         if (val := inverter.power_to_user) is not None:
             device_data["sensors"]["grid_import_power"] = val
 
-        transport = getattr(inverter, "_transport", None)
+        transport = inverter.transport
         if transport and hasattr(transport, "host"):
             device_data["sensors"]["transport_host"] = transport.host
 
@@ -403,7 +423,7 @@ class LocalTransportMixin(_MixinBase):
                 )
             firmware_version = self._firmware_cache[serial]
 
-            if inverter._transport_runtime is None:
+            if inverter.transport_runtime is None:
                 raise TransportReadError(
                     f"Failed to read runtime data from {transport_name}"
                 )
@@ -436,7 +456,7 @@ class LocalTransportMixin(_MixinBase):
                 )
                 self._last_available_state = True
 
-            runtime = inverter._transport_runtime
+            runtime = inverter.transport_runtime
             _LOGGER.debug(
                 "%s update complete - FW: %s, PV: %.0fW, SOC: %d%%, Grid: %.0fW",
                 transport_name,
@@ -751,7 +771,7 @@ class LocalTransportMixin(_MixinBase):
             if is_gridboss:
                 mid_device = self._mid_device_cache[serial]
 
-                transport = mid_device._transport
+                transport = mid_device.transport
                 if transport and not transport.is_connected:
                     await transport.connect()
 
@@ -805,7 +825,7 @@ class LocalTransportMixin(_MixinBase):
             else:
                 inverter = self._inverter_cache[serial]
 
-                transport = inverter._transport
+                transport = inverter.transport
                 if transport and not transport.is_connected:
                     await transport.connect()
 
@@ -837,7 +857,7 @@ class LocalTransportMixin(_MixinBase):
 
                 if serial not in self._firmware_cache:
                     fw = "Unknown"
-                    transport = inverter._transport
+                    transport = inverter.transport
                     read_fw = (
                         getattr(transport, "read_firmware_version", None)
                         if transport
@@ -848,8 +868,8 @@ class LocalTransportMixin(_MixinBase):
                     self._firmware_cache[serial] = fw
                 firmware_version = self._firmware_cache[serial]
 
-                runtime_data = inverter._transport_runtime
-                energy_data = inverter._transport_energy
+                runtime_data = inverter.transport_runtime
+                energy_data = inverter.transport_energy
 
                 if runtime_data is None:
                     raise TransportReadError(
@@ -894,7 +914,7 @@ class LocalTransportMixin(_MixinBase):
                         _build_energy_sensor_mapping(energy_data)
                     )
 
-                battery_data = inverter._transport_battery
+                battery_data = inverter.transport_battery
                 if battery_data:
                     # Skip battery bank creation when battery_count is 0.
                     # In parallel systems with shared batteries, the secondary
@@ -1000,7 +1020,7 @@ class LocalTransportMixin(_MixinBase):
                 device_availability[serial] = True
 
                 if include_params:
-                    transport = inverter._transport
+                    transport = inverter.transport
                     if transport:
                         param_data = await self._read_modbus_parameters(transport)
                     else:
@@ -1861,12 +1881,13 @@ class LocalTransportMixin(_MixinBase):
             validation_enabled = self._data_validation_enabled
             modbus_inverters: list[Any] = []
             for inverter in self.station.all_inverters:
-                transport = getattr(inverter, "_transport", None)
+                transport = inverter.transport
                 if transport is not None:
                     inverter.validate_data = validation_enabled
                     # Propagate split-phase config for per-leg power fallback
                     grid_type = self._get_device_grid_type(inverter.serial_number)
-                    transport.split_phase = grid_type == GRID_TYPE_SPLIT_PHASE
+                    if isinstance(transport, _LOCAL_REGISTER_TRANSPORTS):
+                        transport.split_phase = grid_type == GRID_TYPE_SPLIT_PHASE
                     tt = getattr(transport, "transport_type", "modbus_tcp")
                     self._align_inverter_cache_ttls(inverter, tt)
                     if tt == "modbus_tcp":
@@ -1884,7 +1905,7 @@ class LocalTransportMixin(_MixinBase):
             # cannot be called here because inverter features have not been
             # detected yet — it runs later in _deferred_local_parameter_load().
             for mid in self.station.all_mid_devices:
-                if getattr(mid, "_transport", None) is not None:
+                if mid.transport is not None:
                     mid.validate_data = validation_enabled
 
             # Log hybrid mode status
@@ -1952,21 +1973,21 @@ class LocalTransportMixin(_MixinBase):
         # Check for transport attached to Station device (HYBRID with local_transports)
         if serial and self.station:
             inverter = self.get_inverter_object(serial)
-            transport = getattr(inverter, "_transport", None) if inverter else None
+            transport = inverter.transport if inverter else None
             if transport:
                 return transport
 
         # Check LOCAL mode inverter cache
         if serial and self.connection_type == CONNECTION_TYPE_LOCAL:
             inverter = self._inverter_cache.get(serial)
-            transport = getattr(inverter, "_transport", None) if inverter else None
+            transport = inverter.transport if inverter else None
             if transport:
                 return transport
 
         # Check MID device cache (GridBOSS devices in LOCAL/HYBRID mode)
         if serial:
             mid_device = self._mid_device_cache.get(serial)
-            transport = getattr(mid_device, "_transport", None) if mid_device else None
+            transport = mid_device.transport if mid_device else None
             if transport:
                 return transport
 

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -6,7 +6,7 @@ key dictionaries used by Home Assistant entities.
 """
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.util import dt as dt_util
 
@@ -18,6 +18,15 @@ from .const import (
     INVERTER_FAMILY_DEFAULT_MODELS,
     LEGACY_FAMILY_MAP,
 )
+
+if TYPE_CHECKING:
+    from pylxpweb.devices import Battery, MIDDevice
+    from pylxpweb.transports.data import (
+        BatteryBankData,
+        BatteryData,
+        InverterEnergyData,
+        InverterRuntimeData,
+    )
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -490,7 +499,9 @@ PARALLEL_GROUP_GRIDBOSS_KEYS: frozenset[str] = frozenset(
 )
 
 
-def _build_runtime_sensor_mapping(runtime_data: Any) -> dict[str, Any]:
+def _build_runtime_sensor_mapping(
+    runtime_data: "InverterRuntimeData",
+) -> dict[str, Any]:
     """Build sensor mapping from runtime data object.
 
     This helper extracts runtime data from a transport's RuntimeData object
@@ -633,7 +644,7 @@ def _energy_balance(
     return max(0.0, result)
 
 
-def _build_energy_sensor_mapping(energy_data: Any) -> dict[str, Any]:
+def _build_energy_sensor_mapping(energy_data: "InverterEnergyData") -> dict[str, Any]:
     """Build sensor mapping from energy data object.
 
     This helper extracts energy data from a transport's EnergyData object
@@ -683,7 +694,9 @@ def _build_energy_sensor_mapping(energy_data: Any) -> dict[str, Any]:
     }
 
 
-def _build_battery_bank_sensor_mapping(battery_data: Any) -> dict[str, Any]:
+def _build_battery_bank_sensor_mapping(
+    battery_data: "BatteryBankData",
+) -> dict[str, Any]:
     """Build sensor mapping from battery bank data object.
 
     Computes cross-battery diagnostic metrics directly from the transport
@@ -773,7 +786,9 @@ def _build_battery_bank_sensor_mapping(battery_data: Any) -> dict[str, Any]:
     return sensors
 
 
-def _build_individual_battery_mapping(battery: Any) -> dict[str, Any]:
+def _build_individual_battery_mapping(
+    battery: "Battery | BatteryData",
+) -> dict[str, Any]:
     """Build sensor mapping from a BatteryData or Battery object.
 
     Works with both pylxpweb transport BatteryData (LOCAL/HYBRID overlay)
@@ -845,7 +860,7 @@ def _build_individual_battery_mapping(battery: Any) -> dict[str, Any]:
     return sensors
 
 
-def _build_gridboss_sensor_mapping(mid_device: Any) -> dict[str, Any]:
+def _build_gridboss_sensor_mapping(mid_device: "MIDDevice") -> dict[str, Any]:
     """Build sensor mapping from MIDDevice object for GridBOSS.
 
     Extracts data from a MIDDevice's runtime properties (provided by

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -23,13 +23,17 @@ from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
-    from pylxpweb.devices import Battery, Station
+    from pylxpweb.devices import Battery, BatteryBank, MIDDevice, ParallelGroup, Station
     from pylxpweb.devices.inverters.base import BaseInverter
     from pylxpweb.transports import (
         DongleTransport,
         ModbusSerialTransport,
         ModbusTransport,
     )
+    from pylxpweb.transports.data import BatteryData
+
+    # The device objects accepted by the generic property mapper.
+    _DeviceObject = BaseInverter | Battery | BatteryBank | MIDDevice | ParallelGroup
 
 from pylxpweb.devices.inverters import InverterFamily
 
@@ -296,10 +300,10 @@ if TYPE_CHECKING:
             self, inverter: BaseInverter
         ) -> dict[str, Any]: ...
         async def _process_parallel_group_object(
-            self, group: Any
+            self, group: "ParallelGroup"
         ) -> dict[str, Any]: ...
         async def _process_mid_device_object(
-            self, mid_device: Any
+            self, mid_device: "MIDDevice"
         ) -> dict[str, Any]: ...
         @staticmethod
         def _extract_inverter_features(
@@ -308,7 +312,7 @@ if TYPE_CHECKING:
         def _extract_battery_from_object(self, battery: Battery) -> dict[str, Any]: ...
         @staticmethod
         def _filter_unused_smart_port_sensors(
-            sensors: dict[str, Any], mid_device: Any
+            sensors: dict[str, Any], mid_device: "MIDDevice"
         ) -> None: ...
         @staticmethod
         def _calculate_gridboss_aggregates(
@@ -317,7 +321,7 @@ if TYPE_CHECKING:
 
         # ── FirmwareUpdateMixin methods ──
         def _extract_firmware_update_info(
-            self, device: BaseInverter
+            self, device: "BaseInverter | MIDDevice"
         ) -> dict[str, Any] | None: ...
 
         # ── ParameterManagementMixin methods ──
@@ -341,7 +345,7 @@ if TYPE_CHECKING:
         def _has_dongle_transport(self) -> bool: ...
         def _get_active_transport_intervals(self) -> list[int]: ...
         def _align_inverter_cache_ttls(
-            self, inverter: Any, transport_type: str
+            self, inverter: "BaseInverter", transport_type: str
         ) -> None: ...
 
         # ── LocalTransportMixin attributes ──
@@ -355,7 +359,7 @@ if TYPE_CHECKING:
         def _merge_round_robin_batteries(
             self,
             inverter_serial: str,
-            transport_batteries: list[Any],
+            transport_batteries: list["BatteryData"],
         ) -> dict[str, dict[str, Any]]: ...
 
 else:
@@ -365,7 +369,9 @@ else:
 # ===== Utility Functions =====
 
 
-def _map_device_properties(device: Any, property_map: dict[str, str]) -> dict[str, Any]:
+def _map_device_properties(
+    device: "_DeviceObject", property_map: dict[str, str]
+) -> dict[str, Any]:
     """Map device properties to sensor keys using a property mapping dictionary.
 
     This is a generic utility that extracts properties from any device object
@@ -570,7 +576,7 @@ class DeviceProcessingMixin(_MixinBase):
         # Note: GridBOSS uses a different aggregation strategy — CT summation
         # (L1 + L2) via _safe_sum() in MIDRuntimePropertiesMixin, not energy
         # balance.  See pylxpweb _mid_runtime_properties.py for details.
-        if getattr(inverter, "_transport", None) is not None:
+        if inverter.transport is not None:
             sensors = processed["sensors"]
             sensors["consumption"] = _energy_balance(
                 sensors.get("yield"),
@@ -592,7 +598,7 @@ class DeviceProcessingMixin(_MixinBase):
         # contains real-time Modbus register data for sensors the cloud API
         # does not provide (e.g. bt_temperature reg 108, grid current regs
         # 18/190/191, battery current reg 4).
-        transport_runtime = getattr(inverter, "_transport_runtime", None)
+        transport_runtime = inverter.transport_runtime
         if transport_runtime is not None:
             sensors = processed["sensors"]
             _TRANSPORT_OVERLAY = (
@@ -611,7 +617,7 @@ class DeviceProcessingMixin(_MixinBase):
 
         # Overlay transport-exclusive energy sensors (Modbus-only, regs 133-138).
         # Cloud API does not provide per-leg EPS energy; only available via Modbus.
-        transport_energy = getattr(inverter, "_transport_energy", None)
+        transport_energy = inverter.transport_energy
         if transport_energy is not None:
             sensors = processed["sensors"]
             _ENERGY_OVERLAY = (
@@ -674,7 +680,7 @@ class DeviceProcessingMixin(_MixinBase):
         # because the CAN bus is wired only to the primary.  Creating a
         # battery bank device with no actual batteries leads to
         # Unknown/Unavailable entities (issue #169).
-        transport_battery = getattr(inverter, "_transport_battery", None)
+        transport_battery = inverter.transport_battery
         if transport_battery:
             raw_count = getattr(transport_battery, "battery_count", None)
             bank_count = int(raw_count) if raw_count else 0
@@ -786,7 +792,7 @@ class DeviceProcessingMixin(_MixinBase):
         # data from local Modbus already provides FUNC_EPS_EN which the switch
         # entity uses as a fallback. The cloud remoteRead endpoint frequently
         # returns apiBlocked anyway since the dongle relay is often busy.
-        has_local_transport = getattr(inverter, "_transport", None) is not None
+        has_local_transport = inverter.transport is not None
         if not has_local_transport:
             bb_key = f"bb_{serial}"
             last_bb = self._last_status_fetch.get(bb_key, 0.0)
@@ -1226,7 +1232,9 @@ class DeviceProcessingMixin(_MixinBase):
             "temp_delta": "battery_bank_temp_delta",
         }
 
-    async def _process_parallel_group_object(self, group: Any) -> dict[str, Any]:
+    async def _process_parallel_group_object(
+        self, group: "ParallelGroup"
+    ) -> dict[str, Any]:
         """Process parallel group data from group object using properties.
 
         Args:
@@ -1266,8 +1274,7 @@ class DeviceProcessingMixin(_MixinBase):
         # This mirrors the individual inverter override at line ~507.
         # See: eg4_web_monitor issue #163
         if any(
-            getattr(inv, "_transport_energy", None) is not None
-            for inv in getattr(group, "inverters", [])
+            inv.transport_energy is not None for inv in getattr(group, "inverters", [])
         ):
             sensors = processed["sensors"]
             sensors["consumption"] = _energy_balance(
@@ -1326,7 +1333,9 @@ class DeviceProcessingMixin(_MixinBase):
             "battery_count": "parallel_battery_count",
         }
 
-    async def _process_mid_device_object(self, mid_device: Any) -> dict[str, Any]:
+    async def _process_mid_device_object(
+        self, mid_device: "MIDDevice"
+    ) -> dict[str, Any]:
         """Process GridBOSS/MID device data from device object using properties.
 
         Args:
@@ -1513,7 +1522,7 @@ class DeviceProcessingMixin(_MixinBase):
 
     @staticmethod
     def _filter_unused_smart_port_sensors(
-        sensors: dict[str, Any], mid_device: Any
+        sensors: dict[str, Any], mid_device: "MIDDevice"
     ) -> None:
         """Filter smart port sensors based on port status from the MID device.
 
@@ -1571,7 +1580,7 @@ class DeviceProcessingMixin(_MixinBase):
                 firmware = getattr(mid_device, "firmware_version", "unknown")
                 has_transport = (
                     hasattr(mid_device, "_transport")
-                    and mid_device._transport is not None
+                    and mid_device.transport is not None
                 )
                 _LOGGER.warning(
                     "Invalid Smart Port status values detected for MID device %s "
@@ -2228,7 +2237,7 @@ class BackgroundTaskMixin(_MixinBase):
 
         # Cached inverter transports (LOCAL/HYBRID with local_transports config)
         for serial, inverter in self._inverter_cache.items():
-            transport = getattr(inverter, "_transport", None)
+            transport = inverter.transport
             if transport is not None and getattr(transport, "is_connected", False):
                 try:
                     await transport.disconnect()
@@ -2242,7 +2251,7 @@ class BackgroundTaskMixin(_MixinBase):
 
         # Cached MID device transports (GridBOSS in LOCAL/HYBRID mode)
         for serial, mid_device in self._mid_device_cache.items():
-            transport = getattr(mid_device, "_transport", None)
+            transport = mid_device.transport
             if transport is not None and getattr(transport, "is_connected", False):
                 try:
                     await transport.disconnect()
@@ -2274,7 +2283,7 @@ class FirmwareUpdateMixin(_MixinBase):
     """Mixin for firmware update information extraction."""
 
     def _extract_firmware_update_info(
-        self, device: "BaseInverter"
+        self, device: "BaseInverter | MIDDevice"
     ) -> dict[str, Any] | None:
         """Extract firmware update information from device object.
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.28", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.29", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.2.0"
 }

--- a/tests/mypy.ini
+++ b/tests/mypy.ini
@@ -55,8 +55,10 @@ ignore_missing_imports = True
 [mypy-homeassistant.*]
 ignore_missing_imports = True
 
-[mypy-pylxpweb.*]
-ignore_missing_imports = True
+# pylxpweb ships PEP 561 py.typed; mypy --strict reads its real types so the
+# library<->integration seam (device/data shapes, transport accessors) is
+# enforced at build time.  Do NOT add ignore_missing_imports here — that would
+# silently mask renamed/removed pylxpweb attributes (the eg4-2iw seam contract).
 
 [mypy-serial.*]
 ignore_missing_imports = True

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.0
+pylxpweb>=0.9.29  # keep in sync with manifest.json; the typed seam needs >=0.9.29
 
 # Code quality
 ruff>=0.8.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -418,19 +418,19 @@ class TestCoordinatorCleanup:
         """
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
-        # Simulate cached inverter with an open transport
-        mock_transport_1 = MagicMock()
-        mock_transport_1.is_connected = True
+        # Simulate cached inverter with an open transport.  Real inverter so the
+        # public ``.transport`` accessor returns the assigned transport (a bare
+        # MagicMock's ``.transport`` would return an unrelated auto-child mock).
+        mock_transport_1 = make_transport_spec(is_connected=True)
         mock_transport_1.disconnect = AsyncMock()
-        mock_inv = MagicMock()
+        mock_inv = make_real_inverter("INV001", "FlexBOSS21")
         mock_inv._transport = mock_transport_1
         coordinator._inverter_cache["INV001"] = mock_inv
 
         # Simulate cached MID device with an open transport
-        mock_transport_2 = MagicMock()
-        mock_transport_2.is_connected = True
+        mock_transport_2 = make_transport_spec(is_connected=True)
         mock_transport_2.disconnect = AsyncMock()
-        mock_mid = MagicMock()
+        mock_mid = make_real_mid("MID001", "GridBOSS")
         mock_mid._transport = mock_transport_2
         coordinator._mid_device_cache["MID001"] = mock_mid
 
@@ -1342,7 +1342,10 @@ class TestCacheTTLAdherence:
         modbus_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, modbus_config_entry)
 
-        mock_inverter = MagicMock()
+        # Real inverter so set_cache_ttls() actually mutates the cache-TTL
+        # attributes (on a MagicMock it is a no-op stub and the asserts never see
+        # the new values).
+        mock_inverter = make_real_inverter("INV001", "FlexBOSS21")
         coordinator._align_inverter_cache_ttls(mock_inverter, "modbus_tcp")
 
         expected = timedelta(seconds=coordinator._modbus_interval)
@@ -1355,7 +1358,7 @@ class TestCacheTTLAdherence:
         dongle_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, dongle_config_entry)
 
-        mock_inverter = MagicMock()
+        mock_inverter = make_real_inverter("INV001", "FlexBOSS21")
         coordinator._align_inverter_cache_ttls(mock_inverter, "wifi_dongle")
 
         expected = timedelta(seconds=coordinator._dongle_interval)
@@ -1392,12 +1395,12 @@ class TestCacheTTLAdherence:
         entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, entry)
 
-        mock_modbus = MagicMock()
+        mock_modbus = make_real_inverter("INV001", "FlexBOSS21")
         coordinator._align_inverter_cache_ttls(mock_modbus, "modbus_tcp")
         assert mock_modbus._runtime_cache_ttl == timedelta(seconds=3)
         assert mock_modbus._battery_cache_ttl == timedelta(seconds=3)
 
-        mock_dongle = MagicMock()
+        mock_dongle = make_real_inverter("INV001", "FlexBOSS21")
         coordinator._align_inverter_cache_ttls(mock_dongle, "wifi_dongle")
         assert mock_dongle._runtime_cache_ttl == timedelta(seconds=15)
         assert mock_dongle._battery_cache_ttl == timedelta(seconds=15)
@@ -4738,7 +4741,10 @@ class TestParallelGroupConsumptionEnergyBalance:
 
         mock_group = MagicMock()
         mock_group.name = "A"
-        mock_group.inverters = [MagicMock(serial_number="INV001")]
+        # Real inverter so the injected ``InverterEnergyData()`` is what the
+        # public ``.transport_energy`` accessor returns (a bare MagicMock would
+        # return a truthy auto-child mock regardless of what we inject).
+        mock_group.inverters = [make_real_inverter("INV001", "FlexBOSS21")]
         mock_group.mid_device = None
 
         # Simulate _has_local_energy() = True  →  wrong consumption from pylxpweb
@@ -4797,7 +4803,10 @@ class TestParallelGroupConsumptionEnergyBalance:
 
         mock_group = MagicMock()
         mock_group.name = "A"
-        mock_group.inverters = [MagicMock(serial_number="INV001")]
+        # Real inverter so the public ``.transport_energy`` accessor honestly
+        # returns None (a bare MagicMock's ``.transport_energy`` would be a
+        # truthy auto-child mock, falsely triggering the energy-balance override).
+        mock_group.inverters = [make_real_inverter("INV001", "FlexBOSS21")]
         mock_group.mid_device = None
 
         # Cloud API provides correct consumption
@@ -6076,12 +6085,33 @@ class TestPV456DataPath:
             def __init__(self, rt: InverterRuntimeData) -> None:
                 self._runtime = None
                 self._transport_runtime = rt
+                self._transport = None
+                self._transport_energy = None
+                self._transport_battery = None
                 # 5-string model drives pv4/pv5 creation.
                 self._features = InverterFeatures(pv_string_count=5)
 
             @property
             def pv_string_count(self) -> int:
                 return self._features.pv_string_count
+
+            # Public transport accessors mirror the real BaseInverter (trivial
+            # passthroughs) — _process_inverter_object reads all four.
+            @property
+            def transport(self) -> Any:
+                return self._transport
+
+            @property
+            def transport_runtime(self) -> InverterRuntimeData | None:
+                return self._transport_runtime
+
+            @property
+            def transport_energy(self) -> Any:
+                return self._transport_energy
+
+            @property
+            def transport_battery(self) -> Any:
+                return self._transport_battery
 
             async def refresh(self) -> None:
                 return None

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -33,7 +33,7 @@ from pylxpweb.exceptions import (
 )
 from pylxpweb.transports.data import BatteryBankData, BatteryData, MidboxRuntimeData
 
-from tests.conftest import make_real_mid, make_transport_spec
+from tests.conftest import make_real_inverter, make_real_mid, make_transport_spec
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────
@@ -485,7 +485,7 @@ class TestHybridMode:
         hybrid_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
 
-        inv = _mock_inverter(serial="INV001")
+        inv = make_real_inverter(serial_number="INV001")
         mock_transport = make_transport_spec(
             transport_type="modbus", host="192.168.1.100"
         )
@@ -520,8 +520,8 @@ class TestHybridMode:
         hybrid_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
 
-        inv = _mock_inverter(serial="INV001")
-        inv._transport = None
+        inv = make_real_inverter(serial_number="INV001")
+        # Real inverter has _transport=None by default → .transport returns None.
         coordinator.station = _mock_station([inv])
         # Clear local caches to ensure no fallback
         coordinator._inverter_cache = {}
@@ -844,7 +844,8 @@ class TestBatteryExtraction:
         http_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
 
-        inv = _mock_inverter(serial="INV001", battery_count=2)
+        inv = make_real_inverter(serial_number="INV001")
+        # Real inverter has transport_battery=None → cloud-only path is taken.
         mock_batt1 = MagicMock()
         mock_batt1.battery_index = 0
         mock_batt1.battery_key = "Battery_ID_01"
@@ -861,11 +862,20 @@ class TestBatteryExtraction:
         mock_batt2.current = 9.5
         mock_batt2.soc = 82
 
-        inv._battery_bank.batteries = [mock_batt1, mock_batt2]
+        # Cloud battery metadata lives on the inverter's _battery_bank; the leaf
+        # battery objects are metadata stand-ins (the inverter itself is real).
+        battery_bank = MagicMock()
+        battery_bank.battery_count = 2
+        battery_bank.batteries = [mock_batt1, mock_batt2]
+        inv._battery_bank = battery_bank
         coordinator.station = _mock_station([inv])
         # Populate inverter cache so get_inverter_object() finds the inverter
         # (normally done by _rebuild_inverter_cache in _async_update_http_data)
         coordinator._inverter_cache = {"INV001": inv}
+        # Seed parameters so _process_station_data does not schedule the
+        # background parameter refresh (which would call the real inverter's
+        # refresh() — unrelated to battery extraction under test).
+        coordinator.data = {"parameters": {"INV001": {}}}
 
         with patch.object(
             coordinator,
@@ -923,11 +933,12 @@ class TestBatteryExtraction:
         http_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
 
-        inv = _mock_inverter(serial="INV001")
+        inv = make_real_inverter(serial_number="INV001")
         inv._battery_bank = None  # No cloud batteries
 
         # Transport batteries — real BatteryData/BatteryBankData so the
         # individual-battery read path is exercised against the genuine shape.
+        # Set on the real inverter so .transport_battery returns it.
         mock_transport_battery = BatteryBankData(
             batteries=[
                 BatteryData(
@@ -943,6 +954,10 @@ class TestBatteryExtraction:
 
         coordinator.station = _mock_station([inv])
         coordinator._inverter_cache = {"INV001": inv}
+        # Seed parameters so _process_station_data does not schedule the
+        # background parameter refresh (which would call the real inverter's
+        # refresh() — unrelated to battery extraction under test).
+        coordinator.data = {"parameters": {"INV001": {}}}
 
         mock_mapping = {"battery_voltage": 52.0, "battery_soc": 85}
         with (

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -20,10 +20,11 @@ from pylxpweb.transports.data import (
     BatteryData,
     InverterEnergyData,
     InverterRuntimeData,
+    MidboxRuntimeData,
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from tests.conftest import make_real_inverter, make_transport_spec
+from tests.conftest import make_real_inverter, make_real_mid, make_transport_spec
 
 from custom_components.eg4_web_monitor.const import (
     CONF_BASE_URL,
@@ -335,9 +336,9 @@ class TestTransportAccessors:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_transport = make_transport_spec()
-        mock_inverter = MagicMock()
-        mock_inverter._transport = mock_transport
-        coordinator._inverter_cache["INV001"] = mock_inverter
+        inv = make_real_inverter(serial_number="INV001")
+        inv._transport = mock_transport
+        coordinator._inverter_cache["INV001"] = inv
 
         result = coordinator.get_local_transport("INV001")
         assert result is mock_transport
@@ -352,9 +353,8 @@ class TestTransportAccessors:
         coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
 
         mock_transport = make_transport_spec()
-        mock_inverter = MagicMock()
+        mock_inverter = make_real_inverter(serial_number="INV001")
         mock_inverter._transport = mock_transport
-        mock_inverter.serial_number = "INV001"
 
         mock_station = MagicMock()
         mock_station.all_inverters = [mock_inverter]
@@ -410,9 +410,9 @@ class TestTransportAccessors:
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
         mock_transport = make_transport_spec()
-        mock_mid = MagicMock()
-        mock_mid._transport = mock_transport
-        coordinator._mid_device_cache["GRIDBOSS001"] = mock_mid
+        mid = make_real_mid(serial_number="GRIDBOSS001")
+        mid._transport = mock_transport
+        coordinator._mid_device_cache["GRIDBOSS001"] = mid
 
         result = coordinator.get_local_transport("GRIDBOSS001")
         assert result is mock_transport
@@ -431,12 +431,13 @@ class TestTransportAccessors:
     def test_get_local_transport_mid_device_no_transport(
         self, hass, local_config_entry
     ):
-        """MID device without _transport attribute returns None."""
+        """MID device without an attached transport returns None."""
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
 
-        mock_mid = MagicMock(spec=[])  # No attributes
-        coordinator._mid_device_cache["GRIDBOSS001"] = mock_mid
+        # No transport assigned → real .transport property returns None
+        mid = make_real_mid(serial_number="GRIDBOSS001")
+        coordinator._mid_device_cache["GRIDBOSS001"] = mid
 
         result = coordinator.get_local_transport("GRIDBOSS001")
         assert result is None
@@ -764,16 +765,18 @@ class TestGridBOSSFirmwareCache:
         coordinator = EG4DataUpdateCoordinator(hass, entry)
         coordinator._local_static_phase_done = True
 
-        # Build a mock MIDDevice with a transport that returns firmware
+        # Build a real MIDDevice with a transport that returns firmware.
+        # read_firmware_version is async on the real transport, so the autospec
+        # returns a coroutine — set its awaited result, not a plain return value.
         mock_transport = make_transport_spec(is_connected=True)
         mock_transport.read_firmware_version.return_value = "IAAB-1600"
 
-        mock_mid = MagicMock()
+        # Inject real runtime so has_data is True (the MIDDevice property reads
+        # _transport_runtime). The MIDDevice.firmware_version property would
+        # return "" here (the bug scenario) — firmware must come from transport.
+        mock_mid = make_real_mid(serial_number="GB001", runtime=MidboxRuntimeData())
         mock_mid._transport = mock_transport
-        mock_mid.has_data = True
         mock_mid.refresh = AsyncMock()
-        # MIDDevice.firmware_version property returns None (the bug scenario)
-        mock_mid.firmware_version = None
 
         coordinator._mid_device_cache["GB001"] = mock_mid
 

--- a/tests/test_register_contract.py
+++ b/tests/test_register_contract.py
@@ -36,22 +36,12 @@ from custom_components.eg4_web_monitor.coordinator_mixins import DeviceProcessin
 # keep this set SHRINKING.  Tracked in beads (see issue refs).
 # -------------------------------------------------------------------------
 KNOWN_SEAM_GAPS: dict[tuple[str, str], str] = {
-    # Cloud-only metadata: the EG4 cloud returns powerRatingText / hasRuntimeData
-    # (wired via const/sensors/mappings.py), but the pylxpweb inverter DEVICE
-    # exposes no such property, so the device-object path yields None.  Tracked
-    # for seam consolidation (eg4-2iw).
-    ("inverter", "power_rating_text"): "cloud-only metadata; not a device property",
-    (
-        "inverter",
-        "has_runtime_data",
-    ): "cloud-only flag; not an inverter device property",
-    # BatteryBank exposes cycle_count_delta but not a bank-level cycle_count;
-    # the battery_bank_cycle_count sensor is populated from the local reg-106
-    # path instead.  Tracked for seam consolidation (eg4-2iw).
-    (
-        "battery_bank",
-        "cycle_count",
-    ): "BatteryBank has no cycle_count property (only _delta)",
+    # Empty: the prior gaps (inverter.power_rating_text / has_runtime_data,
+    # battery_bank.cycle_count) were closed in eg4-ohz by exposing honest
+    # device properties on pylxpweb, so the device-object path now resolves
+    # them for real.  Keep this set SHRINKING — add an entry only with a
+    # tracking issue, and `test_known_seam_gaps_are_still_gaps` guards against
+    # stale entries pylxpweb has since provided.
 }
 
 # (label, property_map, target pylxpweb class the map is applied to)


### PR DESCRIPTION
## Summary
Consumes pylxpweb 0.9.29's new typed public surface so the library↔integration seam is enforced by mypy --strict at build time instead of duck-typing + private-attr poking. Maintainability epic eg4-2iw, plus rider bugs eg4-ohz and eg4-xi7.

**Requires pylxpweb>=0.9.29** (joyfulhouse/pylxpweb#167) — CI is red until that release is on PyPI.

## Changes
- Replace private `_transport*` reads and `_*_cache_ttl` writes with pylxpweb's public accessors (`transport`, `transport_runtime`, `transport_energy`, `transport_battery`, `set_cache_ttls()`).
- **eg4-xi7**: hybrid endpoint grouping uses the **public** `host`/`port`; transports without a network endpoint route to the concurrent bucket instead of collapsing into a bogus `:0` group.
- **eg4-2iw.3**: type the device-processing seam — drop `Any` on `_map_device_properties`, `_process_*_object`, the `coordinator_mappings` builders, and `_extract_firmware_update_info` (`BaseInverter | MIDDevice`).
- **eg4-2iw.4**: remove `[mypy-pylxpweb.*] ignore_missing_imports` from `tests/mypy.ini` — pylxpweb ships `py.typed`, so the ignore was a silent no-op masking seam drift; mypy --strict now enforces the contract.
- **eg4-ohz**: `KNOWN_SEAM_GAPS` emptied — the 3 gaps (`power_rating_text`, `has_runtime_data`, `BatteryBank.cycle_count`) now resolve via honest device properties.
- Latent bugs the typed seam surfaced + fixed: a **dead** ghost-battery guard (`batt.voltage is None` never fired — `BatteryData.voltage/soc` are non-optional `0` defaults → corrected to `== 0`, matching pylxpweb's canonical ghost definition) in both the hybrid overlay and local round-robin paths.
- Test fixtures: coordinator MagicMock device objects → real pylxpweb objects (the public accessors don't reflect privates set on a mock).
- `manifest.json`: `pylxpweb>=0.9.29`.

## Testing
- 827 tests pass.
- `mypy --strict` clean (35 files, **with the pylxpweb ignore removed**).
- ruff clean.
- Adversarial review (Codex): **SHIP**, high confidence, 0 findings.
- Live-validated in the hybrid dev container: integration loads, refresh OK (4 devices), eg4-ohz attrs resolve to real values (`power_rating`=12kW/16kW, `has_runtime_data`=True), split-phase per-leg sensors created, no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)