### PR TITLE
refactor(coordinator): consolidate duplicated cloud/local/hybrid paths (E5 / eg4-kh7)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -43,8 +43,7 @@ from .coordinator_mappings import (
 )
 from .coordinator_mixins import (
     _MixinBase,
-    apply_ac_couple_pv_adjustment,
-    apply_gridboss_overlay,
+    apply_gridboss_to_parallel_group,
     compute_total_inverter_power_kw,
 )
 from .utils import clean_battery_display_name
@@ -632,31 +631,24 @@ class HTTPUpdateMixin(_MixinBase):
                                 mid_data
                             )
 
-                            # Apply GridBOSS CT overlay to parallel group.
-                            # GridBOSS CTs are the authoritative source for
-                            # grid and consumption measurements — inverter
-                            # register sums are internal estimates that diverge
-                            # from actual panel readings.  This mirrors the
-                            # overlay in _process_local_parallel_groups().
-                            apply_gridboss_overlay(
-                                group_data.get("sensors", {}),
-                                mid_data.get("sensors", {}),
-                                group.name,
-                            )
-
-                            # Add AC-coupled smart-port power into
-                            # pv_total_power (parity with LOCAL path).  Without
-                            # this, HYBRID AC-coupled users see a low
-                            # pv_total_power.  Configurable via options.
+                            # Apply the canonical GridBOSS workflow to the
+                            # parallel group (overlay + AC-couple PV).  GridBOSS
+                            # CTs are the authoritative source for grid and
+                            # consumption measurements — inverter register sums
+                            # are internal estimates that diverge from actual
+                            # panel readings.  Shared with the LOCAL path; the
+                            # HTTP path keeps the cloud consumption value
+                            # (recompute_consumption=False).
                             include_ac_couple = self.entry.options.get(
                                 CONF_INCLUDE_AC_COUPLE_PV,
                                 self.entry.data.get(CONF_INCLUDE_AC_COUPLE_PV, False),
                             )
-                            apply_ac_couple_pv_adjustment(
+                            apply_gridboss_to_parallel_group(
                                 group_data.get("sensors", {}),
                                 mid_data.get("sensors", {}),
                                 group.name,
                                 include_ac_couple=include_ac_couple,
+                                recompute_consumption=False,
                             )
 
                         except Exception as e:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -39,8 +39,7 @@ from .const import (
 )
 from .coordinator_mixins import (
     _MixinBase,
-    apply_ac_couple_pv_adjustment,
-    apply_gridboss_overlay,
+    apply_gridboss_to_parallel_group,
     compute_total_inverter_power_kw,
 )
 from .coordinator_mappings import (
@@ -1727,49 +1726,24 @@ class LocalTransportMixin(_MixinBase):
                     continue
                 has_mid_device = True
                 gb_sensors = device_data.get("sensors", {})
-                apply_gridboss_overlay(group_sensors, gb_sensors, group_name)
 
-                # Recompute consumption_power from energy balance using the
-                # MID device's authoritative grid_power (from CTs).  The
-                # inverters' own grid registers are unreliable in MID systems,
-                # so their energy-balance consumption_power (already summed
-                # above) is garbage.  We replace it here.
-                #
-                # Formula: consumption = pv + battery_net + grid_power
-                #   pv_total_power  — from inverters (they know their own PV)
-                #   battery_net     — negative of parallel_battery_power
-                #     (parallel_battery_power: positive=charging, so negate for consumption)
-                #   grid_power      — from MID overlay (positive = importing)
-                pv = float(group_sensors.get("pv_total_power", 0.0))
-                bat_power = float(group_sensors.get("parallel_battery_power", 0.0))
-                # grid_power already replaced by overlay above
-                grid = float(group_sensors.get("grid_power", 0.0))
-                battery_net = -bat_power
-                consumption = max(0.0, pv + battery_net + grid)
-                group_sensors["consumption_power"] = consumption
-                _LOGGER.debug(
-                    "LOCAL: Parallel group %s: consumption_power = "
-                    "pv(%s) + bat_net(%s) + grid(%s) = %s",
-                    group_name,
-                    pv,
-                    battery_net,
-                    grid,
-                    consumption,
-                )
-
-                # Add AC couple power to pv_total_power for smart ports in AC
-                # couple mode.  Shared with the HTTP/HYBRID path so both modes
-                # report total solar production consistently.  Configurable via
-                # options (default: disabled).
+                # Apply the canonical GridBOSS workflow to the parallel group.
+                # The MID device has grid CTs and is the authoritative source
+                # for grid interaction — inverters don't see actual grid
+                # import/export, so LOCAL recomputes consumption_power from the
+                # energy balance (recompute_consumption=True).  Shared with the
+                # HTTP/HYBRID path so the overlay/AC-couple sequence cannot
+                # diverge.  AC-couple PV inclusion is configurable via options.
                 include_ac_couple = self.entry.options.get(
                     CONF_INCLUDE_AC_COUPLE_PV,
                     self.entry.data.get(CONF_INCLUDE_AC_COUPLE_PV, False),
                 )
-                apply_ac_couple_pv_adjustment(
+                apply_gridboss_to_parallel_group(
                     group_sensors,
                     gb_sensors,
                     group_name,
                     include_ac_couple=include_ac_couple,
+                    recompute_consumption=True,
                 )
 
                 break  # Only one MID device per system

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -6,7 +6,7 @@ key dictionaries used by Home Assistant entities.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.util import dt as dt_util
 
@@ -20,7 +20,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from pylxpweb.devices import Battery, MIDDevice
+    from pylxpweb.devices import Battery, BatteryBank, MIDDevice
     from pylxpweb.transports.data import (
         BatteryBankData,
         BatteryData,
@@ -694,13 +694,246 @@ def _build_energy_sensor_mapping(energy_data: "InverterEnergyData") -> dict[str,
     }
 
 
+# ---------------------------------------------------------------------------
+# Canonical battery-bank field tables (shared LOCAL/CLOUD/HYBRID adapter).
+#
+# These tables are the SINGLE source of truth for which battery-bank sensors
+# exist and which source attribute feeds each one.  Both the LOCAL path
+# (BatteryBankData transport dataclass) and the CLOUD path (BatteryBank device
+# object) consume them through build_battery_bank_sensors(), and the cloud
+# property map is DERIVED from them — so adding a bank sensor in one place
+# surfaces it in every mode (structural cure for the M2 "fix-one-miss-the-
+# other" duplication).  Behaviour that genuinely differs per source is
+# preserved exactly inside the adapter and documented on each table/helper:
+#   * CLOUD reads computed properties defensively and skips None/"" (parity
+#     with _map_device_properties); LOCAL reads dataclass fields directly and
+#     writes every key (incl. None) to keep the sensors present.
+#   * battery_bank_power priority is reversed (see _compute_bank_power).
+#   * BMS registers are LOCAL-only; cloud min-cell values are derived from
+#     per-battery data (see _derive_cloud_min_cell).
+# ---------------------------------------------------------------------------
+
+# Common bank fields exposed by BOTH BatteryBankData and BatteryBank.
+# sensor_key -> source attribute name.
+_BATTERY_BANK_FIELDS: dict[str, str] = {
+    "battery_bank_soc": "soc",
+    "battery_bank_voltage": "voltage",
+    "battery_bank_current": "current",
+    "battery_bank_max_capacity": "max_capacity",
+    "battery_bank_current_capacity": "current_capacity",
+    "battery_bank_remain_capacity": "remain_capacity",
+    "battery_bank_full_capacity": "full_capacity",
+    "battery_bank_capacity_percent": "capacity_percent",
+    "battery_bank_count": "battery_count",
+    "battery_bank_status": "status",
+    # Bank-level register data (always available, no CAN bus needed)
+    "battery_bank_cycle_count": "cycle_count",
+    "battery_bank_min_soh": "min_soh",
+    "battery_bank_max_cell_temp": "max_cell_temp",
+    "battery_bank_temp_delta": "temp_delta",
+    "battery_bank_cell_voltage_delta_max": "cell_voltage_delta_max",
+}
+
+# CAN-dependent cross-battery diagnostics — require individual battery data
+# (registers 5002+ / cloud per-battery array).  Properties return None when no
+# CAN data is available, so these are None-skipped in BOTH modes (never
+# fabricate; not part of ALL_INVERTER_SENSOR_KEYS).
+_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS: dict[str, str] = {
+    "battery_bank_soc_delta": "soc_delta",
+    "battery_bank_soh_delta": "soh_delta",
+    "battery_bank_voltage_delta": "voltage_delta",
+    "battery_bank_cycle_count_delta": "cycle_count_delta",
+}
+
+# LOCAL-only Modbus bank registers.  The cloud BatteryBank object does NOT
+# expose these (min-cell values are derived from per-battery data instead — see
+# _derive_cloud_min_cell).  Written unconditionally in LOCAL mode (incl. None)
+# to keep the sensors present.
+_BATTERY_BANK_LOCAL_REGISTER_FIELDS: dict[str, str] = {
+    "battery_bank_min_cell_temp": "min_cell_temperature",
+    "battery_bank_min_cell_voltage": "min_cell_voltage",
+    "battery_bank_bms_charge_current_limit": "bms_charge_current_limit",
+    "battery_bank_bms_discharge_current_limit": "bms_discharge_current_limit",
+    "battery_bank_bms_charge_voltage_ref": "bms_charge_voltage_ref",
+    "battery_bank_bms_discharge_cutoff": "bms_discharge_cutoff",
+    "battery_bank_bms_battery_type": "bms_battery_type",
+    "battery_bank_voltage_inv_sample": "battery_voltage_inv_sample",
+}
+
+
+def get_battery_bank_property_map() -> dict[str, str]:
+    """Cloud battery-bank property map, DERIVED from the canonical tables.
+
+    Maps a pylxpweb BatteryBank property name -> sensor key, for the cross-repo
+    contract test and any other consumer.  Built from the same field tables the
+    adapter uses, so the cloud map can never silently drift from the LOCAL
+    sensor set.  charge_power/discharge_power are intermediates consumed by the
+    power calc; battery_power maps to the final power sensor.
+
+    Returns:
+        Dictionary mapping battery bank property names to sensor keys.
+    """
+    property_map: dict[str, str] = {
+        attr: key
+        for key, attr in {
+            **_BATTERY_BANK_FIELDS,
+            **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+        }.items()
+    }
+    property_map["charge_power"] = "_battery_bank_charge_power"
+    property_map["discharge_power"] = "_battery_bank_discharge_power"
+    property_map["battery_power"] = "battery_bank_power"
+    return property_map
+
+
+def _read_bank_value(bank: Any, attr: str, *, defensive: bool) -> Any:
+    """Read *attr* from a battery-bank source object.
+
+    LOCAL transport dataclass fields are plain attributes (safe direct read).
+    CLOUD BatteryBank exposes computed properties that may call float()/int()
+    on not-yet-populated internal data and raise; ``defensive=True`` mirrors
+    _map_device_properties and returns None on TypeError/ValueError/AttributeError.
+    """
+    if not defensive:
+        return getattr(bank, attr, None)
+    try:
+        return getattr(bank, attr, None)
+    except (TypeError, ValueError, AttributeError) as exc:
+        _LOGGER.debug(
+            "battery_bank property %s raised %s: %s", attr, type(exc).__name__, exc
+        )
+        return None
+
+
+def _compute_bank_power(
+    charge: float | None,
+    discharge: float | None,
+    api_power: float | None,
+    *,
+    prefer_api: bool,
+) -> float | None:
+    """Compute battery_bank_power, preserving each source's priority.
+
+    LOCAL prefers the authoritative charge−discharge difference (its
+    battery_power is only a voltage×current fallback).  CLOUD prefers the API's
+    batPower value and falls back to charge−discharge.
+    """
+    charge_discharge = (
+        charge - discharge if charge is not None and discharge is not None else None
+    )
+    if prefer_api:
+        return api_power if api_power is not None else charge_discharge
+    return charge_discharge if charge_discharge is not None else api_power
+
+
+def _derive_cloud_min_cell(bank: Any, sensors: dict[str, Any]) -> None:
+    """Derive bank min cell temp/voltage from per-battery data (CLOUD only).
+
+    The cloud BatteryBank object does not expose min_cell_temperature/
+    min_cell_voltage (those are Modbus bank registers in LOCAL mode), but each
+    per-battery object does.  Mirror LOCAL's battery_bank_min_cell_* sensors
+    when CAN/per-battery data is available; otherwise omit (never fabricate).
+    """
+    batteries = getattr(bank, "batteries", None) or []
+    min_cell_temps = [
+        t for b in batteries if (t := getattr(b, "min_cell_temp", None)) is not None
+    ]
+    if min_cell_temps:
+        sensors["battery_bank_min_cell_temp"] = min(min_cell_temps)
+    min_cell_voltages = [
+        v for b in batteries if (v := getattr(b, "min_cell_voltage", None)) is not None
+    ]
+    if min_cell_voltages:
+        sensors["battery_bank_min_cell_voltage"] = min(min_cell_voltages)
+
+
+def build_battery_bank_sensors(
+    bank: "BatteryBankData | BatteryBank",
+    *,
+    source: Literal["local", "cloud"],
+) -> dict[str, Any]:
+    """Canonical battery-bank sensor adapter for LOCAL/CLOUD/HYBRID.
+
+    Produces the battery-bank sensor dict from either a LOCAL transport
+    ``BatteryBankData`` object (``source="local"``) or a CLOUD ``BatteryBank``
+    device object (``source="cloud"``).  Both paths share the canonical field
+    tables so the common sensor set cannot drift; per-source differences
+    documented on the tables/helpers are preserved exactly.
+
+    The C-rate sensor (``battery_bank_charge_rate``) is computed separately by
+    ``compute_bank_charge_rate()`` at the call site, after this adapter runs.
+
+    Args:
+        bank: ``BatteryBankData`` (LOCAL/HYBRID transport) or ``BatteryBank``
+            (CLOUD device) object.
+        source: ``"local"`` or ``"cloud"`` — selects read semantics.
+
+    Returns:
+        Dictionary mapping sensor keys to values.
+    """
+    is_cloud = source == "cloud"
+    sensors: dict[str, Any] = {}
+
+    # Common fields.  LOCAL writes every key (incl. None) to keep sensors
+    # present; CLOUD skips None/"" exactly like _map_device_properties.
+    for key, attr in _BATTERY_BANK_FIELDS.items():
+        value = _read_bank_value(bank, attr, defensive=is_cloud)
+        if is_cloud and (value is None or value == ""):
+            continue
+        sensors[key] = value
+
+    # CAN cross-battery diagnostics: None-skipped in BOTH modes.
+    for key, attr in _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS.items():
+        value = _read_bank_value(bank, attr, defensive=is_cloud)
+        if value is not None:
+            sensors[key] = value
+
+    # battery_bank_power — source-specific priority.  LOCAL always writes the
+    # key (incl. None); CLOUD writes only when computable.
+    charge = _read_bank_value(bank, "charge_power", defensive=is_cloud)
+    discharge = _read_bank_value(bank, "discharge_power", defensive=is_cloud)
+    api_power = _read_bank_value(bank, "battery_power", defensive=is_cloud)
+    power = _compute_bank_power(charge, discharge, api_power, prefer_api=is_cloud)
+    if not is_cloud or power is not None:
+        sensors["battery_bank_power"] = power
+    if power is None:
+        _LOGGER.warning(
+            "%s battery_bank_power: cannot calculate - "
+            "charge=%s, discharge=%s, battery_power=%s",
+            source.upper(),
+            charge,
+            discharge,
+            api_power,
+        )
+
+    # Source-specific extras.
+    if is_cloud:
+        _derive_cloud_min_cell(bank, sensors)
+    else:
+        for key, attr in _BATTERY_BANK_LOCAL_REGISTER_FIELDS.items():
+            sensors[key] = getattr(bank, attr, None)
+
+    # battery_status backwards-compat alias (v2.2.x mapped batStatus at the
+    # inverter level).  LOCAL always mirrors status (incl. None); CLOUD mirrors
+    # only when present.
+    if not is_cloud:
+        sensors["battery_status"] = sensors.get("battery_bank_status")
+    elif "battery_bank_status" in sensors:
+        sensors["battery_status"] = sensors["battery_bank_status"]
+
+    # Poll timestamp for the battery bank device (both modes).
+    sensors["battery_bank_last_polled"] = dt_util.utcnow()
+
+    return sensors
+
+
 def _build_battery_bank_sensor_mapping(
     battery_data: "BatteryBankData",
 ) -> dict[str, Any]:
-    """Build sensor mapping from battery bank data object.
+    """Build sensor mapping from LOCAL transport battery bank data.
 
-    Computes cross-battery diagnostic metrics directly from the transport
-    BatteryData objects, mirroring BatteryBank's OOP properties for LOCAL mode.
+    Thin wrapper over :func:`build_battery_bank_sensors` (``source="local"``);
+    retained as the LOCAL entry point used by the coordinator and tests.
 
     Args:
         battery_data: BatteryBankData object from pylxpweb transport.
@@ -708,82 +941,7 @@ def _build_battery_bank_sensor_mapping(
     Returns:
         Dictionary mapping sensor keys to values.
     """
-    # Calculate battery_power with fallback:
-    # Primary: charge_power - discharge_power (matches charge/discharge sensors)
-    # Fallback: voltage * current (from battery_power property)
-    charge = battery_data.charge_power
-    discharge = battery_data.discharge_power
-
-    _LOGGER.debug(
-        "LOCAL battery_bank: count=%s, voltage=%s, current=%s, "
-        "charge=%s, discharge=%s, soc=%s, capacity=%s",
-        battery_data.battery_count,
-        battery_data.voltage,
-        battery_data.current,
-        charge,
-        discharge,
-        battery_data.soc,
-        battery_data.max_capacity,
-    )
-
-    battery_power: float | None = None
-    if charge is not None and discharge is not None:
-        battery_power = charge - discharge
-    elif battery_data.battery_power is not None:
-        battery_power = battery_data.battery_power
-    else:
-        _LOGGER.warning(
-            "LOCAL battery_bank_power: cannot calculate - "
-            "voltage=%s, current=%s, charge=%s, discharge=%s",
-            battery_data.voltage,
-            battery_data.current,
-            charge,
-            discharge,
-        )
-
-    sensors: dict[str, Any] = {
-        "battery_bank_soc": battery_data.soc,
-        "battery_bank_voltage": battery_data.voltage,
-        "battery_bank_current": battery_data.current,
-        "battery_bank_power": battery_power,
-        "battery_bank_max_capacity": battery_data.max_capacity,
-        "battery_bank_current_capacity": battery_data.current_capacity,
-        "battery_bank_remain_capacity": battery_data.remain_capacity,
-        "battery_bank_full_capacity": battery_data.full_capacity,
-        "battery_bank_capacity_percent": battery_data.capacity_percent,
-        "battery_bank_count": battery_data.battery_count,
-        "battery_bank_status": battery_data.status,
-        "battery_status": battery_data.status,
-        # Last polled timestamp for battery bank device
-        "battery_bank_last_polled": dt_util.utcnow(),
-        # Bank-level BMS register data (always available, no CAN bus needed)
-        "battery_bank_cycle_count": battery_data.cycle_count,
-        "battery_bank_min_soh": battery_data.min_soh,
-        "battery_bank_max_cell_temp": battery_data.max_cell_temp,
-        "battery_bank_min_cell_temp": battery_data.min_cell_temperature,
-        "battery_bank_temp_delta": battery_data.temp_delta,
-        "battery_bank_cell_voltage_delta_max": battery_data.cell_voltage_delta_max,
-        "battery_bank_min_cell_voltage": battery_data.min_cell_voltage,
-        "battery_bank_bms_charge_current_limit": battery_data.bms_charge_current_limit,
-        "battery_bank_bms_discharge_current_limit": battery_data.bms_discharge_current_limit,
-        "battery_bank_bms_charge_voltage_ref": battery_data.bms_charge_voltage_ref,
-        "battery_bank_bms_discharge_cutoff": battery_data.bms_discharge_cutoff,
-        "battery_bank_bms_battery_type": battery_data.bms_battery_type,
-        "battery_bank_voltage_inv_sample": battery_data.battery_voltage_inv_sample,
-    }
-
-    # CAN-dependent cross-battery diagnostics — require individual battery data
-    # from registers 5002+. Properties return None when no CAN data available,
-    # so only add non-None values (these keys are NOT in ALL_INVERTER_SENSOR_KEYS).
-    can_diagnostic_sensors = {
-        "battery_bank_soc_delta": battery_data.soc_delta,
-        "battery_bank_soh_delta": battery_data.soh_delta,
-        "battery_bank_voltage_delta": battery_data.voltage_delta,
-        "battery_bank_cycle_count_delta": battery_data.cycle_count_delta,
-    }
-    sensors.update({k: v for k, v in can_diagnostic_sensors.items() if v is not None})
-
-    return sensors
+    return build_battery_bank_sensors(battery_data, source="local")
 
 
 def _build_individual_battery_mapping(

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -792,17 +792,22 @@ def _read_bank_value(bank: Any, attr: str, *, defensive: bool) -> Any:
     LOCAL transport dataclass fields are plain attributes (safe direct read).
     CLOUD BatteryBank exposes computed properties that may call float()/int()
     on not-yet-populated internal data and raise; ``defensive=True`` mirrors
-    _map_device_properties and returns None on TypeError/ValueError/AttributeError.
+    ``_map_device_properties`` exactly: it returns None on
+    TypeError/ValueError/AttributeError AND treats an empty string as "no data"
+    (the generic mapper skipped both None and "").  Normalising "" -> None here
+    keeps every consumer (common loop, CAN diagnostics, power calc) faithful to
+    the original cloud behaviour without repeating the "" check at each site.
     """
     if not defensive:
         return getattr(bank, attr, None)
     try:
-        return getattr(bank, attr, None)
+        value = getattr(bank, attr, None)
     except (TypeError, ValueError, AttributeError) as exc:
         _LOGGER.debug(
             "battery_bank property %s raised %s: %s", attr, type(exc).__name__, exc
         )
         return None
+    return None if value == "" else value
 
 
 def _compute_bank_power(
@@ -875,10 +880,11 @@ def build_battery_bank_sensors(
     sensors: dict[str, Any] = {}
 
     # Common fields.  LOCAL writes every key (incl. None) to keep sensors
-    # present; CLOUD skips None/"" exactly like _map_device_properties.
+    # present; CLOUD skips None exactly like _map_device_properties (""
+    # already normalised to None by _read_bank_value's defensive read).
     for key, attr in _BATTERY_BANK_FIELDS.items():
         value = _read_bank_value(bank, attr, defensive=is_cloud)
-        if is_cloud and (value is None or value == ""):
+        if is_cloud and value is None:
             continue
         sensors[key] = value
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -203,6 +203,77 @@ def apply_ac_couple_pv_adjustment(
         )
 
 
+def _recompute_consumption_from_balance(
+    pg_sensors: dict[str, Any], group_name: str
+) -> None:
+    """Recompute consumption_power from the energy balance (LOCAL only).
+
+    In MID (GridBOSS) systems the inverters' own grid registers are unreliable,
+    so the energy-balance consumption_power summed from inverters is garbage.
+    Replace it using the MID device's authoritative grid_power (already overlaid
+    onto ``grid_power`` by :func:`apply_gridboss_overlay`).
+
+    Formula: consumption = pv + battery_net + grid_power
+        pv          — inverters' own PV (pv_total_power)
+        battery_net — negative of parallel_battery_power (positive = charging)
+        grid_power  — from the GridBOSS overlay (positive = importing)
+
+    Args:
+        pg_sensors: Parallel group sensor dict (modified in place).
+        group_name: Parallel group name for debug logging.
+    """
+    pv = float(pg_sensors.get("pv_total_power", 0.0))
+    bat_power = float(pg_sensors.get("parallel_battery_power", 0.0))
+    grid = float(pg_sensors.get("grid_power", 0.0))
+    battery_net = -bat_power
+    consumption = max(0.0, pv + battery_net + grid)
+    pg_sensors["consumption_power"] = consumption
+    _LOGGER.debug(
+        "LOCAL: Parallel group %s: consumption_power = "
+        "pv(%s) + bat_net(%s) + grid(%s) = %s",
+        group_name,
+        pv,
+        battery_net,
+        grid,
+        consumption,
+    )
+
+
+def apply_gridboss_to_parallel_group(
+    pg_sensors: dict[str, Any],
+    gb_sensors: dict[str, Any],
+    group_name: str,
+    *,
+    include_ac_couple: bool,
+    recompute_consumption: bool,
+) -> None:
+    """Apply the full GridBOSS workflow to a parallel group's sensors.
+
+    Single canonical sequence shared by the HTTP/HYBRID and LOCAL coordinators,
+    so the GridBOSS overlay call sites can no longer diverge (cure for F4):
+
+      1. overlay GridBOSS CT measurements (authoritative grid/consumption);
+      2. (LOCAL only, ``recompute_consumption=True``) recompute
+         consumption_power from the energy balance using the overlaid
+         grid_power — folds the LOCAL-only M3 post-step behind a flag;
+      3. add AC-coupled smart-port PV into pv_total_power when enabled.
+
+    Args:
+        pg_sensors: Parallel group sensor dict (modified in place).
+        gb_sensors: GridBOSS/MID device sensor dict.
+        group_name: Parallel group name for debug logging.
+        include_ac_couple: Whether AC-couple PV inclusion is enabled.
+        recompute_consumption: Whether to recompute consumption_power from the
+            energy balance (LOCAL path); the HTTP path keeps the cloud value.
+    """
+    apply_gridboss_overlay(pg_sensors, gb_sensors, group_name)
+    if recompute_consumption:
+        _recompute_consumption_from_balance(pg_sensors, group_name)
+    apply_ac_couple_pv_adjustment(
+        pg_sensors, gb_sensors, group_name, include_ac_couple=include_ac_couple
+    )
+
+
 def compute_total_inverter_power_kw(
     inverters: Any,
 ) -> float:

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -45,7 +45,9 @@ from .coordinator_mappings import (
     _safe_float,
     _write_charge_rate,
     alias_common_voltage_sensors,
+    build_battery_bank_sensors,
     compute_bank_charge_rate,
+    get_battery_bank_property_map,
 )
 from .utils import clean_battery_display_name
 
@@ -1119,118 +1121,32 @@ class DeviceProcessingMixin(_MixinBase):
             )
 
     def _extract_battery_bank_from_object(self, battery_bank: Any) -> dict[str, Any]:
-        """Extract sensor data from BatteryBank object using properties.
+        """Extract sensor data from a CLOUD BatteryBank object.
+
+        Thin wrapper over the shared :func:`build_battery_bank_sensors`
+        (``source="cloud"``); retained as the CLOUD/HYBRID entry point used by
+        the coordinator and tests.
 
         Args:
-            battery_bank: BatteryBank object from pylxpweb
+            battery_bank: BatteryBank object from pylxpweb.
 
         Returns:
-            Dictionary of sensor_key -> value mappings
+            Dictionary of sensor_key -> value mappings.
         """
-        property_map = self._get_battery_bank_property_map()
-        sensors = _map_device_properties(battery_bank, property_map)
-
-        # Last polled timestamp for battery bank device (parity with LOCAL,
-        # which sets battery_bank_last_polled in _build_battery_bank_sensor_mapping).
-        sensors["battery_bank_last_polled"] = dt_util.utcnow()
-
-        # Derive bank-level minimum cell temperature/voltage from per-battery
-        # data.  The cloud BatteryBank object does NOT expose
-        # min_cell_temperature/min_cell_voltage (those come from Modbus bank
-        # registers in LOCAL mode), but each per-battery Battery object does.
-        # Mirror LOCAL's battery_bank_min_cell_* sensors when CAN/per-battery
-        # data is available; otherwise omit (never fabricate).
-        batteries = getattr(battery_bank, "batteries", None) or []
-        min_cell_temps = [
-            t for b in batteries if (t := getattr(b, "min_cell_temp", None)) is not None
-        ]
-        if min_cell_temps:
-            sensors["battery_bank_min_cell_temp"] = min(min_cell_temps)
-        min_cell_voltages = [
-            v
-            for b in batteries
-            if (v := getattr(b, "min_cell_voltage", None)) is not None
-        ]
-        if min_cell_voltages:
-            sensors["battery_bank_min_cell_voltage"] = min(min_cell_voltages)
-
-        # Add battery_status as alias for battery_bank_status for backwards compatibility
-        # In v2.2.x, the batStatus field was mapped to battery_status at the inverter level
-        # This maintains the sensor for users upgrading from v2.2.x
-        if "battery_bank_status" in sensors:
-            sensors["battery_status"] = sensors["battery_bank_status"]
-
-        # Calculate battery_bank_power if not available from API (batPower is optional)
-        # Formula: charge_power - discharge_power (positive = charging, negative = discharging)
-        # charge/discharge are intermediate values (prefixed with _) not exposed as sensors
-        battery_power = sensors.get("battery_bank_power")
-        charge = sensors.pop("_battery_bank_charge_power", None)
-        discharge = sensors.pop("_battery_bank_discharge_power", None)
-
-        if battery_power is not None:
-            _LOGGER.debug(
-                "HTTP battery_bank_power: from API batPower=%s "
-                "(charge=%s, discharge=%s)",
-                battery_power,
-                charge,
-                discharge,
-            )
-        elif charge is not None and discharge is not None:
-            sensors["battery_bank_power"] = charge - discharge
-            _LOGGER.debug(
-                "HTTP battery_bank_power: using charge-discharge fallback: "
-                "charge=%s, discharge=%s, result=%s",
-                charge,
-                discharge,
-                sensors["battery_bank_power"],
-            )
-        else:
-            _LOGGER.warning(
-                "HTTP battery_bank_power: cannot calculate - "
-                "batPower=%s, charge=%s, discharge=%s",
-                battery_power,
-                charge,
-                discharge,
-            )
-
-        return sensors
+        return build_battery_bank_sensors(battery_bank, source="cloud")
 
     @staticmethod
     def _get_battery_bank_property_map() -> dict[str, str]:
         """Get battery bank property mapping dictionary.
 
+        Derived from the canonical battery-bank field tables (see
+        :func:`get_battery_bank_property_map`) so the cloud map cannot drift
+        from the LOCAL sensor set.
+
         Returns:
-            Dictionary mapping battery bank property names to sensor keys
+            Dictionary mapping battery bank property names to sensor keys.
         """
-        return {
-            # Core metrics
-            "voltage": "battery_bank_voltage",
-            "current": "battery_bank_current",
-            "soc": "battery_bank_soc",
-            "charge_power": "_battery_bank_charge_power",
-            "discharge_power": "_battery_bank_discharge_power",
-            "battery_power": "battery_bank_power",
-            # Capacity metrics
-            "max_capacity": "battery_bank_max_capacity",
-            "current_capacity": "battery_bank_current_capacity",
-            "remain_capacity": "battery_bank_remain_capacity",
-            "full_capacity": "battery_bank_full_capacity",
-            "capacity_percent": "battery_bank_capacity_percent",
-            # Status and metadata
-            "battery_count": "battery_bank_count",
-            "status": "battery_bank_status",
-            # Bank-level BMS register data (always available, no CAN bus needed)
-            "cycle_count": "battery_bank_cycle_count",
-            # Cross-battery diagnostics (pylxpweb >= 0.6.7)
-            "soc_delta": "battery_bank_soc_delta",
-            "min_soh": "battery_bank_min_soh",
-            "soh_delta": "battery_bank_soh_delta",
-            "voltage_delta": "battery_bank_voltage_delta",
-            "cell_voltage_delta_max": "battery_bank_cell_voltage_delta_max",
-            "cycle_count_delta": "battery_bank_cycle_count_delta",
-            "max_cell_temp": "battery_bank_max_cell_temp",
-            "temp_delta": "battery_bank_temp_delta",
-        }
+        return get_battery_bank_property_map()
 
     async def _process_parallel_group_object(
         self, group: "ParallelGroup"

--- a/tests/test_battery_bank_adapter.py
+++ b/tests/test_battery_bank_adapter.py
@@ -1,0 +1,135 @@
+"""Unified battery-bank adapter: LOCAL/CLOUD parity contract (eg4-kh7.1).
+
+``build_battery_bank_sensors()`` is the single canonical adapter both the
+LOCAL (``BatteryBankData`` transport) and CLOUD (``BatteryBank`` device) paths
+route through.  These tests lock the invariants that make the consolidation
+durable and structurally cure the M2 "fix-one-miss-the-other" duplication:
+
+* the cloud property map is DERIVED from the same canonical field tables, so
+  it can never silently drift from the LOCAL sensor set;
+* a field added to the common table surfaces in BOTH modes;
+* the genuinely per-source behaviour (reversed power-calc priority, LOCAL-only
+  BMS registers) is preserved exactly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pylxpweb.transports.data import BatteryBankData, BatteryData
+
+from custom_components.eg4_web_monitor.coordinator_mappings import (
+    _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+    _BATTERY_BANK_FIELDS,
+    _BATTERY_BANK_LOCAL_REGISTER_FIELDS,
+    _compute_bank_power,
+    build_battery_bank_sensors,
+    get_battery_bank_property_map,
+)
+
+
+def _make_local_bank() -> BatteryBankData:
+    """LOCAL transport bank with two differing batteries so CAN deltas resolve."""
+    return BatteryBankData(
+        charge_power=500,
+        discharge_power=0,
+        batteries=[
+            BatteryData(soc=95, soh=98, voltage=53.2, cycle_count=10),
+            BatteryData(soc=94, soh=96, voltage=53.1, cycle_count=5),
+        ],
+    )
+
+
+def _make_cloud_bank() -> SimpleNamespace:
+    """Minimal cloud BatteryBank stand-in exposing the common attribute surface.
+
+    Built programmatically from the canonical tables so that adding a field to
+    ``_BATTERY_BANK_FIELDS`` automatically extends the fake — keeping the
+    parity test honest as the tables evolve.
+    """
+    values: dict[str, object] = {}
+    for attr in {
+        **_BATTERY_BANK_FIELDS,
+        **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+    }.values():
+        values[attr] = 1  # non-None sentinel
+    values["status"] = "Charging"  # status is a string, not numeric
+    values["charge_power"] = 500
+    values["discharge_power"] = 0
+    values["battery_power"] = 500
+    values["batteries"] = []  # no per-battery data -> min_cell_* derivation omitted
+    return SimpleNamespace(**values)
+
+
+def test_cloud_property_map_derived_from_canonical_tables() -> None:
+    """The cloud property map is exactly the inverted tables + power intermediates."""
+    expected = {
+        attr: key
+        for key, attr in {
+            **_BATTERY_BANK_FIELDS,
+            **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+        }.items()
+    }
+    expected["charge_power"] = "_battery_bank_charge_power"
+    expected["discharge_power"] = "_battery_bank_discharge_power"
+    expected["battery_power"] = "battery_bank_power"
+
+    assert get_battery_bank_property_map() == expected
+
+
+def test_common_fields_surface_in_both_modes() -> None:
+    """Every canonical common/CAN/power key appears in BOTH LOCAL and CLOUD output."""
+    local = build_battery_bank_sensors(_make_local_bank(), source="local")
+    cloud = build_battery_bank_sensors(_make_cloud_bank(), source="cloud")
+
+    common_keys = (
+        set(_BATTERY_BANK_FIELDS)
+        | set(_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS)
+        | {"battery_bank_power", "battery_bank_last_polled", "battery_status"}
+    )
+    for key in common_keys:
+        assert key in local, f"{key} missing from LOCAL output"
+        assert key in cloud, f"{key} missing from CLOUD output"
+
+
+def test_local_register_fields_are_local_only() -> None:
+    """BMS register fields appear in LOCAL output but never on CLOUD."""
+    local = build_battery_bank_sensors(_make_local_bank(), source="local")
+    cloud = build_battery_bank_sensors(_make_cloud_bank(), source="cloud")
+
+    for key in _BATTERY_BANK_LOCAL_REGISTER_FIELDS:
+        assert key in local, f"{key} missing from LOCAL output"
+
+    # The cloud BatteryBank object genuinely lacks BMS registers; with no
+    # per-battery data the derived min-cell values are omitted too.
+    for key in _BATTERY_BANK_LOCAL_REGISTER_FIELDS:
+        assert key not in cloud, f"{key} unexpectedly present in CLOUD output"
+
+
+def test_cloud_skips_none_local_writes_all() -> None:
+    """CLOUD omits absent fields; LOCAL writes the key (incl. None) to keep it present."""
+    # Cloud bank missing an optional field (min_soh) -> key absent.
+    cloud_bank = _make_cloud_bank()
+    cloud_bank.min_soh = None
+    cloud = build_battery_bank_sensors(cloud_bank, source="cloud")
+    assert "battery_bank_min_soh" not in cloud
+
+    # LOCAL always emits the key even when the underlying value is None.
+    local_bank = BatteryBankData()  # empty -> most fields None
+    local = build_battery_bank_sensors(local_bank, source="local")
+    assert "battery_bank_min_soh" in local
+
+
+def test_power_priority_preserved_per_source() -> None:
+    """LOCAL prefers charge−discharge; CLOUD prefers the authoritative API value."""
+    # Divergent inputs: charge−discharge = 500 vs api battery_power = 999.
+    assert _compute_bank_power(600, 100, 999, prefer_api=True) == 999  # cloud
+    assert _compute_bank_power(600, 100, 999, prefer_api=False) == 500  # local
+
+    # Each source falls back to the other source when its preference is missing.
+    assert _compute_bank_power(None, None, 999, prefer_api=False) == 999
+    assert _compute_bank_power(600, 100, None, prefer_api=True) == 500
+
+    # Nothing computable -> None (LOCAL still writes the key; CLOUD omits it).
+    assert _compute_bank_power(None, None, None, prefer_api=True) is None
+    assert _compute_bank_power(None, None, None, prefer_api=False) is None

--- a/tests/test_battery_bank_adapter.py
+++ b/tests/test_battery_bank_adapter.py
@@ -120,6 +120,32 @@ def test_cloud_skips_none_local_writes_all() -> None:
     assert "battery_bank_min_soh" in local
 
 
+def test_cloud_treats_empty_string_as_no_data() -> None:
+    """CLOUD treats "" like None (parity with _map_device_properties' != "" skip).
+
+    Regression guard for the original generic mapper which skipped both None
+    and empty strings.  Applies to the common loop, the CAN diagnostics, AND
+    the battery_bank_power fallback.
+    """
+    bank = _make_cloud_bank()
+    # battery_power == "" must NOT be written as ""; the power calc falls back
+    # to charge - discharge instead.
+    bank.battery_power = ""
+    bank.charge_power = 600
+    bank.discharge_power = 100
+    # A CAN diagnostic of "" must be omitted (not emitted as "").
+    bank.soc_delta = ""
+    # A common field of "" must be omitted too.
+    bank.min_soh = ""
+
+    cloud = build_battery_bank_sensors(bank, source="cloud")
+
+    assert cloud["battery_bank_power"] == 500  # charge - discharge fallback
+    assert cloud["battery_bank_power"] != ""
+    assert "battery_bank_soc_delta" not in cloud
+    assert "battery_bank_min_soh" not in cloud
+
+
 def test_power_priority_preserved_per_source() -> None:
     """LOCAL prefers charge−discharge; CLOUD prefers the authoritative API value."""
     # Divergent inputs: charge−discharge = 500 vs api battery_power = 999.

--- a/tests/test_mode_parity.py
+++ b/tests/test_mode_parity.py
@@ -1,0 +1,143 @@
+"""Cross-mode entity-set parity: config / config-local / config-hybrid (eg4-kh7.3).
+
+The integration supports three connection modes (CLOUD, LOCAL, HYBRID).  The
+manual full-stack validation captures live entity snapshots per mode
+(``scratchpad/capture_entities.py``) and diffs them
+(``docs/claude/entity-comparison.md``) — but that needs a live Home Assistant
+plus real devices and cannot run in CI.
+
+This test is the automated, CI-reproducible counterpart: it derives the
+sensor-key set each mode produces from the actual mapping/adapter functions and
+asserts the cross-mode parity contract that the live comparison checks by hand:
+
+  * inverter, GridBOSS and parallel-group sensors come from single shared
+    mapping functions, so their key sets are mode-independent by construction
+    (no per-mode fork can creep in);
+  * battery-bank: CLOUD is a strict subset of LOCAL/HYBRID, and the ONLY
+    permitted difference is the documented set of LOCAL-only Modbus BMS
+    registers the cloud API genuinely does not expose.
+
+A new cross-mode divergence (a LOCAL-only field the cloud could provide, or a
+common field dropped from one path) fails here instead of silently in
+production.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pylxpweb.transports.data import (
+    BatteryBankData,
+    BatteryData,
+    InverterEnergyData,
+    InverterRuntimeData,
+)
+
+from custom_components.eg4_web_monitor.coordinator_mappings import (
+    ALL_INVERTER_SENSOR_KEYS,
+    BATTERY_BANK_KEYS,
+    _build_energy_sensor_mapping,
+    _build_runtime_sensor_mapping,
+    build_battery_bank_sensors,
+)
+
+# The ONLY battery-bank keys permitted to exist in LOCAL/HYBRID but not CLOUD:
+# Modbus BMS bank registers the cloud API genuinely does not expose.  (min-cell
+# temp/voltage are NOT here — the cloud path derives them from per-battery
+# data, so they are cross-mode parity keys.)  Adding a LOCAL-only field that
+# the cloud could provide must update both paths, not this list.
+_DOCUMENTED_LOCAL_ONLY_BATTERY_BANK_KEYS: frozenset[str] = frozenset(
+    {
+        "battery_bank_bms_charge_current_limit",
+        "battery_bank_bms_discharge_current_limit",
+        "battery_bank_bms_charge_voltage_ref",
+        "battery_bank_bms_discharge_cutoff",
+        "battery_bank_bms_battery_type",
+        "battery_bank_voltage_inv_sample",
+    }
+)
+
+
+def _local_battery_bank_keys() -> set[str]:
+    """Battery-bank keys produced by the LOCAL/HYBRID (transport) path."""
+    bank = BatteryBankData(
+        charge_power=500,
+        discharge_power=0,
+        batteries=[
+            BatteryData(soc=95, soh=98, voltage=53.2, cycle_count=10),
+            BatteryData(soc=94, soh=96, voltage=53.1, cycle_count=5),
+        ],
+    )
+    return set(build_battery_bank_sensors(bank, source="local"))
+
+
+def _cloud_battery_bank_keys() -> set[str]:
+    """Battery-bank keys produced by the CLOUD path (fully populated)."""
+    from custom_components.eg4_web_monitor.coordinator_mappings import (
+        _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+        _BATTERY_BANK_FIELDS,
+    )
+
+    values: dict[str, object] = {}
+    for attr in {**_BATTERY_BANK_FIELDS, **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS}.values():
+        values[attr] = 1
+    values["status"] = "Charging"
+    values["charge_power"] = 500
+    values["discharge_power"] = 0
+    values["battery_power"] = 500
+    # Per-battery data so the cloud path derives min-cell temp/voltage.
+    values["batteries"] = [
+        SimpleNamespace(min_cell_temp=21.0, min_cell_voltage=3.25),
+        SimpleNamespace(min_cell_temp=19.5, min_cell_voltage=3.21),
+    ]
+    return set(build_battery_bank_sensors(SimpleNamespace(**values), source="cloud"))
+
+
+def test_cloud_battery_bank_is_subset_of_local() -> None:
+    """CLOUD battery-bank keys are all present in LOCAL/HYBRID (minimum parity)."""
+    local = _local_battery_bank_keys()
+    cloud = _cloud_battery_bank_keys()
+    missing_from_local = cloud - local
+    assert not missing_from_local, (
+        "CLOUD emits battery-bank keys LOCAL does not (parity violation): "
+        f"{sorted(missing_from_local)}"
+    )
+
+
+def test_battery_bank_local_only_diff_is_documented() -> None:
+    """The LOCAL−CLOUD battery-bank difference is exactly the documented BMS set."""
+    local = _local_battery_bank_keys()
+    cloud = _cloud_battery_bank_keys()
+    local_only = local - cloud
+    assert local_only == _DOCUMENTED_LOCAL_ONLY_BATTERY_BANK_KEYS, (
+        "Battery-bank cross-mode divergence changed.\n"
+        f"  unexpected LOCAL-only: {sorted(local_only - _DOCUMENTED_LOCAL_ONLY_BATTERY_BANK_KEYS)}\n"
+        f"  no longer LOCAL-only:  {sorted(_DOCUMENTED_LOCAL_ONLY_BATTERY_BANK_KEYS - local_only)}\n"
+        "Update both data paths (preferred) or the documented exception list."
+    )
+
+
+def test_min_cell_values_are_cross_mode_parity_keys() -> None:
+    """min-cell temp/voltage appear in BOTH modes (cloud derives them)."""
+    local = _local_battery_bank_keys()
+    cloud = _cloud_battery_bank_keys()
+    for key in ("battery_bank_min_cell_temp", "battery_bank_min_cell_voltage"):
+        assert key in local, f"{key} missing from LOCAL"
+        assert key in cloud, f"{key} missing from CLOUD"
+
+
+def test_inverter_sensor_mappings_are_mode_independent() -> None:
+    """Inverter runtime/energy use single shared mappings (no per-mode fork)."""
+    runtime_keys = set(_build_runtime_sensor_mapping(InverterRuntimeData()))
+    energy_keys = set(_build_energy_sensor_mapping(InverterEnergyData()))
+    # Every mapped runtime/energy key is part of the canonical inverter set
+    # all three modes create from the same functions.
+    assert runtime_keys | energy_keys <= ALL_INVERTER_SENSOR_KEYS
+
+
+def test_battery_bank_keys_match_canonical_static_set() -> None:
+    """LOCAL battery-bank output matches the static BATTERY_BANK_KEYS contract."""
+    # battery_bank_charge_rate is computed by compute_bank_charge_rate() after
+    # the adapter, so it is in the static frozenset but not the raw mapping.
+    local = _local_battery_bank_keys()
+    assert local == BATTERY_BANK_KEYS - {"battery_bank_charge_rate"}

--- a/tests/test_mode_parity.py
+++ b/tests/test_mode_parity.py
@@ -79,7 +79,10 @@ def _cloud_battery_bank_keys() -> set[str]:
     )
 
     values: dict[str, object] = {}
-    for attr in {**_BATTERY_BANK_FIELDS, **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS}.values():
+    for attr in {
+        **_BATTERY_BANK_FIELDS,
+        **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
+    }.values():
         values[attr] = 1
     values["status"] = "Charging"
     values["charge_power"] = 500

--- a/tests/test_parallel_group_workflow.py
+++ b/tests/test_parallel_group_workflow.py
@@ -1,0 +1,103 @@
+"""Unified parallel-group GridBOSS workflow (eg4-kh7.2).
+
+``apply_gridboss_to_parallel_group()`` is the single canonical sequence both
+the HTTP/HYBRID and LOCAL coordinators call to apply GridBOSS data to a
+parallel group:
+
+    overlay GridBOSS CTs -> (LOCAL-only) recompute consumption -> AC-couple PV
+
+These tests lock that shared sequence, the ``recompute_consumption`` flag that
+folds the LOCAL-only M3 post-step, and the ordering (consumption is computed
+from the pre-AC-couple PV total) so the consolidation cannot silently diverge.
+"""
+
+from __future__ import annotations
+
+from custom_components.eg4_web_monitor.coordinator_mixins import (
+    _recompute_consumption_from_balance,
+    apply_gridboss_to_parallel_group,
+)
+
+
+def test_overlay_applied_in_both_modes() -> None:
+    """GridBOSS CT grid_power overlays onto the parallel group regardless of flag."""
+    for recompute in (True, False):
+        pg = {"pv_total_power": 1000.0, "parallel_battery_power": 0.0}
+        gb = {"grid_power": -250.0}
+        apply_gridboss_to_parallel_group(
+            pg, gb, "A", include_ac_couple=False, recompute_consumption=recompute
+        )
+        assert pg["grid_power"] == -250.0  # overlaid from authoritative CT
+
+
+def test_local_recomputes_consumption_http_keeps_value() -> None:
+    """recompute_consumption=True replaces consumption_power; False preserves it."""
+    gb = {"grid_power": 300.0}  # importing
+
+    # LOCAL: consumption = max(0, pv + (-bat) + grid) = 1000 - 200 + 300 = 1100
+    pg_local = {
+        "pv_total_power": 1000.0,
+        "parallel_battery_power": 200.0,  # charging -> battery_net = -200
+        "consumption_power": 99999.0,  # garbage from inverter energy balance
+    }
+    apply_gridboss_to_parallel_group(
+        pg_local, gb, "A", include_ac_couple=False, recompute_consumption=True
+    )
+    assert pg_local["consumption_power"] == 1100.0
+
+    # HTTP: consumption_power left untouched (cloud value preserved).
+    pg_http = {
+        "pv_total_power": 1000.0,
+        "parallel_battery_power": 200.0,
+        "consumption_power": 850.0,  # cloud-provided
+    }
+    apply_gridboss_to_parallel_group(
+        pg_http, gb, "A", include_ac_couple=False, recompute_consumption=False
+    )
+    assert pg_http["consumption_power"] == 850.0
+
+
+def test_recomputed_consumption_clamped_non_negative() -> None:
+    """Recomputed consumption_power never goes negative."""
+    pg = {"pv_total_power": 100.0, "parallel_battery_power": 0.0, "grid_power": -6000.0}
+    _recompute_consumption_from_balance(pg, "A")
+    # 100 + 0 + (-6000) = -5900 -> clamped to 0.0
+    assert pg["consumption_power"] == 0.0
+
+
+def test_ac_couple_included_only_when_enabled() -> None:
+    """AC-couple smart-port PV is added to pv_total_power only when enabled."""
+    gb = {
+        "smart_port1_status": "ac_couple",
+        "ac_couple1_power_l1": 500.0,
+        "ac_couple1_power_l2": 500.0,
+    }
+    pg_on = {"pv_total_power": 1000.0}
+    apply_gridboss_to_parallel_group(
+        pg_on, gb, "A", include_ac_couple=True, recompute_consumption=False
+    )
+    assert pg_on["pv_total_power"] == 2000.0  # +1000 AC-couple
+
+    pg_off = {"pv_total_power": 1000.0}
+    apply_gridboss_to_parallel_group(
+        pg_off, gb, "A", include_ac_couple=False, recompute_consumption=False
+    )
+    assert pg_off["pv_total_power"] == 1000.0  # unchanged
+
+
+def test_consumption_uses_pre_ac_couple_pv() -> None:
+    """Sequence order: consumption is computed BEFORE AC-couple PV is added."""
+    gb = {
+        "grid_power": 0.0,
+        "smart_port1_status": "ac_couple",
+        "ac_couple1_power_l1": 500.0,
+        "ac_couple1_power_l2": 0.0,
+    }
+    pg = {"pv_total_power": 1000.0, "parallel_battery_power": 0.0}
+    apply_gridboss_to_parallel_group(
+        pg, gb, "A", include_ac_couple=True, recompute_consumption=True
+    )
+    # consumption uses pv BEFORE ac-couple: 1000 + 0 + 0 = 1000
+    assert pg["consumption_power"] == 1000.0
+    # pv_total_power AFTER ac-couple: 1000 + 500 = 1500
+    assert pg["pv_total_power"] == 1500.0


### PR DESCRIPTION
## Summary

Epic **eg4-kh7** — structural cure for the F4/M2/M3 "fix-one-miss-the-other" duplication across the cloud/local/hybrid coordinator paths. **Behavior-preserving**: collapses duplicated logic onto single canonical workflows without changing any runtime output in any mode.

### eg4-kh7.1 — Unify battery-bank extraction
- One adapter `build_battery_bank_sensors(bank, *, source)` in `coordinator_mappings.py`, driven by three canonical field tables (`_BATTERY_BANK_FIELDS`, `_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS`, `_BATTERY_BANK_LOCAL_REGISTER_FIELDS`).
- The cloud property map (`_get_battery_bank_property_map`) is now **derived** from the tables via `get_battery_bank_property_map()`, so the cloud sensor set can no longer silently drift from LOCAL (**M2 cure**).
- Per-source behavior preserved exactly: CLOUD reads properties defensively + skips `None`/`""`; LOCAL reads dataclass fields directly + writes every key (incl. `None`); the reversed `battery_bank_power` priority (LOCAL prefers charge−discharge, CLOUD prefers API `batPower`) lives in `_compute_bank_power`; cloud min-cell values derived from per-battery data; BMS registers stay LOCAL-only.
- The 3 existing entry points are retained as thin wrappers (call sites/tests/patch targets unchanged).

### eg4-kh7.2 — Unify parallel-group + GridBOSS overlay workflow
- One helper `apply_gridboss_to_parallel_group(pg, gb, name, *, include_ac_couple, recompute_consumption)` replaces the open-coded overlay sequence in both `coordinator_http.py` and `coordinator_local.py` (**F4 cure**).
- The LOCAL-only consumption recompute moves into `_recompute_consumption_from_balance()`, folded behind `recompute_consumption` (**M3**); HTTP keeps the cloud value (`False`), LOCAL recomputes (`True`).
- Ordering preserved: `consumption_power` is computed from the **pre-AC-couple** `pv_total_power`.

### eg4-kh7.3 — Automated cross-mode parity check
- `tests/test_mode_parity.py` derives each mode's (CLOUD/LOCAL/HYBRID) sensor-key set from the actual adapter/mapping functions and asserts the cross-mode contract: CLOUD ⊆ LOCAL, the only difference being the documented LOCAL-only Modbus BMS registers; min-cell values are cross-mode parity keys; inverter mappings are mode-independent.
- Runs automatically via the existing `pytest tests/` CI step (the live `scratchpad/capture_entities.py` 6-way diff remains the manual full-stack counterpart — it needs a live HA + devices and cannot run in CI).

## Validation
- **ruff** clean · **mypy --strict** clean (35 files) · **843 tests** pass (+16 new across 3 test files).
- **Live dev-hybrid vs prod-hybrid**: no new divergence introduced by E5. Remaining diffs are all pre-existing/known — instantaneous power live-lag, the eg4-05k cloud-vs-hybrid `consumption_lifetime` gap, and a device-specific Waveshare bank-register read transient (identical on pre-E5 `main`).
- **Codex adversarial review**: round 1 NO-SHIP surfaced a cloud `""`-handling faithfulness gap (the new common loop skipped `""` but the CAN loop + power calc only skipped `None`, whereas the original `_map_device_properties` skipped both). Fixed at a single point — `_read_bank_value(defensive=True)` normalizes `""` → `None` — plus a regression test. Round 2: **SHIP**, no new findings, all surfaces match `main`.

Closes eg4-kh7, eg4-kh7.1, eg4-kh7.2, eg4-kh7.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)