### PR TITLE
refactor(features): unify feature detection on pylxpweb (eg4-xi8)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -21,6 +21,7 @@ from .const import (
 
 if TYPE_CHECKING:
     from pylxpweb.devices import Battery, BatteryBank, MIDDevice
+    from pylxpweb.devices.inverters import InverterFeatures
     from pylxpweb.transports.data import (
         BatteryBankData,
         BatteryData,
@@ -1205,6 +1206,45 @@ def _apply_grid_type_override(features: dict[str, Any], grid_type: str) -> None:
         features["supports_three_phase"] = True
 
 
+def _features_dict_from_inverter_features(feat: "InverterFeatures") -> dict[str, Any]:
+    """Map a pylxpweb ``InverterFeatures`` instance to the integration feature dict.
+
+    Single source of truth for translating pylxpweb's canonical
+    ``InverterFeatures`` capability flags into the keys consumed by
+    ``_should_create_sensor`` (``supports_*``, ``pv_string_count``) and the
+    diagnostic feature sensors (``inverter_family``, ``grid_type``,
+    ``device_type_code``). Both the static-data path (:func:`_features_from_family`)
+    and the live detection path (``DeviceProcessingMixin._extract_inverter_features``)
+    route through this function, so the two always agree for a given device.
+
+    Args:
+        feat: pylxpweb ``InverterFeatures`` instance (from ``detect_features()``
+            or ``from_device_type_code``/``from_family``).
+
+    Returns:
+        Feature dict for ``_should_create_sensor`` filtering and diagnostics.
+    """
+    from pylxpweb.devices.inverters import InverterFamily
+
+    family = feat.model_family
+    return {
+        "inverter_family": (
+            family.value if isinstance(family, InverterFamily) else str(family)
+        ),
+        "grid_type": str(feat.grid_type.value),
+        "device_type_code": feat.device_type_code,
+        "supports_split_phase": feat.split_phase,
+        "supports_three_phase": feat.three_phase_capable,
+        "supports_off_grid": feat.off_grid_capable,
+        "supports_parallel": feat.parallel_support,
+        "supports_volt_watt_curve": feat.volt_watt_curve,
+        "supports_grid_peak_shaving": feat.grid_peak_shaving,
+        "supports_drms": feat.drms_support,
+        "supports_discharge_recovery_hysteresis": feat.discharge_recovery_hysteresis,
+        "pv_string_count": int(feat.pv_string_count),
+    }
+
+
 def _features_from_family(
     family_str: str | None,
     device_type_code: int | None = None,
@@ -1213,82 +1253,46 @@ def _features_from_family(
     """Derive feature flags from inverter family and device type code.
 
     Used by the static-data first refresh to provide correct feature-based
-    sensor filtering without reading Modbus registers. The four feature
-    keys control which phase-specific and capability-specific sensors are
-    created by _should_create_sensor() in sensor.py.
+    sensor filtering without reading Modbus registers, before pylxpweb's
+    register-based ``detect_features()`` runs on the first real poll.
+
+    Capabilities are sourced from pylxpweb's canonical ``InverterFeatures`` (via
+    :meth:`InverterFeatures.from_family`) and mapped through
+    :func:`_features_dict_from_inverter_features` — the same mapper the live
+    detection path uses — so the static and live paths agree for a given device.
+    The only integration-specific layer is the optional user-selected grid-type
+    override.
 
     Args:
-        family_str: Inverter family from config (e.g., "EG4_HYBRID", "EG4_OFFGRID", "LXP").
+        family_str: Inverter family from config (e.g. "EG4_HYBRID", "EG4_OFFGRID",
+            "LXP"). Legacy names ("SNA", "PV_SERIES", "LXP_EU", "LXP_LV") are
+            accepted.
         device_type_code: Raw device type code from register 19, stored in config
-            during discovery. Used to distinguish LXP-EU (12, three-phase) from
-            LXP-LB (44, single/split-phase).
-        grid_type: User-selected grid type override. When provided, overrides
-            the hardcoded split/three-phase flags. None means no override
-            (backward compatible with existing configs).
+            during discovery. Disambiguates families that need it (LXP-EU vs
+            LXP-LB).
+        grid_type: User-selected grid type override. When provided, overrides the
+            phase flags. None means no override (backward compatible).
 
     Returns:
-        Feature dict suitable for _should_create_sensor() filtering.
-        Empty dict when family is unknown (conservative: creates all sensors).
+        Feature dict suitable for ``_should_create_sensor`` filtering. Empty dict
+        when the family is unknown or cannot be resolved without a device type
+        code (conservative: creates all sensors).
     """
-    if not family_str:
+    family = _parse_inverter_family(family_str)
+    if family is None:
         return {}
 
-    # Normalise legacy names (e.g., "SNA" → "EG4_OFFGRID")
-    mapped = LEGACY_FAMILY_MAP.get(family_str, family_str)
+    from pylxpweb.devices.inverters import InverterFeatures
 
-    # Feature mapping mirrors pylxpweb FAMILY_DEFAULT_FEATURES.
-    # Only the four keys used by _should_create_sensor() are needed here.
-    features: dict[str, Any] = {}
+    feat = InverterFeatures.from_family(family, device_type_code)
+    if feat is None:
+        return {}
 
-    # EG4_OFFGRID (12000XP, 6000XP): US split-phase, discharge recovery
-    if mapped == "EG4_OFFGRID":
-        features = {
-            "inverter_family": mapped,
-            "supports_split_phase": True,
-            "supports_three_phase": False,
-            "supports_discharge_recovery_hysteresis": True,
-            "supports_volt_watt_curve": False,
-        }
+    features = _features_dict_from_inverter_features(feat)
 
-    # EG4_HYBRID (18kPV, 12kPV, FlexBOSS): US split-phase, volt-watt
-    # US market — L1/L2 registers valid, R/S/T registers contain garbage
-    elif mapped == "EG4_HYBRID":
-        features = {
-            "inverter_family": mapped,
-            "supports_split_phase": True,
-            "supports_three_phase": False,
-            "supports_discharge_recovery_hysteresis": False,
-            "supports_volt_watt_curve": True,
-        }
-
-    # LXP family: device_type_code distinguishes EU from LB variants.
-    # - LXP-EU (device_type_code 12): three-phase, no split-phase
-    # - LXP-LB (device_type_code 44): NOT three-phase, volt-watt capable
-    #   LXP-LB includes US (split-phase) and BR (single-phase) variants;
-    #   the us_version flag from HOLD_MODEL determines split vs single,
-    #   but we can safely rule out three-phase from device_type_code alone.
-    elif mapped == "LXP" and device_type_code == 12:  # DEVICE_TYPE_CODE_LXP_EU
-        features = {
-            "inverter_family": mapped,
-            "supports_split_phase": False,
-            "supports_three_phase": True,
-            "supports_discharge_recovery_hysteresis": False,
-            "supports_volt_watt_curve": True,
-        }
-    elif mapped == "LXP" and device_type_code == 44:  # DEVICE_TYPE_CODE_LXP_BR/LXP_LB
-        features = {
-            "inverter_family": mapped,
-            "supports_split_phase": True,
-            "supports_three_phase": False,
-            "supports_discharge_recovery_hysteresis": False,
-            "supports_volt_watt_curve": True,
-        }
-
-    # Unknown family or LXP without device_type_code → conservative fallback
-    # creates all sensors; real feature detection after Modbus reads refines.
-
-    # Apply user-selected grid type override once, regardless of family branch
-    if features and grid_type:
+    # The only integration-specific layer on top of pylxpweb's canonical
+    # capabilities: apply the user-selected grid-type override when present.
+    if grid_type:
         _apply_grid_type_override(features, grid_type)
 
     return features

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -35,13 +35,12 @@ if TYPE_CHECKING:
     # The device objects accepted by the generic property mapper.
     _DeviceObject = BaseInverter | Battery | BatteryBank | MIDDevice | ParallelGroup
 
-from pylxpweb.devices.inverters import InverterFamily
-
 from .const import CONF_LOCAL_TRANSPORTS, DOMAIN, MANUFACTURER
 from .coordinator_mappings import (
     _apply_grid_type_override,
     _build_battery_bank_sensor_mapping,
     _energy_balance,
+    _features_dict_from_inverter_features,
     _safe_float,
     _write_charge_rate,
     alias_common_voltage_sensors,
@@ -1015,73 +1014,24 @@ class DeviceProcessingMixin(_MixinBase):
 
     @staticmethod
     def _extract_inverter_features(inverter: "BaseInverter") -> dict[str, Any]:
-        """Extract feature capabilities from inverter object.
+        """Extract feature capabilities from a detected inverter object.
 
-        This method extracts the detected features from a pylxpweb inverter
-        object after detect_features() has been called. The features are used
-        for capability-based sensor filtering.
+        Reads the pylxpweb ``InverterFeatures`` populated by ``detect_features()``
+        and maps it to the integration feature dict via the shared
+        :func:`_features_dict_from_inverter_features` mapper — the same mapper the
+        static-data path (:func:`_features_from_family`) uses — so the live and
+        static feature paths always agree for a given device.
 
         Args:
-            inverter: BaseInverter object with features detected
+            inverter: BaseInverter object with features detected.
 
         Returns:
-            Dictionary of feature flags for sensor filtering
+            Feature dict for sensor filtering, or empty when features are absent.
         """
-        features: dict[str, Any] = {}
-
-        # Get the features object if available
         inverter_features = getattr(inverter, "_features", None)
         if inverter_features is None:
-            return features
-
-        # Extract inverter family (EG4_OFFGRID, EG4_HYBRID, LXP, etc.)
-        if hasattr(inverter_features, "model_family"):
-            family = inverter_features.model_family
-            features["inverter_family"] = (
-                family.value if isinstance(family, InverterFamily) else str(family)
-            )
-        else:
-            features["inverter_family"] = InverterFamily.UNKNOWN.value
-
-        # Extract grid type
-        if hasattr(inverter_features, "grid_type"):
-            features["grid_type"] = str(inverter_features.grid_type.value)
-
-        # Extract device type code for debugging
-        if hasattr(inverter_features, "device_type_code"):
-            features["device_type_code"] = inverter_features.device_type_code
-
-        # Extract boolean capability flags using supports_* properties
-        # Maps feature key to InverterFeatures attribute name
-        # Some attributes don't follow simple "supports_X" -> "X" pattern
-        capability_mapping: dict[str, str] = {
-            "supports_split_phase": "split_phase",
-            "supports_three_phase": "three_phase_capable",
-            "supports_off_grid": "off_grid_capable",
-            "supports_parallel": "parallel_support",
-            "supports_volt_watt_curve": "volt_watt_curve",
-            "supports_grid_peak_shaving": "grid_peak_shaving",
-            "supports_drms": "drms_support",
-            "supports_discharge_recovery_hysteresis": "discharge_recovery_hysteresis",
-        }
-
-        for prop, attr_name in capability_mapping.items():
-            if hasattr(inverter, prop):
-                features[prop] = getattr(inverter, prop, False)
-            elif hasattr(inverter_features, attr_name):
-                # Fallback to features object attribute using correct mapping
-                features[prop] = getattr(inverter_features, attr_name, False)
-
-        # PV (MPPT) string count (0..n) drives per-string PV sensor creation.
-        # Explicit per-model value declared in pylxpweb
-        # (DEVICE_TYPE_CODE_PV_STRING_COUNT).  A 3-string model -> pv1-3 only.
-        pv_string_count = getattr(inverter, "pv_string_count", None)
-        if pv_string_count is None:
-            pv_string_count = getattr(inverter_features, "pv_string_count", None)
-        if pv_string_count is not None:
-            features["pv_string_count"] = int(pv_string_count)
-
-        return features
+            return {}
+        return _features_dict_from_inverter_features(inverter_features)
 
     def _extract_battery_from_object(self, battery: "Battery") -> dict[str, Any]:
         """Extract sensor data from Battery object using properties.

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.29", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.30", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.2.0"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5917,6 +5917,76 @@ class TestPVStringCountFeatureExtraction:
         }
 
 
+class TestStaticLiveFeatureAgreement:
+    """Static and live feature-detection paths agree per known device (eg4-xi8).
+
+    The static-data path (``_features_from_family``, no Modbus reads) and the
+    live path (``_extract_inverter_features``, after ``detect_features()``) now
+    both source capabilities from pylxpweb's ``InverterFeatures`` via the shared
+    ``_features_dict_from_inverter_features`` mapper.  This guards against either
+    path re-introducing a divergent, hand-rolled feature table — exactly the
+    duplication eg4-xi8 removed.  The comparison uses the family-default layer
+    (``from_device_type_code``) that the static path replicates; runtime probing
+    only ever refines this further and is covered by the detect_features tests.
+    """
+
+    # (family string as stored in config, device_type_code) for every known device.
+    KNOWN_DEVICES = [
+        ("EG4_OFFGRID", 54),  # 12000XP / 6000XP
+        ("EG4_HYBRID", 2092),  # 18kPV / 12kPV
+        ("EG4_HYBRID", 10284),  # FlexBOSS21 / FlexBOSS18
+        ("LXP", 12),  # LXP-EU (three-phase)
+        ("LXP", 44),  # LXP-LB (split-phase)
+    ]
+
+    @staticmethod
+    def _make_inverter(device_type_code: int):
+        """Inverter stand-in carrying a real InverterFeatures for the code."""
+        from pylxpweb.devices.inverters._features import InverterFeatures
+
+        class _Inverter:
+            def __init__(self, dtc: int) -> None:
+                self._features = InverterFeatures.from_device_type_code(dtc)
+
+        return _Inverter(device_type_code)
+
+    @pytest.mark.parametrize(("family_str", "device_type_code"), KNOWN_DEVICES)
+    def test_static_matches_live(self, family_str, device_type_code):
+        """Static and live paths derive identical feature dicts for a device."""
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        static = _features_from_family(family_str, device_type_code)
+        live = DeviceProcessingMixin._extract_inverter_features(
+            self._make_inverter(device_type_code)
+        )
+
+        assert static == live
+        # Known devices are never the conservative empty fallback.
+        assert static != {}
+        assert static["inverter_family"] != ""
+        assert "pv_string_count" in static
+
+    def test_grid_override_layers_on_static_only(self):
+        """The user grid-type override is the only static-path-specific layer."""
+        from custom_components.eg4_web_monitor.coordinator_mixins import (
+            DeviceProcessingMixin,
+        )
+
+        # Without override, static == live.
+        static = _features_from_family("LXP", 12)
+        live = DeviceProcessingMixin._extract_inverter_features(self._make_inverter(12))
+        assert static == live
+
+        # LXP-EU defaults to three-phase; a user split-phase override flips only
+        # the phase flags on the static path, diverging from the raw live path.
+        overridden = _features_from_family("LXP", 12, grid_type="split_phase")
+        assert overridden["supports_split_phase"] is True
+        assert overridden["supports_three_phase"] is False
+        assert overridden != live
+
+
 class TestPV456DataPath:
     """pv4-6 values must actually flow into coordinator sensor data.
 


### PR DESCRIPTION
## Summary
**E7 / eg4-xi8** — the integration now consumes pylxpweb's canonical `InverterFeatures` as the single source of family→capability knowledge, instead of maintaining a duplicate hand-rolled table under divergent key names.

Both feature-derivation paths now route through one shared mapper, `_features_dict_from_inverter_features(InverterFeatures) -> dict`:
- **Static path** (`_features_from_family`, zero-read first refresh) delegates to the new `InverterFeatures.from_family()` + the shared mapper. The deleted ~60-line hardcoded `EG4_OFFGRID`/`EG4_HYBRID`/`LXP` capability table is gone.
- **Live path** (`_extract_inverter_features`, after `detect_features()`) delegates to the same mapper; removes the duplicate `capability_mapping` dict and the now-unused `InverterFamily` import.

The only integration-specific layer that remains is the user-selected **grid-type override**.

## Dependency
Requires **`pylxpweb>=0.9.30`** (adds `InverterFeatures.from_family`); manifest bumped. Integration version unchanged (3.2.0) — internal refactor.

## Test plan
- New `TestStaticLiveFeatureAgreement`: static and live paths derive identical feature dicts for every known device (EG4_OFFGRID 54, EG4_HYBRID 2092/10284, LXP 12/44).
- All prior `_features_from_family` invariants preserved (None/unknown→{}, LXP-no-code→{}, LXP+12→three-phase, LXP+44→split-phase, legacy names, grid overrides).
- Full suite: **849 passed**. ruff + mypy --strict clean.
- **Live-validated** (dev-hybrid vs prod-hybrid): entity surface unchanged — common 337, dev-only 147, prod-only 107, identical to baseline; zero feature-driven change. Numeric diffs are live drift + the pre-existing open eg4-05k bug.
- Adversarial (Codex) review: no logic issues; only finding was the release-coupling now resolved by pylxpweb 0.9.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)