### PR TITLE
feat: BMS charge/discharge/force-charge battery-bank sensors (#232)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,4 @@
+{"id":"int-9da94f4a","kind":"field_change","created_at":"2026-04-06T18:37:59.240053Z","actor":"bryanli","issue_id":"eg4-1775497212644-112-388d38fb","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-e5750bdc","kind":"field_change","created_at":"2026-04-06T18:42:16.811001Z","actor":"bryanli","issue_id":"eg4-1775497213366-118-70ff7fa9","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-06227459","kind":"field_change","created_at":"2026-04-06T18:47:43.22275Z","actor":"bryanli","issue_id":"eg4-1775497213601-120-11784d2b","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-57468201","kind":"field_change","created_at":"2026-04-06T18:47:53.304813Z","actor":"bryanli","issue_id":"eg4-1775497214254-125-cdce411f","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}

--- a/.claude/commands/sprint-loop.md
+++ b/.claude/commands/sprint-loop.md
@@ -1,0 +1,101 @@
+---
+description: "Continuous sprint orchestrator: triage, plan, execute, review, merge in a loop. Pass a number to limit iterations (default: 1)."
+---
+
+# Sprint Loop
+
+Orchestrate continuous sprint cycles. Each iteration runs a full sprint:
+triage -> plan -> execute -> review -> merge -> retro.
+
+## Input
+
+- `$ARGUMENTS` — number of sprint iterations to run (default: 1, "all" for continuous until backlog empty)
+
+## Workflow
+
+### Initialization
+
+1. Run bd doctor to ensure beads is healthy:
+   ```bash
+   bd doctor
+   ```
+   If doctor reports errors, fix them before proceeding.
+
+2. Sync GitHub issues into beads:
+   ```bash
+   GITHUB_TOKEN=$(gh auth token) bd github sync --pull-only
+   ```
+2. Check current state:
+   ```bash
+   bd ready --json
+   bd count
+   ```
+3. If no open issues, stop: "Backlog is empty. Nothing to sprint on."
+
+### Sprint Loop
+
+For each iteration (up to `$ARGUMENTS` times):
+
+**Step 1: Generate sprint name**
+
+Use format: `SPRINT-<date>-<seq>` (e.g., `SPRINT-2026-04-06-1`)
+
+**Step 2: Triage**
+
+Run `/triage` to score any unscored open issues.
+
+**Step 3: Plan + Execute Sprint**
+
+Pour a sprint molecule and execute it:
+
+```bash
+bd mol pour sprint --var sprint_name=${SPRINT_NAME} --var max_items=5
+```
+
+Then follow the `/sprint` workflow:
+- Select top issues by priority
+- Group by component affinity
+- Execute in parallel waves (max 4 agents per wave)
+- Review and merge PRs
+- Close fixed issues
+
+**Step 4: Post-Sprint Sync**
+
+```bash
+GITHUB_TOKEN=$(gh auth token) bd github sync
+bd mol squash <mol-id>
+```
+
+**Step 5: Check for next iteration**
+
+- If more iterations remain AND open issues exist: continue to next sprint
+- Otherwise: print summary and stop
+
+### Between Sprints
+
+- Pull latest main: `git checkout main && git pull`
+- Re-sync GitHub issues (new issues may have been filed)
+- Check if any P0/P1 issues appeared (prioritize those in next sprint)
+
+### Summary Report
+
+After all iterations, print:
+
+```
+Sprint Loop Complete
+====================
+Sprints run: N
+Issues fixed: N
+PRs merged: N
+Issues remaining: N (list P0/P1 if any)
+```
+
+### Rules
+
+- **Each sprint gets a fresh subagent** for context isolation (1M window per sprint)
+- **Never skip triage** — new issues may have appeared between sprints
+- **Max 5 issues per sprint** to keep sprints focused
+- **P0 issues always take priority** regardless of sprint plan
+- **If a P0 appears mid-sprint**, interrupt and address it first
+- **Max 3 sprint iterations** in a single session unless user explicitly says "all"
+- **Sync beads to GitHub after every sprint** to keep external state current

--- a/.claude/commands/sprint-plan.md
+++ b/.claude/commands/sprint-plan.md
@@ -1,0 +1,136 @@
+---
+description: "Plan the next sprint: triage unscored issues, rank by priority/effort, select a batch, group into waves, create sprint epic in beads."
+---
+
+# Sprint Plan
+
+Plan a sprint without executing it. Produces a sprint epic with linked issues,
+wave assignments, and implementation notes for L/XL items.
+
+## Input
+
+- `$ARGUMENTS` — optional sprint name (auto-generates as `SPRINT-<date>-<seq>` if omitted)
+
+## Workflow
+
+### Step 0: Health Check
+
+1. Run bd doctor to ensure beads is healthy:
+   ```bash
+   bd doctor
+   ```
+   If doctor reports errors, fix them before proceeding.
+
+### Step 1: Sync and Triage
+
+1. Pull latest issues from GitHub:
+   ```bash
+   GITHUB_TOKEN=$(gh auth token) bd github sync --pull-only
+   ```
+
+2. Count open issues:
+   ```bash
+   bd ready --json
+   ```
+
+3. For any issue without a priority label or with default P2 that hasn't been reviewed:
+   - Read issue details: `bd show <id>`
+   - Read GitHub comments: `gh issue view <N> --comments`
+   - Score priority (P0-P4) and effort (xs/s/m/l/xl)
+   - Update beads:
+     ```bash
+     bd priority <id> <N>
+     bd label add <id> "effort:<size>"
+     bd label add <id> "<type>"
+     ```
+
+### Step 2: Rank and Select
+
+1. List all ready issues sorted by priority, then effort (smallest first within same priority):
+   ```bash
+   bd ready --json
+   ```
+
+2. Apply selection rules:
+   - **Always include**: All P0 issues (critical)
+   - **Include next**: P1 bugs, then P1 features
+   - **Fill remaining**: P2 bugs by effort (xs → xl), then P2 features
+   - **Cap at 5 items** per sprint (adjustable)
+   - **Skip**: Issues labeled `needs-info`, `wontfix`, `duplicate`
+   - **Skip**: Issues requiring pylxpweb changes unless pylxpweb PR is already merged
+
+3. For L/XL items, create an implementation plan:
+   - Launch a `feature-dev:code-architect` agent to analyze the codebase
+   - Produce a plan file at `docs/plans/<sprint-name>-<issue>.md`
+   - Link plan to the beads issue: `bd note <id> "Plan: docs/plans/..."`
+
+### Step 3: Group into Waves
+
+Group selected issues by component affinity for parallel execution:
+
+| Group | Files Touched | Can Parallelize With |
+|-------|---------------|---------------------|
+| config_flow | `config_flow/`, `strings.json` | sensors, transport |
+| coordinator | `coordinator*.py`, `coordinator_mixins.py` | config_flow (if no shared const) |
+| sensors | `sensor.py`, `const/sensors/`, `base_entity.py` | config_flow, transport |
+| transport | pylxpweb, dongle/modbus code | sensors, config_flow |
+| controls | `switch.py`, `number.py`, `select.py` | sensors, config_flow |
+
+Rules:
+- Issues touching the same files go in the same wave (sequential)
+- Issues in different groups go in the same wave (parallel)
+- Schema/const changes (Wave 0) must complete before other waves
+- **Max 4 parallel agents per wave**
+
+### Step 4: Create Sprint Epic
+
+1. Create the epic:
+   ```bash
+   bd create "Sprint: ${SPRINT_NAME}" --type epic --labels "sprint" --priority 1
+   ```
+
+2. Link selected issues as children:
+   ```bash
+   bd link <epic-id> <issue-id> --type parent-child
+   ```
+
+3. Add wave assignments as notes:
+   ```bash
+   bd note <epic-id> "Wave 0: <issue-ids> (sequential - shared const changes)
+   Wave 1: <issue-ids> (parallel - independent groups)
+   Wave 2: <issue-ids> (parallel - depends on wave 1 merges)"
+   ```
+
+### Step 5: Present Plan for Approval
+
+Print the sprint plan as a table:
+
+```
+Sprint: SPRINT-2026-04-06-1
+Epic: eg4-<id>
+═══════════════════════════════════════════════
+
+Wave 0 (sequential):
+  P0 #210 [bug] Individual Battery Data Fails To Update  effort:m  coordinator
+
+Wave 1 (parallel, max 4):
+  P2 #205 [bug] smart_port_1_status ValueError           effort:s  sensors
+  P2 #202 [bug] GridBOSS duplicate unique IDs             effort:s  sensors
+  P2 #206 [bug] 12KPV Grid/EPS Voltage Unknown           effort:m  coordinator
+
+Wave 2 (parallel):
+  P2 #209 [bug] Dashboard entity names mismatch           effort:s  docs
+
+═══════════════════════════════════════════════
+Total: 5 issues | Estimated: ~4.5 hours
+Ready to execute? Run: /sprint SPRINT-2026-04-06-1
+```
+
+### Rules
+
+- **Do NOT execute any fixes** — this is planning only
+- Present the plan and wait for user approval before `/sprint` executes it
+- If no P0/P1 issues exist, include a mix of P2 bugs and small enhancements
+- If backlog is empty, say so and suggest running `/triage` first
+- Always sync with GitHub before and after planning
+- L/XL items should have plans written before sprint execution starts

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -1,0 +1,121 @@
+---
+description: "Execute a sprint: select triaged issues, fix them in parallel worktrees, review, merge. Pass a sprint name or let it auto-generate."
+---
+
+# Execute Sprint
+
+Run a full sprint cycle using beads molecules. This is the core execution engine.
+
+## Input
+
+- `$ARGUMENTS` — optional sprint name (e.g., "SPRINT-42"). Auto-generates if omitted.
+
+## Workflow
+
+### Phase 0: Health Check and Initialize Sprint Molecule
+
+1. Run bd doctor to ensure beads is healthy:
+   ```bash
+   bd doctor
+   ```
+   If doctor reports errors, fix them before proceeding.
+
+2. Cook and pour the sprint formula:
+```bash
+# Cook and pour the sprint formula
+bd cook sprint --var sprint_name=${SPRINT_NAME} --var max_items=5 --var priority_cutoff=2 --persist
+bd mol pour sprint --var sprint_name=${SPRINT_NAME} --var max_items=5
+```
+
+### Phase 1: Plan — Use Existing or Create Sprint Plan
+
+Check if a sprint epic already exists for `${SPRINT_NAME}`:
+```bash
+bd search "Sprint: ${SPRINT_NAME}" --json
+```
+
+- **If epic exists** (from a prior `/sprint-plan` run): load it and its children as the plan.
+- **If no epic exists**: run `/sprint-plan ${SPRINT_NAME}` to triage, rank, group, and create
+  the sprint epic with wave assignments. Wait for user approval before proceeding.
+
+### Phase 2: Execute — Fix Issues in Parallel Waves
+
+For each wave of non-overlapping groups:
+
+**Step A: Launch parallel agents**
+
+For each issue/group in the wave, launch an Agent (isolation: "worktree"):
+- Read the issue: `bd show <id>`
+- Read GitHub comments: `gh issue view <N> --comments`
+- Mark in-progress: `bd update <id> --status in_progress`
+- Investigate root cause (read code, trace execution path)
+- Implement fix following project conventions
+- Run quality checks:
+  ```bash
+  uv run ruff check custom_components/ --fix && uv run ruff format custom_components/
+  uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/
+  uv run pytest tests/ -x --tb=short
+  ```
+- Commit and push branch
+- Create PR: `gh pr create --title "fix: <desc> (#N)" --body "..."`
+
+**Step B: Review PRs (3-reviewer gate)**
+
+For each PR created in this wave, run ALL three reviewers in parallel:
+
+1. **Code-simplifier** — simplify changed files for clarity
+2. **Code-reviewer** (Opus) — comprehensive code review
+3. **Codex adversarial review** (`/codex:rescue`) — challenge implementation choices
+4. **Gemini adversarial review** (`/gemini:adversarial-review`) — challenge approach
+
+All four run in parallel. Fix ALL issues from all reviewers, then push fixes.
+Re-run quality gates after fixes. This is non-negotiable for m/l/xl effort items.
+
+For xs/s effort items: code-simplifier + code-reviewer only (skip adversarial reviews).
+
+**Step C: Merge sequentially**
+
+Merge PRs one at a time to avoid conflicts:
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+After each merge, pull main before next merge:
+```bash
+git checkout main && git pull
+```
+
+**Step D: Close and sync**
+
+```bash
+bd close <issue-id>
+GITHUB_TOKEN=$(gh auth token) bd github sync
+```
+
+### Phase 3: Retro — Summarize Results
+
+1. List all PRs merged in this sprint
+2. Count: issues fixed, tests added, files changed
+3. List any issues that were deferred or blocked
+4. Squash the molecule: `bd mol squash <mol-id>`
+5. Comment on each GitHub issue with install/test instructions (per ship-fix template)
+
+### Rules
+
+- **Max 4 parallel agents** per wave to avoid resource contention
+- **Sequential merges** — never merge PRs in parallel (lockfile conflicts)
+- **Pull main between waves** — ensure each wave starts from latest
+- **Quality gates are non-negotiable** — all tests, lint, types must pass
+- **Effort-proportional research**:
+  - xs/s: read affected code only
+  - m: read related components, run adversarial review
+  - l/xl: use Explore agents, write implementation plan first
+- **Max 3 fix attempts per issue** — if still failing, defer with notes
+- **Cross-repo (pylxpweb) issues**:
+  - During investigation, if root cause is in pylxpweb, label the issue `cross-repo`
+  - Schedule cross-repo issues in their own wave (Wave 0 or last wave)
+  - Fix pylxpweb first → PR → release → then update eg4_web_monitor
+  - pylxpweb path: `/Users/bryanli/Projects/joyfulhouse/python/pylxpweb`
+  - pylxpweb tests: `cd /Users/bryanli/Projects/joyfulhouse/python/pylxpweb && uv run pytest tests/ -x`
+  - pylxpweb release: `gh release create vX.Y.Z --repo joyfulhouse/pylxpweb`
+  - After pylxpweb release, update `manifest.json` in eg4_web_monitor with new version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **BMS permission/request sensors** ([#232](https://github.com/joyfulhouse/eg4_web_monitor/issues/232)): three battery-bank diagnostic sensors surfacing the BMS's charge/discharge/force-charge state, available in cloud, local, and hybrid modes:
+  - **BMS Charge Allowed** and **BMS Discharge Allowed** (Allowed / Blocked) — cleared when the bank is full / empty respectively
+  - **BMS Force Charge Request** (Requested / Idle) — the BMS requesting a full calibration charge; read-only, distinct from the writable Forced Charge control
+
+  Decoded from input register 95 (bitmap `0x01`/`0x02`/`0x20`) in local/hybrid and from the cloud `bmsCharge`/`bmsDischarge`/`bmsForceCharge` fields — the local decode was validated against the cloud values on live hardware. Requires `pylxpweb>=0.9.32`.
+
 ## [3.2.0] - 2026-03-09
 
 The biggest release in the integration's history: 279 commits, 43 beta/RC releases, and contributions from the community. Local polling is no longer experimental — it's production-ready across all four connection modes with full entity parity validated in Docker.

--- a/README.md
+++ b/README.md
@@ -132,15 +132,19 @@ For users who want faster updates and local-only operation, you can connect dire
 
 #### Hardware Requirements
 
+The following is our tested and validated setup. Other RS485 adapters and cables may work, but this is what we use and recommend:
+
 - **RS485 to Ethernet Adapter** - Choose one:
-  - **Waveshare RS485 to ETH (B)** - 1 channel (~$25) - [Amazon](https://amzn.to/3NPanIx)
-  - **Waveshare RS485 to ETH (B) 4CH** - 4 channels (~$45) - [Amazon](https://amzn.to/45whonI) - *Best for multiple inverters*
+  - **Waveshare 2-CH RS485 to ETH** - 2 channels (~$25) - [Amazon](https://amzn.to/3OU5JcV)
+  - **Waveshare 4-CH RS485 to POE ETH** - 4 channels, PoE (~$45) - [Amazon](https://amzn.to/4rYvLub) - *Best for multiple inverters*
 - **RS485 cable** - 2-wire twisted pair, options:
   - Use spare CAT5/CAT6 cable (1 twisted pair)
-  - **Shielded RS485 cable** (recommended for long runs) - [Amazon](https://amzn.to/4sSOUyp)
+  - **Shielded RS485 cable** (recommended for long runs) - [Amazon](https://amzn.to/40nMOcW)
+- **Ferrule crimping tool** - For clean, reliable RS485 terminal connections - [Amazon](https://amzn.to/4ri3Kwg)
 - **Ethernet cable** - To connect adapter to your network
+- **Network switch** - Any managed switch works; we use [Ubiquiti UniFi switches](https://ui.com/us/switching) which are compact, magnetic-mount, and fit nicely in a [conduit box](https://www.currentconnected.com/product/eg4-powerpro-electrical-conduit-box/)
 
-> **Tip:** The 4-channel version allows you to connect multiple inverters or other RS485 devices (like energy meters) to a single adapter. For cable runs over 50 feet, use shielded cable to reduce interference.
+> **Tip:** The 4-channel PoE version allows you to connect multiple inverters or other RS485 devices (like energy meters) to a single adapter and powers the adapter over Ethernet — no separate power supply needed. For cable runs over 50 feet, use shielded cable to reduce interference.
 
 #### Wiring Diagram
 

--- a/custom_components/eg4_web_monitor/const/sensors/inverter.py
+++ b/custom_components/eg4_web_monitor/const/sensors/inverter.py
@@ -734,6 +734,29 @@ SENSOR_TYPES = {
         "icon": "mdi:information",
         "entity_category": "diagnostic",
     },
+    # BMS permission/request flags (reg 95 bitmap / cloud bmsCharge, issue #232).
+    # Read-only BMS state; distinct from the writable "Forced Charge" control.
+    "battery_bank_charge_allowed": {
+        "name": "BMS Charge Allowed",
+        "icon": "mdi:battery-arrow-up",
+        "device_class": "enum",
+        "options": ["Allowed", "Blocked"],
+        "entity_category": "diagnostic",
+    },
+    "battery_bank_discharge_allowed": {
+        "name": "BMS Discharge Allowed",
+        "icon": "mdi:battery-arrow-down",
+        "device_class": "enum",
+        "options": ["Allowed", "Blocked"],
+        "entity_category": "diagnostic",
+    },
+    "battery_bank_force_charge": {
+        "name": "BMS Force Charge Request",
+        "icon": "mdi:battery-alert",
+        "device_class": "enum",
+        "options": ["Requested", "Idle"],
+        "entity_category": "diagnostic",
+    },
     # Cross-battery diagnostics (pylxpweb >= 0.6.7)
     "battery_bank_soc_delta": {
         "name": "Battery Bank SOC Delta",

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -708,16 +708,22 @@ def _build_energy_sensor_mapping(energy_data: "InverterEnergyData") -> dict[str,
 # exist and which source attribute feeds each one.  Both the LOCAL path
 # (BatteryBankData transport dataclass) and the CLOUD path (BatteryBank device
 # object) consume them through build_battery_bank_sensors(), and the cloud
-# property map is DERIVED from them — so adding a bank sensor in one place
-# surfaces it in every mode (structural cure for the M2 "fix-one-miss-the-
-# other" duplication).  Behaviour that genuinely differs per source is
-# preserved exactly inside the adapter and documented on each table/helper:
+# property map is DERIVED from the passthrough tables — so adding a passthrough
+# bank sensor in one place surfaces it in every mode (structural cure for the M2
+# "fix-one-miss-the-other" duplication).  Behaviour that genuinely differs per
+# source is preserved exactly inside the adapter and documented on each
+# table/helper:
 #   * CLOUD reads computed properties defensively and skips None/"" (parity
 #     with _map_device_properties); LOCAL reads dataclass fields directly and
 #     writes every key (incl. None) to keep the sensors present.
 #   * battery_bank_power priority is reversed (see _compute_bank_power).
-#   * BMS registers are LOCAL-only; cloud min-cell values are derived from
-#     per-battery data (see _derive_cloud_min_cell).
+#   * BMS *numeric limit* registers (charge/discharge current, voltage ref,
+#     cutoff, type) are LOCAL-only (_BATTERY_BANK_LOCAL_REGISTER_FIELDS); cloud
+#     min-cell values are derived from per-battery data (_derive_cloud_min_cell).
+#   * BMS *permission/request flags* (reg 95 bits, issue #232) ARE both-mode:
+#     they need a bool->enum encoder so they live in the separate
+#     _BATTERY_BANK_BMS_PERMISSION_FIELDS table (NOT the derived property map),
+#     and CLOUD gets them via the BatteryBank's parent-inverter delegation.
 # ---------------------------------------------------------------------------
 
 # Common bank fields exposed by BOTH BatteryBankData and BatteryBank.
@@ -752,10 +758,13 @@ _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS: dict[str, str] = {
     "battery_bank_cycle_count_delta": "cycle_count_delta",
 }
 
-# LOCAL-only Modbus bank registers.  The cloud BatteryBank object does NOT
-# expose these (min-cell values are derived from per-battery data instead — see
-# _derive_cloud_min_cell).  Written unconditionally in LOCAL mode (incl. None)
-# to keep the sensors present.
+# LOCAL-only Modbus bank registers (numeric BMS limits + min-cell values).  The
+# cloud BatteryBank object does NOT expose these (cloud min-cell values are
+# derived from per-battery data instead — see _derive_cloud_min_cell).  Written
+# unconditionally in LOCAL mode (incl. None) to keep the sensors present.
+# NOTE: only LOCAL-exclusive registers belong here.  A new BMS field the cloud
+# can also supply (like the reg-95 permission flags) goes in a both-mode table
+# (see _BATTERY_BANK_BMS_PERMISSION_FIELDS), not here.
 _BATTERY_BANK_LOCAL_REGISTER_FIELDS: dict[str, str] = {
     "battery_bank_min_cell_temp": "min_cell_temperature",
     "battery_bank_min_cell_voltage": "min_cell_voltage",
@@ -772,10 +781,16 @@ def get_battery_bank_property_map() -> dict[str, str]:
     """Cloud battery-bank property map, DERIVED from the canonical tables.
 
     Maps a pylxpweb BatteryBank property name -> sensor key, for the cross-repo
-    contract test and any other consumer.  Built from the same field tables the
-    adapter uses, so the cloud map can never silently drift from the LOCAL
-    sensor set.  charge_power/discharge_power are intermediates consumed by the
-    power calc; battery_power maps to the final power sensor.
+    contract test and any other consumer.  Built from the two PASSTHROUGH field
+    tables the adapter uses, so the cloud map can never silently drift from the
+    LOCAL sensor set.  charge_power/discharge_power are intermediates consumed by
+    the power calc; battery_power maps to the final power sensor.
+
+    Scope: this covers only the passthrough tables.  The encoder-based
+    _BATTERY_BANK_BMS_PERMISSION_FIELDS (reg 95 flags, issue #232) is NOT here —
+    its bool->enum encoding can't be expressed as a flat attr->key map — and is
+    seam-guarded separately by test_register_contract.py and the
+    test_bms_permission_* adapter tests.
 
     Returns:
         Dictionary mapping battery bank property names to sensor keys.

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -6,6 +6,7 @@ key dictionaries used by Home Assistant entities.
 """
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.util import dt as dt_util
@@ -270,6 +271,11 @@ BATTERY_BANK_CORE_KEYS: frozenset[str] = frozenset(
         "battery_bank_bms_battery_type",  # reg 80
         "battery_bank_voltage_inv_sample",  # reg 107
         "battery_bank_charge_rate",
+        # BMS permission/request flags (reg 95 bitmap / cloud bmsCharge, #232).
+        # Enum states; available in both LOCAL and CLOUD via the parent inverter.
+        "battery_bank_charge_allowed",  # reg 95 bit 0x01 / bmsCharge
+        "battery_bank_discharge_allowed",  # reg 95 bit 0x02 / bmsDischarge
+        "battery_bank_force_charge",  # reg 95 bit 0x20 / bmsForceCharge
     }
 )
 
@@ -853,6 +859,38 @@ def _derive_cloud_min_cell(bank: Any, sensors: dict[str, Any]) -> None:
         sensors["battery_bank_min_cell_voltage"] = min(min_cell_voltages)
 
 
+def _bms_permission_state(value: bool | None) -> str | None:
+    """Map a BMS allow-charge / allow-discharge flag to its enum sensor state.
+
+    Returns display-ready English values (matching the codebase convention of
+    English status strings, e.g. battery_bank_status="Charging"); ``None`` keeps
+    the entity ``unavailable`` when the flag is unknown.
+    """
+    if value is None:
+        return None
+    return "Allowed" if value else "Blocked"
+
+
+def _bms_force_charge_state(value: bool | None) -> str | None:
+    """Map the BMS force-charge request flag to its enum sensor state."""
+    if value is None:
+        return None
+    return "Requested" if value else "Idle"
+
+
+# BMS permission/request flags (issue #232): sensor key -> (bank source attr,
+# bool->enum-state encoder).  Both BatteryBankData (LOCAL, reg 95 decode) and
+# BatteryBank (CLOUD, parent-inverter delegation) expose these attrs, so the
+# flags surface in every mode.
+_BATTERY_BANK_BMS_PERMISSION_FIELDS: tuple[
+    tuple[str, str, Callable[[bool | None], str | None]], ...
+] = (
+    ("battery_bank_charge_allowed", "allow_charge", _bms_permission_state),
+    ("battery_bank_discharge_allowed", "allow_discharge", _bms_permission_state),
+    ("battery_bank_force_charge", "force_charge", _bms_force_charge_state),
+)
+
+
 def build_battery_bank_sensors(
     bank: "BatteryBankData | BatteryBank",
     *,
@@ -888,6 +926,17 @@ def build_battery_bank_sensors(
         if is_cloud and value is None:
             continue
         sensors[key] = value
+
+    # BMS permission/request flags (issue #232).  Available in BOTH modes:
+    # LOCAL decodes input register 95 onto BatteryBankData; CLOUD's BatteryBank
+    # delegates to its parent inverter's bmsCharge/bmsDischarge/bmsForceCharge.
+    # Encoded as enum states.  LOCAL writes every key (incl. None) to keep the
+    # entity present; CLOUD skips None (parity with the common loop).
+    for perm_key, perm_attr, encode in _BATTERY_BANK_BMS_PERMISSION_FIELDS:
+        state = encode(_read_bank_value(bank, perm_attr, defensive=is_cloud))
+        if is_cloud and state is None:
+            continue
+        sensors[perm_key] = state
 
     # CAN cross-battery diagnostics: None-skipped in BOTH modes.
     for key, attr in _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS.items():

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.30", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.32", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.2.0"
 }

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -756,6 +756,27 @@ From `_build_battery_bank_sensor_mapping()`, sourced from regular registers:
 etc.) require individual battery data from the 5002+ register range. When
 batteries don't communicate on 5002+, these sensors return None.
 
+### BMS Permission/Request Flags (register 95 bitmap, issue #232)
+
+Input register 95 is a BMS permission/request **bitmap** (not the legacy
+idle/standby/active enum). pylxpweb `decode_bms_permissions()` splits it into
+three flags, validated against the cloud API booleans. The integration encodes
+each as an `enum` sensor on the **battery-bank device** (both modes via
+`build_battery_bank_sensors`).
+
+| HA Sensor Key | Reg 95 bit | Cloud field | States |
+|---------------|-----------|-------------|--------|
+| `battery_bank_charge_allowed` | `0x01` | `bmsCharge` | Allowed / Blocked |
+| `battery_bank_discharge_allowed` | `0x02` | `bmsDischarge` | Allowed / Blocked |
+| `battery_bank_force_charge` | `0x20` | `bmsForceCharge` | Requested / Idle |
+
+- **LOCAL/HYBRID:** decoded from reg 95 onto `BatteryBankData` (and
+  `InverterRuntimeData` / `BaseInverter.bms_allow_charge` etc.).
+- **CLOUD:** the `BatteryBank` device delegates to its parent inverter's
+  `bmsCharge` / `bmsDischarge` / `bmsForceCharge` runtime booleans.
+- `battery_bank_force_charge` (BMS calibration request) is **read-only** and
+  distinct from the writable "Forced Charge" control (holding reg 21 bit 11).
+
 ---
 
 ## 8. Parallel Group Data

--- a/docs/plans/2026-05-31-issue-232-bms-status-design.md
+++ b/docs/plans/2026-05-31-issue-232-bms-status-design.md
@@ -1,0 +1,138 @@
+# Issue #232 — BMS Charge/Discharge/Force-Charge Status Entities
+
+**Date:** 2026-05-31
+**Issue:** [#232](https://github.com/joyfulhouse/eg4_web_monitor/issues/232) — Add binary_sensors for battery BMS status fields
+**Status:** Implemented (pylxpweb 0.9.32 + integration); pending pylxpweb release
+
+## Problem
+
+The BMS reports three permission/request flags that are currently surfaced
+nowhere in Home Assistant:
+
+| Concept | Cloud API field | Register 95 bit |
+|---|---|---|
+| Charge allowed | `bmsCharge` | `0x01` |
+| Discharge allowed | `bmsDischarge` | `0x02` |
+| Force-charge request (calibration) | `bmsForceCharge` | `0x20` |
+
+The cloud API already returns these as booleans (`RuntimeInfo`,
+`pylxpweb/models.py:514-516`). In LOCAL (Modbus) mode they must be decoded
+from input register 95, which `pylxpweb` currently models as the **enum**
+`battery_status_inv` (`{0:Idle, 1:Unknown(1), 2:StandBy, 3:Active}`).
+
+### Register 95 is a bitmap, not an enum
+
+The existing enum values are exactly the bitmap combinations of
+`0x01`(charge) | `0x02`(discharge):
+
+| raw | enum label | bitmap reading |
+|---|---|---|
+| `0x00` | Idle | neither |
+| `0x01` | **"Unknown(1)"** | charge-only (battery low) |
+| `0x02` | StandBy | discharge-only (battery full) |
+| `0x03` | Active | both |
+| `0x20` | (unobserved by EG4) | force-charge request |
+
+`0x01` being labelled "Unknown(1)" is the tell: under the bitmap model it is
+plainly "charge allowed, discharge blocked." The enum had no firmware citation
+(it predates the canonical-register migration and traces to a legacy
+`BATTERY_STATUS_MAP`). The committed firmware decompilation is the ESP32
+WiFi-dongle (a transparent Modbus bridge) and does not itself interpret reg 95.
+
+**Source of truth for validation:** the authoritative cloud booleans. The LOCAL
+reg-95 decode is confirmed by cross-checking the decoded bits against
+`bmsCharge`/`bmsDischarge`/`bmsForceCharge` (available together only in HYBRID).
+
+## Decisions (from issue author + maintainer)
+
+1. **Reg 95 = bitmap** (`0x01`/`0x02`/`0x20`), validated against cloud data.
+2. **Reuse the sensor platform** (no new `binary_sensor.py`) — boolean
+   diagnostic sensors, following the existing `off_grid`/`has_data` precedent.
+3. **Decode in pylxpweb + release** — the register source-of-truth library owns
+   the decode; the integration consumes the typed seam. Ships cloud AND local.
+4. **Attach to the battery-bank device** — grouped with the existing bank BMS
+   sensors (`battery_bank_status`, balance/protection/fault/warning, current
+   limits). Routed by the `battery_bank_` key prefix.
+
+## Architecture
+
+Both modes converge through the existing unified bank adapter
+`build_battery_bank_sensors(bank, source)` (`coordinator_mappings.py:856`),
+which reads source attributes off the bank object in both modes. The cloud
+`BatteryBank` holds a parent-inverter reference (`battery_bank.py:85`), so it
+can expose the same attributes the local `BatteryBankData` does.
+
+### pylxpweb changes (release 0.9.31 → 0.9.32)
+
+1. **Decode helper** — module-level
+   `decode_bms_permissions(raw: int) -> tuple[bool, bool, bool]` returning
+   `(allow_charge, allow_discharge, force_charge)` from bits `0x01/0x02/0x20`.
+   Single source of the bit layout, unit-tested for every combination.
+2. **`InverterRuntimeData`** (local dataclass, `transports/data.py`) — add
+   `bms_allow_charge | bms_allow_discharge | bms_force_charge: bool | None`,
+   decoded from reg 95 (`battery_status_inv`) in `from_modbus_registers`
+   (special-case like `soc_soh_packed`). `None` for cloud-built instances.
+3. **`BaseInverter`** dual-source properties (`_runtime_properties.py`,
+   mirroring `is_using_generator`): `bms_allow_charge/.../bms_force_charge`
+   → transport value first, else cloud `RuntimeInfo.bmsCharge/...`.
+4. **`BatteryBankData`** (local bank dataclass) — add
+   `allow_charge/allow_discharge/force_charge: bool | None`, decoded from reg 95
+   via the shared helper in its `from_modbus_registers`.
+5. **`BatteryBank`** (cloud device) — add `allow_charge/allow_discharge/
+   force_charge` properties delegating to `self._inverter.bms_allow_charge/...`
+   (None-safe when no parent inverter).
+6. Keep the existing `battery_status_inv` enum entry as-is (read-but-unsurfaced)
+   to avoid behaviour regression; annotate its register description with the
+   bitmap meaning.
+7. Version bump + CHANGELOG; release via CI/CD (`gh release create v0.9.32`).
+
+### Integration changes
+
+1. **`coordinator_mappings.py`** — add to `_BATTERY_BANK_FIELDS` (both modes):
+   - `battery_bank_charge_allowed` → `allow_charge`
+   - `battery_bank_discharge_allowed` → `allow_discharge`
+   - `battery_bank_force_charge` → `force_charge`
+
+   Add the three keys to `BATTERY_BANK_CORE_KEYS`. The cloud property map
+   auto-derives via `get_battery_bank_property_map()`.
+2. **`const/sensors/inverter.py`** — three new `SENSOR_TYPES` entries
+   (name + icon + `entity_category: diagnostic`, boolean value). Names
+   disambiguate the read-only BMS force-charge **request** from the writable
+   "Forced Charge" control (holding reg 21 bit 11):
+   - `battery_bank_charge_allowed` → "BMS Charge Allowed" (`mdi:battery-arrow-up`)
+   - `battery_bank_discharge_allowed` → "BMS Discharge Allowed" (`mdi:battery-arrow-down`)
+   - `battery_bank_force_charge` → "BMS Force Charge Request" (`mdi:battery-alert`)
+3. **`strings.json` / `translations/*.json`** — intentionally NOT modified.
+   The integration sets `_attr_name` directly and uses no `translation_key` for
+   sensors, so the enum **values are display-ready English** ("Allowed"/
+   "Blocked"/"Requested"/"Idle"), matching the peer `battery_bank_status`
+   (which also has no strings.json entry). Verified against HA core: a
+   `device_class=enum` sensor with `options` and no `translation_key` emits **no
+   warning** and renders the raw option values. Full i18n of the states would
+   require adding `translation_key` plumbing (absent integration-wide today) and
+   is left as a separate enhancement rather than shipping fake/dormant locale
+   entries.
+4. **`manifest.json`** + **`tests/requirements-test.txt`** — `pylxpweb>=0.9.32`.
+5. **`docs/DATA_MAPPING.md`** — document reg-95 bitmap → sensor mapping.
+
+## Validation ("confirm reading with cloud data")
+
+- **pylxpweb unit test** — `decode_bms_permissions` for all bit combinations
+  (`0x00,0x01,0x02,0x03,0x20,0x21,0x22,0x23`).
+- **pylxpweb property tests** — cloud path returns `RuntimeInfo` booleans;
+  local path returns reg-95-decoded booleans; bank delegation works both ways.
+- **HYBRID cross-check** — debug-level log when transport reg-95 decode and
+  cloud booleans disagree (operationalises the cloud-as-arbiter confirmation).
+- **Live confirmation (DONE 2026-05-31)** — `scratchpad/confirm_reg95_vs_cloud.py`
+  read reg 95 over Modbus from both hybrid inverters and compared the decode to
+  the cloud booleans: 18kPV `4512670118` and FlexBOSS21 `52842P0581` both read
+  `reg95=0x03` → `(charge, discharge, force)=(True, True, False)`, **exactly
+  matching** `bmsCharge/bmsDischarge/bmsForceCharge` from the cloud API. ✅
+- Integration tests: mapping (cloud+local), static-key contract, sensor
+  creation, mode parity.
+
+## Scope / non-goals
+
+- These are **bank-aggregate** signals (inverter's view of the BMS). No
+  per-individual-battery allow/force fields exist in the API or registers.
+- No new HA platform; no change to the writable Forced Charge control.

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.29  # keep in sync with manifest.json; the typed seam needs >=0.9.29
+pylxpweb>=0.9.32  # keep in sync with manifest.json; BMS permission flags (#232) need >=0.9.32
 
 # Code quality
 ruff>=0.8.0

--- a/tests/test_battery_bank_adapter.py
+++ b/tests/test_battery_bank_adapter.py
@@ -22,9 +22,16 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
     _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
     _BATTERY_BANK_FIELDS,
     _BATTERY_BANK_LOCAL_REGISTER_FIELDS,
+    BATTERY_BANK_CORE_KEYS,
     _compute_bank_power,
     build_battery_bank_sensors,
     get_battery_bank_property_map,
+)
+
+_BMS_PERMISSION_KEYS = (
+    "battery_bank_charge_allowed",
+    "battery_bank_discharge_allowed",
+    "battery_bank_force_charge",
 )
 
 
@@ -159,3 +166,54 @@ def test_power_priority_preserved_per_source() -> None:
     # Nothing computable -> None (LOCAL still writes the key; CLOUD omits it).
     assert _compute_bank_power(None, None, None, prefer_api=True) is None
     assert _compute_bank_power(None, None, None, prefer_api=False) is None
+
+
+# ---------------------------------------------------------------------------
+# BMS permission/request flags (reg 95 bitmap / cloud bmsCharge, issue #232)
+# ---------------------------------------------------------------------------
+
+
+def test_bms_permission_keys_are_core_keys() -> None:
+    """The three flags are part of the static bank sensor set (every mode)."""
+    for key in _BMS_PERMISSION_KEYS:
+        assert key in BATTERY_BANK_CORE_KEYS
+
+
+def test_bms_permission_local_enum_encoding() -> None:
+    """LOCAL decodes BatteryBankData flags into enum states."""
+    bank = BatteryBankData(allow_charge=True, allow_discharge=False, force_charge=True)
+    local = build_battery_bank_sensors(bank, source="local")
+    assert local["battery_bank_charge_allowed"] == "Allowed"
+    assert local["battery_bank_discharge_allowed"] == "Blocked"
+    assert local["battery_bank_force_charge"] == "Requested"
+
+
+def test_bms_permission_local_writes_none_when_absent() -> None:
+    """LOCAL writes the key (incl. None) so the entity stays present."""
+    local = build_battery_bank_sensors(BatteryBankData(), source="local")
+    for key in _BMS_PERMISSION_KEYS:
+        assert key in local
+        assert local[key] is None
+
+
+def test_bms_permission_cloud_enum_encoding() -> None:
+    """CLOUD reads the delegated flags off the BatteryBank object."""
+    bank = _make_cloud_bank()
+    bank.allow_charge = True
+    bank.allow_discharge = True
+    bank.force_charge = False
+    cloud = build_battery_bank_sensors(bank, source="cloud")
+    assert cloud["battery_bank_charge_allowed"] == "Allowed"
+    assert cloud["battery_bank_discharge_allowed"] == "Allowed"
+    assert cloud["battery_bank_force_charge"] == "Idle"
+
+
+def test_bms_permission_cloud_skips_none() -> None:
+    """CLOUD omits the keys when the parent inverter can't supply the flags."""
+    bank = _make_cloud_bank()
+    bank.allow_charge = None
+    bank.allow_discharge = None
+    bank.force_charge = None
+    cloud = build_battery_bank_sensors(bank, source="cloud")
+    for key in _BMS_PERMISSION_KEYS:
+        assert key not in cloud

--- a/tests/test_mode_parity.py
+++ b/tests/test_mode_parity.py
@@ -74,6 +74,7 @@ def _local_battery_bank_keys() -> set[str]:
 def _cloud_battery_bank_keys() -> set[str]:
     """Battery-bank keys produced by the CLOUD path (fully populated)."""
     from custom_components.eg4_web_monitor.coordinator_mappings import (
+        _BATTERY_BANK_BMS_PERMISSION_FIELDS,
         _BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
         _BATTERY_BANK_FIELDS,
     )
@@ -84,6 +85,10 @@ def _cloud_battery_bank_keys() -> set[str]:
         **_BATTERY_BANK_CAN_DIAGNOSTIC_FIELDS,
     }.values():
         values[attr] = 1
+    # BMS permission/request flags (issue #232) are both-mode: the cloud
+    # BatteryBank delegates them to its parent inverter, so expose them here.
+    for _key, perm_attr, _encode in _BATTERY_BANK_BMS_PERMISSION_FIELDS:
+        values[perm_attr] = True
     values["status"] = "Charging"
     values["charge_power"] = 500
     values["discharge_power"] = 0

--- a/tests/test_register_contract.py
+++ b/tests/test_register_contract.py
@@ -95,3 +95,29 @@ def test_known_seam_gaps_are_still_gaps() -> None:
                 f"{label}.{attr} now exists on {cls.__name__}; drop it from KNOWN_SEAM_GAPS"
             )
     assert not resolved, "Stale KNOWN_SEAM_GAPS entries:\n  " + "\n  ".join(resolved)
+
+
+def test_bms_permission_attrs_exist_on_bank_classes() -> None:
+    """Seam guard for the encoder-based BMS permission table (issue #232).
+
+    The reg-95 permission flags bypass ``get_battery_bank_property_map()`` (a
+    bool->enum encoder cannot be a flat attr->key entry), so the generic
+    property-map contract above does not cover them.  Assert their source
+    attributes resolve on BOTH bank classes the adapter reads from, so a future
+    pylxpweb rename/removal fails CI here instead of going silently unavailable.
+    """
+    from pylxpweb.transports.data import BatteryBankData
+
+    from custom_components.eg4_web_monitor.coordinator_mappings import (
+        _BATTERY_BANK_BMS_PERMISSION_FIELDS,
+    )
+
+    offenders = [
+        attr
+        for _key, attr, _encode in _BATTERY_BANK_BMS_PERMISSION_FIELDS
+        if not hasattr(BatteryBank, attr) or not hasattr(BatteryBankData, attr)
+    ]
+    assert not offenders, (
+        "BMS permission source attrs missing from a bank class (seam drift):\n  "
+        + "\n  ".join(sorted(offenders))
+    )


### PR DESCRIPTION
## Summary

Resolves #232 — surfaces the BMS permission/request flags as Home Assistant entities for the first time. Three new **battery-bank** diagnostic sensors, available in **cloud, local, and hybrid**:

| Sensor | States | Meaning |
|---|---|---|
| **BMS Charge Allowed** | Allowed / Blocked | BMS permits charging (Blocked when full) |
| **BMS Discharge Allowed** | Allowed / Blocked | BMS permits discharging (Blocked when empty) |
| **BMS Force Charge Request** | Requested / Idle | BMS requesting a full calibration charge (read-only) |

## Root cause / key finding

The issue author reported that input **register 95 is a bitmap**, while `pylxpweb` modeled it as an enum (`Idle/StandBy/Active`). Investigation confirmed the bitmap: the enum values are exactly the bit combinations of `0x01`(charge)|`0x02`(discharge), and `0x01` was even labelled *"Unknown(1)"* — i.e. "charge-allowed, discharge-blocked" that had never been decoded. The cloud `bmsCharge`/`bmsDischarge`/`bmsForceCharge` booleans are the same three flags, server-decoded.

## What the change does

**pylxpweb** (released as [v0.9.32](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.32)):
- `decode_bms_permissions()` + `BMS_PERMISSION_*` masks (`0x01`/`0x02`/`0x20`)
- reg-95 decode onto `InverterRuntimeData` + `BatteryBankData`; dual-source `BaseInverter.bms_allow_charge/_discharge/_force_charge`; cloud `BatteryBank` delegates to its parent inverter

**Integration** (this PR):
- 3 enum `SENSOR_TYPES` entries + `BATTERY_BANK_CORE_KEYS`, wired through the unified `build_battery_bank_sensors` adapter (cloud + local converge on the same keys)
- `manifest.json` / `requirements-test.txt` → `pylxpweb>=0.9.32`; `DATA_MAPPING.md` documented
- `Force Charge Request` is deliberately named to not collide with the writable "Forced Charge" control (holding reg 21 bit 11)

## Test plan

- **pylxpweb:** 2067 tests pass, `mypy --strict` clean, ruff clean (incl. new `test_bms_permissions.py` covering every bit combination + dual-source paths)
- **Integration:** 854 tests pass, mypy clean, ruff clean (new parity tests in `test_battery_bank_adapter.py`, `test_mode_parity.py`)
- **Live confirmation:** read reg 95 over Modbus from both hybrid inverters and compared to the cloud booleans — 18kPV `4512670118` and FlexBOSS21 `52842P0581` both `reg95=0x03` → `(charge, discharge, force)=(True, True, False)`, **exactly matching** `bmsCharge`/`bmsDischarge`/`bmsForceCharge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)