### PR TITLE
fix: daily consumption resets at midnight in LOCAL mode (#227)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -73,11 +73,6 @@ if TYPE_CHECKING:
 # concrete local types lets the typed seam verify the split_phase write.
 _LOCAL_REGISTER_TRANSPORTS = (ModbusTransport, ModbusSerialTransport, DongleTransport)
 
-# Derived from energy balance arithmetic; small decreases are normal
-# timing artifacts (not corruption).  Clamped to prevent HA
-# total_increasing warnings.
-_COMPUTED_ENERGY_KEYS = frozenset({"consumption", "consumption_lifetime"})
-
 # Minimum battery serial length to consider valid.  Shorter serials are
 # likely truncated register reads from incomplete CAN bus transfers and
 # are skipped to avoid creating phantom battery entities.
@@ -590,39 +585,6 @@ class LocalTransportMixin(_MixinBase):
             model="Parallel Group",
         )
 
-    def _clamp_computed_energy(
-        self,
-        device_id: str,
-        sensors: dict[str, Any],
-    ) -> None:
-        """Clamp computed energy values so they never decrease.
-
-        Small decreases are normal timing artifacts from reading multiple
-        registers at different instants.  Clamping prevents HA
-        total_increasing state class warnings.
-        """
-        if not self.data:
-            return
-        prev_sensors = (
-            self.data.get("devices", {}).get(device_id, {}).get("sensors", {})
-        )
-        if not prev_sensors:
-            return
-
-        for key in _COMPUTED_ENERGY_KEYS:
-            prev = prev_sensors.get(key)
-            curr = sensors.get(key)
-            if prev is not None and curr is not None and curr < prev:
-                _LOGGER.debug(
-                    "Clamping %s for %s: %.1f -> %.1f (keeping %.1f)",
-                    key,
-                    device_id,
-                    prev,
-                    curr,
-                    prev,
-                )
-                sensors[key] = prev
-
     async def _process_single_local_device(
         self,
         config: dict[str, Any],
@@ -1046,8 +1008,6 @@ class LocalTransportMixin(_MixinBase):
                     sensors.get("rectifier_power"),
                     sensors.get("grid_import_power"),
                 )
-
-                self._clamp_computed_energy(serial, sensors)
 
                 processed["devices"][serial] = device_data
                 device_availability[serial] = True
@@ -1796,9 +1756,7 @@ class LocalTransportMixin(_MixinBase):
                                 group_sensors[vkey] = val
                         break
 
-            # Clamp computed energy values before storing the parallel group.
             group_device_id = f"parallel_group_{group_name.lower()}"
-            self._clamp_computed_energy(group_device_id, group_sensors)
 
             group_sensors["parallel_group_last_polled"] = dt_util.utcnow()
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2565,6 +2565,44 @@ class TestParallelGroupAggregationMath:
         assert total_consumption == 7600  # 2800 + 4800
 
     @pytest.mark.asyncio
+    async def test_midnight_reset_consumption_not_clamped(self, hass, local_entry):
+        """Regression #227: daily consumption must reset to zero at midnight.
+
+        The removed ``_clamp_computed_energy`` held computed consumption at its
+        daily peak and rejected any decrease, so the midnight drop-to-zero never
+        reached Home Assistant.  HA's ``total_increasing`` state class detects
+        meter resets natively, so the integration must publish the decrease as-is
+        instead of pinning the sensor to the previous (peak) value.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, local_entry)
+        # Previous cycle = yesterday's accumulated peak.
+        coordinator.data = {
+            "devices": {
+                "parallel_group_a": {
+                    "sensors": {"consumption": 50.0, "consumption_lifetime": 5000.0}
+                },
+                "MASTER001": {
+                    "sensors": {"consumption": 25.0, "consumption_lifetime": 2500.0}
+                },
+                "SLAVE002": {
+                    "sensors": {"consumption": 25.0, "consumption_lifetime": 2500.0}
+                },
+            }
+        }
+        # Midnight: per-inverter daily consumption resets to 0; lifetime climbs.
+        processed = self._make_processed(
+            {"consumption": 0.0, "consumption_lifetime": 2500.1},
+            {"consumption": 0.0, "consumption_lifetime": 2500.1},
+        )
+        await coordinator._process_local_parallel_groups(processed)
+
+        sensors = processed["devices"]["parallel_group_a"]["sensors"]
+        # Daily consumption reflects the reset — NOT held at the previous peak.
+        assert sensors["consumption"] == 0.0
+        # Lifetime counter continues to accumulate (sum of both inverters).
+        assert sensors["consumption_lifetime"] == pytest.approx(5000.2)
+
+    @pytest.mark.asyncio
     async def test_mixed_grid_state_one_importing_one_exporting(
         self, hass, local_entry
     ):
@@ -5469,111 +5507,6 @@ class TestStaticParallelGroupDeviceRegistration:
         assert device is not None
         assert device.name == "Parallel Group A"
         assert device.model == "Parallel Group"
-
-
-class TestComputedEnergyClamp:
-    """Test _clamp_computed_energy for consumption/consumption_lifetime."""
-
-    @pytest.fixture
-    def coordinator_with_prev_consumption(self, hass):
-        """Coordinator with previous cycle's consumption data."""
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            title="EG4 - Clamp Test",
-            data={
-                CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
-                CONF_DST_SYNC: False,
-                CONF_LIBRARY_DEBUG: False,
-                CONF_LOCAL_TRANSPORTS: [
-                    {
-                        "serial": "INV001",
-                        "host": "192.168.1.100",
-                        "port": 502,
-                        "transport_type": "modbus_tcp",
-                        "inverter_family": "EG4_HYBRID",
-                        "model": "FlexBOSS21",
-                    },
-                ],
-            },
-            entry_id="clamp_test",
-        )
-        coordinator = EG4DataUpdateCoordinator(hass, entry)
-        coordinator.data = {
-            "devices": {
-                "INV001": {
-                    "sensors": {
-                        "consumption": 24.9,
-                        "consumption_lifetime": 4885.0,
-                    }
-                },
-                "parallel_group_a": {
-                    "sensors": {
-                        "consumption": 49.8,
-                        "consumption_lifetime": 9770.0,
-                    }
-                },
-            }
-        }
-        return coordinator
-
-    def test_decreasing_consumption_clamped(self, coordinator_with_prev_consumption):
-        """Consumption that decreased is clamped to previous value."""
-        sensors = {"consumption": 24.8, "consumption_lifetime": 4884.9}
-        coordinator_with_prev_consumption._clamp_computed_energy("INV001", sensors)
-        assert sensors["consumption"] == 24.9
-        assert sensors["consumption_lifetime"] == 4885.0
-
-    def test_increasing_consumption_passes(self, coordinator_with_prev_consumption):
-        """Consumption that increased is not clamped."""
-        sensors = {"consumption": 25.1, "consumption_lifetime": 4886.0}
-        coordinator_with_prev_consumption._clamp_computed_energy("INV001", sensors)
-        assert sensors["consumption"] == 25.1
-        assert sensors["consumption_lifetime"] == 4886.0
-
-    def test_equal_consumption_passes(self, coordinator_with_prev_consumption):
-        """Equal consumption values are not clamped."""
-        sensors = {"consumption": 24.9, "consumption_lifetime": 4885.0}
-        coordinator_with_prev_consumption._clamp_computed_energy("INV001", sensors)
-        assert sensors["consumption"] == 24.9
-        assert sensors["consumption_lifetime"] == 4885.0
-
-    def test_parallel_group_clamped(self, coordinator_with_prev_consumption):
-        """PG consumption also gets clamped."""
-        sensors = {"consumption": 49.7, "consumption_lifetime": 9769.5}
-        coordinator_with_prev_consumption._clamp_computed_energy(
-            "parallel_group_a", sensors
-        )
-        assert sensors["consumption"] == 49.8
-        assert sensors["consumption_lifetime"] == 9770.0
-
-    def test_first_cycle_no_clamp(self, hass):
-        """First cycle (no previous data) does not clamp."""
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            title="EG4 - First Cycle",
-            data={
-                CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
-                CONF_DST_SYNC: False,
-                CONF_LIBRARY_DEBUG: False,
-                CONF_LOCAL_TRANSPORTS: [],
-            },
-            entry_id="first_cycle_clamp",
-        )
-        coordinator = EG4DataUpdateCoordinator(hass, entry)
-        coordinator.data = None  # First cycle
-
-        sensors = {"consumption": 24.8, "consumption_lifetime": 4884.9}
-        coordinator._clamp_computed_energy("INV001", sensors)
-        # Values unchanged — no previous data to clamp against
-        assert sensors["consumption"] == 24.8
-        assert sensors["consumption_lifetime"] == 4884.9
-
-    def test_none_values_not_clamped(self, coordinator_with_prev_consumption):
-        """None values (unavailable) are not clamped."""
-        sensors = {"consumption": None, "consumption_lifetime": None}
-        coordinator_with_prev_consumption._clamp_computed_energy("INV001", sensors)
-        assert sensors["consumption"] is None
-        assert sensors["consumption_lifetime"] is None
 
 
 class TestChargeRates:


### PR DESCRIPTION
## Summary

Fixes #227 — the daily **Consumption** sensor never resets to zero at midnight in **LOCAL** mode (WiFi Dongle / Modbus). It holds at the day's peak and only rises when consumption surpasses that peak.

## Root cause

In LOCAL mode, `consumption`/`consumption_lifetime` are *computed* from an energy balance (`_energy_balance(yield, discharging, grid_import, charging, grid_export)`). The local coordinator then ran `_clamp_computed_energy`, an **unbounded monotonic guard**:

```python
if prev is not None and curr is not None and curr < prev:
    sensors[key] = prev   # rejects the midnight 25 kWh -> 0 reset
```

It was added (#153) to smooth tiny multi-register timing jitter, but being unbounded it also rejected the **legitimate midnight reset**, pinning the daily sensor at its peak.

**Why LOCAL-only:** the clamp lives only in `coordinator_local` (MODBUS / DONGLE / LOCAL paths). CLOUD reads the server-computed `todayUsage` directly, and HYBRID never calls the clamp — so cloud and hybrid reset correctly. (The "upgrade from an old config" theory does not apply: the clamp is unconditional, independent of `data_validation`.)

## Fix

`consumption` is `state_class: total_increasing`; Home Assistant detects meter resets (>10% drops) natively and absorbs sub-10% dips. So the integration must not clamp. This removes:

- `_clamp_computed_energy` method
- `_COMPUTED_ENERGY_KEYS` constant
- both call sites (per-inverter + parallel group)

Tiny same-day derivation jitter can now reach HA, which treats it as noise — strictly better than permanently pinning the sensor at its peak.

## Test plan

- ❌→✅ New regression `test_midnight_reset_consumption_not_clamped` (prev peak 50 → current 0 must publish 0) — **fails** with the clamp present, **passes** after removal.
- Removed obsolete `TestComputedEnergyClamp` (it asserted the buggy held-at-peak behavior).
- ✅ Full suite: **853 passed**
- ✅ `ruff check` + `ruff format` clean
- ✅ `mypy --strict` clean
- ✅ Platinum + Gold tier validators pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)