### PR TITLE
fix(#261): require pylxpweb 0.9.36b16 — Fault/Warning Code no longer unknown on a bms_data drop (3.4.0-beta.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0-beta.15] - 2026-06-22
+
+> Requires [pylxpweb 0.9.36b16](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.36b16)
+> (installed automatically; the manifest requirement is bumped).
+
+### Fixed
+
+- **`Fault Code` / `Warning Code` no longer flicker to "unknown" on a dropped `bms_data` read** ([#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261)): beta.14 fixed the *full link-down* case (the codes hold their last value when the local Modbus link drops entirely), but they still went **unknown** in the far more common case where only the BMS register block (`bms_data`, regs 80-112) dropped while the rest of the read succeeded — the frequent WiFi-dongle mismatch storms [@ivanfmartinez](https://github.com/ivanfmartinez) reported, which (as he noted) did *not* correlate with full link-downs. The inverter's own fault/warning registers (60-63) read a healthy `0`, but pylxpweb merged that `0` with the now-missing BMS fallback code as `0 if 0 else None` → `None`, and a `None` code is dropped from the sensor payload (so the sensor reads *unknown*) in **both** HYBRID and LOCAL mode. Fixed in [pylxpweb 0.9.36b16](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.36b16): a known-healthy `0` is preserved when only the BMS read drops, and the codes go `None` only when neither register was read at all. An active fault from either source is still reported. The manifest now requires `pylxpweb>=0.9.36b16`.
+
 ## [3.4.0-beta.14] - 2026-06-21
 
 > Requires [pylxpweb 0.9.36b15](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.36b15)

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.36b15", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.4.0-beta.14"
+  "requirements": ["pylxpweb>=0.9.36b16", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.4.0-beta.15"
 }


### PR DESCRIPTION
## Summary

Follow-up to the [#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261) work in `3.4.0-beta.14`. The reporter ([@ivanfmartinez](https://github.com/ivanfmartinez)) confirmed **Fault Code** still went **unknown** after beta.14 — and that it did **not** correlate with the dongle-mismatch storms, so it wasn't the full-link-down case beta.14's carry-forward handles.

## What was still wrong

The transport-only `Fault Code` / `Warning Code` come from the inverter fault/warning registers (60-63, always read) merged with a BMS fallback (regs 99-100, in the droppable `bms_data` block). On a `bms_data`-only drop the inverter registers still read a healthy `0`, but pylxpweb merged that as `0 if 0 else None` → **`None`**, and a `None` code is dropped from the sensor payload → **unknown** (in **both** HYBRID and LOCAL mode). The runtime is still present on these polls, so beta.14's `transport_runtime is None` carry-forward never fired.

## This PR

Pure manifest/release plumbing — the fix itself is in the library:

- Requirement → **`pylxpweb>=0.9.36b16`** ([joyfulhouse/pylxpweb#187](https://github.com/joyfulhouse/pylxpweb/pull/187)), which preserves a known-healthy `0` when only the BMS read drops, and returns `None` only when neither register was read.
- Version → **`3.4.0-beta.15`**, CHANGELOG entry added.

**Merge after `pylxpweb 0.9.36b16` is published** (otherwise the requirement won't resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)