### PR TITLE
release: 3.4.0-beta.17 — #258 5th-battery stays fresh (pylxpweb 0.9.36b18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0-beta.17] - 2026-06-23
+
+> Requires [pylxpweb 0.9.36b18](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.36b18)
+> (installed automatically; the manifest requirement is bumped).
+
 ### Fixed
+
+- **HYBRID `>4`-battery systems: the 5th battery no longer slows to hourly updates** ([#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)): beta.16 restored cloud login and added a freshness overlay so a stale *local* battery yields to the fresher *cloud* value. But on the reporter's non-rotating 18kPV firmware, the moment the firmware placed the 5th battery into a Modbus slot even once, pylxpweb's never-evict accumulator cached that block and re-presented it forever — making the library believe the local side already surfaced all five batteries. That switched off the supplemental cloud refresh that had been keeping the 5th battery current, so it dropped from ~5-minute to roughly hourly updates and looked "stuck"/"dropped" on the dashboard. The supplemental-refresh gate now ignores any battery whose local reading has fallen behind its freshest sibling, so the cloud refresh keeps running and every battery stays current. Requires [pylxpweb 0.9.36b18](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.36b18), which also adds raw round-robin slot logging to help pin down why this firmware barely rotates. Reported by @firestormo.
 
 - **12000XP (and other SNA-platform units) missing all controls in Cloud mode** ([#259](https://github.com/joyfulhouse/eg4_web_monitor/issues/259)): a 15 kW 12000XP reported its model over the cloud as `SNA-US 15K`, and the integration decided which inverters get writable entities (switches, numbers, selects) purely by matching that model string against a list of known substrings (`xp`, `12k`, `18k`, …). `SNA-US 15K` contains none of them — `"15k"` was not in the list and there is no `xp`/`sna` token — so the device was created with **no Controls and no Configuration blocks at all**: no Quick Charge, no charge/discharge limits, no operating-mode selects. (A 12 kW unit reporting `SNA-US 12K` slipped through by accidentally matching `"12k"`, which is why other 12000XP owners did have controls.) The control gate now also accepts any device whose detected inverter family is one the integration drives (`EG4_OFFGRID`, `EG4_HYBRID`, `LXP`) — a signal that is available in every connection mode (cloud included) — so these units get their full control set regardless of how the cloud spells the model name. Off-grid units still correctly omit the grid-tied-only controls (Peak Shaving / Forced Discharge). Reported by @brendonlobo123 and @ivanfmartinez.
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.36b17", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.4.0-beta.16"
+  "requirements": ["pylxpweb>=0.9.36b18", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.4.0-beta.17"
 }


### PR DESCRIPTION
## Summary

Cuts **3.4.0-beta.17**, requiring **pylxpweb 0.9.36b18** ([joyfulhouse/pylxpweb#192](https://github.com/joyfulhouse/pylxpweb/pull/192)).

Follow-up to beta.16 on [#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258). The reporter's beta.16 retest log showed the 5th battery still degrading after midnight. Root cause (verified from the 13h log): on his non-rotating 18kPV firmware the inverter placed the 5th battery into a local Modbus slot **exactly once in 13h**; pylxpweb's never-evict accumulator cached that frozen block and re-presented it forever, which made the supplemental cloud refresh (that had been keeping the 5th fresh every ~5 min) **switch off** — so the 5th dropped to hourly updates and looked stuck.

pylxpweb 0.9.36b18 fixes the supplemental-refresh gate (a frozen/stale local battery no longer suppresses the cloud refresh) and adds raw round-robin slot logging so we can finally characterize this firmware's (non-)rotation toward a true local-path fix.

## Changes
- `manifest.json`: version `3.4.0-beta.17`, `pylxpweb>=0.9.36b18`.
- `CHANGELOG.md`: beta.17 entry for #258; bundles the already-merged #259 SNA-platform control-gate fix.

## Validation
- Integration test suite: **1455 passed, 1 skipped** against the live b18.
- No integration code changes (release bump only); the fix is entirely in pylxpweb.

> Merge after [pylxpweb#192](https://github.com/joyfulhouse/pylxpweb/pull/192) is merged and 0.9.36b18 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)