### PR TITLE
fix: accept string plant selection so multi-station accounts can onboard (#275)

### DIFF
--- a/custom_components/eg4_web_monitor/_config_flow/helpers.py
+++ b/custom_components/eg4_web_monitor/_config_flow/helpers.py
@@ -131,7 +131,7 @@ def find_plant_by_id(
     """Find a plant in the plants list by its ID."""
     if not plants:
         return None
-    return next((p for p in plants if p.get("plantId") == plant_id), None)
+    return next((p for p in plants if str(p.get("plantId")) == str(plant_id)), None)
 
 
 def migrate_legacy_entry(data: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/eg4_web_monitor/_config_flow/schemas.py
+++ b/custom_components/eg4_web_monitor/_config_flow/schemas.py
@@ -148,18 +148,22 @@ def build_plant_selection_schema(
     Returns:
         Voluptuous schema for plant selection step.
     """
-    plant_options = {plant["plantId"]: plant["name"] for plant in plants}
+    plant_options = {str(plant["plantId"]): plant["name"] for plant in plants}
 
     if current:
         return vol.Schema(
             {
-                vol.Required(CONF_PLANT_ID, default=current): vol.In(plant_options),
+                vol.Required(CONF_PLANT_ID, default=str(current)): vol.All(
+                    vol.Coerce(str), vol.In(plant_options)
+                ),
             }
         )
 
     return vol.Schema(
         {
-            vol.Required(CONF_PLANT_ID): vol.In(plant_options),
+            vol.Required(CONF_PLANT_ID): vol.All(
+                vol.Coerce(str), vol.In(plant_options)
+            ),
         }
     )
 
@@ -263,7 +267,7 @@ def build_serial_schema(
             CONF_SERIAL_BAUDRATE,
             default=defaults.get(CONF_SERIAL_BAUDRATE, DEFAULT_SERIAL_BAUDRATE),
         )
-    ] = vol.In(SERIAL_BAUDRATE_OPTIONS)
+    ] = vol.All(vol.Coerce(int), vol.In(SERIAL_BAUDRATE_OPTIONS))
 
     # Parity selector
     schema_fields[
@@ -279,7 +283,7 @@ def build_serial_schema(
             CONF_SERIAL_STOPBITS,
             default=defaults.get(CONF_SERIAL_STOPBITS, DEFAULT_SERIAL_STOPBITS),
         )
-    ] = vol.In(SERIAL_STOPBITS_OPTIONS)
+    ] = vol.All(vol.Coerce(int), vol.In(SERIAL_STOPBITS_OPTIONS))
 
     # Unit ID
     schema_fields[

--- a/tests/test_config_flow_schemas.py
+++ b/tests/test_config_flow_schemas.py
@@ -10,6 +10,7 @@ from custom_components.eg4_web_monitor._config_flow.schemas import (
     build_modbus_schema,
     build_plant_selection_schema,
     build_reauth_schema,
+    build_serial_schema,
 )
 from custom_components.eg4_web_monitor.const import (
     CONF_BASE_URL,
@@ -22,6 +23,8 @@ from custom_components.eg4_web_monitor.const import (
     CONF_MODBUS_PORT,
     CONF_MODBUS_UNIT_ID,
     CONF_PLANT_ID,
+    CONF_SERIAL_BAUDRATE,
+    CONF_SERIAL_STOPBITS,
     CONF_VERIFY_SSL,
     DEFAULT_DONGLE_PORT,
     DEFAULT_MODBUS_PORT,
@@ -159,31 +162,42 @@ class TestBuildPlantSelectionSchema:
 
     def test_returns_schema(self):
         """Test that function returns a valid schema."""
-        plants = [{"plantId": "123", "name": "Test Plant"}]
+        plants = [{"plantId": 123, "name": "Test Plant"}]
         schema = build_plant_selection_schema(plants)
         assert isinstance(schema, vol.Schema)
 
     def test_requires_plant_id(self):
         """Test that plant ID is required."""
-        plants = [{"plantId": "123", "name": "Test Plant"}]
+        plants = [{"plantId": 123, "name": "Test Plant"}]
         schema = build_plant_selection_schema(plants)
 
         with pytest.raises(vol.MultipleInvalid):
             schema({})
 
     def test_validates_plant_id(self):
-        """Test that invalid plant ID is rejected."""
-        plants = [{"plantId": "123", "name": "Test Plant"}]
+        """Test that a plant ID not in the list is rejected."""
+        plants = [{"plantId": 123, "name": "Test Plant"}]
         schema = build_plant_selection_schema(plants)
 
         with pytest.raises(vol.MultipleInvalid):
-            schema({CONF_PLANT_ID: "invalid"})
+            schema({CONF_PLANT_ID: "999"})
+
+    def test_string_submission_accepted_against_int_plant_ids(self):
+        """Test that a string submission against int station ids is accepted."""
+        plants = [
+            {"plantId": 12345, "name": "Plant A"},
+            {"plantId": 67890, "name": "Plant B"},
+        ]
+        schema = build_plant_selection_schema(plants)
+        result = schema({CONF_PLANT_ID: "67890"})
+        assert result[CONF_PLANT_ID] == "67890"
+        assert isinstance(result[CONF_PLANT_ID], str)
 
     def test_accepts_valid_plant_id(self):
-        """Test that valid plant ID is accepted."""
+        """Test that a valid plant ID is accepted and stored as a string."""
         plants = [
-            {"plantId": "123", "name": "Plant 1"},
-            {"plantId": "456", "name": "Plant 2"},
+            {"plantId": 123, "name": "Plant 1"},
+            {"plantId": 456, "name": "Plant 2"},
         ]
         schema = build_plant_selection_schema(plants)
         result = schema({CONF_PLANT_ID: "456"})
@@ -192,10 +206,10 @@ class TestBuildPlantSelectionSchema:
     def test_uses_current_as_default(self):
         """Test that current plant is used as default."""
         plants = [
-            {"plantId": "123", "name": "Plant 1"},
-            {"plantId": "456", "name": "Plant 2"},
+            {"plantId": 123, "name": "Plant 1"},
+            {"plantId": 456, "name": "Plant 2"},
         ]
-        schema = build_plant_selection_schema(plants, current="456")
+        schema = build_plant_selection_schema(plants, current=456)
         result = schema({})
         assert result[CONF_PLANT_ID] == "456"
 
@@ -244,3 +258,34 @@ class TestBuildHttpReconfigureSchema:
         assert result[CONF_BASE_URL] == "https://old.example.com"
         assert result[CONF_VERIFY_SSL] is False
         assert result[CONF_DST_SYNC] is False
+
+
+class TestBuildSerialSchema:
+    """Tests for build_serial_schema function."""
+
+    def test_defaults_pass_validation(self):
+        """Test that untouched defaults validate cleanly."""
+        schema = build_serial_schema()
+        result = schema({})
+        assert result[CONF_SERIAL_BAUDRATE] == 19200
+        assert result[CONF_SERIAL_STOPBITS] == 1
+
+    def test_baudrate_string_coerced_to_int(self):
+        """Test that a baudrate submitted as a string is coerced to int."""
+        schema = build_serial_schema()
+        result = schema({CONF_SERIAL_BAUDRATE: "115200"})
+        assert result[CONF_SERIAL_BAUDRATE] == 115200
+        assert isinstance(result[CONF_SERIAL_BAUDRATE], int)
+
+    def test_stopbits_string_coerced_to_int(self):
+        """Test that stopbits submitted as a string is coerced to int."""
+        schema = build_serial_schema()
+        result = schema({CONF_SERIAL_STOPBITS: "2"})
+        assert result[CONF_SERIAL_STOPBITS] == 2
+        assert isinstance(result[CONF_SERIAL_STOPBITS], int)
+
+    def test_invalid_baudrate_rejected(self):
+        """Test that a baudrate not in the option list is rejected."""
+        schema = build_serial_schema()
+        with pytest.raises(vol.MultipleInvalid):
+            schema({CONF_SERIAL_BAUDRATE: "12345"})


### PR DESCRIPTION
Summary:
Station selection failed for multi-station cloud accounts with `value must be one of [ids]`. The API returns `station.id` as an int (int-keyed options), but the frontend submits the selected value as a string, so `vol.In` rejected it.
Closes #275 

### Changes
- `build_plant_selection_schema`: key options by string and validate with `vol.All(vol.Coerce(str), vol.In(...))`. plant_id is stored as a string throughout the integration (`int()` applied only at the API call).
- `find_plant_by_id`: compare ids as strings so the string plant_id matches the int `station.id`.
- `build_serial_schema`: same class of bug — baudrate/stopbits are int-keyed; wrapped with `vol.Coerce(int)`.

### Tests
- Updated `TestBuildPlantSelectionSchema` to use int station ids (mirrors the API) and added a regression test for string submission.
- Added `TestBuildSerialSchema` covering baudrate/stopbits string coercion.
- Config-flow / schema / helper / reconfigure suites pass (154); ruff + mypy --strict clean.
