### PR TITLE
fix: carry once-published batteries forward across transient merge gaps (#258)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -358,6 +358,16 @@ class EG4DataUpdateCoordinator(
         # duplicate/misreported battery serial).  Sticky until restart;
         # positional registry rows are left untouched as orphans.
         self._battery_migration_suppressed: set[str] = set()
+        # Last published battery mapping per inverter (#258 beta.18): battery
+        # entity availability is key-presence in device_data["batteries"], and
+        # the HYBRID/CLOUD paths rebuild that dict from the cloud payload as
+        # the BASELINE every cycle — a battery the cloud momentarily omits
+        # (rotating >4 packs feed the cloud through the same firmware page
+        # rotation) vanished and its entities flipped unavailable.  A battery
+        # once published is carried forward with its last-known data instead;
+        # staleness stays visible via battery_last_seen, never via
+        # availability flapping.  Outer key = inverter serial.
+        self._battery_carry_forward: dict[str, dict[str, dict[str, Any]]] = {}
 
         # Shared-battery secondary inverters: in parallel systems the CAN bus
         # connects only to the primary.  Secondaries (role >= 2) with

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -10,6 +10,7 @@ self._http_polling_interval, etc.) accessed via mixin protocol.
 import asyncio
 import logging
 import time as _time
+from collections.abc import Collection
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -581,6 +582,75 @@ class HTTPUpdateMixin(_MixinBase):
             _LOGGER.exception("Unexpected error updating data: %s", e)
             raise UpdateFailed(f"Unexpected error: {e}") from e
 
+    def _apply_battery_carry_forward(
+        self,
+        inverter_serial: str,
+        device_data: dict[str, Any],
+        exclude: Collection[str] = (),
+    ) -> None:
+        """Keep once-published batteries published across transient gaps (#258).
+
+        Battery entity availability is literally key-presence in
+        ``device_data["batteries"]``, and the HYBRID/CLOUD paths rebuild that
+        dict from the cloud payload as the *baseline* every cycle.  On rotating
+        >4-battery packs the cloud is fed through the same firmware page
+        rotation as the local reads, so a fresh ``getBatteryInfo`` can
+        momentarily omit a subset of batteries — beta.18 field logs show
+        subsets of battery entities flipping unavailable seconds after a cloud
+        refresh while pylxpweb's local accumulator still held every battery.
+
+        A battery that has ever been published for this inverter is carried
+        forward with its last-known mapping instead of being dropped.  The
+        carried mapping keeps its original ``battery_last_seen`` /
+        ``battery_last_polled`` stamps, so staleness stays visible as data —
+        never as availability flapping (the #261/#282 sticky precedent).
+
+        Two guards keep identities from doubling:
+
+        - ``exclude``: legacy positional keys that are aliases of a battery
+          published under its canonical key this cycle (#252 migration pairs).
+          Carrying one would re-mint the positional entity and permanently
+          block the registry migration ("legacy key still active").
+        - serial supersede: a cached key whose ``battery_serial_number`` is
+          already published under a different key was re-keyed by the payload;
+          carrying the old key would publish the same physical pack twice.
+
+        Args:
+            inverter_serial: Parent inverter serial number.
+            device_data: The inverter's device data dict (mutated in place).
+            exclude: Keys never to carry forward (legacy migration aliases).
+        """
+        current: dict[str, dict[str, Any]] = device_data.get("batteries") or {}
+        cache = self._battery_carry_forward.get(inverter_serial)
+
+        if cache:
+            current_serials = {
+                sn
+                for mapping in current.values()
+                if isinstance(sn := mapping.get("battery_serial_number"), str) and sn
+            }
+            carried: list[str] = []
+            for key, mapping in cache.items():
+                if key in current or key in exclude:
+                    continue
+                sn = mapping.get("battery_serial_number")
+                if isinstance(sn, str) and sn in current_serials:
+                    continue
+                current[key] = mapping
+                carried.append(key)
+            if carried:
+                _LOGGER.debug(
+                    "Carrying forward %d batteries missing from this cycle for %s: %s",
+                    len(carried),
+                    inverter_serial,
+                    carried,
+                )
+
+        if not current:
+            return
+        device_data["batteries"] = current
+        self._battery_carry_forward[inverter_serial] = dict(current)
+
     async def _process_station_data(self) -> dict[str, Any]:
         """Process station data using device objects."""
         if not self.station:
@@ -846,6 +916,7 @@ class HTTPUpdateMixin(_MixinBase):
             inverter = self.get_inverter_object(serial)
             if not inverter:
                 _LOGGER.debug("No inverter object found for serial %s", serial)
+                self._apply_battery_carry_forward(serial, device_data)
                 continue
 
             # Get cloud battery metadata (already cached, no API call)
@@ -980,8 +1051,18 @@ class HTTPUpdateMixin(_MixinBase):
 
                 # Rename any pre-#252 positional registry entries to the
                 # canonical keys (one-shot; no-op when nothing matches).
+                # Runs BEFORE the carry-forward so carried legacy keys can
+                # never count as "still active" and block the migration.
                 self._register_battery_key_migrations(
                     serial, key_migrations, device_data["batteries"].keys()
+                )
+
+                # Batteries the fresh cloud payload momentarily omitted keep
+                # their last-known data instead of flipping unavailable
+                # (#258 beta.18).  The legacy aliases of batteries published
+                # this cycle are never carried.
+                self._apply_battery_carry_forward(
+                    serial, device_data, exclude=key_migrations.keys()
                 )
 
                 _LOGGER.debug(
@@ -1000,6 +1081,10 @@ class HTTPUpdateMixin(_MixinBase):
                     list(transport_batteries),
                     getattr(transport_battery, "battery_count", None),
                 )
+                # The round-robin cache never evicts, but a session that
+                # earlier published cloud-keyed batteries (hybrid → local
+                # fallback flip) must not drop them (#258).
+                self._apply_battery_carry_forward(serial, device_data)
                 _LOGGER.debug(
                     "LOCAL: %d individual batteries for %s (round-robin cache)",
                     len(device_data.get("batteries", {})),
@@ -1014,6 +1099,7 @@ class HTTPUpdateMixin(_MixinBase):
                     serial,
                     battery_bank,
                 )
+                self._apply_battery_carry_forward(serial, device_data)
                 continue
 
             batteries = getattr(battery_bank, "batteries", None)
@@ -1025,6 +1111,7 @@ class HTTPUpdateMixin(_MixinBase):
                     batteries,
                     getattr(battery_bank, "data", None),
                 )
+                self._apply_battery_carry_forward(serial, device_data)
                 continue
 
             _LOGGER.debug("Found %d batteries for inverter %s", len(batteries), serial)
@@ -1079,6 +1166,12 @@ class HTTPUpdateMixin(_MixinBase):
                     cloud_key_migrations,
                     device_data.get("batteries", {}).keys(),
                 )
+
+            # Batteries the fresh cloud payload momentarily omitted keep their
+            # last-known data instead of flipping unavailable (#258 beta.18).
+            self._apply_battery_carry_forward(
+                serial, device_data, exclude=cloud_key_migrations.keys()
+            )
 
         # Check if we need to refresh parameters for any inverters
         if "parameters" not in processed:

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import time as _time
 from collections.abc import Collection
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -43,6 +43,7 @@ from .coordinator_mappings import (
     compute_parallel_group_charge_rate,
 )
 from .coordinator_mixins import (
+    BATTERY_CARRY_FORWARD_MAX_AGE,
     _MixinBase,
     apply_gridboss_to_parallel_group,
     compute_total_inverter_power_kw,
@@ -605,7 +606,8 @@ class HTTPUpdateMixin(_MixinBase):
         ``battery_last_polled`` stamps, so staleness stays visible as data —
         never as availability flapping (the #261/#282 sticky precedent).
 
-        Two guards keep identities from doubling:
+        Two guards keep identities from doubling, and one bound keeps carried
+        keys from becoming immortal:
 
         - ``exclude``: legacy positional keys that are aliases of a battery
           published under its canonical key this cycle (#252 migration pairs).
@@ -614,6 +616,12 @@ class HTTPUpdateMixin(_MixinBase):
         - serial supersede: a cached key whose ``battery_serial_number`` is
           already published under a different key was re-keyed by the payload;
           carrying the old key would publish the same physical pack twice.
+          The published-serial set grows as carried mappings are admitted, so
+          two cached keys sharing one serial can never both be carried.
+        - eviction bound: a cached key whose ``battery_last_seen`` aged past
+          ``BATTERY_CARRY_FORWARD_MAX_AGE`` is a physically removed (or
+          permanently vanished) pack, not a transient gap — it is evicted
+          (one INFO) so removal converges without a Home Assistant restart.
 
         Args:
             inverter_serial: Parent inverter serial number.
@@ -624,20 +632,43 @@ class HTTPUpdateMixin(_MixinBase):
         cache = self._battery_carry_forward.get(inverter_serial)
 
         if cache:
+            now = dt_util.utcnow()
             current_serials = {
                 sn
                 for mapping in current.values()
                 if isinstance(sn := mapping.get("battery_serial_number"), str) and sn
             }
             carried: list[str] = []
-            for key, mapping in cache.items():
-                if key in current or key in exclude:
+            evicted: list[str] = []
+            for key, mapping in list(cache.items()):
+                if key in current:
+                    continue
+                last_seen = mapping.get("battery_last_seen")
+                if (
+                    isinstance(last_seen, datetime)
+                    and now - dt_util.as_utc(last_seen) > BATTERY_CARRY_FORWARD_MAX_AGE
+                ):
+                    del cache[key]
+                    evicted.append(key)
+                    continue
+                if key in exclude:
                     continue
                 sn = mapping.get("battery_serial_number")
                 if isinstance(sn, str) and sn in current_serials:
                     continue
                 current[key] = mapping
                 carried.append(key)
+                if isinstance(sn, str) and sn:
+                    current_serials.add(sn)
+            if evicted:
+                _LOGGER.info(
+                    "Evicting %d batteries for %s not seen for over %s "
+                    "(physically removed or permanently vanished): %s",
+                    len(evicted),
+                    inverter_serial,
+                    BATTERY_CARRY_FORWARD_MAX_AGE,
+                    evicted,
+                )
             if carried:
                 _LOGGER.debug(
                     "Carrying forward %d batteries missing from this cycle for %s: %s",
@@ -1083,8 +1114,16 @@ class HTTPUpdateMixin(_MixinBase):
                 )
                 # The round-robin cache never evicts, but a session that
                 # earlier published cloud-keyed batteries (hybrid → local
-                # fallback flip) must not drop them (#258).
-                self._apply_battery_carry_forward(serial, device_data)
+                # fallback flip) must not drop them (#258).  Legacy positional
+                # aliases of serials the rr merge knows are excluded — a
+                # no-serial pack whose serial just arrived had its positional
+                # key retired by the merge, and the cached positional mapping
+                # carries no serial for the supersede guard to match.
+                self._apply_battery_carry_forward(
+                    serial,
+                    device_data,
+                    exclude=set(self._battery_serial_to_key.get(serial, {}).values()),
+                )
                 _LOGGER.debug(
                     "LOCAL: %d individual batteries for %s (round-robin cache)",
                     len(device_data.get("batteries", {})),

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -8,6 +8,7 @@ aggregation, and static entity creation.
 import asyncio
 import logging
 import time
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
@@ -39,6 +40,7 @@ from .const import (
     MANUFACTURER,
 )
 from .coordinator_mixins import (
+    BATTERY_CARRY_FORWARD_MAX_AGE,
     _PARAMETER_RETRY_INTERVAL,
     _MixinBase,
     apply_gridboss_to_parallel_group,
@@ -257,6 +259,14 @@ class LocalTransportMixin(_MixinBase):
                 fallback_keys.discard(slot_fallback_key)
                 if slot_fallback_key != battery_key:
                     cache.pop(slot_fallback_key, None)
+                    # Retirement is authoritative across BOTH sticky layers
+                    # (#258 review P1): the carry-forward cache published this
+                    # positional key on earlier cycles and would resurrect it
+                    # otherwise (a no-serial mapping carries no serial for the
+                    # supersede guard to match).
+                    self._battery_carry_forward.get(inverter_serial, {}).pop(
+                        slot_fallback_key, None
+                    )
                     _LOGGER.debug(
                         "RR [%s] slot %d: retired positional fallback %s "
                         "(serial %s now known)",
@@ -1148,13 +1158,43 @@ class LocalTransportMixin(_MixinBase):
                     # A genuine shared-battery secondary never populates the
                     # cache, so this can only re-serve batteries this
                     # inverter itself reported earlier.
-                    device_data["batteries"] = dict(cached_batteries)
-                    _LOGGER.debug(
-                        "LOCAL: %s serving %d individual batteries "
-                        "from cache (no battery data this poll)",
-                        serial,
-                        len(device_data["batteries"]),
-                    )
+                    #
+                    # Bounded (#258 review): an entry not read for over
+                    # BATTERY_CARRY_FORWARD_MAX_AGE is a physically removed
+                    # pack, not a transient — evict it so removal converges
+                    # instead of re-serving frozen data until restart.
+                    now = dt_util.utcnow()
+                    aged = [
+                        key
+                        for key, mapping in cached_batteries.items()
+                        if isinstance(
+                            last_seen := mapping.get("battery_last_seen"),
+                            datetime,
+                        )
+                        and now - dt_util.as_utc(last_seen)
+                        > BATTERY_CARRY_FORWARD_MAX_AGE
+                    ]
+                    for key in aged:
+                        cached_batteries.pop(key, None)
+                        self._battery_carry_forward.get(serial, {}).pop(key, None)
+                    if aged:
+                        _LOGGER.info(
+                            "LOCAL: Evicting %d batteries for %s not seen for "
+                            "over %s (physically removed or permanently "
+                            "vanished): %s",
+                            len(aged),
+                            serial,
+                            BATTERY_CARRY_FORWARD_MAX_AGE,
+                            aged,
+                        )
+                    if cached_batteries:
+                        device_data["batteries"] = dict(cached_batteries)
+                        _LOGGER.debug(
+                            "LOCAL: %s serving %d individual batteries "
+                            "from cache (no battery data this poll)",
+                            serial,
+                            len(device_data["batteries"]),
+                        )
 
                 device_data["sensors"]["firmware_version"] = firmware_version
                 device_data["sensors"]["connection_transport"] = _get_transport_label(

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -1136,20 +1136,25 @@ class LocalTransportMixin(_MixinBase):
                                 len(battery_data.batteries),
                                 len(self._battery_rr_cache.get(serial, {})),
                             )
-                        elif serial in self._battery_rr_cache:
-                            # Individual battery registers unavailable this poll
-                            # (e.g. transient read failure).  Serve cached data
-                            # so entities stay available rather than going
-                            # unavailable until the next successful read.
-                            device_data["batteries"] = dict(
-                                self._battery_rr_cache[serial]
-                            )
-                            _LOGGER.debug(
-                                "LOCAL: %s serving %d individual batteries "
-                                "from cache (no battery data this poll)",
-                                serial,
-                                len(device_data["batteries"]),
-                            )
+                if not device_data["batteries"] and (
+                    cached_batteries := self._battery_rr_cache.get(serial)
+                ):
+                    # Individual batteries unavailable this poll — transient
+                    # read failure, a cleared transport battery cache, or a
+                    # momentary reg 96 = 0 under-report (#258; reg 96 is
+                    # unreliable on parallel/rotating systems).  Serve the
+                    # round-robin cache so entities stay available rather
+                    # than flipping unavailable until the next good read.
+                    # A genuine shared-battery secondary never populates the
+                    # cache, so this can only re-serve batteries this
+                    # inverter itself reported earlier.
+                    device_data["batteries"] = dict(cached_batteries)
+                    _LOGGER.debug(
+                        "LOCAL: %s serving %d individual batteries "
+                        "from cache (no battery data this poll)",
+                        serial,
+                        len(device_data["batteries"]),
+                    )
 
                 device_data["sensors"]["firmware_version"] = firmware_version
                 device_data["sensors"]["connection_transport"] = _get_transport_label(

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -579,6 +579,8 @@ if TYPE_CHECKING:
         _battery_fallback_keys: dict[str, set[str]]
         _battery_noserial_polls: dict[str, dict[int, int]]
         _battery_migration_suppressed: set[str]
+        # ── Battery carry-forward (#258, coordinator.py) ──
+        _battery_carry_forward: dict[str, dict[str, dict[str, Any]]]
 
         def _register_battery_key_migrations(
             self,

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -69,6 +69,17 @@ _LOGGER = logging.getLogger(__name__)
 # dongle outage doesn't add a full parameter read to every ~20-30 s poll.
 _PARAMETER_RETRY_INTERVAL = timedelta(minutes=2)
 
+# Eviction bound for once-published batteries served from cache (#258 review).
+# The carry-forward and the LOCAL round-robin re-serve absorb seconds-to-
+# minutes cloud/transport gaps; without a bound a PHYSICALLY REMOVED pack
+# would survive until restart with frozen SoC feeding bank aggregates and
+# automations, negating pylxpweb's empty-bank convergence.  6 hours is far
+# above every transient this covers, and safe versus the 2026-06-28 9-hour
+# firmware page pinning: during pinning the accumulator still SERVES the
+# batteries as fresh current-cycle data, so cached-serve is not what holds
+# them — only a battery gone from BOTH cloud and accumulator ages here.
+BATTERY_CARRY_FORWARD_MAX_AGE = timedelta(hours=6)
+
 # Track devices that have already been warned about invalid smart port status
 # to avoid log spam on every poll cycle
 _warned_smart_port_devices: set[str] = set()

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -1351,6 +1351,198 @@ class TestBatteryExtraction:
         assert batteries["INV001-BAT002"]["battery_soc"] == 82
 
 
+# ── Battery carry-forward across transient merge-set shrinkage ───────
+
+
+def _cloud_battery(key: str, sn: str | None, index: int, soc: int) -> MagicMock:
+    """Cloud battery metadata stand-in matching the pylxpweb Battery shape."""
+    return MagicMock(
+        battery_key=key,
+        battery_sn=sn,
+        battery_index=index,
+        soc=soc,
+        model=None,
+        bms_model=None,
+        battery_type_text=None,
+    )
+
+
+def _carry_forward_fake_map(b: Any) -> dict[str, Any]:
+    """Battery mapping stub carrying identity + staleness like the real one."""
+    sn = getattr(b, "battery_sn", None) or getattr(b, "serial_number", None)
+    return {
+        "battery_soc": b.soc,
+        "battery_serial_number": sn if isinstance(sn, str) else None,
+        "battery_last_seen": dt_util.utcnow(),
+    }
+
+
+class TestBatteryCarryForward:
+    """#258 beta.18 regression: batteries flip unavailable on merge-set shrink.
+
+    Reporter's HYBRID rig (2× LXP, 8 rotating batteries, WiFi dongles): the
+    local accumulator held all 8 batteries through both drop windows, yet
+    SUBSETS of battery entities flipped unavailable (01-04 at 16:06:45,
+    05+ at 17:58:27) seconds after a fresh cloud getBatteryInfo. The HYBRID
+    merge uses the cloud payload as the BASELINE, so any battery the cloud
+    momentarily omits (or re-keys) vanishes from the merged dict — and
+    availability is literally key-presence. A battery once published must
+    stay published: carry the last-known mapping forward, staleness stays
+    visible via battery_last_seen.
+    """
+
+    def _make_coordinator(self, hass, http_config_entry):
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+        inv = make_real_inverter(serial_number="INV001")
+        # Hybrid identity: transport attached, no live battery page this
+        # cycle (matches the reporter's firmware-pinned all-empty pages).
+        inv._transport = MagicMock()
+        inv._transport_battery = BatteryBankData(batteries=[])
+        coordinator.station = _mock_station([inv])
+        coordinator._inverter_cache = {"INV001": inv}
+        coordinator.data = {"parameters": {"INV001": {}}}
+        return coordinator, inv
+
+    async def _run_cycle(self, coordinator) -> dict[str, Any]:
+        def _fresh_device_data(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "type": "inverter",
+                "model": "FlexBOSS21",
+                "sensors": {},
+                "batteries": {},
+            }
+
+        with (
+            patch.object(
+                coordinator,
+                "_process_inverter_object",
+                new=AsyncMock(side_effect=_fresh_device_data),
+            ),
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_http._build_individual_battery_mapping",
+                side_effect=_carry_forward_fake_map,
+            ),
+        ):
+            result = await coordinator._process_station_data()
+        batteries: dict[str, Any] = result["devices"]["INV001"]["batteries"]
+        return batteries
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_cloud_payload_shrink_carries_forward_missing_batteries(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Batteries the cloud momentarily omits keep their last-known data."""
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+
+        bank = MagicMock()
+        bank.batteries = [
+            _cloud_battery("INV001_BAT001", "BAT001", 0, 85),
+            _cloud_battery("INV001_BAT002", "BAT002", 1, 82),
+            _cloud_battery("INV001_BAT003", "BAT003", 2, 79),
+        ]
+        inv._battery_bank = bank
+
+        first = await self._run_cycle(coordinator)
+        assert set(first) == {"INV001-BAT001", "INV001-BAT002", "INV001-BAT003"}
+        first_seen_bat2 = first["INV001-BAT002"]["battery_last_seen"]
+
+        # Cycle 2: the fresh cloud payload carries only BAT001 (the exact
+        # beta.18 drop shape — subsets vanish, grouped by firmware page).
+        bank.batteries = [_cloud_battery("INV001_BAT001", "BAT001", 0, 86)]
+
+        second = await self._run_cycle(coordinator)
+        # Present battery refreshed; missing ones carried forward, not dropped.
+        assert second["INV001-BAT001"]["battery_soc"] == 86
+        assert second["INV001-BAT002"]["battery_soc"] == 82
+        assert second["INV001-BAT003"]["battery_soc"] == 79
+        # Carried entries keep their original staleness stamp (never re-stamped).
+        assert second["INV001-BAT002"]["battery_last_seen"] == first_seen_bat2
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_cloud_bank_gone_carries_forward_all_batteries(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """A cycle with no cloud bank and no transport keeps every battery."""
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+
+        bank = MagicMock()
+        bank.batteries = [
+            _cloud_battery("INV001_BAT001", "BAT001", 0, 85),
+            _cloud_battery("INV001_BAT002", "BAT002", 1, 82),
+        ]
+        inv._battery_bank = bank
+
+        first = await self._run_cycle(coordinator)
+        assert len(first) == 2
+
+        # Cycle 2: cloud bank lost entirely, transport cache cleared — the
+        # cycle falls through every battery branch.
+        inv._battery_bank = None
+        inv._transport = None
+        inv._transport_battery = None
+
+        second = await self._run_cycle(coordinator)
+        assert second["INV001-BAT001"]["battery_soc"] == 85
+        assert second["INV001-BAT002"]["battery_soc"] == 82
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_carry_forward_skips_identity_republished_under_new_key(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """A battery re-keyed by the cloud must not linger under its old key.
+
+        Carrying the old key alongside the new one would publish the same
+        physical pack twice (one frozen), and a lingering legacy positional
+        key would permanently block the #252 registry migration ("legacy key
+        still active").
+        """
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+
+        bank = MagicMock()
+        # Placeholder batteryKey, no serial → positional canonical key.
+        bank.batteries = [_cloud_battery("INV001_Battery_ID_01", None, 0, 70)]
+        inv._battery_bank = bank
+
+        first = await self._run_cycle(coordinator)
+        assert set(first) == {"INV001-01"}
+
+        # Cycle 2: the cloud now reports the real serial for the same pack —
+        # the canonical key changes and INV001-01 becomes its legacy alias.
+        bank.batteries = [_cloud_battery("INV001_BAT001", "BAT001", 0, 71)]
+
+        second = await self._run_cycle(coordinator)
+        assert second["INV001-BAT001"]["battery_soc"] == 71
+        assert "INV001-01" not in second
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_carry_forward_skips_serial_present_under_different_key(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Same serial under a changed cloud batteryKey is superseded, not doubled."""
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+
+        bank = MagicMock()
+        bank.batteries = [_cloud_battery("INV001_BAT001", "BAT001", 0, 85)]
+        inv._battery_bank = bank
+
+        first = await self._run_cycle(coordinator)
+        assert set(first) == {"INV001-BAT001"}
+
+        # Cycle 2: the cloud batteryKey format changes for the SAME serial.
+        bank.batteries = [_cloud_battery("BAT001", "BAT001", 0, 87)]
+
+        second = await self._run_cycle(coordinator)
+        assert second["BAT001"]["battery_soc"] == 87
+        # The old key is not carried — its serial is already published.
+        assert "INV001-BAT001" not in second
+        assert len(second) == 1
+
+
 # ── _refresh_station_devices (serialized dongle access) ──────────────
 
 

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -1,6 +1,7 @@
 """Tests for the HTTP/cloud update mixin (coordinator_http.py)."""
 
 import asyncio
+import logging
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import Any
@@ -1541,6 +1542,161 @@ class TestBatteryCarryForward:
         # The old key is not carried — its serial is already published.
         assert "INV001-BAT001" not in second
         assert len(second) == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_physically_removed_battery_converges_within_bound(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry, caplog
+    ):
+        """A removed pack leaves within BATTERY_CARRY_FORWARD_MAX_AGE (no restart).
+
+        pylxpweb's 3-streak empty-bank convergence retires the accumulator and
+        the cloud stops reporting the pack — carry-forward must not hold the
+        key immortally with frozen SoC feeding bank aggregates.  Once
+        battery_last_seen ages past the bound the key is evicted (one INFO).
+        """
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+
+        bank = MagicMock()
+        bank.batteries = [
+            _cloud_battery("INV001_BAT001", "BAT001", 0, 85),
+            _cloud_battery("INV001_BAT002", "BAT002", 1, 82),
+        ]
+        inv._battery_bank = bank
+
+        first = await self._run_cycle(coordinator)
+        assert len(first) == 2
+
+        # The pack is physically removed: pylxpweb retires the accumulator
+        # and the cloud stops reporting it.
+        bank.batteries = [_cloud_battery("INV001_BAT001", "BAT001", 0, 85)]
+
+        # Within the bound: still carried (this is the #258 fix itself).
+        second = await self._run_cycle(coordinator)
+        assert "INV001-BAT002" in second
+
+        # Beyond the bound: evicted, and stays evicted.
+        coordinator._battery_carry_forward["INV001"]["INV001-BAT002"][
+            "battery_last_seen"
+        ] = dt_util.utcnow() - timedelta(hours=7)
+        with caplog.at_level(logging.INFO):
+            third = await self._run_cycle(coordinator)
+        assert "INV001-BAT002" not in third
+        assert "INV001-BAT002" not in coordinator._battery_carry_forward["INV001"]
+        assert any(
+            "INV001-BAT002" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.INFO and "Evict" in r.getMessage()
+        )
+        fourth = await self._run_cycle(coordinator)
+        assert "INV001-BAT002" not in fourth
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_carry_forward_single_pack_not_double_published(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Two cached keys sharing one serial must not both be carried."""
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+        inv._battery_bank = None
+        inv._transport = None
+        inv._transport_battery = None
+
+        fresh = dt_util.utcnow()
+        coordinator._battery_carry_forward["INV001"] = {
+            "INV001-BAT001": {
+                "battery_soc": 85,
+                "battery_serial_number": "BAT001",
+                "battery_last_seen": fresh,
+            },
+            "BAT001": {
+                "battery_soc": 84,
+                "battery_serial_number": "BAT001",
+                "battery_last_seen": fresh,
+            },
+        }
+
+        result = await self._run_cycle(coordinator)
+        assert len(result) == 1, (
+            f"one physical pack must publish once, got {set(result)}"
+        )
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_local_fallback_does_not_resurrect_retired_positional_key(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """rr-merge retirement is authoritative over the carry-forward cache.
+
+        Cloud bank absent (LOCAL fallback branch): a no-serial pack is cached
+        positionally as INV001-01; when its serial later appears the rr merge
+        retires the positional key — the carry-forward cache must not re-add
+        it (the cached positional mapping has no serial for the supersede
+        guard to match).
+        """
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+        inv._battery_bank = None
+
+        # 3 debounce polls (_NO_SERIAL_EXPOSE_POLLS) expose the positional key.
+        no_serial = BatteryData(battery_index=0, serial_number="", voltage=52.0, soc=90)
+        inv._transport_battery = BatteryBankData(battery_count=1, batteries=[no_serial])
+        result: dict[str, Any] = {}
+        for _ in range(3):
+            result = await self._run_cycle(coordinator)
+        assert "INV001-01" in result
+        assert "INV001-01" in coordinator._battery_carry_forward["INV001"]
+
+        # The serial arrives: rr merge retires INV001-01 for the serial key.
+        with_serial = BatteryData(
+            battery_index=0, serial_number="BATTERYSER001", voltage=52.0, soc=91
+        )
+        inv._transport_battery = BatteryBankData(
+            battery_count=1, batteries=[with_serial]
+        )
+        result = await self._run_cycle(coordinator)
+        assert "INV001-BATTERYSER001" in result
+        assert "INV001-01" not in result, "retired positional key resurrected"
+        assert "INV001-01" not in coordinator._battery_carry_forward["INV001"]
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_transient_duplicate_serial_leaves_no_lasting_entity(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """A transient dup-serial poll must not mint a lasting extra battery.
+
+        One corrupt poll shows two slots with the same serial (the LOCAL merge
+        mints a positional collision key); the next clean poll retires it and
+        the carry-forward must not resurrect it.
+        """
+        coordinator, inv = self._make_coordinator(hass, http_config_entry)
+        inv._battery_bank = None
+
+        dup_a = BatteryData(
+            battery_index=0, serial_number="BATTERYSER001", voltage=52.0, soc=90
+        )
+        dup_b = BatteryData(
+            battery_index=1, serial_number="BATTERYSER001", voltage=51.9, soc=89
+        )
+        inv._transport_battery = BatteryBankData(
+            battery_count=2, batteries=[dup_a, dup_b]
+        )
+        result = await self._run_cycle(coordinator)
+        assert "INV001-BATTERYSER001" in result
+        assert "INV001-02" in result  # positional collision key
+
+        # Clean poll: both slots report distinct serials.
+        clean_b = BatteryData(
+            battery_index=1, serial_number="BATTERYSER002", voltage=51.9, soc=89
+        )
+        inv._transport_battery = BatteryBankData(
+            battery_count=2, batteries=[dup_a, clean_b]
+        )
+        result = await self._run_cycle(coordinator)
+        assert "INV001-BATTERYSER001" in result
+        assert "INV001-BATTERYSER002" in result
+        assert "INV001-02" not in result, "collision key must not persist"
+        assert "INV001-02" not in coordinator._battery_carry_forward["INV001"]
 
 
 # ── _refresh_station_devices (serialized dongle access) ──────────────

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2553,6 +2553,82 @@ class TestBatteryRRCacheFallback:
         # No fallback possible — batteries stays empty
         assert device["batteries"] == {}
 
+    async def test_cache_fallback_when_reg96_reads_zero(self, hass: Any) -> None:
+        """A transient reg 96 = 0 must not drop accumulated batteries (#258).
+
+        reg 96 under-reports on parallel/rotating systems.  A genuine
+        shared-battery secondary never populates the round-robin cache, so
+        serving a non-empty cache here can only ever re-serve batteries this
+        inverter itself reported earlier.
+        """
+        serial = "DONGLE001"
+        entry = self._make_config_entry(hass, serial)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator._local_static_phase_done = True
+
+        coordinator._battery_rr_cache[serial] = {
+            f"{serial}-01": {"soc": 80, "voltage": 52.8},
+            f"{serial}-02": {"soc": 79, "voltage": 52.7},
+        }
+
+        # This poll: reg 96 reads 0 (bank gate) with an empty page.
+        mock_inverter = self._make_mock_inverter(battery_count=0, batteries=[])
+        coordinator._inverter_cache[serial] = mock_inverter
+        coordinator._firmware_cache[serial] = "FAAB-2525"
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
+            return_value={"state_of_charge": 79},
+        ):
+            processed: dict[str, Any] = {
+                "devices": {},
+                "parallel_groups": {},
+                "parameters": {},
+            }
+            await coordinator._process_single_local_device(
+                config=entry.data[CONF_LOCAL_TRANSPORTS][0],
+                processed=processed,
+                device_availability={},
+            )
+
+        device = processed["devices"][serial]
+        assert len(device["batteries"]) == 2
+        assert f"{serial}-01" in device["batteries"]
+
+    async def test_cache_fallback_when_transport_battery_none(self, hass: Any) -> None:
+        """A cleared transport battery cache must not drop accumulated batteries."""
+        serial = "DONGLE001"
+        entry = self._make_config_entry(hass, serial)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator._local_static_phase_done = True
+
+        coordinator._battery_rr_cache[serial] = {
+            f"{serial}-01": {"soc": 80, "voltage": 52.8},
+        }
+
+        mock_inverter = self._make_mock_inverter(battery_count=4, batteries=[])
+        mock_inverter._transport_battery = None
+        coordinator._inverter_cache[serial] = mock_inverter
+        coordinator._firmware_cache[serial] = "FAAB-2525"
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
+            return_value={"state_of_charge": 79},
+        ):
+            processed: dict[str, Any] = {
+                "devices": {},
+                "parallel_groups": {},
+                "parameters": {},
+            }
+            await coordinator._process_single_local_device(
+                config=entry.data[CONF_LOCAL_TRANSPORTS][0],
+                processed=processed,
+                device_availability={},
+            )
+
+        device = processed["devices"][serial]
+        assert f"{serial}-01" in device["batteries"]
+
 
 class TestBatteryControlModeMethods:
     """Coordinator helpers for the battery control regime (SOC vs Voltage)."""

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2629,6 +2629,68 @@ class TestBatteryRRCacheFallback:
         device = processed["devices"][serial]
         assert f"{serial}-01" in device["batteries"]
 
+    async def test_cache_reserve_evicts_aged_entries(
+        self, hass: Any, caplog: Any
+    ) -> None:
+        """The re-serve path must not immortalize a physically removed pack.
+
+        A cached battery whose battery_last_seen aged past
+        BATTERY_CARRY_FORWARD_MAX_AGE is evicted from the round-robin cache
+        (one INFO) instead of being re-served with frozen data forever —
+        otherwise pylxpweb's empty-bank convergence is negated at this layer.
+        """
+        import logging as _logging
+
+        from homeassistant.util import dt as dt_util
+
+        serial = "DONGLE001"
+        entry = self._make_config_entry(hass, serial)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator._local_static_phase_done = True
+
+        now = dt_util.utcnow()
+        coordinator._battery_rr_cache[serial] = {
+            f"{serial}-01": {"soc": 80, "battery_last_seen": now},
+            f"{serial}-02": {
+                "soc": 79,
+                "battery_last_seen": now - timedelta(hours=7),
+            },
+        }
+
+        mock_inverter = self._make_mock_inverter(battery_count=4, batteries=[])
+        mock_inverter._transport_battery = None
+        coordinator._inverter_cache[serial] = mock_inverter
+        coordinator._firmware_cache[serial] = "FAAB-2525"
+
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
+                return_value={"state_of_charge": 79},
+            ),
+            caplog.at_level(_logging.INFO),
+        ):
+            processed: dict[str, Any] = {
+                "devices": {},
+                "parallel_groups": {},
+                "parameters": {},
+            }
+            await coordinator._process_single_local_device(
+                config=entry.data[CONF_LOCAL_TRANSPORTS][0],
+                processed=processed,
+                device_availability={},
+            )
+
+        device = processed["devices"][serial]
+        assert f"{serial}-01" in device["batteries"]
+        assert f"{serial}-02" not in device["batteries"], "aged entry re-served"
+        # Authoritative eviction: gone from the cache too, with one INFO.
+        assert f"{serial}-02" not in coordinator._battery_rr_cache[serial]
+        assert any(
+            f"{serial}-02" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == _logging.INFO and "Evict" in r.getMessage()
+        )
+
 
 class TestBatteryControlModeMethods:
     """Coordinator helpers for the battery control regime (SOC vs Voltage)."""

--- a/tests/test_modbus_block_size.py
+++ b/tests/test_modbus_block_size.py
@@ -277,12 +277,23 @@ class TestLegacyTransportConstruction:
         mock_create.assert_called_once()
         assert mock_create.call_args.kwargs["max_input_block_size"] == 120
 
-    def test_fast_with_released_lib_stays_conservative(self) -> None:
-        """Against real 0.9.36b19 detection, the kwarg is simply absent."""
+    def test_fast_with_feature_less_lib_stays_conservative(self) -> None:
+        """When detection reports no support, the kwarg is simply absent.
+
+        The feature-less library (< 0.9.36b20) is SIMULATED by patching
+        ``input_block_size_kwargs`` to return ``{}`` — asserting against the
+        real detection of whatever pylxpweb happens to be installed made this
+        test version-dependent (it failed under the manifest-mandated b20,
+        which supports the feature).
+        """
         with (
             patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient"),
             patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client"),
             patch("pylxpweb.transports.create_transport") as mock_create,
+            patch(
+                "custom_components.eg4_web_monitor.coordinator.input_block_size_kwargs",
+                return_value={},
+            ),
         ):
             EG4DataUpdateCoordinator(
                 _mock_hass(),


### PR DESCRIPTION
## Root cause (beta.18 DEBUG log, @ivanfmartinez's 2×LXP / 8-battery HYBRID rig)

**The local side never lost a battery.** pylxpweb's serial-keyed accumulator reports `Battery accumulator: 8 batteries populated (slots [0..7])` on **every** read through both drop windows — 818 consecutive times after the second firmware page first appeared at 14:20:44 (log lines 4895 and 10893 bracket the two drops). The raw pages show the firmware alternating two 4-battery pages and pinning to all-empty pages for long stretches (`RR raw page: 0=empty 1=empty 2=empty 3=empty (reg96=8)`, e.g. line 10892) — exactly the population the accumulator exists for, and it did its job.

**The loss is in the integration's HYBRID merge.** Battery entity availability is literally key-presence in `device_data["batteries"]` (`base_entity.py` `EG4BatteryEntity.available`), and the HYBRID branch of `_process_station_data()` rebuilds that dict **from the cloud payload as the baseline** every cycle — the transport data is only an *overlay on cloud-present batteries* (`bat_serial not in cloud_by_serial → continue`). A battery the fresh cloud `getBatteryInfo` momentarily omits (or re-keys) vanishes from the merged dict even while the local accumulator holds fresh-enough data for it.

Both reporter drop timestamps land seconds after a **fresh** (non-cached) `getBatteryInfo` POST:

| drop (reporter) | fresh cloud POST | log line |
|---|---|---|
| 16:06:45 | 16:06:44.227 | 4905 |
| 17:58:27 | 17:58:23.124 | 10888 |

The rig's rotating >4-slot bank feeds the **cloud** through the same firmware page rotation the local reads see, so a cloud payload that momentarily carries a page-grouped subset is exactly what produces "batteries 01–04 unavailable at one time, 05+ at another".

### The "duplicate serials in the accumulator" observation is a logging artifact

The 17:58:26 accumulator dump (lines 10893–10902) shows `Pos 4`/`Pos 6` both as `…BCW?017` and `Pos 3`/`Pos 7` both as `…BCW?016` — but the `Pos N:` debug decodes only register offsets 17–23 (14 chars), while the accumulator identity and `BatteryData.serial_number` use `read_battery_serial` (offsets 17–24, 15 chars: the final serial character lives in offset 24's **low byte** — visible as `offset24=0x0437` → `'7'`). The raw-page lines print the full identities: `0177 / 0172` and `0165 / 0167` — **8 distinct serials, no collapse**. The companion pylxpweb PR fixes the misleading dump and adds a real within-page duplicate-serial guard as defense-in-depth.

## Fix

**`_apply_battery_carry_forward()`** (`coordinator_http.py`), called from every battery branch of `_process_station_data()` (HYBRID merge, LOCAL-only round-robin, CLOUD-only, and the no-bank / no-batteries early exits):

- A battery **once published** for an inverter keeps its last-known mapping when a cycle's merge output omits it — availability never flaps. Carried mappings keep their original `battery_last_seen` / `battery_last_polled` stamps, so staleness stays visible **as data**, never as availability (the #261/#282 sticky precedent).
- **Identity guards** (no #252 regressions):
  - legacy positional aliases of batteries published this cycle are excluded (carrying one would re-mint a positional entity and permanently block the #252 registry migration via the "legacy key still active" gate);
  - a cached key whose `battery_serial_number` is already published under a different key is superseded, not doubled (cloud re-keying a pack must not show it twice).
- **LOCAL path** (`coordinator_local.py`): the round-robin cache is now also served when `transport_battery` is `None` or reg 96 transiently reads 0 (previously only when the batteries *list* was empty). A genuine shared-battery secondary never populates the cache, so nothing is fabricated for it.

## Tests

- `TestBatteryCarryForward` (4 tests): cloud payload shrink keeps all batteries with original `battery_last_seen`; cloud bank + transport both gone keeps all; re-keyed identity is superseded under both guard paths.
- `TestBatteryRRCacheFallback` (+2): reg 96 = 0 and `transport_battery=None` with a populated rr cache.
- Full suite: **1653 passed** (baseline 1650), ruff + mypy strict clean. The single `test_fast_with_released_lib_stays_conservative` failure is a pre-existing environment artifact (that test hard-asserts the installed pylxpweb is ≤ b19 without block-size support; this env installs b20 per the beta.18 requirement) — it fails identically on a clean `integration/3.4.0` checkout.

## Honest residual uncertainty

The reporter's log has DEBUG only for `pylxpweb.*`, not `custom_components.eg4_web_monitor`, and cloud response bodies aren't logged — so the exact shape of the shrunken/re-keyed cloud payload at the two drops can't be read directly from the log; it is inferred from the airtight elimination of the local path plus the drop↔fresh-POST correlation (2 drops in ~4h, both within ~4 s of one of the ~130 fresh POSTs). The carry-forward is deliberately mechanism-agnostic: **any** transient merge-set shrinkage (cloud omission, re-key, bank fetch failure, link-down) is now covered.

## Verification asks for @ivanfmartinez

1. Run with this build and confirm no battery entity flips unavailable across ≥24 h (the drops previously appeared within ~2–4 h windows).
2. If possible, also enable `custom_components.eg4_web_monitor: debug` — a `Carrying forward N batteries missing from this cycle` line at a former drop time confirms the mechanism directly.
3. The `battery_last_seen` attribute on each battery shows honest data age — rotation staleness will surface there instead of as unavailable entities.

Companion pylxpweb PR: duplicate-serial disambiguation + full-serial debug dump (defense-in-depth; no version bump).

Fixes remaining #258 battery-entity gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review-round fixes (Opus MERGE+MERGE, Codex FIX-THEN-MERGE×2 — all findings addressed)

**Bounded eviction (both reviewers — the immortal-key problem).** Carried keys now age out: a cached mapping whose `battery_last_seen` exceeds **`BATTERY_CARRY_FORWARD_MAX_AGE` = 6 hours** is evicted with one INFO, so a physically removed pack converges without an HA restart instead of feeding frozen SoC into bank aggregates and automations forever. Rationale for 6 h: it is orders of magnitude above the seconds-to-minutes cloud/transport gaps carry-forward absorbs, and it is safe versus the 2026-06-28 **9-hour** firmware page pinning — during pinning the pylxpweb accumulator still *serves* the batteries as fresh current-cycle data, so cached-serve is not what holds them; only a battery gone from BOTH the cloud payload and the accumulator ages against the bound. The same bound now gates the LOCAL `_battery_rr_cache` re-serve path (Codex confirmed it re-inserted removed packs too). Test: physical-removal convergence within the bound, both HYBRID and LOCAL.

**Codex P1 — LOCAL fallback carried without exclusions.** A no-serial pack cached positionally (`INV-01`) was resurrected after the rr merge retired it for the arriving serial (its cached mapping has no serial for the supersede guard). Retirement is now authoritative across both sticky layers — `_merge_round_robin_batteries()` purges the retired key from the carry-forward cache — and the fallback branch passes the legacy-alias exclusion set. Test: the exact scenario.

**Opus P2 — supersede snapshot.** `current_serials` now grows as carried mappings are admitted, so two cached keys sharing one serial can never both be carried. Test included.

**Cross-layer guard for the pylxpweb `@posN` reconciliation** (companion PR): integration-level test that a transient duplicate-serial poll does not leave a lasting extra battery entity (collision key retired on the next clean poll, not resurrected).

**Inherited train fix (separate commit):** `test_fast_with_released_lib_stays_conservative` asserted against the installed pylxpweb version (failed under the manifest-mandated b20); it now simulates the feature-less library by patching `input_block_size_kwargs()` → `{}`.

**Informational (Opus):** for a *genuine* duplicate-serial pack pair the preservation win exists only at the pylxpweb layer — the serial IS the HA battery identity, so HA can only ever represent such twins as one device plus a positional collision key. Inherent to serial-keyed identity, documented here for the record.

Updated gates: **1659 passed** (1653 + 5 new review-round tests + the rehabilitated block-size test), 0 failed; ruff + mypy strict clean.
