### PR TITLE
chore: dead code cleanup and simplification

### DIFF
--- a/custom_components/eg4_web_monitor/_config_flow/__init__.py
+++ b/custom_components/eg4_web_monitor/_config_flow/__init__.py
@@ -142,7 +142,6 @@ class EG4ConfigFlow(
         self._base_url: str = DEFAULT_BASE_URL
         self._verify_ssl: bool = DEFAULT_VERIFY_SSL
         self._dst_sync: bool = True
-        self._library_debug: bool = False  # Legacy: kept for migration only
         self._plant_id: str | None = None
         self._plant_name: str | None = None
         self._plants: list[dict[str, Any]] | None = None

--- a/custom_components/eg4_web_monitor/_config_flow/discovery.py
+++ b/custom_components/eg4_web_monitor/_config_flow/discovery.py
@@ -69,36 +69,6 @@ class DiscoveredDevice:
     parallel_master_slave: int = 0
     parallel_phase: int = 0
 
-    @property
-    def parallel_group_name(self) -> str | None:
-        """Get parallel group name (e.g., 'A', 'B') or None if standalone.
-
-        Returns:
-            Group name ('A' for group 1, 'B' for group 2, etc.) or None
-            if the device is standalone.
-        """
-        if self.parallel_number == 0:
-            return None
-        return chr(ord("A") + self.parallel_number - 1)
-
-    @property
-    def is_standalone(self) -> bool:
-        """Check if device is standalone (not in parallel group).
-
-        Returns:
-            True if device is standalone, False if in a parallel group.
-        """
-        return self.parallel_number == 0 or self.parallel_master_slave == 0
-
-    @property
-    def is_master(self) -> bool:
-        """Check if device is the master in a parallel group.
-
-        Returns:
-            True if device is the master (primary) inverter.
-        """
-        return self.parallel_master_slave == 1
-
 
 def _get_model_from_device_type(device_type_code: int) -> tuple[str, str]:
     """Derive model name and family from device type code.

--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -325,8 +325,6 @@ def _apply_sensor_config(
     sensor_config: dict[str, Any] = cast(
         "dict[str, Any]", SENSOR_TYPES.get(sensor_key, {})
     )
-    entity._sensor_config = sensor_config
-
     entity._attr_native_unit_of_measurement = sensor_config.get("unit")
     entity._attr_device_class = sensor_config.get("device_class")
     entity._attr_state_class = sensor_config.get("state_class")
@@ -381,7 +379,6 @@ class EG4BaseSensor(EG4DeviceEntity):
 
     Attributes:
         _sensor_key: The sensor key for lookup in SENSOR_TYPES.
-        _sensor_config: Configuration dictionary for this sensor.
         _last_reported_value: Last reported numeric value for monotonic guard.
     """
 
@@ -495,7 +492,6 @@ class EG4BaseBatterySensor(EG4BatteryEntity):
 
     Attributes:
         _sensor_key: The sensor key for lookup in SENSOR_TYPES.
-        _sensor_config: Configuration dictionary for this sensor.
         _last_reported_value: Last reported numeric value for monotonic guard.
     """
 
@@ -599,7 +595,6 @@ class EG4BatteryBankEntity(EG4DeviceEntity):
 
     Attributes:
         _sensor_key: The sensor key for lookup in SENSOR_TYPES.
-        _sensor_config: Configuration dictionary for this sensor.
         _last_reported_value: Last reported numeric value for monotonic guard.
     """
 

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -88,9 +88,6 @@ async def async_setup_entry(
     for serial, device_data in coordinator.data["devices"].items():
         # Check if this device has individual batteries
         if "batteries" in device_data:
-            device_info = coordinator.data.get("device_info", {}).get(serial, {})
-            parent_model = device_info.get("deviceTypeText4APP", "Unknown")
-
             for battery_key in device_data["batteries"]:
                 # Create refresh button for each individual battery
                 phase2_entities.append(
@@ -98,8 +95,6 @@ async def async_setup_entry(
                         coordinator=coordinator,
                         parent_serial=serial,
                         battery_key=battery_key,
-                        parent_model=parent_model,
-                        battery_id=battery_key,
                     )
                 )
 
@@ -142,15 +137,11 @@ async def async_setup_entry(
                 if battery_key in known:
                     continue
                 known.add(battery_key)
-                device_info = coordinator.data.get("device_info", {}).get(serial, {})
-                parent_model = device_info.get("deviceTypeText4APP", "Unknown")
                 new_entities.append(
                     EG4BatteryRefreshButton(
                         coordinator=coordinator,
                         parent_serial=serial,
                         battery_key=battery_key,
-                        parent_model=parent_model,
-                        battery_id=battery_key,
                     )
                 )
         if new_entities:
@@ -278,19 +269,14 @@ class EG4BatteryRefreshButton(EG4BatteryEntity, ButtonEntity):
     - Availability checking for battery presence
     """
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
         self,
         coordinator: EG4DataUpdateCoordinator,
         parent_serial: str,
         battery_key: str,
-        parent_model: str,
-        battery_id: str,
     ) -> None:
         """Initialize the battery refresh button."""
         super().__init__(coordinator, parent_serial, battery_key)
-
-        self._parent_model = parent_model
-        self._battery_id = battery_id
 
         # Create unique identifiers - match battery device pattern
         self._attr_unique_id = f"{parent_serial}_{battery_key}_refresh_data"
@@ -319,7 +305,7 @@ class EG4BatteryRefreshButton(EG4BatteryEntity, ButtonEntity):
 
         # Add parent device info
         attributes["parent_device"] = self._parent_serial
-        attributes["battery_id"] = self._battery_id
+        attributes["battery_id"] = self._battery_key
 
         return attributes if attributes else None
 

--- a/custom_components/eg4_web_monitor/const/brand.py
+++ b/custom_components/eg4_web_monitor/const/brand.py
@@ -18,7 +18,6 @@ class BrandConfig:
     Attributes:
         domain: Home Assistant integration domain (e.g., "eg4_web_monitor")
         brand_name: Full brand name for display (e.g., "EG4 Electronics")
-        short_name: Short brand name for entity IDs (e.g., "EG4")
         entity_prefix: Prefix for entity IDs (e.g., "eg4")
         default_base_url: Default API base URL for this brand
         default_verify_ssl: Default SSL verification setting
@@ -27,7 +26,6 @@ class BrandConfig:
 
     domain: str
     brand_name: str
-    short_name: str
     entity_prefix: str
     default_base_url: str
     default_verify_ssl: bool
@@ -38,7 +36,6 @@ class BrandConfig:
 BRAND_EG4 = BrandConfig(
     domain="eg4_web_monitor",
     brand_name="EG4 Electronics",
-    short_name="EG4",
     entity_prefix="eg4",
     default_base_url="https://monitor.eg4electronics.com",
     default_verify_ssl=True,

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -31,7 +31,7 @@ else:
     )
 
 from pylxpweb import LuxpowerClient
-from pylxpweb.devices import Battery, Station
+from pylxpweb.devices import Station
 from pylxpweb.devices.inverters.base import BaseInverter
 from .const import (
     BLOCK_SIZE_PRESET_REGISTERS,
@@ -568,22 +568,6 @@ class EG4DataUpdateCoordinator(
     def get_inverter_object(self, serial: str) -> BaseInverter | None:
         """Get inverter device object by serial number (O(1) cached lookup)."""
         return self._inverter_cache.get(serial)
-
-    def get_battery_object(self, serial: str, battery_index: int) -> Battery | None:
-        """Get battery object by inverter serial and battery index."""
-        inverter = self.get_inverter_object(serial)
-        battery_bank = getattr(inverter, "_battery_bank", None) if inverter else None
-        if not battery_bank:
-            return None
-
-        if not hasattr(battery_bank, "batteries"):
-            return None
-
-        for battery in battery_bank.batteries:
-            if battery.index == battery_index:
-                return cast(Battery, battery)
-
-        return None
 
     def has_http_api(self) -> bool:
         """Check if HTTP API is available (HTTP or Hybrid mode).

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -48,12 +48,8 @@ def _get_model(
 # Silver tier requirement: Specify parallel update count
 MAX_PARALLEL_UPDATES = 2
 
-# Operating mode options
+# Operating mode options (FUNC_SET_TO_STANDBY: true = Normal, false = Standby)
 OPERATING_MODE_OPTIONS = ["Normal", "Standby"]
-OPERATING_MODE_MAPPING = {
-    "Normal": True,  # True = normal mode (FUNC_SET_TO_STANDBY = true means Normal)
-    "Standby": False,  # False = standby mode (FUNC_SET_TO_STANDBY = false means Standby)
-}
 
 # PV Input Mode options (register 20, HOLD_PV_INPUT_MODE)
 # Maps display label -> raw register value

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -258,7 +258,7 @@ async def async_setup_entry(
                             f"{serial}_{key}" for key in _SUPPRESSED_OFFGRID_SWITCH_KEYS
                         ),
                     )
-                for mode_key, mode_config in WORKING_MODES.items():
+                for mode_config in WORKING_MODES.values():
                     param = mode_config.get("param", "")
                     # Grid-tied-only controls are inert on EG4_OFFGRID
                     # hardware — see GRID_TIED_ONLY_WORKING_MODE_PARAMS.
@@ -309,7 +309,6 @@ async def async_setup_entry(
                         EG4WorkingModeSwitch(
                             coordinator=coordinator,
                             serial=serial,
-                            mode_key=mode_key,
                             mode_config=mode_config,
                         )
                     )
@@ -705,11 +704,9 @@ class EG4WorkingModeSwitch(EG4BaseSwitch):
         self,
         coordinator: EG4DataUpdateCoordinator,
         serial: str,
-        mode_key: str,
         mode_config: dict[str, Any],
     ) -> None:
         """Initialize the working mode switch."""
-        self._mode_key = mode_key
         self._mode_config = mode_config
 
         # Clean parameter name for entity key (remove func_ prefix for cleaner

--- a/tests/test_button_entities.py
+++ b/tests/test_button_entities.py
@@ -109,8 +109,6 @@ class TestEG4BatteryRefreshButton:
             coordinator=coordinator,
             parent_serial="1234567890",
             battery_key="1234567890-01",
-            parent_model="FlexBOSS21",
-            battery_id="1234567890-01",
         )
 
         assert entity._parent_serial == "1234567890"
@@ -135,8 +133,6 @@ class TestEG4BatteryRefreshButton:
             coordinator=coordinator,
             parent_serial="1234567890",
             battery_key="1234567890-01",
-            parent_model="FlexBOSS21",
-            battery_id="1234567890-01",
         )
 
         await entity.async_press()
@@ -156,8 +152,6 @@ class TestEG4BatteryRefreshButton:
             coordinator=coordinator,
             parent_serial="1234567890",
             battery_key="1234567890-01",
-            parent_model="FlexBOSS21",
-            battery_id="1234567890-01",
         )
 
         assert "1234567890" in entity.unique_id

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -813,27 +813,21 @@ class TestWorkingModeSwitch:
         """Boolean parameter value -> is_on."""
         coordinator = _mock_coordinator(parameters={"FUNC_AC_CHARGE": True})
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         assert switch.is_on is True
 
     def test_is_on_from_params_int(self):
         """Integer param value 1 -> True."""
         coordinator = _mock_coordinator(parameters={"FUNC_AC_CHARGE": 1})
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         assert switch.is_on is True
 
     def test_is_on_false_when_missing(self):
         """Missing parameter -> False."""
         coordinator = _mock_coordinator()
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         assert switch.is_on is False
 
     @pytest.mark.asyncio
@@ -841,9 +835,7 @@ class TestWorkingModeSwitch:
         """Local mode: writes PARAM_FUNC_AC_CHARGE."""
         coordinator = _mock_coordinator(has_local=True, has_http=True)
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -856,9 +848,7 @@ class TestWorkingModeSwitch:
         """Cloud mode: calls enable_ac_charge_mode."""
         coordinator = _mock_coordinator(has_local=False, has_http=True)
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -870,9 +860,7 @@ class TestWorkingModeSwitch:
         """Peak shaving uses local named parameter write (reg 179 bit 7)."""
         coordinator = _mock_coordinator(has_local=True, has_http=False)
         mode_config = WORKING_MODES["peak_shaving_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "peak_shaving_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -885,9 +873,7 @@ class TestWorkingModeSwitch:
         """Battery backup ctrl uses local named parameter write (reg 233 bit 1)."""
         coordinator = _mock_coordinator(has_local=True, has_http=False)
         mode_config = WORKING_MODES["battery_backup_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "battery_backup_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -899,9 +885,7 @@ class TestWorkingModeSwitch:
         """Extra attributes include description and function_parameter."""
         coordinator = _mock_coordinator()
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         attrs = switch.extra_state_attributes
         assert attrs["function_parameter"] == "FUNC_AC_CHARGE"
         assert "description" in attrs
@@ -965,9 +949,7 @@ class TestCloudFallback:
             side_effect=HomeAssistantError("Modbus timeout")
         )
         mode_config = WORKING_MODES["battery_backup_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "battery_backup_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -979,9 +961,7 @@ class TestCloudFallback:
         """Local write succeeds -> cloud API NOT called."""
         coordinator = _mock_coordinator(has_local=True, has_http=True)
         mode_config = WORKING_MODES["ac_charge_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "ac_charge_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -999,9 +979,7 @@ class TestCloudFallback:
             side_effect=HomeAssistantError("Modbus timeout")
         )
         mode_config = WORKING_MODES["peak_shaving_mode"]
-        switch = EG4WorkingModeSwitch(
-            coordinator, "1234567890", "peak_shaving_mode", mode_config
-        )
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
         _prep(switch)
         await switch.async_turn_on()
 
@@ -1380,7 +1358,6 @@ class TestGridSellbackSwitchBehavior:
         return EG4WorkingModeSwitch(
             coordinator=coordinator,
             serial="1234567890",
-            mode_key=mode_key,
             mode_config=WORKING_MODES[mode_key],
         )
 
@@ -1508,7 +1485,6 @@ def _make_fast_zero_export_switch(coordinator) -> EG4WorkingModeSwitch:
     return EG4WorkingModeSwitch(
         coordinator=coordinator,
         serial="1234567890",
-        mode_key="fast_zero_export_mode",
         mode_config=WORKING_MODES["fast_zero_export_mode"],
     )
 


### PR DESCRIPTION
Conservative dead-code removal pass over `custom_components/eg4_web_monitor/`, vulture-led (`--min-confidence 80` then a wider 60% pass plus an AST cross-reference sweep), with every hit manually verified by repo-wide grep — including tests, string-based dispatch (`_get_cache("...")`, dynamic `_last_{type}_poll` attribute names), and quoted type annotations — before deletion.

## Removals (all verified zero-reference)

| File | Removed | Why safe |
|---|---|---|
| `coordinator.py` | `get_battery_object()` method + now-unused `Battery` import | Zero callers anywhere: code, tests, services, no getattr/string references |
| `select.py` | `OPERATING_MODE_MAPPING` dict | Never referenced; FUNC_SET_TO_STANDBY semantics comment preserved on `OPERATING_MODE_OPTIONS` |
| `_config_flow/discovery.py` | `DiscoveredDevice.parallel_group_name` / `.is_standalone` / `.is_master` properties | Never read; the raw `parallel_number` / `parallel_master_slave` dataclass fields they wrap are kept |
| `const/brand.py` | `BrandConfig.short_name` field | Never read; entity ID prefixing uses `entity_prefix` |
| `switch.py` | `EG4WorkingModeSwitch` `mode_key` ctor param + `self._mode_key` dead store | Attribute never read; call site + 13 test sites updated; setup loop now iterates `WORKING_MODES.values()` |
| `button.py` | `EG4BatteryRefreshButton` `parent_model` param (dead store) + `battery_id` param (redundant) + dead `device_info` lookups at both call sites + stale pylint disable | `_parent_model` never read; `battery_id` was passed `battery_key` at every call site — `extra_state_attributes` now uses `self._battery_key`, byte-identical output |
| `base_entity.py` | `entity._sensor_config` dead store in `_apply_sensor_config` + 3 stale docstring Attributes entries | Callers use the function's return value; attribute never read by any subclass |
| `_config_flow/__init__.py` | `self._library_debug` flow-state init | Never read; options flow reads `CONF_LIBRARY_DEBUG` from entry options directly |

## Deliberately KEPT (vulture flagged, verified live)

- `TYPE_CHECKING` imports `BatteryData`/`BatteryBankData`/`InverterRuntimeData`/`InverterEnergyData` in `coordinator_mappings.py`/`coordinator_mixins.py`/`coordinator_local.py` — used in quoted annotations (ruff F401 agrees they're used)
- `_last_modbus_poll`/`_last_dongle_poll` — accessed via dynamic attribute-name tuples in `_should_poll_transport()`
- `_device_info_cache` family — accessed via `self._get_cache("_device_info_cache")` string dispatch
- `BATTERY_BANK_KEYS` + `DeviceProcessingMixin._get_battery_bank_property_map()` — production-unused but load-bearing for the key-drift-prevention contract harness (`test_coordinator.py`, `test_register_contract.py`)
- `device_types.__getattr__` deprecation shim — intentional public deprecation machinery (v3.2.0 legacy family constants)
- All `async_setup_entry`/`async_step_*`/`is_on`/`async_install(backup, **kwargs)`/`entry_data` etc. — HA framework entry points and required override signatures
- `_battery_id`-style HA `**kwargs` hits in switch/update — framework signatures

## Guarantees

- **Zero functional change**: no `unique_id` / `entity_id` / `translation_key` lines in the diff (grep-verified)
- No linter suppressions added (one stale pylint disable *removed*)
- `manifest.json`, `strings.json`, `translations/`, `CHANGELOG.md`, `CLAUDE.md` untouched

## Validation

- `ruff check --fix` + `ruff format`: clean
- `mypy --config-file tests/mypy.ini` (strict): 40 files, no issues
- `pytest tests/`: **1751 passed, 3 skipped**
- Net delta: **+16 / −122** (−106 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)