### PR TITLE
fix: LOCAL battery carry-forward eviction unreachable on non-empty polls

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -338,7 +338,54 @@ class LocalTransportMixin(_MixinBase):
             list(legacy_key_map.keys()),
         )
 
+        # Age-based eviction must run on every merge, not only on empty
+        # polls: this method returns the full accumulated cache, so once any
+        # battery has been seen device_data["batteries"] is never empty and
+        # the empty-poll re-serve branch downstream is unreachable.  Without
+        # this, a physically removed pack would be re-served with frozen
+        # values until restart.  Mirrors the unconditional HYBRID/CLOUD
+        # bound in _apply_battery_carry_forward.  Rotating batteries are
+        # safe: their mapping is re-stamped whenever their page comes
+        # around, well within the bound.
+        self._evict_aged_rr_batteries(inverter_serial)
+
         return dict(cache)
+
+    def _evict_aged_rr_batteries(self, inverter_serial: str) -> None:
+        """Evict round-robin cache entries aged past the carry-forward bound.
+
+        An entry whose ``battery_last_seen`` is older than
+        BATTERY_CARRY_FORWARD_MAX_AGE is a physically removed pack, not a
+        transient — evict it from the rr-cache (and the carry-forward
+        layer, which would otherwise resurrect it) so removal converges
+        without an HA restart (#258 review).
+        """
+        cache = self._battery_rr_cache.get(inverter_serial)
+        if not cache:
+            return
+        now = dt_util.utcnow()
+        aged = [
+            key
+            for key, mapping in cache.items()
+            if isinstance(
+                last_seen := mapping.get("battery_last_seen"),
+                datetime,
+            )
+            and now - dt_util.as_utc(last_seen) > BATTERY_CARRY_FORWARD_MAX_AGE
+        ]
+        for key in aged:
+            cache.pop(key, None)
+            self._battery_carry_forward.get(inverter_serial, {}).pop(key, None)
+        if aged:
+            _LOGGER.info(
+                "LOCAL: Evicting %d batteries for %s not seen for "
+                "over %s (physically removed or permanently "
+                "vanished): %s",
+                len(aged),
+                inverter_serial,
+                BATTERY_CARRY_FORWARD_MAX_AGE,
+                aged,
+            )
 
     async def _read_modbus_parameters(
         self, transport: Any, device_data: dict[str, Any] | None = None
@@ -1186,30 +1233,7 @@ class LocalTransportMixin(_MixinBase):
                     # BATTERY_CARRY_FORWARD_MAX_AGE is a physically removed
                     # pack, not a transient — evict it so removal converges
                     # instead of re-serving frozen data until restart.
-                    now = dt_util.utcnow()
-                    aged = [
-                        key
-                        for key, mapping in cached_batteries.items()
-                        if isinstance(
-                            last_seen := mapping.get("battery_last_seen"),
-                            datetime,
-                        )
-                        and now - dt_util.as_utc(last_seen)
-                        > BATTERY_CARRY_FORWARD_MAX_AGE
-                    ]
-                    for key in aged:
-                        cached_batteries.pop(key, None)
-                        self._battery_carry_forward.get(serial, {}).pop(key, None)
-                    if aged:
-                        _LOGGER.info(
-                            "LOCAL: Evicting %d batteries for %s not seen for "
-                            "over %s (physically removed or permanently "
-                            "vanished): %s",
-                            len(aged),
-                            serial,
-                            BATTERY_CARRY_FORWARD_MAX_AGE,
-                            aged,
-                        )
+                    self._evict_aged_rr_batteries(serial)
                     if cached_batteries:
                         device_data["batteries"] = dict(cached_batteries)
                         _LOGGER.debug(

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2772,6 +2772,79 @@ class TestBatteryRRCacheFallback:
             if r.levelno == _logging.INFO and "Evict" in r.getMessage()
         )
 
+    async def test_merge_evicts_aged_entries_on_nonempty_poll(
+        self, hass: Any, caplog: Any
+    ) -> None:
+        """Rotating pack: removal converges even though polls stay non-empty.
+
+        ``_merge_round_robin_batteries`` returns the full accumulated cache,
+        so once any battery has been seen ``device_data["batteries"]`` is
+        never empty and the empty-poll re-serve branch (which used to host
+        the only eviction) is unreachable.  The BATTERY_CARRY_FORWARD_MAX_AGE
+        bound must therefore apply on every merge: a battery that stopped
+        appearing (physically removed) is evicted while live batteries —
+        including one merely on a page not covered by this rotation
+        position — survive.
+        """
+        import logging as _logging
+
+        from custom_components.eg4_web_monitor.utils import local_battery_key
+
+        serial = "DONGLE001"
+        entry = self._make_config_entry(hass, serial)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+        def _batt(index: int, batt_serial: str) -> BatteryData:
+            return BatteryData(
+                battery_index=index,
+                serial_number=batt_serial,
+                voltage=52.5,
+                soc=90,
+            )
+
+        sn_live = "BATLIVE00001"
+        sn_carried = "BATCARRY0001"
+        sn_removed = "BATGONE00001"
+
+        # Poll 1: all three batteries appear (fresh timestamps).
+        coordinator._merge_round_robin_batteries(
+            serial,
+            [_batt(0, sn_live), _batt(1, sn_carried), _batt(2, sn_removed)],
+        )
+        cache = coordinator._battery_rr_cache[serial]
+        key_live = local_battery_key(serial, sn_live, 0)
+        key_carried = local_battery_key(serial, sn_carried, 1)
+        key_removed = local_battery_key(serial, sn_removed, 2)
+        assert set(cache) == {key_live, key_carried, key_removed}
+
+        # Time passes: the removed battery hasn't been read for over 6h;
+        # the carried battery was last read 5h ago (rotation page not
+        # covered recently, still within the bound).
+        now = dt_util.utcnow()
+        cache[key_removed]["battery_last_seen"] = now - timedelta(hours=7)
+        cache[key_carried]["battery_last_seen"] = now - timedelta(hours=5)
+        coordinator._battery_carry_forward.setdefault(serial, {})[key_removed] = dict(
+            cache[key_removed]
+        )
+
+        # Poll 2 (NON-empty): only the live battery's page is covered.
+        with caplog.at_level(_logging.INFO):
+            merged = coordinator._merge_round_robin_batteries(
+                serial, [_batt(0, sn_live)]
+            )
+
+        assert key_live in merged
+        assert key_carried in merged, "within-bound carried battery evicted"
+        assert key_removed not in merged, "aged battery re-served on non-empty poll"
+        # Authoritative eviction across both sticky layers, with one INFO.
+        assert key_removed not in coordinator._battery_rr_cache[serial]
+        assert key_removed not in coordinator._battery_carry_forward[serial]
+        assert any(
+            key_removed in r.getMessage()
+            for r in caplog.records
+            if r.levelno == _logging.INFO and "Evict" in r.getMessage()
+        )
+
 
 class TestBatteryControlModeMethods:
     """Coordinator helpers for the battery control regime (SOC vs Voltage)."""


### PR DESCRIPTION
## Root cause

The 6-hour `BATTERY_CARRY_FORWARD_MAX_AGE` eviction in `coordinator_local.py` sat inside the `if not device_data["batteries"]:` re-serve branch — reachable only when a poll returned **zero** batteries. But `_merge_round_robin_batteries()` returns `dict(cache)` (the full accumulated round-robin cache), so once any battery had ever been seen, `device_data["batteries"]` was never empty and the eviction branch was dead code on the live path.

## Failure scenario

LOCAL mode, rotating multi-battery pack (>4 banks): physically remove one battery. Its rr-cache entry is never re-stamped, but every non-empty poll re-serves it via the merged dict — its HA entities stay populated with frozen values indefinitely. Only an HA restart cleared it. This contradicted the beta.19 documented intent ("physical removal converges, no restart") and diverged from HYBRID/CLOUD, where `_apply_battery_carry_forward` (coordinator_http.py) applies the same 6h bound unconditionally every cycle.

## Fix

- Extracted the eviction into `_evict_aged_rr_batteries(inverter_serial)` — evicts rr-cache entries whose `battery_last_seen` aged past `BATTERY_CARRY_FORWARD_MAX_AGE` (constant shared from `coordinator_mixins.py`, not duplicated), purging both sticky layers (rr-cache + `_battery_carry_forward`) with the same INFO log.
- Called unconditionally at the end of every `_merge_round_robin_batteries()` (after the merge loop, so batteries seen this poll are re-stamped fresh before eviction — a battery merely on a page not covered by the current rotation position is restamped whenever its page comes around, well within 6h).
- The empty-poll re-serve branch now calls the same helper (eviction mutates the cache dict in place, so the re-served dict reflects it); the authoritative positional-fallback retirement is untouched.

Preserved behaviors: fresh timestamps for polled batteries, original `battery_last_seen` for carried entries, entries without a timestamp never evicted, existing empty-poll eviction test unchanged and passing.

## Tests

- New: `test_merge_evicts_aged_entries_on_nonempty_poll` (tests/test_coordinator_local.py, `TestBatteryRRCacheFallback`) — rotating pack, battery disappears from transport reads while polls stay non-empty, >6h stale entry evicted from merged result + both caches (with INFO log), while the live battery and a 5h-old carried battery survive.
- Existing `test_cache_reserve_evicts_aged_entries` (empty-poll path) still passes.

Full suite: **1752 passed, 3 skipped**. Gates: ruff check/format clean, mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)