### PR TITLE
fix: HYBRID number/select/time controls fall back to cloud on local write failure

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -1052,9 +1052,13 @@ class EG4DataUpdateCoordinator(
                     serial, PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage
                 )
             except Exception as err:
-                await self._raise_partial_battery_mode_write(serial, err)
+                await self._raise_partial_battery_mode_write(
+                    serial, charge_voltage, err
+                )
             if not discharge_result.success:
-                await self._raise_partial_battery_mode_write(serial, None)
+                await self._raise_partial_battery_mode_write(
+                    serial, charge_voltage, None
+                )
 
         await async_write_with_cloud_fallback(
             self,
@@ -1069,7 +1073,7 @@ class EG4DataUpdateCoordinator(
         )
 
     async def _raise_partial_battery_mode_write(
-        self, serial: str, err: Exception | None
+        self, serial: str, charge_voltage: bool, err: Exception | None
     ) -> NoReturn:
         """Re-read parameters after a partial battery-mode cloud write, then raise.
 
@@ -1077,9 +1081,12 @@ class EG4DataUpdateCoordinator(
         179 holds a MIXED regime (same convergence pattern as the schedule
         time entities' partial hour/minute cloud writes). A best-effort
         parameter refresh re-reads the device so entities reflect the actual
-        state; ``_refresh_device_parameters`` internally skips the read when
-        the local link is down (the cloud param poll or link recovery
-        converges later).
+        state. When the local link is DOWN the re-read is impossible
+        (``_refresh_device_parameters`` skips it), so the KNOWN-succeeded
+        charge bit is seeded into the cache instead — the failed discharge
+        bit is left untouched (the device still holds its previous value) —
+        so the cache converges on what actually landed while the error still
+        surfaces.
         """
         _LOGGER.warning(
             "Battery control mode write for %s partially applied (discharge "
@@ -1088,14 +1095,19 @@ class EG4DataUpdateCoordinator(
             serial,
             f": {err}" if err else "",
         )
-        try:
-            await self._refresh_device_parameters(serial)
-        except Exception:
-            _LOGGER.debug(
-                "Best-effort parameter re-read after partial battery mode "
-                "write failed for %s",
-                serial,
+        if self.is_transport_link_down(serial):
+            self.note_parameters_written(
+                serial, {PARAM_FUNC_BAT_CHARGE_CONTROL: charge_voltage}
             )
+        else:
+            try:
+                await self._refresh_device_parameters(serial)
+            except Exception:
+                _LOGGER.debug(
+                    "Best-effort parameter re-read after partial battery mode "
+                    "write failed for %s",
+                    serial,
+                )
         raise HomeAssistantError(
             f"Failed to set battery control mode for {serial}: the regime may "
             "be partially applied (charge and discharge bits are written "

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -5,7 +5,7 @@ import logging
 import time
 from datetime import datetime, timedelta
 from collections.abc import Callable, Collection
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -102,6 +102,7 @@ from .coordinator_mixins import (
     DSTSyncMixin,
     FirmwareUpdateMixin,
     ParameterManagementMixin,
+    is_transport_link_down as _device_transport_link_down,
 )
 from .const.sensors import SENSOR_TYPES
 from .utils import async_write_with_cloud_fallback
@@ -586,22 +587,46 @@ class EG4DataUpdateCoordinator(
         pylxpweb keeps the transport ATTACHED while the link is down (reads
         keep probing every cycle), so ``has_local_transport()`` stays True
         during an outage. Control writes use this to prefer the cloud
-        immediately instead of waiting out a doomed Modbus timeout.
-        Duck-typed via ``getattr`` so MID devices and older pylxpweb versions
-        without the property simply report the link as up.
+        immediately instead of waiting out a doomed Modbus timeout, and
+        parameter refreshes use it to skip local reads that would hang.
+
+        Delegates to :func:`coordinator_mixins.is_transport_link_down` — the
+        single implementation, whose strict guards (transport must be
+        attached, ``transport_link_down`` must be a real bool) keep stale
+        attributes without a transport and older pylxpweb versions from ever
+        reporting a down link.
 
         Args:
             serial: Device serial to check.
 
         Returns:
-            True if the device object reports ``transport_link_down``.
+            True only when the device reports an attached-but-dead link.
         """
         device: Any = self.get_inverter_object(serial) or self._get_device_object(
             serial
         )
         if device is None:
             device = self._mid_device_cache.get(serial)
-        return bool(getattr(device, "transport_link_down", False))
+        return _device_transport_link_down(device)
+
+    def note_parameters_written(self, serial: str, values: dict[str, Any]) -> None:
+        """Merge acknowledged written parameter values into the cache and notify.
+
+        Convergence for cloud-fallback writes while a local transport is
+        attached: the follow-up local parameter refresh is skipped (link
+        down) or may fail, and the #282 sticky carry-forward would otherwise
+        pin the stale pre-write value until link recovery — visually
+        reverting the entity after its optimistic value clears. The written
+        value IS device truth (the cloud write was acknowledged), expressed
+        in the same local-raw representation the attached-transport cache
+        uses. A later successful parameter read overwrites it with fresh
+        device data.
+        """
+        if not self.data:
+            return
+        params = self.data.setdefault("parameters", {}).setdefault(serial, {})
+        params.update(values)
+        self.async_update_listeners()
 
     def _has_modbus_transport(self) -> bool:
         """Check if any Modbus TCP/Serial transport is configured."""
@@ -1017,13 +1042,19 @@ class EG4DataUpdateCoordinator(
             charge_result = await client.api.control.control_function(
                 serial, PARAM_FUNC_BAT_CHARGE_CONTROL, charge_voltage
             )
-            discharge_result = await client.api.control.control_function(
-                serial, PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage
-            )
-            if not (charge_result.success and discharge_result.success):
+            if not charge_result.success:
+                # Nothing written yet — no partial state to converge on.
                 raise HomeAssistantError(
                     f"Failed to set battery control mode for {serial}"
                 )
+            try:
+                discharge_result = await client.api.control.control_function(
+                    serial, PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage
+                )
+            except Exception as err:
+                await self._raise_partial_battery_mode_write(serial, err)
+            if not discharge_result.success:
+                await self._raise_partial_battery_mode_write(serial, None)
 
         await async_write_with_cloud_fallback(
             self,
@@ -1031,7 +1062,45 @@ class EG4DataUpdateCoordinator(
             "battery control mode",
             local_write=_local_write,
             cloud_write=_cloud_write,
+            local_values={
+                PARAM_FUNC_BAT_CHARGE_CONTROL: charge_voltage,
+                PARAM_FUNC_BAT_DISCHARGE_CONTROL: discharge_voltage,
+            },
         )
+
+    async def _raise_partial_battery_mode_write(
+        self, serial: str, err: Exception | None
+    ) -> NoReturn:
+        """Re-read parameters after a partial battery-mode cloud write, then raise.
+
+        The charge bit was written but the discharge bit was not — register
+        179 holds a MIXED regime (same convergence pattern as the schedule
+        time entities' partial hour/minute cloud writes). A best-effort
+        parameter refresh re-reads the device so entities reflect the actual
+        state; ``_refresh_device_parameters`` internally skips the read when
+        the local link is down (the cloud param poll or link recovery
+        converges later).
+        """
+        _LOGGER.warning(
+            "Battery control mode write for %s partially applied (discharge "
+            "bit failed%s); re-reading device parameters to reflect the "
+            "actual state",
+            serial,
+            f": {err}" if err else "",
+        )
+        try:
+            await self._refresh_device_parameters(serial)
+        except Exception:
+            _LOGGER.debug(
+                "Best-effort parameter re-read after partial battery mode "
+                "write failed for %s",
+                serial,
+            )
+        raise HomeAssistantError(
+            f"Failed to set battery control mode for {serial}: the regime may "
+            "be partially applied (charge and discharge bits are written "
+            "separately) — device state was re-read"
+        ) from err
 
     def _get_device_object(self, serial: str) -> BaseInverter | Any | None:
         """Get device object (inverter or MID device) by serial number.

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -104,6 +104,7 @@ from .coordinator_mixins import (
     ParameterManagementMixin,
 )
 from .const.sensors import SENSOR_TYPES
+from .utils import async_write_with_cloud_fallback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -579,6 +580,29 @@ class EG4DataUpdateCoordinator(
         """
         return self.client is not None
 
+    def is_transport_link_down(self, serial: str) -> bool:
+        """Whether pylxpweb has declared this device's local transport link down.
+
+        pylxpweb keeps the transport ATTACHED while the link is down (reads
+        keep probing every cycle), so ``has_local_transport()`` stays True
+        during an outage. Control writes use this to prefer the cloud
+        immediately instead of waiting out a doomed Modbus timeout.
+        Duck-typed via ``getattr`` so MID devices and older pylxpweb versions
+        without the property simply report the link as up.
+
+        Args:
+            serial: Device serial to check.
+
+        Returns:
+            True if the device object reports ``transport_link_down``.
+        """
+        device: Any = self.get_inverter_object(serial) or self._get_device_object(
+            serial
+        )
+        if device is None:
+            device = self._mid_device_cache.get(serial)
+        return bool(getattr(device, "transport_link_down", False))
+
     def _has_modbus_transport(self) -> bool:
         """Check if any Modbus TCP/Serial transport is configured."""
         if self._modbus_transport is not None:
@@ -966,7 +990,8 @@ class EG4DataUpdateCoordinator(
 
         Sets register 179 bit 9 (charge) and bit 10 (discharge): SOC clears the
         bit, Voltage sets it. Routes through the local transport when available,
-        else the cloud function-control API.
+        falling back to the cloud function-control API on local write failure
+        (both paths set absolute bit state, so a double-write is safe).
 
         Raises:
             HomeAssistantError: If no write path is available or a write fails.
@@ -974,28 +999,39 @@ class EG4DataUpdateCoordinator(
         charge_voltage = charge_mode == CONTROL_MODE_VOLTAGE
         discharge_voltage = discharge_mode == CONTROL_MODE_VOLTAGE
 
-        if self.has_local_transport(serial):
+        async def _local_write() -> None:
             await self.write_named_parameter(
                 PARAM_FUNC_BAT_CHARGE_CONTROL, charge_voltage, serial=serial
             )
             await self.write_named_parameter(
                 PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage, serial=serial
             )
-        elif self.client is not None:
-            charge_result = await self.client.api.control.control_function(
+
+        async def _cloud_write() -> None:
+            client = self.client
+            if client is None:
+                raise HomeAssistantError(
+                    "No local transport or cloud API available to set "
+                    "battery control mode."
+                )
+            charge_result = await client.api.control.control_function(
                 serial, PARAM_FUNC_BAT_CHARGE_CONTROL, charge_voltage
             )
-            discharge_result = await self.client.api.control.control_function(
+            discharge_result = await client.api.control.control_function(
                 serial, PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage
             )
             if not (charge_result.success and discharge_result.success):
                 raise HomeAssistantError(
                     f"Failed to set battery control mode for {serial}"
                 )
-        else:
-            raise HomeAssistantError(
-                "No local transport or cloud API available to set battery control mode."
-            )
+
+        await async_write_with_cloud_fallback(
+            self,
+            serial,
+            "battery control mode",
+            local_write=_local_write,
+            cloud_write=_cloud_write,
+        )
 
     def _get_device_object(self, serial: str) -> BaseInverter | Any | None:
         """Get device object (inverter or MID device) by serial number.

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -2380,11 +2380,28 @@ class ParameterManagementMixin(_MixinBase):
             _LOGGER.error("Failed to refresh parameters for device %s: %s", serial, e)
 
     async def _refresh_device_parameters(self, serial: str) -> None:
-        """Refresh parameters for a specific device using device object."""
+        """Refresh parameters for a specific device using device object.
+
+        Skipped while the device's local transport link is down: pylxpweb's
+        parameter fetch has no ``transport_link_down`` gate (unlike its
+        runtime/energy/battery reads), so an attached-but-dead link would
+        attempt local Modbus reads that Python 3.11's ``asyncio.wait_for``
+        cannot interrupt (multi-minute hangs). The regular poll re-probes
+        the link every cycle and parameters refresh on recovery; entities
+        converge on written values via ``note_parameters_written()``.
+        """
         try:
             inverter = self.get_inverter_object(serial)
             if not inverter:
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
+                return
+
+            if is_transport_link_down(inverter):
+                _LOGGER.debug(
+                    "Skipping parameter refresh for %s: local transport link "
+                    "is down (re-probed by the regular poll cycle)",
+                    serial,
+                )
                 return
 
             # Use force=True to bypass cache when refreshing parameters after changes

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import math
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any, TYPE_CHECKING
 
 from homeassistant.const import EntityCategory
@@ -117,6 +117,7 @@ from .const import (
 )
 from .coordinator import EG4DataUpdateCoordinator
 from .utils import (
+    async_write_with_cloud_fallback,
     flag_offgrid_control_suppression,
     is_offgrid_family,
     is_supported_control_model,
@@ -395,26 +396,51 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
         *,
         local_param: str,
         local_value: int | float | None = None,
-        cloud_method: str,
-        cloud_kwargs: dict[str, Any],
+        cloud_method: str | None = None,
+        cloud_kwargs: dict[str, Any] | None = None,
+        cloud_write: Callable[[], Awaitable[Any]] | None = None,
         label: str,
     ) -> None:
-        """Write parameter via local transport or cloud API with optimistic context."""
+        """Write parameter via local transport or cloud API with optimistic context.
+
+        The local write is attempted first when a transport is attached; on
+        failure (or a known-down link) it falls back to the cloud path when a
+        cloud client exists — HYBRID parity with the switch platform's
+        ``_execute_local_with_fallback``. ``cloud_write`` overrides the
+        default inverter-method cloud path for entities whose verified cloud
+        route is a direct named-parameter write.
+        """
         _LOGGER.info("Setting %s for %s", label, self.serial)
         self._warn_if_ineffective()
-        with optimistic_value_context(self, value):
-            if self.coordinator.has_local_transport(self.serial):
-                write_val = local_value if local_value is not None else int(value)
-                await self.coordinator.write_named_parameter(
-                    local_param, write_val, serial=self.serial
+
+        async def _local_write() -> None:
+            write_val = local_value if local_value is not None else int(value)
+            await self.coordinator.write_named_parameter(
+                local_param, write_val, serial=self.serial
+            )
+            await asyncio.sleep(0.5)
+
+        async def _cloud_via_method() -> None:
+            inverter = self._get_inverter_or_raise()
+            method = getattr(inverter, cloud_method or "", None)
+            if method is None:
+                raise HomeAssistantError(
+                    f"Failed to set {label}: pylxpweb is missing {cloud_method}"
                 )
-                await asyncio.sleep(0.5)
-            else:
-                inverter = self._get_inverter_or_raise()
-                success = await getattr(inverter, cloud_method)(**cloud_kwargs)
-                if not success:
-                    raise HomeAssistantError(f"Failed to set {label}")
-                await inverter.refresh()
+            success = await method(**(cloud_kwargs or {}))
+            if not success:
+                raise HomeAssistantError(f"Failed to set {label}")
+            await inverter.refresh()
+
+        with optimistic_value_context(self, value):
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self.serial,
+                label,
+                local_write=_local_write,
+                cloud_write=cloud_write
+                or (_cloud_via_method if cloud_method else None),
+            )
             await self._refresh_related_entities()
 
     async def _write_voltage_register(
@@ -430,29 +456,41 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
         Voltage limit registers store decivolts (V × 10). The local path writes
         the named parameter via the transport's name map; the cloud path writes
         the raw register address directly (avoiding read/write name aliasing).
+        In HYBRID mode a failed local write falls back to the cloud path.
         """
         raw_value = int(round(value * 10))
         _LOGGER.info("Setting %s for %s to %.1f V", label, self.serial, value)
         self._warn_if_ineffective()
-        with optimistic_value_context(self, value):
-            if self.coordinator.has_local_transport(self.serial):
-                await self.coordinator.write_named_parameter(
-                    param_name, raw_value, serial=self.serial
-                )
-                await asyncio.sleep(0.5)
-            elif self.coordinator.client is not None:
-                result = await self.coordinator.client.api.control.write_parameters(
-                    self.serial, {register: raw_value}
-                )
-                if not result.success:
-                    raise HomeAssistantError(f"Failed to set {label}")
-                inverter = self.coordinator.get_inverter_object(self.serial)
-                if inverter:
-                    await inverter.refresh(force=True, include_parameters=True)
-            else:
+
+        async def _local_write() -> None:
+            await self.coordinator.write_named_parameter(
+                param_name, raw_value, serial=self.serial
+            )
+            await asyncio.sleep(0.5)
+
+        async def _cloud_write() -> None:
+            client = self.coordinator.client
+            if client is None:
                 raise HomeAssistantError(
                     "No local transport or cloud API available for parameter write."
                 )
+            result = await client.api.control.write_parameters(
+                self.serial, {register: raw_value}
+            )
+            if not result.success:
+                raise HomeAssistantError(f"Failed to set {label}")
+            inverter = self.coordinator.get_inverter_object(self.serial)
+            if inverter:
+                await inverter.refresh(force=True, include_parameters=True)
+
+        with optimistic_value_context(self, value):
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self.serial,
+                label,
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
             await self._refresh_related_entities()
 
     async def _refresh_related_entities(self) -> None:
@@ -649,24 +687,35 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
             "Setting System Charge SOC Limit for %s to %d%%", self.serial, int_value
         )
         self._warn_if_ineffective()
-        with optimistic_value_context(self, value):
-            if self.coordinator.has_local_transport(self.serial):
-                await self.coordinator.write_named_parameter(
-                    PARAM_HOLD_SYSTEM_CHARGE_SOC_LIMIT, int_value, serial=self.serial
-                )
-            elif self.coordinator.client is not None:
-                result = await self.coordinator.client.api.control.set_system_charge_soc_limit(
-                    self.serial, int_value
-                )
-                if not result.success:
-                    raise HomeAssistantError(f"Failed to set SOC limit to {int_value}%")
-                inverter = self.coordinator.get_inverter_object(self.serial)
-                if inverter:
-                    await inverter.refresh(force=True, include_parameters=True)
-            else:
+
+        async def _local_write() -> None:
+            await self.coordinator.write_named_parameter(
+                PARAM_HOLD_SYSTEM_CHARGE_SOC_LIMIT, int_value, serial=self.serial
+            )
+
+        async def _cloud_write() -> None:
+            client = self.coordinator.client
+            if client is None:
                 raise HomeAssistantError(
                     "No local transport or cloud API available for parameter write."
                 )
+            result = await client.api.control.set_system_charge_soc_limit(
+                self.serial, int_value
+            )
+            if not result.success:
+                raise HomeAssistantError(f"Failed to set SOC limit to {int_value}%")
+            inverter = self.coordinator.get_inverter_object(self.serial)
+            if inverter:
+                await inverter.refresh(force=True, include_parameters=True)
+
+        with optimistic_value_context(self, value):
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self.serial,
+                f"system charge SOC limit to {int_value}%",
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
             await self._refresh_related_entities()
 
 
@@ -1001,29 +1050,40 @@ class PVStartVoltageNumber(EG4BaseNumberEntity):
             )
 
         _LOGGER.info("Setting PV start voltage for %s to %d V", self.serial, int_value)
-        with optimistic_value_context(self, value):
-            if self.coordinator.has_local_transport(self.serial):
-                # Local Modbus: write raw decivolts (140V -> 1400)
-                await self.coordinator.write_named_parameter(
-                    PARAM_HOLD_START_PV_VOLT, int_value * 10, serial=self.serial
-                )
-                await asyncio.sleep(0.5)
-            elif self.coordinator.client is not None:
-                # Cloud API: write human-readable volts
-                result = await self.coordinator.client.api.control.write_parameter(
-                    self.serial, "HOLD_START_PV_VOLT", str(int_value)
-                )
-                if not result.success:
-                    raise HomeAssistantError(
-                        f"Failed to set PV start voltage to {int_value} V"
-                    )
-                inverter = self.coordinator.get_inverter_object(self.serial)
-                if inverter:
-                    await inverter.refresh(force=True, include_parameters=True)
-            else:
+
+        async def _local_write() -> None:
+            # Local Modbus: write raw decivolts (140V -> 1400)
+            await self.coordinator.write_named_parameter(
+                PARAM_HOLD_START_PV_VOLT, int_value * 10, serial=self.serial
+            )
+            await asyncio.sleep(0.5)
+
+        async def _cloud_write() -> None:
+            # Cloud API: write human-readable volts
+            client = self.coordinator.client
+            if client is None:
                 raise HomeAssistantError(
                     "No local transport or cloud API available for parameter write."
                 )
+            result = await client.api.control.write_parameter(
+                self.serial, "HOLD_START_PV_VOLT", str(int_value)
+            )
+            if not result.success:
+                raise HomeAssistantError(
+                    f"Failed to set PV start voltage to {int_value} V"
+                )
+            inverter = self.coordinator.get_inverter_object(self.serial)
+            if inverter:
+                await inverter.refresh(force=True, include_parameters=True)
+
+        with optimistic_value_context(self, value):
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self.serial,
+                f"PV start voltage to {int_value} V",
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
             await self._refresh_related_entities()
 
 
@@ -1353,20 +1413,17 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
             raise HomeAssistantError(
                 f"Start discharge power threshold must be an integer value, got {value}"
             )
-        if self.coordinator.has_local_transport(self.serial):
-            await self._write_parameter(
-                value,
-                local_param=PARAM_HOLD_PTOUSER_START_DISCHARGE,
-                local_value=int_value,
-                # Unreachable with a local transport; kept honest for the
-                # shared helper's signature (pylxpweb >= 0.9.36b18 has the
-                # named Modbus method).
-                cloud_method="set_start_discharge_power",
-                cloud_kwargs={"watts": int_value},
-                label=f"start discharge power threshold to {int_value} W",
-            )
-            return
-        await self._write_cloud_named_parameter(int_value)
+        await self._write_parameter(
+            value,
+            local_param=PARAM_HOLD_PTOUSER_START_DISCHARGE,
+            local_value=int_value,
+            # The named-param cloud writer is BOTH the cloud-mode path and
+            # the HYBRID local-failure fallback; pylxpweb's
+            # set_start_discharge_power is deliberately bypassed (see
+            # _write_cloud_named_parameter).
+            cloud_write=lambda: self._write_cloud_named_parameter(int_value),
+            label=f"start discharge power threshold to {int_value} W",
+        )
 
     async def _write_cloud_named_parameter(self, watts: int) -> None:
         """Write the threshold via the generic cloud named-parameter API.
@@ -1378,32 +1435,27 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
         raw register by address, and its cloud read leg looks up the wrong
         key (the guessed HOLD_PTOUSER_START_DISCHARGE never exists on the
         server), so the named-param call is the only website-verified path.
+
+        Bare writer: logging, ineffective-regime warning, optimistic state
+        and the related-entity refresh are provided by ``_write_parameter``.
         """
         client = self.coordinator.client
         if client is None:
             raise HomeAssistantError(
                 "No local transport or cloud API available for parameter write."
             )
-        _LOGGER.info(
-            "Setting start discharge power threshold for %s to %d W",
+        result = await client.api.control.write_parameter(
             self.serial,
-            watts,
+            PARAM_HOLD_P_TO_USER_START_DISCHG,
+            str(watts),
         )
-        self._warn_if_ineffective()
-        with optimistic_value_context(self, float(watts)):
-            result = await client.api.control.write_parameter(
-                self.serial,
-                PARAM_HOLD_P_TO_USER_START_DISCHG,
-                str(watts),
+        if not result.success:
+            raise HomeAssistantError(
+                f"Failed to set start discharge power threshold to {watts} W"
             )
-            if not result.success:
-                raise HomeAssistantError(
-                    f"Failed to set start discharge power threshold to {watts} W"
-                )
-            inverter = self.coordinator.get_inverter_object(self.serial)
-            if inverter:
-                await inverter.refresh(force=True, include_parameters=True)
-            await self._refresh_related_entities()
+        inverter = self.coordinator.get_inverter_object(self.serial)
+        if inverter:
+            await inverter.refresh(force=True, include_parameters=True)
 
 
 class StartChargePowerNumber(EG4BaseNumberEntity):

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -412,9 +412,9 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
         """
         _LOGGER.info("Setting %s for %s", label, self.serial)
         self._warn_if_ineffective()
+        write_val = local_value if local_value is not None else int(value)
 
         async def _local_write() -> None:
-            write_val = local_value if local_value is not None else int(value)
             await self.coordinator.write_named_parameter(
                 local_param, write_val, serial=self.serial
             )
@@ -440,6 +440,7 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
                 local_write=_local_write,
                 cloud_write=cloud_write
                 or (_cloud_via_method if cloud_method else None),
+                local_values={local_param: write_val},
             )
             await self._refresh_related_entities()
 
@@ -480,7 +481,10 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             if not result.success:
                 raise HomeAssistantError(f"Failed to set {label}")
             inverter = self.coordinator.get_inverter_object(self.serial)
-            if inverter:
+            if inverter and not self.coordinator.is_transport_link_down(self.serial):
+                # Skipped on a down link: pylxpweb's parameter fetch has no
+                # link gate and the local reads would hang; the cache seed
+                # (local_values) converges the entity instead.
                 await inverter.refresh(force=True, include_parameters=True)
 
         with optimistic_value_context(self, value):
@@ -490,6 +494,7 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
                 label,
                 local_write=_local_write,
                 cloud_write=_cloud_write,
+                local_values={param_name: raw_value},
             )
             await self._refresh_related_entities()
 
@@ -705,7 +710,9 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
             if not result.success:
                 raise HomeAssistantError(f"Failed to set SOC limit to {int_value}%")
             inverter = self.coordinator.get_inverter_object(self.serial)
-            if inverter:
+            if inverter and not self.coordinator.is_transport_link_down(self.serial):
+                # Skipped on a down link: the local parameter reads would
+                # hang; the cache seed (local_values) converges the entity.
                 await inverter.refresh(force=True, include_parameters=True)
 
         with optimistic_value_context(self, value):
@@ -715,6 +722,7 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
                 f"system charge SOC limit to {int_value}%",
                 local_write=_local_write,
                 cloud_write=_cloud_write,
+                local_values={PARAM_HOLD_SYSTEM_CHARGE_SOC_LIMIT: int_value},
             )
             await self._refresh_related_entities()
 
@@ -1073,7 +1081,9 @@ class PVStartVoltageNumber(EG4BaseNumberEntity):
                     f"Failed to set PV start voltage to {int_value} V"
                 )
             inverter = self.coordinator.get_inverter_object(self.serial)
-            if inverter:
+            if inverter and not self.coordinator.is_transport_link_down(self.serial):
+                # Skipped on a down link: the local parameter reads would
+                # hang; the cache seed (local_values) converges the entity.
                 await inverter.refresh(force=True, include_parameters=True)
 
         with optimistic_value_context(self, value):
@@ -1083,6 +1093,7 @@ class PVStartVoltageNumber(EG4BaseNumberEntity):
                 f"PV start voltage to {int_value} V",
                 local_write=_local_write,
                 cloud_write=_cloud_write,
+                local_values={PARAM_HOLD_START_PV_VOLT: int_value * 10},
             )
             await self._refresh_related_entities()
 
@@ -1454,7 +1465,9 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
                 f"Failed to set start discharge power threshold to {watts} W"
             )
         inverter = self.coordinator.get_inverter_object(self.serial)
-        if inverter:
+        if inverter and not self.coordinator.is_transport_link_down(self.serial):
+            # Skipped on a down link: the local parameter reads would hang;
+            # _write_parameter's cache seed (local_values) converges the entity.
             await inverter.refresh(force=True, include_parameters=True)
 
 

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -407,7 +407,11 @@ class EG4PVInputModeSelect(CoordinatorEntity, SelectEntity):
                 if not result.success:
                     raise HomeAssistantError(f"Failed to set PV input mode to {option}")
                 inverter = self.coordinator.get_inverter_object(self._serial)
-                if inverter:
+                if inverter and not self.coordinator.is_transport_link_down(
+                    self._serial
+                ):
+                    # Skipped on a down link: the local parameter reads would
+                    # hang; the cache seed (local_values) converges the entity.
                     await inverter.refresh(force=True, include_parameters=True)
 
             await async_write_with_cloud_fallback(
@@ -416,6 +420,7 @@ class EG4PVInputModeSelect(CoordinatorEntity, SelectEntity):
                 f"PV input mode to {option}",
                 local_write=_local_write,
                 cloud_write=_cloud_write,
+                local_values={PARAM_HOLD_PV_INPUT_MODE: int_value},
             )
 
             _LOGGER.info(
@@ -686,7 +691,11 @@ class EG4BatteryControlModeSelect(CoordinatorEntity, SelectEntity):
                         f"Failed to set {self._control_name} to {option}"
                     )
                 inverter = self.coordinator.get_inverter_object(self._serial)
-                if inverter:
+                if inverter and not self.coordinator.is_transport_link_down(
+                    self._serial
+                ):
+                    # Skipped on a down link: the local parameter reads would
+                    # hang; the cache seed (local_values) converges the entity.
                     await inverter.refresh(force=True, include_parameters=True)
 
             await async_write_with_cloud_fallback(
@@ -695,6 +704,7 @@ class EG4BatteryControlModeSelect(CoordinatorEntity, SelectEntity):
                 f"{self._control_name} to {option}",
                 local_write=_local_write,
                 cloud_write=_cloud_write,
+                local_values={self._param_key: voltage_mode},
             )
 
             self._optimistic_state = None

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -28,6 +28,7 @@ from .const import (
 from .coordinator import EG4DataUpdateCoordinator
 from .base_entity import _get_model_from_coordinator
 from .utils import (
+    async_write_with_cloud_fallback,
     create_device_info,
     generate_entity_id,
     generate_unique_id,
@@ -387,14 +388,20 @@ class EG4PVInputModeSelect(CoordinatorEntity, SelectEntity):
             self._optimistic_state = option
             self.async_write_ha_state()
 
-            if self.coordinator.has_local_transport(self._serial):
+            async def _local_write() -> None:
                 # Local Modbus: write register value directly
                 await self.coordinator.write_named_parameter(
                     PARAM_HOLD_PV_INPUT_MODE, int_value, serial=self._serial
                 )
-            elif self.coordinator.client is not None:
+
+            async def _cloud_write() -> None:
                 # Cloud API: write via generic parameter write
-                result = await self.coordinator.client.api.control.write_parameter(
+                client = self.coordinator.client
+                if client is None:
+                    raise HomeAssistantError(
+                        "No local transport or cloud API available for parameter write."
+                    )
+                result = await client.api.control.write_parameter(
                     self._serial, "HOLD_PV_INPUT_MODE", str(int_value)
                 )
                 if not result.success:
@@ -402,10 +409,14 @@ class EG4PVInputModeSelect(CoordinatorEntity, SelectEntity):
                 inverter = self.coordinator.get_inverter_object(self._serial)
                 if inverter:
                     await inverter.refresh(force=True, include_parameters=True)
-            else:
-                raise HomeAssistantError(
-                    "No local transport or cloud API available for parameter write."
-                )
+
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self._serial,
+                f"PV input mode to {option}",
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
 
             _LOGGER.info(
                 "Successfully set PV input mode to %s for device %s",
@@ -515,24 +526,34 @@ class EG4SmartPortModeSelect(CoordinatorEntity, SelectEntity):
             self._optimistic_state = option
             self.async_write_ha_state()
 
-            if self.coordinator.has_local_transport(self._serial):
+            async def _local_write() -> None:
                 await self.coordinator.write_named_parameter(
                     f"BIT_MIDBOX_SP_MODE_{self._port}",
                     int_value,
                     serial=self._serial,
                 )
-            elif self.coordinator.client is not None:
-                result = await self.coordinator.client.api.control.set_smart_port_mode(
+
+            async def _cloud_write() -> None:
+                client = self.coordinator.client
+                if client is None:
+                    raise HomeAssistantError(
+                        "No local transport or cloud API available for parameter write."
+                    )
+                result = await client.api.control.set_smart_port_mode(
                     self._serial, self._port, int_value
                 )
                 if not result.success:
                     raise HomeAssistantError(
                         f"Failed to set smart port {self._port} mode to {option}"
                     )
-            else:
-                raise HomeAssistantError(
-                    "No local transport or cloud API available for parameter write."
-                )
+
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self._serial,
+                f"smart port {self._port} mode to {option}",
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
 
             _LOGGER.info(
                 "Successfully set smart port %d mode to %s for device %s",
@@ -646,12 +667,18 @@ class EG4BatteryControlModeSelect(CoordinatorEntity, SelectEntity):
             self._optimistic_state = option
             self.async_write_ha_state()
 
-            if self.coordinator.has_local_transport(self._serial):
+            async def _local_write() -> None:
                 await self.coordinator.write_named_parameter(
                     self._param_key, voltage_mode, serial=self._serial
                 )
-            elif self.coordinator.client is not None:
-                result = await self.coordinator.client.api.control.control_function(
+
+            async def _cloud_write() -> None:
+                client = self.coordinator.client
+                if client is None:
+                    raise HomeAssistantError(
+                        "No local transport or cloud API available for parameter write."
+                    )
+                result = await client.api.control.control_function(
                     self._serial, self._param_key, voltage_mode
                 )
                 if not result.success:
@@ -661,10 +688,14 @@ class EG4BatteryControlModeSelect(CoordinatorEntity, SelectEntity):
                 inverter = self.coordinator.get_inverter_object(self._serial)
                 if inverter:
                     await inverter.refresh(force=True, include_parameters=True)
-            else:
-                raise HomeAssistantError(
-                    "No local transport or cloud API available for parameter write."
-                )
+
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self._serial,
+                f"{self._control_name} to {option}",
+                local_write=_local_write,
+                cloud_write=_cloud_write,
+            )
 
             self._optimistic_state = None
             # The inverter firmware syncs the battery control regime across the

--- a/custom_components/eg4_web_monitor/time.py
+++ b/custom_components/eg4_web_monitor/time.py
@@ -305,7 +305,15 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
                 cloud_write=lambda: self._async_write_cloud(boundary_value),
             )
             write_ok = True
-            refresh_ok = await self._async_refresh_parameters()
+            if self.coordinator.is_transport_link_down(self.serial):
+                # The packed register cannot be re-read on a dead link (and
+                # refresh_all_device_parameters skips this serial). Leave
+                # refresh_ok False so the optimistic value is RETAINED —
+                # the acknowledged cloud write IS device truth — until
+                # fresh parameter data arrives on link recovery.
+                refresh_ok = False
+            else:
+                refresh_ok = await self._async_refresh_parameters()
         finally:
             if not write_ok or refresh_ok:
                 # Write failed (entity falls back to the parameter cache —
@@ -369,7 +377,9 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         device holds a mixed schedule time. A best-effort parameter refresh
         (its own errors suppressed) re-reads the device so the entity shows
         the actual (mixed) state once the optimistic value is dropped by
-        the caller's failure path.
+        the caller's failure path. Skipped while the local transport link
+        is down — the re-read would hang on the dead link; the cloud param
+        poll or link recovery converges the entity later.
         """
         _LOGGER.warning(
             "Cloud schedule write for %s partially applied (%s failed%s); "
@@ -378,7 +388,8 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
             failed_param,
             f": {err}" if err else "",
         )
-        await self._async_refresh_parameters()
+        if not self.coordinator.is_transport_link_down(self.serial):
+            await self._async_refresh_parameters()
         raise HomeAssistantError(
             f"Failed to set {failed_param} for {self.serial}: the schedule "
             "time may be partially applied (hour and minute are written "

--- a/custom_components/eg4_web_monitor/time.py
+++ b/custom_components/eg4_web_monitor/time.py
@@ -48,7 +48,11 @@ from . import EG4ConfigEntry
 from .base_entity import EG4BaseTime
 from .const import SCHEDULE_TIME_TYPES, ScheduleTimeSpec
 from .coordinator import EG4DataUpdateCoordinator
-from .utils import is_offgrid_family, is_supported_control_model
+from .utils import (
+    async_write_with_cloud_fallback,
+    is_offgrid_family,
+    is_supported_control_model,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -287,16 +291,19 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         write_ok = False
         refresh_ok = False
         try:
-            if self.coordinator.has_local_transport(self.serial):
+
+            async def _local_write() -> None:
                 await self.coordinator.write_register(
                     self._register, packed, serial=self.serial
                 )
-            elif self.coordinator.client is not None:
-                await self._async_write_cloud(boundary_value)
-            else:
-                raise HomeAssistantError(
-                    "No local transport or cloud API available for parameter write."
-                )
+
+            await async_write_with_cloud_fallback(
+                self.coordinator,
+                self.serial,
+                f"{self._spec.key} schedule time",
+                local_write=_local_write,
+                cloud_write=lambda: self._async_write_cloud(boundary_value),
+            )
             write_ok = True
             refresh_ok = await self._async_refresh_parameters()
         finally:

--- a/custom_components/eg4_web_monitor/utils.py
+++ b/custom_components/eg4_web_monitor/utils.py
@@ -52,6 +52,7 @@ async def async_write_with_cloud_fallback(
     *,
     local_write: Callable[[], Awaitable[Any]],
     cloud_write: Callable[[], Awaitable[Any]] | None = None,
+    local_values: dict[str, Any] | None = None,
 ) -> None:
     """Attempt a local register write, falling back to the cloud API.
 
@@ -82,11 +83,21 @@ async def async_write_with_cloud_fallback(
         cloud_write: Coroutine factory performing the equivalent cloud write,
             or None when the action has no cloud path (raw-register-only
             controls) — local errors then propagate unchanged.
+        local_values: The written parameters in the LOCAL-RAW representation
+            the attached-transport cache uses. When the write lands via the
+            cloud path while a local transport is attached, these are merged
+            into the coordinator's parameter cache
+            (:meth:`EG4DataUpdateCoordinator.note_parameters_written`) so the
+            entity converges on the written value — the follow-up local
+            parameter refresh is skipped on a down link, and without the
+            seed the entity would revert to the stale pre-write cache value
+            once its optimistic state clears.
 
     Raises:
         HomeAssistantError: If all available write paths fail, or none exist.
     """
-    if coordinator.has_local_transport(serial):
+    local_attached = coordinator.has_local_transport(serial)
+    if local_attached:
         cloud_available = cloud_write is not None and coordinator.has_http_api()
         if cloud_available and coordinator.is_transport_link_down(serial):
             _LOGGER.warning(
@@ -110,6 +121,12 @@ async def async_write_with_cloud_fallback(
                 )
     if cloud_write is not None and coordinator.has_http_api():
         await cloud_write()
+        if local_attached and local_values:
+            # Cloud fallback with an attached local transport: seed the
+            # (local-raw) parameter cache with the acknowledged write so
+            # the entity shows the new value even though the local param
+            # re-read is skipped/unreliable while the link is down.
+            coordinator.note_parameters_written(serial, local_values)
         return
     raise HomeAssistantError(
         "No local transport or cloud API available for parameter write."

--- a/custom_components/eg4_web_monitor/utils.py
+++ b/custom_components/eg4_web_monitor/utils.py
@@ -2,14 +2,18 @@
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .coordinator import EG4DataUpdateCoordinator
 
 from .const import (
     BATTERY_KEY_PREFIX,
@@ -39,6 +43,77 @@ CONTROL_CAPABLE_FAMILIES: frozenset[str] = frozenset(
         INVERTER_FAMILY_LXP,
     }
 )
+
+
+async def async_write_with_cloud_fallback(
+    coordinator: "EG4DataUpdateCoordinator",
+    serial: str,
+    action_name: str,
+    *,
+    local_write: Callable[[], Awaitable[Any]],
+    cloud_write: Callable[[], Awaitable[Any]] | None = None,
+) -> None:
+    """Attempt a local register write, falling back to the cloud API.
+
+    The non-switch counterpart of ``EG4BaseSwitch._execute_local_with_fallback``:
+    time/number/select controls used to choose the local write path purely on
+    transport ATTACHMENT, but pylxpweb keeps the transport attached while the
+    link is down (``transport_link_down`` — reads keep probing every cycle).
+    In HYBRID mode with a down local link and a healthy cloud, those writes
+    raised without ever trying their cloud branch, while switches fell back.
+
+    Semantics:
+
+    - Local transport attached, link believed up: try ``local_write`` first;
+      on ``HomeAssistantError`` retry via ``cloud_write`` when a cloud client
+      exists (both paths set absolute state, so a double-write is safe).
+      Without a cloud client the local error propagates unchanged, so
+      LOCAL-only installs keep their existing error behavior.
+    - Local transport attached but pylxpweb reports the link DOWN: go straight
+      to the cloud instead of waiting out a doomed Modbus timeout. Reads keep
+      probing the link each poll cycle, so recovery re-enables local writes.
+    - No local transport: cloud path, or the standard no-transport error.
+
+    Args:
+        coordinator: The data update coordinator (transport + cloud access).
+        serial: Device serial number the write targets.
+        action_name: Human-readable action label for log messages.
+        local_write: Coroutine factory performing the local register write.
+        cloud_write: Coroutine factory performing the equivalent cloud write,
+            or None when the action has no cloud path (raw-register-only
+            controls) — local errors then propagate unchanged.
+
+    Raises:
+        HomeAssistantError: If all available write paths fail, or none exist.
+    """
+    if coordinator.has_local_transport(serial):
+        cloud_available = cloud_write is not None and coordinator.has_http_api()
+        if cloud_available and coordinator.is_transport_link_down(serial):
+            _LOGGER.warning(
+                "Local transport link is down for device %s; writing %s via "
+                "the cloud API",
+                serial,
+                action_name,
+            )
+        else:
+            try:
+                await local_write()
+                return
+            except HomeAssistantError:
+                if not cloud_available:
+                    raise
+                _LOGGER.warning(
+                    "Local transport write failed for %s on device %s, "
+                    "falling back to cloud API",
+                    action_name,
+                    serial,
+                )
+    if cloud_write is not None and coordinator.has_http_api():
+        await cloud_write()
+        return
+    raise HomeAssistantError(
+        "No local transport or cloud API available for parameter write."
+    )
 
 
 def is_supported_control_model(device_data: dict[str, Any]) -> bool:

--- a/tests/test_battery_control_mode.py
+++ b/tests/test_battery_control_mode.py
@@ -47,6 +47,7 @@ def _mock_coordinator(
     coordinator = MagicMock()
     coordinator.has_local_transport = MagicMock(return_value=has_local)
     coordinator.has_http_api = MagicMock(return_value=not has_local)
+    coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.is_local_only = MagicMock(return_value=has_local)
     coordinator.last_update_success = True
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2949,6 +2949,49 @@ class TestBatteryControlModeMethods:
 
         coordinator._refresh_device_parameters.assert_awaited_once_with("INV001")
 
+    async def test_battery_control_mode_partial_write_link_down_seeds_charge_bit(
+        self, hass, local_config_entry
+    ):
+        """HYBRID link-down partial write: the re-read is impossible (gated),
+        so the KNOWN-succeeded charge bit is seeded into the cache — the
+        failed discharge bit stays untouched (device still holds its old
+        value) — while the error still surfaces (codex medium on PR #301)."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        coordinator.data = {
+            "parameters": {
+                "INV001": {
+                    "FUNC_BAT_CHARGE_CONTROL": False,
+                    "FUNC_BAT_DISCHARGE_CONTROL": False,
+                }
+            }
+        }
+        coordinator.async_update_listeners = MagicMock()
+        ok = MagicMock()
+        ok.success = True
+        failed = MagicMock()
+        failed.success = False
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.control_function = AsyncMock(
+            side_effect=[ok, failed]
+        )
+        coordinator._refresh_device_parameters = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="partially applied"):
+            await coordinator.async_write_battery_control_mode(
+                "INV001", "voltage", "voltage"
+            )
+
+        # Re-read skipped (link down), succeeded charge bit seeded, failed
+        # discharge bit unchanged (pre-write cache value).
+        coordinator._refresh_device_parameters.assert_not_awaited()
+        params = coordinator.data["parameters"]["INV001"]
+        assert params["FUNC_BAT_CHARGE_CONTROL"] is True
+        assert params["FUNC_BAT_DISCHARGE_CONTROL"] is False
+        coordinator.async_update_listeners.assert_called_once()
+
 
 class TestLinkDownParameterRefreshGate:
     """Parameter refreshes must skip attached-but-dead links (codex P1 on

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2859,6 +2859,46 @@ class TestBatteryControlModeMethods:
         assert calls[0][0] == ("INV001", "FUNC_BAT_CHARGE_CONTROL", False)
         assert calls[1][0] == ("INV001", "FUNC_BAT_DISCHARGE_CONTROL", True)
 
+    async def test_async_write_battery_control_mode_hybrid_fallback(
+        self, hass, local_config_entry
+    ):
+        """HYBRID: a failed local write falls back to the cloud
+        function-control API instead of raising (switch parity)."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        result = MagicMock()
+        result.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.control_function = AsyncMock(return_value=result)
+
+        await coordinator.async_write_battery_control_mode("INV001", "voltage", "soc")
+
+        coordinator.write_named_parameter.assert_awaited_once()
+        calls = coordinator.client.api.control.control_function.call_args_list
+        assert calls[0][0] == ("INV001", "FUNC_BAT_CHARGE_CONTROL", True)
+        assert calls[1][0] == ("INV001", "FUNC_BAT_DISCHARGE_CONTROL", False)
+
+    async def test_async_write_battery_control_mode_local_only_failure_raises(
+        self, hass, local_config_entry
+    ):
+        """LOCAL-only: no cloud client -> the local write error propagates."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        coordinator.client = None
+
+        with pytest.raises(HomeAssistantError, match="timeout"):
+            await coordinator.async_write_battery_control_mode(
+                "INV001", "voltage", "soc"
+            )
+
 
 # ── Transport link-down flow (eg4-57g / #226 attached-but-dead) ──────
 

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -2899,6 +2899,139 @@ class TestBatteryControlModeMethods:
                 "INV001", "voltage", "soc"
             )
 
+    async def test_battery_control_mode_partial_cloud_write_converges(
+        self, hass, local_config_entry
+    ):
+        """Cloud two-bit write: charge bit lands, discharge bit fails ->
+        device parameters are re-read (best effort) BEFORE the error
+        propagates, so entities reflect the actual (mixed) reg-179 regime
+        (same pattern as the schedule time partial hour/minute writes)."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=False)
+        ok = MagicMock()
+        ok.success = True
+        failed = MagicMock()
+        failed.success = False
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.control_function = AsyncMock(
+            side_effect=[ok, failed]
+        )
+        coordinator._refresh_device_parameters = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="partially applied"):
+            await coordinator.async_write_battery_control_mode(
+                "INV001", "voltage", "soc"
+            )
+
+        coordinator._refresh_device_parameters.assert_awaited_once_with("INV001")
+
+    async def test_battery_control_mode_partial_cloud_exception_converges(
+        self, hass, local_config_entry
+    ):
+        """A raised exception on the discharge-bit write converges the same
+        way (re-read then raise)."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=False)
+        ok = MagicMock()
+        ok.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.control_function = AsyncMock(
+            side_effect=[ok, RuntimeError("connection reset")]
+        )
+        coordinator._refresh_device_parameters = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="partially applied"):
+            await coordinator.async_write_battery_control_mode(
+                "INV001", "voltage", "soc"
+            )
+
+        coordinator._refresh_device_parameters.assert_awaited_once_with("INV001")
+
+
+class TestLinkDownParameterRefreshGate:
+    """Parameter refreshes must skip attached-but-dead links (codex P1 on
+    PR #301): pylxpweb's parameter fetch has no transport_link_down gate
+    (unlike runtime/energy/battery), so a local param read on a down link
+    hangs for minutes (Python 3.11 asyncio.wait_for cannot interrupt
+    in-flight pymodbus reads)."""
+
+    @staticmethod
+    def _fake_inverter(*, link_down: bool, parameters: dict | None = None):
+        inv = MagicMock()
+        inv.transport = object()
+        inv.transport_link_down = link_down
+        inv.refresh = AsyncMock()
+        inv.parameters = parameters or {}
+        return inv
+
+    async def test_refresh_all_skips_only_down_link_serials(
+        self, hass, local_config_entry
+    ):
+        """refresh_all_device_parameters: the down serial is skipped, the
+        healthy sibling is still refreshed."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        down = self._fake_inverter(link_down=True)
+        up = self._fake_inverter(link_down=False, parameters={"HOLD_X": 1})
+        coordinator._inverter_cache = {"DOWN1": down, "UP1": up}
+        coordinator.data = {
+            "devices": {
+                "DOWN1": {"type": "inverter"},
+                "UP1": {"type": "inverter"},
+            }
+        }
+
+        await coordinator.refresh_all_device_parameters()
+
+        down.refresh.assert_not_awaited()
+        up.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+        assert coordinator.data["parameters"]["UP1"] == {"HOLD_X": 1}
+
+    async def test_async_refresh_device_parameters_skips_down_link(
+        self, hass, local_config_entry
+    ):
+        """The single-serial public refresh path is gated the same way."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        down = self._fake_inverter(link_down=True)
+        coordinator._inverter_cache = {"DOWN1": down}
+        coordinator.data = {"devices": {"DOWN1": {"type": "inverter"}}}
+        coordinator.async_request_refresh = AsyncMock()
+
+        await coordinator.async_refresh_device_parameters("DOWN1")
+
+        down.refresh.assert_not_awaited()
+
+    async def test_note_parameters_written_merges_and_notifies(
+        self, hass, local_config_entry
+    ):
+        """Acknowledged written values merge into the cache and notify
+        listeners (entity convergence after a skipped local re-read)."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.data = {"parameters": {"INV001": {"HOLD_A": 1}}}
+        coordinator.async_update_listeners = MagicMock()
+
+        coordinator.note_parameters_written("INV001", {"HOLD_B": 2})
+
+        assert coordinator.data["parameters"]["INV001"] == {"HOLD_A": 1, "HOLD_B": 2}
+        coordinator.async_update_listeners.assert_called_once()
+
+    async def test_note_parameters_written_no_data_is_noop(
+        self, hass, local_config_entry
+    ):
+        """Before the first refresh (data=None) the seed is a no-op."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.data = None
+        coordinator.async_update_listeners = MagicMock()
+
+        coordinator.note_parameters_written("INV001", {"HOLD_B": 2})
+
+        coordinator.async_update_listeners.assert_not_called()
+
 
 # ── Transport link-down flow (eg4-57g / #226 attached-but-dead) ──────
 

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -745,6 +745,64 @@ class TestHybridCloudFallback:
         inverter.set_ac_charge_soc_limit.assert_called_once_with(soc_percent=75)
 
     @pytest.mark.asyncio
+    async def test_link_down_write_skips_local_param_refresh_and_seeds_cache(self):
+        """Known-down link: the cloud write must NOT be followed by a local
+        parameter read (pylxpweb's param fetch has no link gate and would
+        hang); instead the acknowledged value is seeded into the cache so
+        the entity converges on the written value, not the stale pre-write
+        cache (codex P1 on PR #301)."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        result = MagicMock()
+        result.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.set_system_charge_soc_limit = AsyncMock(
+            return_value=result
+        )
+        entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(90.0)
+
+        coordinator.write_named_parameter.assert_not_awaited()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.refresh.assert_not_awaited()
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90}
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_write_seeds_cache_with_local_raw_value(self):
+        """Attempt-then-fallback (link not yet flagged down): the cloud
+        write also seeds the local-raw cache so a failed follow-up local
+        read cannot revert the entity (#282 carry-forward keeps the seed)."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(80.0)
+
+        coordinator.note_parameters_written.assert_called_once()
+        serial_arg, values = coordinator.note_parameters_written.call_args[0]
+        assert serial_arg == "1234567890"
+        assert list(values.values()) == [80]
+
+    @pytest.mark.asyncio
+    async def test_cloud_only_write_does_not_seed_cache(self):
+        """Pure-cloud (no local transport): no seeding — the cloud param
+        cache is refreshed normally and uses cloud-scaled values."""
+        coordinator = _mock_coordinator(has_local=False, has_http=True)
+        entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(80.0)
+
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_system_charge_soc_local_failure_falls_back_to_cloud(self):
         """Inline 3-way site (system charge SOC): cloud API branch used."""
         coordinator = _mock_coordinator(has_local=True, has_http=True)

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -55,6 +55,7 @@ def _mock_coordinator(
         return_value=(has_local or local_only)
     )
     coordinator.has_http_api = MagicMock(return_value=has_http)
+    coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.is_local_only = MagicMock(return_value=local_only)
     coordinator.last_update_success = True
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
@@ -690,6 +691,81 @@ class TestWriteParameter:
         entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
         assert entity.native_min_value == 0
         assert entity.native_max_value == 101
+
+
+class TestHybridCloudFallback:
+    """HYBRID number writes fall back to the cloud when the local write
+    fails (switch parity — pylxpweb keeps the transport attached while the
+    link is down, so attachment alone must not pin the local path)."""
+
+    @pytest.mark.asyncio
+    async def test_write_parameter_local_failure_falls_back_to_cloud(self):
+        """_write_parameter: local raises -> inverter cloud method used."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(80.0)
+
+        coordinator.write_named_parameter.assert_awaited_once()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_ac_charge_soc_limit.assert_called_once_with(soc_percent=80)
+
+    @pytest.mark.asyncio
+    async def test_write_parameter_local_only_failure_still_raises(self):
+        """LOCAL-only: no cloud client -> the local error propagates."""
+        coordinator = _mock_coordinator(has_local=True, has_http=False)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        with pytest.raises(HomeAssistantError, match="timeout"):
+            await entity.async_set_native_value(80.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_ac_charge_soc_limit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_parameter_link_down_prefers_cloud_immediately(self):
+        """Known-down link: the doomed local write is skipped entirely."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        entity = ACChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(75.0)
+
+        coordinator.write_named_parameter.assert_not_awaited()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_ac_charge_soc_limit.assert_called_once_with(soc_percent=75)
+
+    @pytest.mark.asyncio
+    async def test_system_charge_soc_local_failure_falls_back_to_cloud(self):
+        """Inline 3-way site (system charge SOC): cloud API branch used."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        result = MagicMock()
+        result.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.set_system_charge_soc_limit = AsyncMock(
+            return_value=result
+        )
+        entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(90.0)
+
+        coordinator.write_named_parameter.assert_awaited_once()
+        coordinator.client.api.control.set_system_charge_soc_limit.assert_called_once_with(
+            "1234567890", 90
+        )
 
 
 class TestACChargePowerWrite:

--- a/tests/test_select_entities.py
+++ b/tests/test_select_entities.py
@@ -9,6 +9,7 @@ from pylxpweb import OperatingMode
 from custom_components.eg4_web_monitor.select import (
     async_setup_entry,
     EG4OperatingModeSelect,
+    EG4PVInputModeSelect,
     EG4SmartPortModeSelect,
     OPERATING_MODE_OPTIONS,
     SMART_PORT_MODE_OPTIONS,
@@ -27,6 +28,8 @@ def _mock_coordinator(
     """Build a mock EG4DataUpdateCoordinator for select tests."""
     coordinator = MagicMock()
     coordinator.last_update_success = True
+    coordinator.has_http_api = MagicMock(return_value=True)
+    coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.async_refresh_device_parameters = AsyncMock()
 
@@ -235,6 +238,8 @@ def _mock_gridboss_coordinator(
     """Build a mock coordinator with a GridBOSS device for smart port tests."""
     coordinator = MagicMock()
     coordinator.last_update_success = True
+    coordinator.has_http_api = MagicMock(return_value=True)
+    coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.async_request_refresh = AsyncMock()
     coordinator.write_named_parameter = AsyncMock()
@@ -411,6 +416,7 @@ class TestSmartPortModeSelect:
         """No transport raises HomeAssistantError."""
         coordinator = _mock_gridboss_coordinator()
         coordinator.has_local_transport = MagicMock(return_value=False)
+        coordinator.has_http_api = MagicMock(return_value=False)
         coordinator.client = None
         device_data = coordinator.data["devices"]["gb123"]
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
@@ -420,3 +426,94 @@ class TestSmartPortModeSelect:
 
         with pytest.raises(HomeAssistantError, match="No local transport"):
             await select.async_select_option("Smart Load")
+
+    @pytest.mark.asyncio
+    async def test_select_hybrid_local_failure_falls_back_to_cloud(self):
+        """HYBRID: local write fails -> cloud set_smart_port_mode used."""
+        coordinator = _mock_gridboss_coordinator()
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        result_mock = MagicMock()
+        result_mock.success = True
+        coordinator.client.api.control.set_smart_port_mode = AsyncMock(
+            return_value=result_mock
+        )
+        device_data = coordinator.data["devices"]["gb123"]
+        select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=2)
+        select.hass = MagicMock()
+        select.entity_id = "select.test_smart_port_2_mode"
+        select.async_write_ha_state = MagicMock()
+
+        await select.async_select_option("AC Couple")
+
+        coordinator.write_named_parameter.assert_awaited_once()
+        coordinator.client.api.control.set_smart_port_mode.assert_called_once_with(
+            "gb123", 2, 2
+        )
+
+
+class TestPVInputModeSelectFallback:
+    """PV input mode writes: local path, HYBRID cloud fallback, LOCAL-only
+    error propagation (GH hybrid link-down parity with switches)."""
+
+    def _select(self, coordinator) -> EG4PVInputModeSelect:
+        device_data = coordinator.data["devices"]["1234567890"]
+        select = EG4PVInputModeSelect(coordinator, "1234567890", device_data)
+        select.hass = MagicMock()
+        select.entity_id = "select.test_pv_input_mode"
+        select.async_write_ha_state = MagicMock()
+        return select
+
+    @pytest.mark.asyncio
+    async def test_local_write_success(self):
+        """Local path writes the named register parameter."""
+        coordinator = _mock_coordinator()
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock()
+        select = self._select(coordinator)
+
+        await select.async_select_option("PV1 & PV2")
+
+        coordinator.write_named_parameter.assert_awaited_once_with(
+            "HOLD_PV_INPUT_MODE", 4, serial="1234567890"
+        )
+
+    @pytest.mark.asyncio
+    async def test_hybrid_local_failure_falls_back_to_cloud(self):
+        """HYBRID: local write fails -> cloud write_parameter used."""
+        coordinator = _mock_coordinator()
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        result_mock = MagicMock()
+        result_mock.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.write_parameter = AsyncMock(
+            return_value=result_mock
+        )
+        select = self._select(coordinator)
+
+        await select.async_select_option("PV1")
+
+        coordinator.write_named_parameter.assert_awaited_once()
+        coordinator.client.api.control.write_parameter.assert_called_once_with(
+            "1234567890", "HOLD_PV_INPUT_MODE", "1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_local_only_failure_still_raises(self):
+        """LOCAL-only: no cloud client -> the local error propagates."""
+        coordinator = _mock_coordinator()
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.has_http_api = MagicMock(return_value=False)
+        coordinator.client = None
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write parameter: timeout")
+        )
+        select = self._select(coordinator)
+
+        with pytest.raises(HomeAssistantError, match="timeout"):
+            await select.async_select_option("PV1")

--- a/tests/test_select_entities.py
+++ b/tests/test_select_entities.py
@@ -517,3 +517,33 @@ class TestPVInputModeSelectFallback:
 
         with pytest.raises(HomeAssistantError, match="timeout"):
             await select.async_select_option("PV1")
+
+    @pytest.mark.asyncio
+    async def test_link_down_skips_local_write_and_param_refresh_seeds_cache(self):
+        """Known-down link: the local write AND the follow-up local
+        parameter read are both skipped (pylxpweb's param fetch has no link
+        gate and would hang, codex P1 on PR #301); the acknowledged cloud
+        value is seeded into the cache so the entity converges."""
+        coordinator = _mock_coordinator()
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        coordinator.write_named_parameter = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.write_parameter = AsyncMock(
+            return_value=result_mock
+        )
+        select = self._select(coordinator)
+
+        await select.async_select_option("PV2")
+
+        coordinator.write_named_parameter.assert_not_awaited()
+        coordinator.client.api.control.write_parameter.assert_called_once_with(
+            "1234567890", "HOLD_PV_INPUT_MODE", "2"
+        )
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.refresh.assert_not_awaited()
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {"HOLD_PV_INPUT_MODE": 2}
+        )

--- a/tests/test_time_entities.py
+++ b/tests/test_time_entities.py
@@ -822,6 +822,28 @@ class TestWritePaths:
         coordinator.write_register.assert_not_awaited()
         assert coordinator.client.api.control.write_parameter.await_count == 2
 
+    @pytest.mark.asyncio
+    async def test_link_down_write_skips_param_refresh_and_retains_optimistic(self):
+        """Known-down link: the post-write parameter refresh must NOT run
+        (pylxpweb's param fetch has no link gate — the local reads would
+        hang, codex P1 on PR #301); the optimistic value is RETAINED — the
+        acknowledged cloud write is device truth — until fresh parameter
+        data arrives on link recovery."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            parameters={"HOLD_AC_CHARGE_START_HOUR_1": _pack(8, 0)},
+        )
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        entity = _entity(coordinator, window=1, is_end=False)
+        _prep(entity)
+
+        await entity.async_set_value(time(20, 30))
+
+        coordinator.write_register.assert_not_awaited()
+        coordinator.refresh_all_device_parameters.assert_not_awaited()
+        assert entity._optimistic_retained is True
+        assert entity.native_value == time(20, 30)
+
     @pytest.mark.parametrize("schedule", SCHEDULE_KEYS)
     @pytest.mark.asyncio
     async def test_midnight_crossing_end_before_start_is_allowed(self, schedule):

--- a/tests/test_time_entities.py
+++ b/tests/test_time_entities.py
@@ -55,6 +55,8 @@ def _mock_coordinator(
     """Build a mock coordinator for time entity tests."""
     coordinator = MagicMock()
     coordinator.has_local_transport = MagicMock(return_value=has_local)
+    coordinator.has_http_api = MagicMock(return_value=has_client)
+    coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.is_local_only = MagicMock(return_value=local_only)
     coordinator.last_update_success = True
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
@@ -767,6 +769,59 @@ class TestWritePaths:
         with pytest.raises(HomeAssistantError):
             await entity.async_set_value(time(8, 0))
 
+    @pytest.mark.asyncio
+    async def test_hybrid_local_write_failure_falls_back_to_cloud(self):
+        """HYBRID: transport attached but the register write fails (e.g.
+        transport_link_down Modbus timeout) -> the cloud named-parameter
+        branch is used and the service call succeeds (switch parity)."""
+        coordinator = _mock_coordinator(has_local=True)
+        coordinator.write_register = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write register 68: timeout")
+        )
+        entity = _entity(coordinator, window=1, is_end=False)
+        _prep(entity)
+
+        await entity.async_set_value(time(8, 15))
+
+        coordinator.write_register.assert_awaited_once()
+        calls = coordinator.client.api.control.write_parameter.await_args_list
+        assert [c.args for c in calls] == [
+            ("1234567890", "HOLD_AC_CHARGE_START_HOUR", "8"),
+            ("1234567890", "HOLD_AC_CHARGE_START_MINUTE", "15"),
+        ]
+        coordinator.refresh_all_device_parameters.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_local_only_write_failure_still_raises(self):
+        """LOCAL-only: no cloud to fall back to -> the local error propagates."""
+        coordinator = _mock_coordinator(
+            has_local=True, has_client=False, local_only=True
+        )
+        coordinator.write_register = AsyncMock(
+            side_effect=HomeAssistantError("Failed to write register 68: timeout")
+        )
+        entity = _entity(coordinator, window=1, is_end=False)
+        _prep(entity)
+
+        with pytest.raises(HomeAssistantError, match="register 68"):
+            await entity.async_set_value(time(8, 15))
+
+        coordinator.write_register.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_known_link_down_prefers_cloud_immediately(self):
+        """HYBRID with pylxpweb reporting transport_link_down: the doomed
+        local write is skipped entirely and the cloud is used directly."""
+        coordinator = _mock_coordinator(has_local=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        entity = _entity(coordinator, window=1, is_end=False)
+        _prep(entity)
+
+        await entity.async_set_value(time(20, 30))
+
+        coordinator.write_register.assert_not_awaited()
+        assert coordinator.client.api.control.write_parameter.await_count == 2
+
     @pytest.mark.parametrize("schedule", SCHEDULE_KEYS)
     @pytest.mark.asyncio
     async def test_midnight_crossing_end_before_start_is_allowed(self, schedule):
@@ -1046,10 +1101,13 @@ class TestWriteFailureConvergence:
 
     @pytest.mark.asyncio
     async def test_local_write_failure_clears_optimistic(self):
-        """A failed LOCAL write (single register, no partial state) drops the
-        optimistic value and keeps the cached time."""
+        """A failed LOCAL-only write (single register, no partial state, no
+        cloud to fall back to) drops the optimistic value and keeps the
+        cached time. With a cloud client the same failure falls back to the
+        cloud instead (TestWritePaths hybrid fallback tests)."""
         coordinator = _mock_coordinator(
             has_local=True,
+            has_client=False,
             parameters={"HOLD_AC_CHARGE_START_HOUR_1": _pack(8, 0)},
         )
         coordinator.write_register = AsyncMock(


### PR DESCRIPTION
## Verification (claim CONFIRMED)

- pylxpweb `devices/base.py:220-229` (`transport_link_down` docstring): *"The transport stays attached and reads keep being attempted every refresh cycle"* — so during a link-down outage the transport object remains on the inverter.
- `coordinator_local.py:2766` `get_local_transport()` returns `inverter.transport` regardless of link state; `has_local_transport()` (2804) is pure attachment.
- The local-vs-cloud branch was `if has_local_transport(): local ... elif client: cloud` at:
  - `time.py:290` (schedule boundary writes)
  - `number.py:406/438` (`_write_parameter` / `_write_voltage_register`) plus inline sites (system charge SOC 653, PV start voltage 1005, start-discharge threshold 1416)
  - `select.py:390/518/649` (PV input mode, smart port mode, battery control mode)
  - `coordinator.py:977` (`async_write_battery_control_mode`)
- A failed local write raises `HomeAssistantError` from `write_register`/`write_named_parameter` (coordinator.py:819/905) and the `elif` cloud branch is never reached.
- Switches route through `EG4BaseSwitch._execute_local_with_fallback()` (base_entity.py:1168-1203), which catches the local `HomeAssistantError` and retries via cloud — confirming the asymmetry: with a down local link and a healthy cloud, flipping a switch worked but schedule/number/select writes failed until the link recovered.

## Root cause

Control write-path selection keyed on transport **attachment**, but attachment is intentionally sticky across link outages in pylxpweb. Attachment ≠ link health.

## Fix

New shared helper `utils.async_write_with_cloud_fallback(coordinator, serial, action_name, *, local_write, cloud_write)` giving time/number/select/coordinator writes the same semantics switches get from `_execute_local_with_fallback()`:

- **Local attempt first**; on `HomeAssistantError`, retry via the cloud path when a cloud client exists (both paths set absolute state — double-write safe).
- **Known-down link short-circuit**: new `coordinator.is_transport_link_down(serial)` (duck-typed `getattr(device, "transport_link_down", False)` — reliable public pylxpweb property, inert on older versions and MID devices without it) prefers the cloud immediately instead of waiting out a doomed Modbus timeout.
- **LOCAL-only**: no cloud client → the original local error propagates unchanged (same error type/message users see today).
- **CLOUD-only**: unchanged (same cloud branches, same `"No local transport or cloud API available for parameter write."` when neither exists).
- On successful cloud fallback, each site's existing post-write refresh/optimistic handling runs exactly as its cloud branch always did (matching switch behavior).

Converted sites: `time.py` schedule writes; `number.py` `_write_parameter`/`_write_voltage_register` (covers AC/PV charge power, SOC limits, currents, voltage limits, forced-discharge, grid sell-back, peak shaving), system-charge-SOC, PV-start-voltage, and start-discharge threshold — whose fallback is pinned via a new `cloud_write` override to its **website-verified named-param cloud writer** (pylxpweb's `set_start_discharge_power` cloud leg is deliberately bypassed, unchanged from GH #272); `select.py` PV input mode, smart port mode, battery control mode; `coordinator.async_write_battery_control_mode`.

Intentionally NOT converted:
- **Quick Charge Duration** — its cloud path stores a start-minute preference, not an equivalent live register write; falling back would silently change semantics (and its `ServiceValidationError` idle-write rejection must not trigger a cloud retry).
- **Start Charge Power (reg 117)** — no cloud parameter exists; LOCAL-only by design.
- Switch platform — already falls back; left untouched (adding the link-down short-circuit there is a possible follow-up).

## Tests (13 new, suite 1751 → 1764 passed / 3 skipped)

- `test_time_entities.py`: hybrid local-failure → cloud named-param fallback; LOCAL-only failure still raises; known-link-down skips the local write; existing local-failure-clears-optimistic test updated to LOCAL-only (its old assertion encoded the bug).
- `test_number_entities.py`: `TestHybridCloudFallback` — `_write_parameter` fallback (AC Charge SOC), LOCAL-only re-raise, link-down cloud preference, inline system-charge-SOC fallback.
- `test_select_entities.py`: PV input mode local-success / hybrid fallback / LOCAL-only re-raise; smart port hybrid fallback.
- `test_coordinator_local.py`: battery-control-mode hybrid fallback + LOCAL-only re-raise (real coordinator).
- Mock coordinators gained `has_http_api` / `is_transport_link_down(False)` defaults; all existing local-success and cloud-path tests pass unchanged.

## Gates

- `uv run ruff check custom_components/ --fix && uv run ruff format custom_components/` — clean
- `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — no issues in 40 files
- `uv run pytest tests/ -x` — 1764 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix round 2 (Codex adversarial review P1 — commit 7841beb)

**P1 confirmed and fixed**: the fallback avoided the dead-link hang on the WRITE, but every converted site then ran an unconditional parameter refresh that was not link-down-aware. pylxpweb's `_fetch_parameters` (devices/base.py:1189-1236) has NO `transport_link_down` gate (unlike runtime/energy/battery), so with a transport attached-but-down the follow-up `inverter.refresh(force=True, include_parameters=True)` attempted local Modbus reads that Python 3.11 `asyncio.wait_for` cannot interrupt (3-5 min hangs, inside `optimistic_value_context`). Downstream, once the optimistic value cleared, the #282 sticky carry-forward pinned the stale pre-write value — the entity visually reverted until link recovery.

### Gating (integration-side)
- `_refresh_device_parameters` (coordinator_mixins.py) now skips serials whose link is down — the **single choke point**: `refresh_all_device_parameters` therefore skips ONLY down-link serials (healthy siblings still refresh), and `async_refresh_device_parameters` is gated identically.
- All inline `_cloud_write` closures' `inverter.refresh(force=True, include_parameters=True)` calls (number: voltage-register helper, system-charge-SOC, PV-start-voltage, start-discharge; select: PV input, battery control) gated on `not coordinator.is_transport_link_down(serial)`.
- time.py: the post-write refresh and the partial-write re-read are gated on link-down.

### Convergence story (what the entity shows after a link-down cloud write)
- **number/select**: `async_write_with_cloud_fallback` gains `local_values` — the written parameters in the LOCAL-RAW representation the attached-transport cache uses. When the write lands via the cloud while a local transport is attached (link-down short-circuit AND attempt-then-fallback), the values are merged into the coordinator parameter cache via the new `coordinator.note_parameters_written()` (which notifies listeners). The acknowledged cloud write IS device truth, so the entity converges on the written value immediately; any later successful parameter read overwrites the seed with fresh device data. Pure-cloud installs never seed (cloud cache stays cloud-scaled, refresh path unchanged).
- **time**: uses its existing optimistic-retention machinery — with the refresh skipped, `refresh_ok` stays False so the optimistic value is RETAINED (not cleared-and-reverted) until fresh parameter data arrives on link recovery, exactly its designed write-succeeded-refresh-failed semantics.
- **smart port select**: reads from device sensors, post-write is `async_request_refresh()` (the regular poll cycle, which IS link-down aware in pylxpweb and falls back to cloud midbox data in HYBRID) — no seed needed.

### Secondary review items (fixed)
1. **Helper consolidation**: `coordinator.is_transport_link_down(serial)` now delegates to the pre-existing module-level `coordinator_mixins.is_transport_link_down(device)` — single implementation with the stricter guards (transport must be attached; `transport_link_down` must be a real bool, so stale attributes without a transport and older pylxpweb never report down).
2. **Battery-control-mode partial cloud write**: the two-register cloud write now mirrors the schedule-time partial-write pattern — if the charge bit lands but the discharge bit fails (unsuccessful result OR exception), device parameters are re-read best-effort (internally link-down gated) before a "partially applied" error propagates.

### Tests (+11 this round; the original 13 are unweakened)
- Link-down write skips the local param refresh and seeds the cache (number system-SOC, select PV input — assert `inverter.refresh` with `include_parameters` not awaited + `note_parameters_written` payload).
- Link-down time write skips `refresh_all_device_parameters` and retains the optimistic value.
- `refresh_all_device_parameters` skips only the down-link serial (healthy sibling still refreshed); `async_refresh_device_parameters` gated (real coordinator).
- `note_parameters_written` merge+notify and data-None no-op.
- Fallback write seeds the local-raw value; pure-cloud write never seeds.
- Battery-control-mode partial cloud write converges (unsuccessful-result and exception variants).

### Test count reconciliation
Reviewer's 1751 = the base `integration/3.4.0` (beta.20) count. This branch: round 1 added 13 (1764 passed), this round adds 11 — **1775 passed, 3 skipped** (1778 collected). ruff clean, mypy strict clean (40 files).

### Flagged upstream (NOT implemented here, per review)
pylxpweb `_fetch_parameters` should get its own `transport_link_down` guard like runtime/energy/battery — to be filed on joyfulhouse/pylxpweb.
