### PR TITLE
fix: switch/select availability gates on coordinator health (parity with other entity types)

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -976,9 +976,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         """Return if entity is available.
 
         Returns:
-            True if the device is an inverter and available, False otherwise.
+            True if the coordinator is healthy and the device is an inverter,
+            False otherwise.
         """
-        return bool(self._device_data.get("type") == "inverter")
+        return bool(
+            self.coordinator.last_update_success
+            and self._device_data.get("type") == "inverter"
+        )
 
     def _get_inverter_or_raise(self) -> Any:
         """Get inverter device object or raise HomeAssistantError.

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -243,6 +243,8 @@ class EG4OperatingModeSelect(CoordinatorEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
         # Check if the device supports operating mode control
         if self.coordinator.data and "devices" in self.coordinator.data:
             device_data = self.coordinator.data["devices"].get(self._serial, {})
@@ -364,6 +366,8 @@ class EG4PVInputModeSelect(CoordinatorEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
         if self.coordinator.data and "devices" in self.coordinator.data:
             device_data = self.coordinator.data["devices"].get(self._serial, {})
             return bool(device_data.get("type") == "inverter")
@@ -507,6 +511,8 @@ class EG4SmartPortModeSelect(CoordinatorEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
         if self.coordinator.data and "devices" in self.coordinator.data:
             device_data = self.coordinator.data["devices"].get(self._serial, {})
             return bool(device_data.get("type") == DEVICE_TYPE_GRIDBOSS)
@@ -650,6 +656,8 @@ class EG4BatteryControlModeSelect(CoordinatorEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
         if self.coordinator.data and "devices" in self.coordinator.data:
             device_data = self.coordinator.data["devices"].get(self._serial, {})
             return bool(device_data.get("type") == "inverter")

--- a/tests/test_battery_control_mode.py
+++ b/tests/test_battery_control_mode.py
@@ -327,6 +327,23 @@ class TestBatteryControlSelects:
         )
         assert select.current_option is None
 
+    def test_available_on_healthy_coordinator(self) -> None:
+        coordinator = _mock_coordinator()
+        select = EG4BatteryChargeControlSelect(
+            coordinator, "1234567890", {"type": "inverter", "model": "FlexBOSS21"}
+        )
+        assert select.available is True
+
+    def test_unavailable_on_coordinator_failure(self) -> None:
+        # Coordinator failure makes the select unavailable (parity with
+        # number/time entities).
+        coordinator = _mock_coordinator()
+        coordinator.last_update_success = False
+        select = EG4BatteryChargeControlSelect(
+            coordinator, "1234567890", {"type": "inverter", "model": "FlexBOSS21"}
+        )
+        assert select.available is False
+
     @pytest.mark.asyncio
     async def test_select_local_writes_named_bit(self) -> None:
         coordinator = _mock_coordinator(has_local=True)

--- a/tests/test_select_entities.py
+++ b/tests/test_select_entities.py
@@ -173,6 +173,15 @@ class TestOperatingModeSelect:
         select = EG4OperatingModeSelect(coordinator, "1234567890", device_data)
         assert select.available is True
 
+    def test_unavailable_on_coordinator_failure(self):
+        """Coordinator failure makes the select unavailable (parity with
+        number/time entities)."""
+        coordinator = _mock_coordinator()
+        coordinator.last_update_success = False
+        device_data = coordinator.data["devices"]["1234567890"]
+        select = EG4OperatingModeSelect(coordinator, "1234567890", device_data)
+        assert select.available is False
+
     @pytest.mark.asyncio
     async def test_select_normal(self):
         """Select Normal calls set_operating_mode(NORMAL)."""
@@ -331,6 +340,15 @@ class TestSmartPortModeSelect:
         select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
         assert select.available is False
 
+    def test_unavailable_on_coordinator_failure(self):
+        """Coordinator failure makes the smart port select unavailable
+        (parity with number/time entities)."""
+        coordinator = _mock_gridboss_coordinator()
+        coordinator.last_update_success = False
+        device_data = coordinator.data["devices"]["gb123"]
+        select = EG4SmartPortModeSelect(coordinator, "gb123", device_data, port=1)
+        assert select.available is False
+
     def test_entity_name(self):
         """Name includes port number."""
         coordinator = _mock_gridboss_coordinator()
@@ -452,6 +470,26 @@ class TestSmartPortModeSelect:
         coordinator.client.api.control.set_smart_port_mode.assert_called_once_with(
             "gb123", 2, 2
         )
+
+
+class TestPVInputModeSelectAvailability:
+    """PV input select availability gates on coordinator health."""
+
+    def test_available_on_healthy_coordinator(self):
+        """Available with healthy coordinator + inverter device."""
+        coordinator = _mock_coordinator()
+        device_data = coordinator.data["devices"]["1234567890"]
+        select = EG4PVInputModeSelect(coordinator, "1234567890", device_data)
+        assert select.available is True
+
+    def test_unavailable_on_coordinator_failure(self):
+        """Coordinator failure makes the select unavailable (parity with
+        number/time entities)."""
+        coordinator = _mock_coordinator()
+        coordinator.last_update_success = False
+        device_data = coordinator.data["devices"]["1234567890"]
+        select = EG4PVInputModeSelect(coordinator, "1234567890", device_data)
+        assert select.available is False
 
 
 class TestPVInputModeSelectFallback:

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -429,6 +429,20 @@ class TestQuickChargeSwitch:
         switch._optimistic_state = True
         assert switch.is_on is True
 
+    def test_available_on_healthy_coordinator(self):
+        """Available with healthy coordinator + inverter device."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        assert switch.available is True
+
+    def test_unavailable_on_coordinator_failure(self):
+        """Coordinator failure makes the switch unavailable (parity with
+        number/time entities — EG4BaseSwitch gates on last_update_success)."""
+        coordinator = _mock_coordinator()
+        coordinator.last_update_success = False
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        assert switch.available is False
+
     @pytest.mark.asyncio
     async def test_turn_on(self):
         """Turn on calls enable_quick_charge with the default duration (60)."""


### PR DESCRIPTION
## Finding

Low severity, long-standing oversight from the 2025-12 control-entity work (d7f02db): switch and select entities omit the coordinator-health availability gate that every other entity type has.

- `EG4BaseSwitch.available` (base_entity.py) was `return bool(self._device_data.get("type") == "inverter")` — device-type only.
- The four select `available` overrides (`EG4OperatingModeSelect`, `EG4PVInputModeSelect`, `EG4SmartPortModeSelect`, `EG4BatteryControlModeSelect` + its charge/discharge subclasses) were also device-type-only.
- By contrast `EG4BaseNumber`, `EG4BaseTime`, and all sensor bases gate on `self.coordinator.last_update_success`.

Result: when the coordinator fails, sensors/numbers/times go unavailable but switches/selects stay clickable against stale data (writes then fail loudly — low impact, but inconsistent UX).

## Fix

Add the `last_update_success` conjunct to `EG4BaseSwitch.available` and the four select overrides, matching the number/time pattern exactly. Device-type semantics unchanged. `EG4DSTSwitch` already had the gate. Re-verified against post-PR-#301 HEAD — #301 added no new switch/select classes needing the gate.

## Tests

- `tests/test_switch_entities.py`: `test_available_on_healthy_coordinator`, `test_unavailable_on_coordinator_failure` (EG4QuickChargeSwitch, exercises the EG4BaseSwitch path shared by all inverter switches)
- `tests/test_select_entities.py`: `TestOperatingModeSelect::test_unavailable_on_coordinator_failure`, `TestSmartPortModeSelect::test_unavailable_on_coordinator_failure`, `TestPVInputModeSelectAvailability` (healthy + failure)
- `tests/test_battery_control_mode.py`: `TestBatteryControlSelects::test_available_on_healthy_coordinator`, `test_unavailable_on_coordinator_failure`

Full suite: **1785 passed, 3 skipped**. ruff + mypy (strict config) clean. No existing test asserted the old stay-available behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)