### PR TITLE
fix: Quick Charge switch state on XP family (#296)

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -5,6 +5,7 @@ All entity classes should inherit from these bases to ensure consistent behavior
 """
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from datetime import time as dt_time
 import logging
@@ -1001,8 +1002,8 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
     async def _execute_switch_action(
         self,
         action_name: str,
-        enable_method: str,
-        disable_method: str,
+        enable_method: str | Callable[..., Awaitable[bool]],
+        disable_method: str | Callable[..., Awaitable[bool]],
         turn_on: bool,
         refresh_params: bool = False,
         api_delay: float = 1.0,
@@ -1024,8 +1025,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
 
         Args:
             action_name: Human-readable name of the action for logging.
-            enable_method: Name of the method to call when turning on.
-            disable_method: Name of the method to call when turning off.
+            enable_method: Method to call when turning on — either the name of
+                a method on the inverter object, or an awaitable callable
+                (e.g. a cloud-direct bound method for families whose local
+                register is firmware-rejected, #296).
+            disable_method: Method to call when turning off (same forms).
             turn_on: True to enable, False to disable.
             refresh_params: If True, refresh parameters instead of just data.
             api_delay: Seconds to wait for API to propagate changes (default 1.0).
@@ -1036,7 +1040,12 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         Raises:
             HomeAssistantError: If the action fails.
         """
-        method_name = enable_method if turn_on else disable_method
+        method_ref = enable_method if turn_on else disable_method
+        method_name = (
+            method_ref
+            if isinstance(method_ref, str)
+            else getattr(method_ref, "__name__", action_name)
+        )
         action_verb = "Enabling" if turn_on else "Disabling"
 
         try:
@@ -1053,8 +1062,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
 
             inverter = self._get_inverter_or_raise()
 
-            # Call the appropriate method
-            method = getattr(inverter, method_name, None)
+            # Call the appropriate method: an inverter method looked up by
+            # name, or a pre-bound callable (cloud-direct path, #296).
+            method = (
+                getattr(inverter, method_ref, None)
+                if isinstance(method_ref, str)
+                else method_ref
+            )
             if method is None:
                 self._optimistic_state = None
                 self.async_write_ha_state()

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -782,9 +782,23 @@ class DeviceProcessingMixin(_MixinBase):
         this read fails and returns None, and the number falls back to the
         stored cloud-start preference (the setter's reg-234 write would then
         surface its own error).
+
+        Skipped while the transport link is down: a raw ``read_parameters``
+        on an attached-but-dead link is the multi-minute pymodbus hang class
+        that Python 3.11's ``asyncio.wait_for`` cannot interrupt (same gate
+        as ``_refresh_device_parameters``) — and this read fires on every
+        30s-throttled status poll, in exactly the HYBRID configuration where
+        the link can be down. Degrades to None like a failed read.
         """
         transport = getattr(inverter, "transport", None)
         if transport is None:
+            return None
+        if is_transport_link_down(inverter):
+            _LOGGER.debug(
+                "Skipping reg 234 read for %s: local transport link is down "
+                "(Quick Charge Duration falls back to the stored preference)",
+                inverter.serial_number,
+            )
             return None
         try:
             regs = await transport.read_parameters(234, 1)

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -62,6 +62,14 @@ from .utils import clean_battery_display_name, is_offgrid_family
 
 _LOGGER = logging.getLogger(__name__)
 
+# Bound (seconds) on the offgrid cloud quick-charge status read (#296). The
+# read shares the pylxpweb client's station-wide retry/backoff state; during a
+# cloud 502 storm an escalated backoff can sleep up to ~60s inside the call,
+# which would hold a coordinator semaphore slot for the storm's duration. A
+# timeout is treated as a failed read (carry-forward). Full backoff-domain
+# isolation is a pylxpweb architectural item deliberately not attempted here.
+QUICK_CHARGE_CLOUD_STATUS_TIMEOUT = 10.0
+
 # Rate floor between parameter refresh ATTEMPTS (#282).  A failed/partial
 # parameter read no longer stamps _last_parameter_refresh, so the refresh
 # re-arms early instead of serving a degraded snapshot for the whole
@@ -760,6 +768,37 @@ class DeviceProcessingMixin(_MixinBase):
             and getattr(inverter, "transport", None) is not None
         )
 
+    async def _read_offgrid_quick_charge_minute(
+        self, inverter: "BaseInverter"
+    ) -> int | None:
+        """Best-effort local read of holding reg 234 (minutes) for offgrid HYBRID.
+
+        The offgrid cloud-status route (#296) bypasses pylxpweb's reg 233+234
+        detail read, but the Quick Charge Duration number mirrors — and its
+        setter writes — reg 234 whenever a local transport is configured. So
+        the register read is kept local here to keep the number's read and
+        write sides pointing at the same truth. Only reg 233 is proven
+        firmware-rejected on the XP; if reg 234 turns out equally unsupported
+        this read fails and returns None, and the number falls back to the
+        stored cloud-start preference (the setter's reg-234 write would then
+        surface its own error).
+        """
+        transport = getattr(inverter, "transport", None)
+        if transport is None:
+            return None
+        try:
+            regs = await transport.read_parameters(234, 1)
+            raw = regs.get(234)
+            return int(raw) if raw is not None else None
+        except Exception as e:
+            _LOGGER.debug(
+                "Could not read holding reg 234 for %s: %s (Quick Charge "
+                "Duration falls back to the stored preference)",
+                inverter.serial_number,
+                e,
+            )
+            return None
+
     async def _read_quick_charge_status(
         self, inverter: "BaseInverter", device_data: dict[str, Any]
     ) -> dict[str, Any] | None:
@@ -772,17 +811,31 @@ class DeviceProcessingMixin(_MixinBase):
         read so consumers can distinguish a fresh read from a carried-forward
         one. Returns None when the installed pylxpweb exposes no read method.
         """
+        quick_charge_minute: int | None = None
         client = self.client
         if client is not None and self._quick_charge_prefers_cloud(
             inverter, device_data
         ):
-            status = await client.api.control.get_quick_charge_status(
-                inverter.serial_number
+            # Bound the cloud read: it shares the pylxpweb client's
+            # station-wide retry/backoff state, and during a 502 storm an
+            # escalated backoff sleep (up to ~60s) would otherwise hold a
+            # coordinator slot for the whole storm. A timeout is a failed
+            # read — the caller's carry-forward path handles it.
+            status = await asyncio.wait_for(
+                client.api.control.get_quick_charge_status(inverter.serial_number),
+                timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
             )
+            # Active flag from the cloud, duration register read locally so
+            # the Duration number's read and write sides agree (#296 round 2).
+            quick_charge_minute = await self._read_offgrid_quick_charge_minute(inverter)
         elif hasattr(inverter, "get_quick_charge_detail"):
             # Prefer the full detail (remaining time + task metadata);
             # version-guard for older pylxpweb exposing only the boolean.
             status = await inverter.get_quick_charge_detail()
+            # Raw holding reg 234 (minutes); None on cloud. Lets the duration
+            # number mirror the live register on LOCAL/HYBRID instead of a
+            # stored preference. getattr guards older pylxpweb without it.
+            quick_charge_minute = getattr(status, "quickChargeMinute", None)
         elif hasattr(inverter, "get_quick_charge_status"):
             return {
                 "hasUnclosedQuickChargeTask": (
@@ -797,11 +850,7 @@ class DeviceProcessingMixin(_MixinBase):
             "remainTimeBeforeQuickChargeStop": (status.remainTimeBeforeQuickChargeStop),
             "unclosedQuickChargeTaskId": status.unclosedQuickChargeTaskId,
             "unclosedQuickChargeTaskStatus": status.unclosedQuickChargeTaskStatus,
-            # Raw holding reg 234 (minutes); None on cloud. Lets the
-            # duration number mirror the live register on LOCAL/HYBRID
-            # instead of a stored preference. getattr guards older
-            # pylxpweb without the field.
-            "quickChargeMinute": getattr(status, "quickChargeMinute", None),
+            "quickChargeMinute": quick_charge_minute,
             "fetched_at": time.monotonic(),
         }
 
@@ -891,8 +940,13 @@ class DeviceProcessingMixin(_MixinBase):
                 inverter, device_data
             ):
                 # EG4_OFFGRID + HYBRID: register 233 is firmware-rejected, so
-                # the cloud getStatusInfo is the authoritative live state (#296).
-                status = await client.api.control.get_quick_charge_status(serial)
+                # the cloud getStatusInfo is the authoritative live state
+                # (#296). Bounded like the throttled fetch — a backoff-stalled
+                # cloud call must not hang the caller; timeout -> unknown.
+                status = await asyncio.wait_for(
+                    client.api.control.get_quick_charge_status(serial),
+                    timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
+                )
                 return bool(status.hasUnclosedQuickChargeTask)
             if hasattr(inverter, "get_quick_charge_detail"):
                 detail = await inverter.get_quick_charge_detail()

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -58,7 +58,7 @@ from .coordinator_mappings import (
     drop_offgrid_cloud_output_power,
     get_battery_bank_property_map,
 )
-from .utils import clean_battery_display_name
+from .utils import clean_battery_display_name, is_offgrid_family
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -737,17 +737,102 @@ class DeviceProcessingMixin(_MixinBase):
                 return transport.get("grid_type")
         return None
 
+    def _quick_charge_prefers_cloud(
+        self, inverter: "BaseInverter", device_data: dict[str, Any]
+    ) -> bool:
+        """True when quick charge state/control must come from the cloud API.
+
+        The EG4_OFFGRID family (12000XP/6000XP) firmware rejects holding
+        register 233 with ILLEGAL DATA ADDRESS (issue #296) — the register
+        pylxpweb's transport-preferring quick-charge paths read and write.
+        A quick charge started via the cloud endpoint (the local-write
+        fallback, and what the EG4 app reflects) is therefore invisible to
+        the local read. When such a device has a transport attached AND a
+        cloud client is available (HYBRID), bypass the transport and use the
+        cloud getStatusInfo/start/stop endpoints directly. Fails closed
+        (False) for every other family, cloud-only devices (whose pylxpweb
+        paths already use the cloud), and LOCAL-only installs (no cloud to
+        prefer).
+        """
+        return (
+            is_offgrid_family(device_data)
+            and self.client is not None
+            and getattr(inverter, "transport", None) is not None
+        )
+
+    async def _read_quick_charge_status(
+        self, inverter: "BaseInverter", device_data: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Read the live quick-charge status into the coordinator dict shape.
+
+        Transport-aware via pylxpweb (cloud getStatusInfo; LOCAL/HYBRID
+        registers 233/234), except for EG4_OFFGRID + HYBRID where register
+        233 is firmware-rejected and the cloud endpoint is authoritative
+        (#296). ``fetched_at`` (monotonic) records when the data was actually
+        read so consumers can distinguish a fresh read from a carried-forward
+        one. Returns None when the installed pylxpweb exposes no read method.
+        """
+        client = self.client
+        if client is not None and self._quick_charge_prefers_cloud(
+            inverter, device_data
+        ):
+            status = await client.api.control.get_quick_charge_status(
+                inverter.serial_number
+            )
+        elif hasattr(inverter, "get_quick_charge_detail"):
+            # Prefer the full detail (remaining time + task metadata);
+            # version-guard for older pylxpweb exposing only the boolean.
+            status = await inverter.get_quick_charge_detail()
+        elif hasattr(inverter, "get_quick_charge_status"):
+            return {
+                "hasUnclosedQuickChargeTask": (
+                    await inverter.get_quick_charge_status()
+                ),
+                "fetched_at": time.monotonic(),
+            }
+        else:
+            return None
+        return {
+            "hasUnclosedQuickChargeTask": status.hasUnclosedQuickChargeTask,
+            "remainTimeBeforeQuickChargeStop": (status.remainTimeBeforeQuickChargeStop),
+            "unclosedQuickChargeTaskId": status.unclosedQuickChargeTaskId,
+            "unclosedQuickChargeTaskStatus": status.unclosedQuickChargeTaskStatus,
+            # Raw holding reg 234 (minutes); None on cloud. Lets the
+            # duration number mirror the live register on LOCAL/HYBRID
+            # instead of a stored preference. getattr guards older
+            # pylxpweb without the field.
+            "quickChargeMinute": getattr(status, "quickChargeMinute", None),
+            "fetched_at": time.monotonic(),
+        }
+
+    def _carry_forward_quick_charge_status(
+        self, serial: str, target: dict[str, Any]
+    ) -> None:
+        """Copy the previous cycle's quick-charge status into ``target``.
+
+        The carried dict keeps its original ``fetched_at`` stamp, so consumers
+        (the Quick Charge switch's post-write retention, #296) still see it as
+        stale data rather than a fresh confirming read.
+        """
+        if self.data and serial in self.data.get("devices", {}):
+            prev = self.data["devices"][serial].get("quick_charge_status")
+            if prev is not None:
+                target["quick_charge_status"] = prev
+
     async def _fetch_quick_charge_status(
         self, inverter: "BaseInverter", target: dict[str, Any]
     ) -> None:
         """Fetch + store ``quick_charge_status`` into ``target`` (throttled).
 
         Transport-aware via pylxpweb: cloud reads getStatusInfo; LOCAL/HYBRID
-        reads registers 233 (active) + 234 (remaining minutes). Shared by the
+        reads registers 233 (active) + 234 (remaining minutes) — except the
+        EG4_OFFGRID family in HYBRID, which reads the cloud endpoint because
+        register 233 is firmware-rejected there (#296). Shared by the
         HTTP/HYBRID (`_process_inverter_object`) and LOCAL
         (`_process_single_local_device`) paths so the Quick Charge switch and
         remaining sensor work in every mode. Carries the previous value
-        forward when the throttle window has not elapsed.
+        forward when the throttle window has not elapsed or the read failed
+        (a transient error must not flip the switch to a lying OFF).
         """
         interval = 30  # seconds
         if not hasattr(self, "_last_status_fetch"):
@@ -757,31 +842,9 @@ class DeviceProcessingMixin(_MixinBase):
         qc_key = f"qc_{serial}"
         if now - self._last_status_fetch.get(qc_key, 0.0) >= interval:
             try:
-                # Prefer the full detail (remaining time + task metadata);
-                # version-guard for older pylxpweb exposing only the boolean.
-                if hasattr(inverter, "get_quick_charge_detail"):
-                    status = await inverter.get_quick_charge_detail()
-                    target["quick_charge_status"] = {
-                        "hasUnclosedQuickChargeTask": status.hasUnclosedQuickChargeTask,
-                        "remainTimeBeforeQuickChargeStop": (
-                            status.remainTimeBeforeQuickChargeStop
-                        ),
-                        "unclosedQuickChargeTaskId": status.unclosedQuickChargeTaskId,
-                        "unclosedQuickChargeTaskStatus": (
-                            status.unclosedQuickChargeTaskStatus
-                        ),
-                        # Raw holding reg 234 (minutes); None on cloud. Lets the
-                        # duration number mirror the live register on LOCAL/HYBRID
-                        # instead of a stored preference. getattr guards older
-                        # pylxpweb without the field.
-                        "quickChargeMinute": getattr(status, "quickChargeMinute", None),
-                    }
-                elif hasattr(inverter, "get_quick_charge_status"):
-                    target["quick_charge_status"] = {
-                        "hasUnclosedQuickChargeTask": (
-                            await inverter.get_quick_charge_status()
-                        ),
-                    }
+                status_dict = await self._read_quick_charge_status(inverter, target)
+                if status_dict is not None:
+                    target["quick_charge_status"] = status_dict
                 self._last_status_fetch[qc_key] = now
                 _LOGGER.debug(
                     "Quick charge status for %s: %s",
@@ -793,10 +856,9 @@ class DeviceProcessingMixin(_MixinBase):
                 _LOGGER.debug(
                     "Could not fetch quick charge status for %s: %s", serial, e
                 )
-        elif self.data and serial in self.data.get("devices", {}):
-            prev = self.data["devices"][serial].get("quick_charge_status")
-            if prev is not None:
-                target["quick_charge_status"] = prev
+                self._carry_forward_quick_charge_status(serial, target)
+        else:
+            self._carry_forward_quick_charge_status(serial, target)
 
     async def is_quick_charge_active_live(self, serial: str) -> bool | None:
         """Return whether a quick charge is running *right now* for ``serial``.
@@ -821,6 +883,17 @@ class DeviceProcessingMixin(_MixinBase):
         if inverter is None:
             return None
         try:
+            client = self.client
+            device_data: dict[str, Any] = (
+                (self.data or {}).get("devices", {}).get(serial, {})
+            )
+            if client is not None and self._quick_charge_prefers_cloud(
+                inverter, device_data
+            ):
+                # EG4_OFFGRID + HYBRID: register 233 is firmware-rejected, so
+                # the cloud getStatusInfo is the authoritative live state (#296).
+                status = await client.api.control.get_quick_charge_status(serial)
+                return bool(status.hasUnclosedQuickChargeTask)
             if hasattr(inverter, "get_quick_charge_detail"):
                 detail = await inverter.get_quick_charge_detail()
                 return bool(detail.hasUnclosedQuickChargeTask)

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -328,6 +328,12 @@ async def async_setup_entry(
 # (ON -> stale OFF at t+TTL -> eventual fresh ON) during exactly the cloud
 # 502 storms the reporter's environment produces. A fresh read normally lands
 # within one 30s status throttle window and ends the hold.
+#
+# Intentional trade-off: because the hold is fresh-data-terminated, a
+# PERMANENT status-source outage after a command retains the commanded state
+# indefinitely (the last thing we know the inverter accepted) — this reverses
+# the earlier "a dead status source can never pin state forever" guarantee.
+# Showing the accepted command beats flapping to provably pre-write data.
 QUICK_CHARGE_OPTIMISTIC_TTL = 300.0
 
 

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 import math
+import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import EntityCategory
@@ -317,6 +319,13 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
+# Upper bound (seconds) on the Quick Charge switch's post-write optimistic
+# retention (#296). A fresh status read normally lands within one 30s status
+# throttle window and clears the hold; the TTL only exists so a dead status
+# source can never pin the commanded state forever.
+QUICK_CHARGE_OPTIMISTIC_TTL = 300.0
+
+
 class EG4QuickChargeSwitch(EG4BaseSwitch):
     """Switch to control quick charge functionality."""
 
@@ -333,6 +342,46 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
             name="Quick Charge",
             icon="mdi:battery-charging",
         )
+        # Post-write optimistic retention (#296): after a successful
+        # enable/disable, hold the commanded state until a quick-charge
+        # status read FRESHER than the write confirms either state. The
+        # coordinator refresh inside _execute_switch_action can serve a
+        # stale/carried-forward status (30s throttle) or one read before the
+        # cloud registered the new task — clearing optimistic state on that
+        # data flipped the switch OFF ~7s after a successful (cloud-fallback)
+        # start while the inverter kept charging.
+        self._pending_state: bool | None = None
+        self._pending_since: float = 0.0
+
+    def _prefers_cloud_control(self) -> bool:
+        """True when quick charge must be driven via the cloud endpoints.
+
+        The EG4_OFFGRID family (12000XP/6000XP) firmware rejects writes to
+        holding register 233 (ILLEGAL DATA ADDRESS, #296), so pylxpweb's
+        local-first enable/disable burns a doomed Modbus write + warning on
+        every toggle before falling back to the cloud. Go straight to the
+        cloud start/stop endpoints when a cloud client is configured; other
+        families keep the local-first behavior (register 233 works there).
+        """
+        return is_offgrid_family(self._device_data) and self.coordinator.has_http_api()
+
+    async def _cloud_enable_quick_charge(self, minute: int | None = None) -> bool:
+        """Start quick charge via the cloud endpoint (offgrid family, #296)."""
+        client = self.coordinator.client
+        if client is None:
+            return False
+        result = await client.api.control.start_quick_charge(
+            self._serial, minute=minute
+        )
+        return bool(result.success)
+
+    async def _cloud_disable_quick_charge(self) -> bool:
+        """Stop quick charge via the cloud endpoint (offgrid family, #296)."""
+        client = self.coordinator.client
+        if client is None:
+            return False
+        result = await client.api.control.stop_quick_charge(self._serial)
+        return bool(result.success)
 
     @property
     def is_on(self) -> bool | None:
@@ -341,11 +390,27 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
         if self._optimistic_state is not None:
             return self._optimistic_state
 
-        # Check if we have quick charge status data from coordinator
         quick_charge_status = self._device_data.get("quick_charge_status")
-        if quick_charge_status and isinstance(quick_charge_status, dict):
+        status = quick_charge_status if isinstance(quick_charge_status, dict) else None
+
+        # Post-write retention (#296): keep the commanded state until a
+        # status read performed AFTER the write lands. A carried-forward or
+        # pre-write status must not clobber a successful start/stop; a fresh
+        # read (fetched_at newer than the write) is trusted either way, and
+        # the TTL bounds the hold if no fresh read ever arrives.
+        if self._pending_state is not None:
+            fetched_at = status.get("fetched_at") if status else None
+            fresh = fetched_at is not None and fetched_at >= self._pending_since
+            expired = (
+                time.monotonic() - self._pending_since > QUICK_CHARGE_OPTIMISTIC_TTL
+            )
+            if not fresh and not expired:
+                return self._pending_state
+            self._pending_state = None
+
+        if status:
             # Parse the hasUnclosedQuickChargeTask field from getStatusInfo response
-            has_unclosed_task = quick_charge_status.get("hasUnclosedQuickChargeTask")
+            has_unclosed_task = status.get("hasUnclosedQuickChargeTask")
             if has_unclosed_task is not None:
                 return bool(has_unclosed_task)
 
@@ -386,24 +451,44 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
         minute = self.coordinator._quick_charge_minutes.get(
             self._serial, QUICK_CHARGE_DURATION_DEFAULT
         )
-        await self._execute_switch_action(
-            action_name="quick charge",
-            enable_method="enable_quick_charge",
-            disable_method="disable_quick_charge",
-            turn_on=True,
-            refresh_params=False,
-            enable_kwargs={"minute": minute},
-        )
+        await self._async_set_quick_charge(True, enable_kwargs={"minute": minute})
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off quick charge."""
+        await self._async_set_quick_charge(False)
+
+    async def _async_set_quick_charge(
+        self, turn_on: bool, enable_kwargs: dict[str, Any] | None = None
+    ) -> None:
+        """Run the enable/disable action and arm the post-write retention.
+
+        pylxpweb's enable/disable prefer the local transport (register 233);
+        on the EG4_OFFGRID family that register is firmware-rejected, so the
+        cloud-direct callables are used instead (#296). On success the
+        commanded state is retained until a status read fresher than the
+        write confirms either state (see ``is_on``); a failed action clears
+        any prior hold and re-raises.
+        """
+        enable_method: str | Callable[..., Awaitable[bool]] = "enable_quick_charge"
+        disable_method: str | Callable[..., Awaitable[bool]] = "disable_quick_charge"
+        if self._prefers_cloud_control():
+            enable_method = self._cloud_enable_quick_charge
+            disable_method = self._cloud_disable_quick_charge
+
+        self._pending_state = None
         await self._execute_switch_action(
             action_name="quick charge",
-            enable_method="enable_quick_charge",
-            disable_method="disable_quick_charge",
-            turn_on=False,
+            enable_method=enable_method,
+            disable_method=disable_method,
+            turn_on=turn_on,
             refresh_params=False,
+            enable_kwargs=enable_kwargs,
         )
+        # Success (no exception raised): hold the commanded state until a
+        # fresh post-write status read confirms either state (#296).
+        self._pending_state = turn_on
+        self._pending_since = time.monotonic()
+        self.async_write_ha_state()
 
 
 class EG4BatteryBackupSwitch(EG4BaseSwitch):

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -319,10 +319,15 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-# Upper bound (seconds) on the Quick Charge switch's post-write optimistic
-# retention (#296). A fresh status read normally lands within one 30s status
-# throttle window and clears the hold; the TTL only exists so a dead status
-# source can never pin the commanded state forever.
+# Bound (seconds) on how long the Quick Charge switch distrusts a FRESH but
+# UNCONFIRMING status read after a successful write (#296): within the bound
+# the cloud may simply not have registered the new task yet; past it a fresh
+# read is trusted in either direction. Known-stale data (carried forward, or
+# read before the write) NEVER overrides the commanded state regardless of
+# this bound — falling back to it at expiry would reproduce the reported flap
+# (ON -> stale OFF at t+TTL -> eventual fresh ON) during exactly the cloud
+# 502 storms the reporter's environment produces. A fresh read normally lands
+# within one 30s status throttle window and ends the hold.
 QUICK_CHARGE_OPTIMISTIC_TTL = 300.0
 
 
@@ -393,19 +398,25 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
         quick_charge_status = self._device_data.get("quick_charge_status")
         status = quick_charge_status if isinstance(quick_charge_status, dict) else None
 
-        # Post-write retention (#296): keep the commanded state until a
-        # status read performed AFTER the write lands. A carried-forward or
-        # pre-write status must not clobber a successful start/stop; a fresh
-        # read (fetched_at newer than the write) is trusted either way, and
-        # the TTL bounds the hold if no fresh read ever arrives.
+        # Post-write retention (#296): the commanded state holds until a
+        # status read performed AFTER the write (fetched_at newer than the
+        # write) reports on the charge. Known-stale data — carried forward or
+        # read pre-write — never overrides the command, even past the TTL:
+        # trusting it at expiry would flap the switch to the pre-write value
+        # mid-charge (Codex review). A fresh CONFIRMING read ends the hold
+        # immediately; a fresh UNCONFIRMING read is trusted only after the
+        # TTL (within it, the cloud may not have registered the task yet).
         if self._pending_state is not None:
             fetched_at = status.get("fetched_at") if status else None
-            fresh = fetched_at is not None and fetched_at >= self._pending_since
+            if fetched_at is None or fetched_at < self._pending_since:
+                return self._pending_state  # stale/absent — hold
+            reported = status.get("hasUnclosedQuickChargeTask") if status else None
+            confirming = reported is not None and bool(reported) == self._pending_state
             expired = (
                 time.monotonic() - self._pending_since > QUICK_CHARGE_OPTIMISTIC_TTL
             )
-            if not fresh and not expired:
-                return self._pending_state
+            if not confirming and not expired:
+                return self._pending_state  # fresh but unconfirming — hold
             self._pending_state = None
 
         if status:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7016,7 +7016,11 @@ class TestQuickChargeOffgridCloudStatus:
     def _offgrid_inverter() -> MagicMock:
         inverter = MagicMock()
         inverter.serial_number = "61062J0147"
-        inverter.transport = object()  # HYBRID: local transport attached
+        # HYBRID: local transport attached; reg 234 (duration/remaining
+        # minutes) reads 45 locally.
+        transport = MagicMock()
+        transport.read_parameters = AsyncMock(return_value={234: 45})
+        inverter.transport = transport
         inverter.get_quick_charge_detail = AsyncMock()
         return inverter
 
@@ -7050,8 +7054,34 @@ class TestQuickChargeOffgridCloudStatus:
         status = target["quick_charge_status"]
         assert status["hasUnclosedQuickChargeTask"] is True
         assert status["remainTimeBeforeQuickChargeStop"] == 3540
-        assert status["quickChargeMinute"] is None
+        # Duration register stays LOCAL (reg 234) so the Duration number's
+        # read and write sides agree on offgrid+HYBRID (Codex round 2).
+        assert status["quickChargeMinute"] == 45
+        inverter.transport.read_parameters.assert_awaited_once_with(234, 1)
         assert status["fetched_at"] <= time.monotonic()
+
+    async def test_fetch_offgrid_reg234_read_failure_falls_back_to_none(
+        self, hass, mock_config_entry
+    ):
+        """If the local reg-234 read fails (possibly firmware-rejected like
+        reg 233 — unverified on XP), quickChargeMinute is None and the
+        Duration number falls back to the stored preference; the cloud
+        active flag is unaffected."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+        inverter = self._offgrid_inverter()
+        inverter.transport.read_parameters = AsyncMock(
+            side_effect=OSError("illegal data address")
+        )
+        target: dict[str, Any] = {
+            "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
+        }
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        status = target["quick_charge_status"]
+        assert status["hasUnclosedQuickChargeTask"] is True
+        assert status["quickChargeMinute"] is None
 
     async def test_fetch_keeps_local_detail_for_other_families(
         self, hass, mock_config_entry
@@ -7118,6 +7148,39 @@ class TestQuickChargeOffgridCloudStatus:
 
         assert target["quick_charge_status"] is prev
         assert target["quick_charge_status"]["fetched_at"] == 1234.5
+
+    async def test_cloud_status_read_is_time_bounded(
+        self, hass, mock_config_entry, monkeypatch
+    ):
+        """A backoff-stalled cloud status call is cut off by asyncio.wait_for
+        and treated as a failed read (carry-forward) instead of holding a
+        coordinator slot for the whole 502-storm backoff."""
+        import asyncio
+
+        from custom_components.eg4_web_monitor import coordinator_mixins
+
+        monkeypatch.setattr(
+            coordinator_mixins, "QUICK_CHARGE_CLOUD_STATUS_TIMEOUT", 0.01
+        )
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+
+        async def _stalled(serial: str) -> Any:
+            await asyncio.sleep(5)
+
+        coordinator.client.api.control.get_quick_charge_status = AsyncMock(
+            side_effect=_stalled
+        )
+        prev = {"hasUnclosedQuickChargeTask": True, "fetched_at": 1234.5}
+        coordinator.data = {"devices": {"61062J0147": {"quick_charge_status": prev}}}
+        inverter = self._offgrid_inverter()
+        target: dict[str, Any] = {
+            "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
+        }
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        assert target["quick_charge_status"] is prev  # timeout -> carry-forward
 
     async def test_active_live_uses_cloud_for_offgrid_hybrid(
         self, hass, mock_config_entry

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -33,6 +33,7 @@ from custom_components.eg4_web_monitor.const import (
     DEFAULT_SENSOR_UPDATE_INTERVAL_HTTP,
     DEFAULT_SENSOR_UPDATE_INTERVAL_LOCAL,
     DOMAIN,
+    INVERTER_FAMILY_EG4_OFFGRID,
 )
 from custom_components.eg4_web_monitor.coordinator import (
     EG4DataUpdateCoordinator,
@@ -6989,3 +6990,154 @@ class TestIsQuickChargeActiveLive:
         inverter = MagicMock(spec=[])
         with patch.object(coordinator, "get_inverter_object", return_value=inverter):
             assert await coordinator.is_quick_charge_active_live("1234567890") is None
+
+
+class TestQuickChargeOffgridCloudStatus:
+    """EG4_OFFGRID + HYBRID quick-charge status comes from the cloud (#296).
+
+    The XP firmware rejects holding register 233 (ILLEGAL DATA ADDRESS), so a
+    quick charge started via the cloud endpoint is invisible to the local
+    register read pylxpweb's get_quick_charge_detail prefers when a transport
+    is attached. With a cloud client available, the coordinator reads the
+    cloud getStatusInfo directly for that family.
+    """
+
+    @staticmethod
+    def _cloud_status(active: bool) -> MagicMock:
+        status = MagicMock()
+        status.hasUnclosedQuickChargeTask = active
+        status.remainTimeBeforeQuickChargeStop = 3540 if active else 0
+        status.unclosedQuickChargeTaskId = 7 if active else None
+        status.unclosedQuickChargeTaskStatus = "WAIT_CHARGE" if active else None
+        status.quickChargeMinute = None
+        return status
+
+    @staticmethod
+    def _offgrid_inverter() -> MagicMock:
+        inverter = MagicMock()
+        inverter.serial_number = "61062J0147"
+        inverter.transport = object()  # HYBRID: local transport attached
+        inverter.get_quick_charge_detail = AsyncMock()
+        return inverter
+
+    def _coordinator_with_cloud(
+        self, hass, mock_config_entry, *, active: bool = True
+    ) -> EG4DataUpdateCoordinator:
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        client = MagicMock()
+        client.api.control.get_quick_charge_status = AsyncMock(
+            return_value=self._cloud_status(active)
+        )
+        coordinator.client = client
+        return coordinator
+
+    async def test_fetch_uses_cloud_for_offgrid_hybrid(self, hass, mock_config_entry):
+        """Offgrid + transport + cloud client -> cloud getStatusInfo is the
+        status source; the transport-preferring detail read is bypassed."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+        inverter = self._offgrid_inverter()
+        target: dict[str, Any] = {
+            "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
+        }
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        coordinator.client.api.control.get_quick_charge_status.assert_awaited_once_with(
+            "61062J0147"
+        )
+        inverter.get_quick_charge_detail.assert_not_awaited()
+        status = target["quick_charge_status"]
+        assert status["hasUnclosedQuickChargeTask"] is True
+        assert status["remainTimeBeforeQuickChargeStop"] == 3540
+        assert status["quickChargeMinute"] is None
+        assert status["fetched_at"] <= time.monotonic()
+
+    async def test_fetch_keeps_local_detail_for_other_families(
+        self, hass, mock_config_entry
+    ):
+        """Non-offgrid families keep the transport-preferring detail read
+        (register 233 works there)."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+        inverter = self._offgrid_inverter()
+        detail = self._cloud_status(False)
+        detail.quickChargeMinute = 60
+        inverter.get_quick_charge_detail = AsyncMock(return_value=detail)
+        target: dict[str, Any] = {"features": {"inverter_family": "EG4_HYBRID"}}
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        inverter.get_quick_charge_detail.assert_awaited_once()
+        coordinator.client.api.control.get_quick_charge_status.assert_not_awaited()
+        status = target["quick_charge_status"]
+        assert status["hasUnclosedQuickChargeTask"] is False
+        assert status["quickChargeMinute"] == 60
+        assert "fetched_at" in status
+
+    async def test_fetch_offgrid_without_cloud_uses_transport_read(
+        self, hass, mock_config_entry
+    ):
+        """Offgrid LOCAL-only (no cloud client): only the transport read
+        exists — unchanged behavior."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = None
+        inverter = self._offgrid_inverter()
+        inverter.get_quick_charge_detail = AsyncMock(
+            return_value=self._cloud_status(False)
+        )
+        target: dict[str, Any] = {
+            "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
+        }
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        inverter.get_quick_charge_detail.assert_awaited_once()
+        assert target["quick_charge_status"]["hasUnclosedQuickChargeTask"] is False
+
+    async def test_fetch_failure_carries_previous_status_forward(
+        self, hass, mock_config_entry
+    ):
+        """A failed read carries the previous cycle's status forward (with its
+        original fetched_at) instead of dropping the key — a transient error
+        must not flip the switch to a lying OFF."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = None
+        prev = {
+            "hasUnclosedQuickChargeTask": True,
+            "fetched_at": 1234.5,
+        }
+        coordinator.data = {"devices": {"61062J0147": {"quick_charge_status": prev}}}
+        inverter = self._offgrid_inverter()
+        inverter.get_quick_charge_detail = AsyncMock(side_effect=OSError("bus stalled"))
+        target: dict[str, Any] = {"features": {}}
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        assert target["quick_charge_status"] is prev
+        assert target["quick_charge_status"]["fetched_at"] == 1234.5
+
+    async def test_active_live_uses_cloud_for_offgrid_hybrid(
+        self, hass, mock_config_entry
+    ):
+        """is_quick_charge_active_live reads the cloud for offgrid HYBRID —
+        the reg-233 read cannot see a cloud-started charge."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+        coordinator.data = {
+            "devices": {
+                "61062J0147": {
+                    "type": "inverter",
+                    "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID},
+                }
+            }
+        }
+        inverter = self._offgrid_inverter()
+        with patch.object(coordinator, "get_inverter_object", return_value=inverter):
+            assert await coordinator.is_quick_charge_active_live("61062J0147") is True
+        inverter.get_quick_charge_detail.assert_not_awaited()
+        coordinator.client.api.control.get_quick_charge_status.assert_awaited_once_with(
+            "61062J0147"
+        )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7060,6 +7060,30 @@ class TestQuickChargeOffgridCloudStatus:
         inverter.transport.read_parameters.assert_awaited_once_with(234, 1)
         assert status["fetched_at"] <= time.monotonic()
 
+    async def test_fetch_offgrid_reg234_skipped_when_link_down(
+        self, hass, mock_config_entry
+    ):
+        """Codex round-3: an attached-but-dead transport link must not be
+        touched — a raw read_parameters on it is the uninterruptible
+        multi-minute pymodbus hang class (same gate as
+        _refresh_device_parameters). No transport read is attempted; minute
+        degrades to None (stored-preference fallback); the cloud active flag
+        is unaffected."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = self._coordinator_with_cloud(hass, mock_config_entry)
+        inverter = self._offgrid_inverter()
+        inverter.transport_link_down = True
+        target: dict[str, Any] = {
+            "features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
+        }
+
+        await coordinator._fetch_quick_charge_status(inverter, target)
+
+        inverter.transport.read_parameters.assert_not_awaited()
+        status = target["quick_charge_status"]
+        assert status["hasUnclosedQuickChargeTask"] is True
+        assert status["quickChargeMinute"] is None
+
     async def test_fetch_offgrid_reg234_read_failure_falls_back_to_none(
         self, hass, mock_config_entry
     ):

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -1,5 +1,7 @@
 """Tests for EG4 switch entities."""
 
+import time
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -113,6 +115,13 @@ def _mock_coordinator(
         control_response.success = True
         mock_client = MagicMock()
         mock_client.api.control.control_function = AsyncMock(
+            return_value=control_response
+        )
+        # Cloud quick charge endpoints (offgrid cloud-direct path, #296)
+        mock_client.api.control.start_quick_charge = AsyncMock(
+            return_value=control_response
+        )
+        mock_client.api.control.stop_quick_charge = AsyncMock(
             return_value=control_response
         )
         coordinator.client = mock_client
@@ -509,6 +518,229 @@ class TestQuickChargeSwitch:
         switch = EG4QuickChargeSwitch(coordinator, "1234567890")
         attrs = switch.extra_state_attributes
         assert attrs is None or "minutes_remaining" not in attrs
+
+
+_OFFGRID_FEATURES = {"features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}}
+
+
+class TestQuickChargeSwitchOffgridCloudFirst:
+    """EG4_OFFGRID (12000XP/6000XP) drives quick charge via the cloud (#296).
+
+    The XP firmware rejects holding register 233 (ILLEGAL DATA ADDRESS), so
+    pylxpweb's local-first enable/disable burns a doomed Modbus write on every
+    toggle before falling back to the cloud. The switch goes straight to the
+    cloud start/stop endpoints for that family when a cloud client exists.
+    """
+
+    @pytest.mark.asyncio
+    async def test_offgrid_hybrid_turn_on_uses_cloud_endpoint(self):
+        """Offgrid + cloud: start_quick_charge called; no local-first attempt."""
+        coordinator = _mock_coordinator(
+            model="12000XP",
+            device_data=dict(_OFFGRID_FEATURES),
+            transport_attached=True,
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        coordinator.client.api.control.start_quick_charge.assert_awaited_once_with(
+            "1234567890", minute=60
+        )
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_quick_charge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_offgrid_hybrid_turn_off_uses_cloud_endpoint(self):
+        """Offgrid + cloud: stop_quick_charge called; no local-first attempt."""
+        coordinator = _mock_coordinator(
+            model="12000XP",
+            device_data=dict(_OFFGRID_FEATURES),
+            transport_attached=True,
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_off()
+
+        coordinator.client.api.control.stop_quick_charge.assert_awaited_once_with(
+            "1234567890"
+        )
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.disable_quick_charge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_offgrid_without_cloud_uses_inverter_method(self):
+        """Offgrid LOCAL-only: no cloud to prefer — the inverter method runs
+        (and fails honestly if the firmware rejects it)."""
+        coordinator = _mock_coordinator(
+            has_http=False,
+            has_local=True,
+            local_only=True,
+            model="12000XP",
+            device_data=dict(_OFFGRID_FEATURES),
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_quick_charge.assert_called_once_with(minute=60)
+
+    @pytest.mark.asyncio
+    async def test_non_offgrid_keeps_local_first_method(self):
+        """Hybrid families keep pylxpweb's local-first enable (233 works)."""
+        coordinator = _mock_coordinator(
+            device_data={"features": {"inverter_family": "EG4_HYBRID"}},
+            transport_attached=True,
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_quick_charge.assert_called_once_with(minute=60)
+        coordinator.client.api.control.start_quick_charge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_offgrid_cloud_start_failure_raises(self):
+        """A failed cloud start raises and does not arm the retention hold."""
+        coordinator = _mock_coordinator(
+            model="12000XP",
+            device_data=dict(_OFFGRID_FEATURES),
+            transport_attached=True,
+        )
+        failure = MagicMock()
+        failure.success = False
+        coordinator.client.api.control.start_quick_charge = AsyncMock(
+            return_value=failure
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+        assert switch._pending_state is None
+        assert switch.is_on is False
+
+
+class TestQuickChargeSwitchOptimisticRetention:
+    """Post-write retention (#296): a successful enable must survive stale or
+    carried-forward status polls until a read FRESHER than the write confirms
+    either state, bounded by a TTL."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_arms_retention(self):
+        """A successful turn_on holds ON even though the coordinator has no
+        confirming status (the reporter's 7-second flip-off)."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        assert switch._optimistic_state is None  # base machinery cleared it
+        assert switch.is_on is True  # retention holds the commanded state
+
+    @pytest.mark.asyncio
+    async def test_stale_status_does_not_clobber_retention(self):
+        """A status read from BEFORE the write (stale fetched_at) is ignored."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        # Simulate the next poll carrying forward a pre-write idle status.
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": False,
+            "fetched_at": switch._pending_since - 10.0,
+        }
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_statusless_poll_does_not_clobber_retention(self):
+        """A poll with no quick_charge_status at all keeps the held state."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        coordinator.data["devices"]["1234567890"].pop("quick_charge_status", None)
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_fresh_confirming_read_clears_retention(self):
+        """A post-write read confirming ON clears the hold; state stays ON."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": True,
+            "fetched_at": time.monotonic() + 1.0,
+        }
+        assert switch.is_on is True
+        assert switch._pending_state is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_off_read_is_trusted(self):
+        """A post-write read reporting idle wins over the hold (fresh data is
+        authoritative in either direction)."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": False,
+            "fetched_at": time.monotonic() + 1.0,
+        }
+        assert switch.is_on is False
+        assert switch._pending_state is None
+
+    @pytest.mark.asyncio
+    async def test_retention_ttl_expiry(self):
+        """The hold cannot stick forever: past the TTL the switch falls back
+        to the (absent/idle) coordinator status."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        switch._pending_since = (
+            time.monotonic() - switch_module.QUICK_CHARGE_OPTIMISTIC_TTL - 1.0
+        )
+        assert switch.is_on is False
+        assert switch._pending_state is None
+
+    @pytest.mark.asyncio
+    async def test_turn_off_arms_retention_off(self):
+        """Turn-off retention: a stale still-active status can't flip the
+        switch back ON after a successful stop."""
+        coordinator = _mock_coordinator(
+            device_data={
+                "quick_charge_status": {
+                    "hasUnclosedQuickChargeTask": True,
+                    "fetched_at": time.monotonic() - 60.0,
+                }
+            }
+        )
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_off()
+
+        assert switch.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_failed_enable_does_not_arm_retention(self):
+        """A failed enable raises and leaves no hold behind."""
+        coordinator = _mock_coordinator()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_quick_charge = AsyncMock(return_value=False)
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+        assert switch._pending_state is None
+        assert switch.is_on is False
 
 
 # ── BatteryBackupSwitch ──────────────────────────────────────────────

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -681,9 +681,10 @@ class TestQuickChargeSwitchOptimisticRetention:
         assert switch._pending_state is None
 
     @pytest.mark.asyncio
-    async def test_fresh_off_read_is_trusted(self):
-        """A post-write read reporting idle wins over the hold (fresh data is
-        authoritative in either direction)."""
+    async def test_fresh_off_read_within_ttl_holds(self):
+        """A post-write read reporting idle within the TTL does NOT end the
+        hold — the cloud may simply not have registered the new task yet
+        (propagation lag)."""
         coordinator = _mock_coordinator()
         switch = EG4QuickChargeSwitch(coordinator, "1234567890")
         _prep(switch)
@@ -693,13 +694,14 @@ class TestQuickChargeSwitchOptimisticRetention:
             "hasUnclosedQuickChargeTask": False,
             "fetched_at": time.monotonic() + 1.0,
         }
-        assert switch.is_on is False
-        assert switch._pending_state is None
+        assert switch.is_on is True
+        assert switch._pending_state is True
 
     @pytest.mark.asyncio
-    async def test_retention_ttl_expiry(self):
-        """The hold cannot stick forever: past the TTL the switch falls back
-        to the (absent/idle) coordinator status."""
+    async def test_fresh_off_read_after_ttl_is_trusted(self):
+        """Past the TTL a fresh unconfirming read is trusted — the hard bound
+        that keeps the hold from sticking forever on a genuinely idle
+        inverter."""
         coordinator = _mock_coordinator()
         switch = EG4QuickChargeSwitch(coordinator, "1234567890")
         _prep(switch)
@@ -708,8 +710,62 @@ class TestQuickChargeSwitchOptimisticRetention:
         switch._pending_since = (
             time.monotonic() - switch_module.QUICK_CHARGE_OPTIMISTIC_TTL - 1.0
         )
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": False,
+            # Fresh: read after the (backdated) write.
+            "fetched_at": time.monotonic(),
+        }
         assert switch.is_on is False
         assert switch._pending_state is None
+
+    @pytest.mark.asyncio
+    async def test_ttl_expiry_with_stale_data_does_not_flap(self):
+        """Codex round-2 blocker: at TTL expiry a KNOWN-STALE (pre-write)
+        status must not reclaim the switch — that would reproduce the original
+        bug at t+TTL (ON -> stale OFF -> eventual fresh ON) during a cloud 502
+        storm. The hold survives until fresh data, which is then trusted."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        # Stale pre-write idle status (e.g. carried forward through a 502
+        # storm), and the TTL has expired.
+        stale = {
+            "hasUnclosedQuickChargeTask": False,
+            "fetched_at": switch._pending_since - 10.0,
+        }
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = stale
+        switch._pending_since = (
+            time.monotonic() - switch_module.QUICK_CHARGE_OPTIMISTIC_TTL - 1.0
+        )
+        stale["fetched_at"] = switch._pending_since - 10.0  # keep it pre-write
+        assert switch.is_on is True  # no flap to the stale value
+        assert switch._pending_state is True
+
+        # A fresh read finally lands and is trusted in either direction.
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": True,
+            "fetched_at": time.monotonic(),
+        }
+        assert switch.is_on is True
+        assert switch._pending_state is None
+
+    @pytest.mark.asyncio
+    async def test_ttl_expiry_with_no_data_holds(self):
+        """With NO status data at all the hold also survives the TTL —
+        absence of data is not evidence of idle."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+        await switch.async_turn_on()
+
+        coordinator.data["devices"]["1234567890"].pop("quick_charge_status", None)
+        switch._pending_since = (
+            time.monotonic() - switch_module.QUICK_CHARGE_OPTIMISTIC_TTL - 1.0
+        )
+        assert switch.is_on is True
+        assert switch._pending_state is True
 
     @pytest.mark.asyncio
     async def test_turn_off_arms_retention_off(self):


### PR DESCRIPTION
Fixes #296.

## Root cause (from reporter's log, 12000XP v2 `61062J0147`, HYBRID)

The 12000XP/6000XP (EG4_OFFGRID) firmware rejects holding register 233 with `function=0x86, code=2` (ILLEGAL DATA ADDRESS). Register 233 is what pylxpweb's transport-preferring quick-charge paths **read AND write** whenever a local transport is attached:

1. **Switch reads OFF while charging** — the coordinator's status fetch used `get_quick_charge_detail()`, which reads reg 233 locally in HYBRID. The charge actually started via the **cloud fallback** endpoint (the one the EG4 app reflects), so the local read could never see it.
2. **~7-second ON window** — `_execute_switch_action` clears optimistic state unconditionally after the post-write coordinator refresh; that refresh served non-confirming status data (carried-forward under the 30s throttle, or read before the cloud registered the task), flipping the switch OFF while the inverter kept charging.
3. **Doomed local write on every toggle** — local-first `enable_quick_charge` burned a firmware-rejected reg-233 write + warning log before falling back to cloud.

## Fix

- **Cloud status source for offgrid HYBRID** (`coordinator_mixins.py`): `_fetch_quick_charge_status` / `is_quick_charge_active_live` read `client.api.control.get_quick_charge_status()` directly when the device is `is_offgrid_family()` **and** has a transport attached **and** a cloud client exists. Every other family/mode is unchanged. The Duration register (holding 234, minutes) is still read via the **local transport** on this route so the Quick Charge Duration number's read and write sides agree (see review round 2 below).
- **Post-write optimistic retention** (`switch.py`): real status reads are stamped with `fetched_at` (monotonic); after a successful enable/disable the switch retains the commanded state until a status read **fresher than the write** reports on the charge. A fresh CONFIRMING read ends the hold immediately; a fresh UNCONFIRMING read is trusted only after a 300s TTL (within it, the cloud may not have registered the task yet — pylxpweb also invalidates the getStatusInfo cache on start/stop, so fresh data normally lands within one 30s throttle window). **Known-stale data (carried-forward or pre-write) never overrides the command, even past the TTL** — trusting it at expiry would flap the switch to the pre-write value mid-charge during a cloud 502 storm.
- **Cloud-first control for offgrid** (`switch.py`): `EG4QuickChargeSwitch` calls the cloud start/stop endpoints directly for the offgrid family when a cloud client is configured (no doomed reg-233 write, no warning spam). Non-offgrid keeps local-first; offgrid LOCAL-only keeps the honest local attempt. `_execute_switch_action` accepts bound callables as well as inverter method names.
- **Transient-error robustness**: a failed status read carries the previous cycle's status forward (with its original `fetched_at`) instead of dropping the key.

## Codex adversarial review round 2 (both blockers fixed)

- **Blocker 1 (TTL flap)**: at TTL expiry the switch previously fell through to the carried status dict — which could be the stale PRE-write value, reproducing the original bug at t+300s (ON → stale OFF → eventual fresh ON). Retention now ends only on FRESH data; the TTL is solely the bound past which a fresh-but-unconfirming read is trusted. Stale/absent data holds the commanded state indefinitely (it clears on the first fresh read, which the 30s status cycle produces as soon as the cloud responds). Tests cover the exact flap scenario.
- **Blocker 2 (Duration read/write split)**: the cloud status model carries `quickChargeMinute=None`, which would have permanently decoupled the Duration number's display (stored preference) from its setter (local reg-234 write). Chose **option (a)**: the offgrid cloud route reads reg 234 via the local transport for `quickChargeMinute` — minimal and honest, cloud supplies only the active flag. Only reg 233 is proven XP-rejected; if reg 234 reads also fail on the XP, the value degrades to None → stored-preference fallback, and the setter's own write surfaces its error.
- **Mitigation**: the cloud-routed status reads share the pylxpweb client's station-wide retry/backoff state; during a 502 storm an escalated backoff (up to ~60s `asyncio.sleep`) could hold a coordinator semaphore slot. Both cloud status reads are now bounded with `asyncio.wait_for` (10s); a timeout is a failed read → existing carry-forward. **Full backoff-domain isolation is a pylxpweb architectural item deliberately not attempted here.**

## Tests

- 19 new tests across `test_switch_entities.py` / `test_coordinator.py`: offgrid HYBRID turn on/off use cloud endpoints (never the local-first method), offgrid LOCAL-only + non-offgrid unchanged, cloud-start failure raises without arming retention, retention survives stale/statusless polls, fresh confirming read clears, fresh unconfirming within TTL holds / after TTL trusted, **stale data at TTL expiry does not flap (then fresh read trusted)**, no-data past TTL holds, coordinator cloud-status routing, local reg-234 read on the cloud route (+ its failure fallback), `fetched_at` stamping, carry-forward on read failure, cloud read time-bound (timeout → carry-forward), `is_quick_charge_active_live` offgrid routing.
- Full suite: **1807 passed, 3 skipped**. ruff + ruff format + mypy (strict config) clean.

## Codex re-verify round 3 (both items applied)

- **Link-down gate**: `_read_offgrid_quick_charge_minute()` now early-returns None when `is_transport_link_down(inverter)` — a raw `read_parameters` on an attached-but-dead link is the uninterruptible multi-minute pymodbus hang class (same gate as `_refresh_device_parameters`), and this read fires on every 30s-throttled status poll on offgrid+HYBRID. Test asserts no transport read is attempted and the minute degrades to the stored-preference fallback.
- **Retention trade-off on the record**: the post-write hold is fresh-data-terminated, so a **permanent** status-source outage after a command retains the commanded state indefinitely — this intentionally reverses the earlier "a dead status source can never pin state forever" guarantee. Showing the last state the inverter provably accepted beats flapping to known pre-write data; the first fresh read (either direction) ends the hold.

## Residual unknowns (no XP hardware)

- Whether reg 233 **reads** fail or return unrelated data on the XP — either way the cloud is now the source in HYBRID. LOCAL-only XP quick charge remains firmware-limited (writes rejected; unchanged, fails honestly).
- Whether reg 234 (`SNA_HOLD_QUICK_CHARGE_MINUTE`) reads/writes work on the XP — the Duration number now reads reg 234 locally on the offgrid HYBRID route; if that read fails it falls back to the stored cloud preference, and a mid-charge duration write may still be firmware-rejected (surfaced as an error).
- Which register (if any) actually carries quick-charge state on the XP family locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
