### PR TITLE
fix: positional battery retirement tracks exposed keys across slot shifts (#302)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -360,6 +360,13 @@ class EG4DataUpdateCoordinator(
         # duplicate/misreported battery serial).  Sticky until restart;
         # positional registry rows are left untouched as orphans.
         self._battery_migration_suppressed: set[str] = set()
+        # Positional fallback keys already announced by the shifted-slot
+        # retirement sweep (#302).  The retired key's registry rows can
+        # survive as orphans (the #252 migration renames first-seen-order
+        # legacy keys, which need not match the slot-position fallback), so
+        # the retirement is logged at INFO once per key — repeats from a
+        # flapping serial fall back to DEBUG.
+        self._battery_shift_retire_logged: set[str] = set()
         # Last published battery mapping per inverter (#258 beta.18): battery
         # entity availability is key-presence in device_data["batteries"], and
         # the HYBRID/CLOUD paths rebuild that dict from the cloud payload as

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -159,12 +159,14 @@ class LocalTransportMixin(_MixinBase):
         keys_this_poll: dict[str, int] = {}
         # Exposure record for the shifted-slot retirement sweep (#302):
         # positional keys re-claimed by a serial-less battery this poll, and
-        # every slot that reported serial-less data this poll (pending or
-        # exposed).
+        # every virtual slot the transport served this poll in ANY state
+        # (ghost, truncated, serial-less or serial) — a slot absent from the
+        # served set is an upstream reservation hole, never a transient.
         positional_keys_this_poll: set[str] = set()
-        noserial_slots_this_poll: set[int] = set()
+        slots_this_poll: set[int] = set()
 
         for batt in transport_batteries:
+            slots_this_poll.add(batt.battery_index)
             # Skip ghost batteries with no CAN bus data — BatteryData voltage/soc
             # are non-optional (default 0), so an empty slot reads 0/0 not None.
             if batt.voltage == 0 and batt.soc == 0:
@@ -188,7 +190,6 @@ class LocalTransportMixin(_MixinBase):
                 # (#252 cold start — see _NO_SERIAL_EXPOSE_POLLS).
                 seen_polls = noserial_polls.get(slot, 0) + 1
                 noserial_polls[slot] = seen_polls
-                noserial_slots_this_poll.add(slot)
                 fallback_key = f"{inverter_serial}-{slot + 1:02d}"
                 if seen_polls < _NO_SERIAL_EXPOSE_POLLS:
                     poll_slots_skipped += 1
@@ -336,16 +337,37 @@ class LocalTransportMixin(_MixinBase):
                     self._battery_carry_forward.get(inverter_serial, {}).pop(
                         stale_key, None
                     )
-                _LOGGER.debug(
-                    "RR [%s]: retired shifted positional fallback %s "
-                    "(new serial(s) %s claimed fresh virtual slots)",
+                # INFO once per key (mirrors _suppress_battery_migration): the
+                # #252 migration renames first-seen-order legacy keys, which
+                # need not match this slot-position fallback, so the retired
+                # key's HA device/entities can survive as registry orphans the
+                # user has to remove manually.  Flapping-serial repeats DEBUG.
+                level = (
+                    logging.DEBUG
+                    if stale_key in self._battery_shift_retire_logged
+                    else logging.INFO
+                )
+                self._battery_shift_retire_logged.add(stale_key)
+                _LOGGER.log(
+                    level,
+                    "RR [%s]: retired stale positional battery fallback %s — "
+                    "its serial became readable at a shifted slot (new "
+                    "serial(s): %s). If a battery device/entities keyed %r "
+                    "remain in Home Assistant, they are orphaned and can be "
+                    "removed from the device page (#302)",
                     inverter_serial,
                     stale_key,
                     new_serials,
+                    stale_key,
                 )
-            for stale_slot in [
-                s for s in noserial_polls if s not in noserial_slots_this_poll
-            ]:
+            # Debounce counters whose slot the transport did not serve AT ALL
+            # this poll belong to upstream-evicted reservation holes — pop
+            # them (a stale pending counter would otherwise inject a phantom
+            # positional key into active_keys below, permanently blocking the
+            # one-shot #252 migration).  Slots served in any state — including
+            # ghost or truncated reads that skipped the counter increment —
+            # keep their debounce progress.
+            for stale_slot in [s for s in noserial_polls if s not in slots_this_poll]:
                 noserial_polls.pop(stale_slot)
 
         if key_migrations:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -157,6 +157,12 @@ class LocalTransportMixin(_MixinBase):
         key_migrations: dict[str, str] = {}
         # Canonical keys claimed this poll → slot, for duplicate detection.
         keys_this_poll: dict[str, int] = {}
+        # Exposure record for the shifted-slot retirement sweep (#302):
+        # positional keys re-claimed by a serial-less battery this poll, and
+        # every slot that reported serial-less data this poll (pending or
+        # exposed).
+        positional_keys_this_poll: set[str] = set()
+        noserial_slots_this_poll: set[int] = set()
 
         for batt in transport_batteries:
             # Skip ghost batteries with no CAN bus data — BatteryData voltage/soc
@@ -182,6 +188,7 @@ class LocalTransportMixin(_MixinBase):
                 # (#252 cold start — see _NO_SERIAL_EXPOSE_POLLS).
                 seen_polls = noserial_polls.get(slot, 0) + 1
                 noserial_polls[slot] = seen_polls
+                noserial_slots_this_poll.add(slot)
                 fallback_key = f"{inverter_serial}-{slot + 1:02d}"
                 if seen_polls < _NO_SERIAL_EXPOSE_POLLS:
                     poll_slots_skipped += 1
@@ -196,6 +203,7 @@ class LocalTransportMixin(_MixinBase):
                     )
                     continue
                 fallback_keys.add(fallback_key)
+                positional_keys_this_poll.add(fallback_key)
                 cache[fallback_key] = _build_individual_battery_mapping(batt)
                 _LOGGER.debug(
                     "RR [%s] slot %d: no serial, fallback key %s (V=%.1f SoC=%s)",
@@ -243,6 +251,7 @@ class LocalTransportMixin(_MixinBase):
                 )
                 collision_key = f"{inverter_serial}-{slot + 1:02d}"
                 fallback_keys.add(collision_key)
+                positional_keys_this_poll.add(collision_key)
                 cache[collision_key] = _build_individual_battery_mapping(batt)
                 continue
             keys_this_poll[battery_key] = slot
@@ -296,6 +305,48 @@ class LocalTransportMixin(_MixinBase):
                 batt.voltage or 0.0,
                 batt.soc or 0,
             )
+
+        # Shifted-slot positional retirement (#302).  When a positional slot's
+        # serial becomes readable, pylxpweb (post pylxpweb#204) evicts its
+        # "pos:N" accumulator entry and mints the serial a NEW virtual slot —
+        # preserving the old slot as a reservation hole — so the serial's
+        # battery_index no longer points at the slot whose positional key was
+        # exposed.  The same-slot retirement above then misses the exposed
+        # key, leaving a frozen positional twin (until the 6h age bound,
+        # #300) and a stale debounce counter that keeps blocking the #252
+        # registry migration through active_keys below.
+        #
+        # BatteryData carries no bank-position metadata that survives the
+        # eviction, so the exposed key is matched by ABSENCE instead of by
+        # position: the transport serves its full accumulator on every poll,
+        # so an exposed positional key that no serial-less battery re-claimed
+        # this poll has been evicted upstream — exactly the pos:N entries the
+        # arriving serial(s) reconciled.  Gated on new_serials so the swept
+        # polls are precisely the reconciliation events; steady-state polls
+        # (including transient ghost reads of a still-serial-less battery)
+        # keep the pre-#302 behavior.
+        if new_serials:
+            for stale_key in sorted(fallback_keys - positional_keys_this_poll):
+                fallback_keys.discard(stale_key)
+                # A placeholder serial (Battery_ID_NN) can canonically claim
+                # the very key it was exposed under — never drop a mapping a
+                # serial owns as of this poll.
+                if stale_key not in keys_this_poll:
+                    cache.pop(stale_key, None)
+                    self._battery_carry_forward.get(inverter_serial, {}).pop(
+                        stale_key, None
+                    )
+                _LOGGER.debug(
+                    "RR [%s]: retired shifted positional fallback %s "
+                    "(new serial(s) %s claimed fresh virtual slots)",
+                    inverter_serial,
+                    stale_key,
+                    new_serials,
+                )
+            for stale_slot in [
+                s for s in noserial_polls if s not in noserial_slots_this_poll
+            ]:
+                noserial_polls.pop(stale_slot)
 
         if key_migrations:
             # Rotation trust guard: with more distinct serials than register

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -590,6 +590,7 @@ if TYPE_CHECKING:
         _battery_fallback_keys: dict[str, set[str]]
         _battery_noserial_polls: dict[str, dict[int, int]]
         _battery_migration_suppressed: set[str]
+        _battery_shift_retire_logged: set[str]
         # ── Battery carry-forward (#258, coordinator.py) ──
         _battery_carry_forward: dict[str, dict[str, dict[str, Any]]]
 

--- a/tests/test_issue_252_battery_identity.py
+++ b/tests/test_issue_252_battery_identity.py
@@ -22,6 +22,7 @@ positional duplicates when the canonical entity already exists, and carrying
 device customizations (area/name/labels) to the canonical device.
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -741,7 +742,7 @@ class TestShiftedSlotRetirement:
     """
 
     async def test_shifted_index_retires_exposed_fallback_immediately(
-        self, hass, mock_config_entry
+        self, hass, mock_config_entry, caplog
     ):
         """Serial arriving at a SHIFTED index still retires the exposed twin.
 
@@ -761,13 +762,26 @@ class TestShiftedSlotRetirement:
 
         # Serial becomes readable: pylxpweb evicts pos:0 and mints the serial
         # virtual slot 1; slot 0 stays a reservation hole (never served again).
-        result = coordinator._merge_round_robin_batteries(
-            INV, [_transport_battery(1, BAT_SN_1)]
-        )
+        with caplog.at_level(logging.INFO):
+            result = coordinator._merge_round_robin_batteries(
+                INV, [_transport_battery(1, BAT_SN_1)]
+            )
 
         # The exposed positional twin retired immediately — no 6h wait.
         assert set(result) == {f"{INV}-{BAT_SN_1}"}
         assert coordinator._battery_fallback_keys[INV] == set()
+        # The retirement is user-visible at INFO naming the stale key: its
+        # registry rows can survive as orphans (the #252 migration renames
+        # first-seen-order legacy keys, which need not match the
+        # slot-position fallback), so users need a discoverable trace.
+        retire_logs = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.INFO
+            and "retired stale positional battery fallback" in record.getMessage()
+            and f"{INV}-01" in record.getMessage()
+        ]
+        assert len(retire_logs) == 1
         # The stale slot-0 debounce counter is popped too.
         assert coordinator._battery_noserial_polls[INV] == {}
         # Retirement is authoritative over the carry-forward layer.
@@ -860,6 +874,61 @@ class TestShiftedSlotRetirement:
         device_registry = dr.async_get(hass)
         assert device_registry.async_get_device({(DOMAIN, old_key)}) is None
         assert device_registry.async_get_device({(DOMAIN, new_key)}) is not None
+
+    async def test_shift_retirement_log_is_one_shot_per_key(
+        self, hass, mock_config_entry, caplog
+    ):
+        """A key already announced retires at DEBUG, not INFO (no log spam)."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        # Simulate an earlier announcement of this key (flapping serial).
+        coordinator._battery_shift_retire_logged.add(f"{INV}-01")
+
+        no_serial = [_transport_battery(0, "")]
+        for _ in range(3):
+            coordinator._merge_round_robin_batteries(INV, no_serial)
+        with caplog.at_level(logging.INFO):
+            result = coordinator._merge_round_robin_batteries(
+                INV, [_transport_battery(1, BAT_SN_1)]
+            )
+
+        # Retirement itself still happens...
+        assert set(result) == {f"{INV}-{BAT_SN_1}"}
+        # ...but without a second INFO record.
+        assert not [
+            record
+            for record in caplog.records
+            if record.levelno == logging.INFO
+            and "retired stale positional battery fallback" in record.getMessage()
+        ]
+
+    async def test_ghost_read_sibling_keeps_debounce_counter(
+        self, hass, mock_config_entry
+    ):
+        """A ghost-read sibling slot keeps its debounce progress.
+
+        The counter sweep only pops slots the transport did not serve AT ALL
+        (upstream reservation holes).  A sibling served as a ghost this poll
+        (voltage=0, soc=0 — skipped before the counter increment) must not
+        have its pending debounce reset by an unrelated serial arrival.
+        """
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        pair = [_transport_battery(0, ""), _transport_battery(1, "")]
+        for _ in range(2):  # both pending: counters {0: 2, 1: 2}
+            coordinator._merge_round_robin_batteries(INV, pair)
+        assert coordinator._battery_noserial_polls[INV] == {0: 2, 1: 2}
+
+        # Slot 0's serial arrives (shifted to virtual slot 2, hole at 0);
+        # slot 1's battery reads ghost this poll but IS served.
+        ghost = BatteryData(battery_index=1, serial_number="", voltage=0.0, soc=0)
+        coordinator._merge_round_robin_batteries(
+            INV, [_transport_battery(2, BAT_SN_1), ghost]
+        )
+
+        # Reconciled hole's stale counter popped; ghost sibling's retained.
+        assert coordinator._battery_noserial_polls[INV] == {1: 2}
 
 
 # ── Rotation trust guard (third review, LOCAL only) ───────────────────

--- a/tests/test_issue_252_battery_identity.py
+++ b/tests/test_issue_252_battery_identity.py
@@ -727,6 +727,141 @@ class TestNoSerialThenSerialSequence:
         assert set(result) == {f"{INV}-01"}
 
 
+# ── #302: retirement across pylxpweb#204 virtual-slot shifts ──────────
+
+
+class TestShiftedSlotRetirement:
+    """Exposed positional keys retire even when battery_index shifts (#302).
+
+    Since pylxpweb#204, reconciling a "pos:N" accumulator entry evicts it and
+    mints the arriving serial a NEW virtual slot (the old slot stays a
+    reservation hole), so the serial's ``battery_index`` no longer matches the
+    slot whose positional key the integration exposed.  Retirement must key
+    off the exposure record, not the shifted index.
+    """
+
+    async def test_shifted_index_retires_exposed_fallback_immediately(
+        self, hass, mock_config_entry
+    ):
+        """Serial arriving at a SHIFTED index still retires the exposed twin.
+
+        Regression for #302: pre-fix the merge retired {INV}-02 (current
+        index) instead of the exposed {INV}-01, leaving a frozen positional
+        twin until the 6h age bound and an orphaned debounce counter.
+        """
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        no_serial = [_transport_battery(0, "")]
+        for _ in range(3):  # exposed after _NO_SERIAL_EXPOSE_POLLS
+            result = coordinator._merge_round_robin_batteries(INV, no_serial)
+        assert set(result) == {f"{INV}-01"}
+        # Carry-forward layer also published the positional key earlier.
+        coordinator._battery_carry_forward[INV] = {f"{INV}-01": {"battery_soc": 90}}
+
+        # Serial becomes readable: pylxpweb evicts pos:0 and mints the serial
+        # virtual slot 1; slot 0 stays a reservation hole (never served again).
+        result = coordinator._merge_round_robin_batteries(
+            INV, [_transport_battery(1, BAT_SN_1)]
+        )
+
+        # The exposed positional twin retired immediately — no 6h wait.
+        assert set(result) == {f"{INV}-{BAT_SN_1}"}
+        assert coordinator._battery_fallback_keys[INV] == set()
+        # The stale slot-0 debounce counter is popped too.
+        assert coordinator._battery_noserial_polls[INV] == {}
+        # Retirement is authoritative over the carry-forward layer.
+        assert f"{INV}-01" not in coordinator._battery_carry_forward[INV]
+
+        # And it stays gone on subsequent polls.
+        result = coordinator._merge_round_robin_batteries(
+            INV, [_transport_battery(1, BAT_SN_1)]
+        )
+        assert set(result) == {f"{INV}-{BAT_SN_1}"}
+
+    async def test_shifted_retirement_spares_still_serialless_sibling(
+        self, hass, mock_config_entry
+    ):
+        """Only the reconciled battery's positional key retires.
+
+        A still-serial-less sibling re-claims its positional key on the same
+        poll (the transport serves the full accumulator every poll), so the
+        absence-based sweep must leave it — and its debounce counter — alone.
+        """
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        pair = [_transport_battery(0, ""), _transport_battery(1, "")]
+        for _ in range(3):
+            result = coordinator._merge_round_robin_batteries(INV, pair)
+        assert set(result) == {f"{INV}-01", f"{INV}-02"}
+
+        # Slot 0's serial arrives (shifted to fresh virtual slot 2); slot 1's
+        # battery is still serial-less and re-served from the accumulator.
+        result = coordinator._merge_round_robin_batteries(
+            INV, [_transport_battery(2, BAT_SN_1), _transport_battery(1, "")]
+        )
+
+        assert set(result) == {f"{INV}-{BAT_SN_1}", f"{INV}-02"}
+        assert coordinator._battery_fallback_keys[INV] == {f"{INV}-02"}
+        assert set(coordinator._battery_noserial_polls[INV]) == {1}
+
+    async def test_shifted_placeholder_serial_keeps_claimed_key(
+        self, hass, mock_config_entry
+    ):
+        """Placeholder serial claiming the exposed key at a shifted index.
+
+        'Battery_ID_01' canonically collapses to {INV}-01 — the very key the
+        integration exposed for the pre-serial reads.  The sweep must clear
+        the exposure record without deleting the mapping the serial now owns.
+        """
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        no_serial = [_transport_battery(0, "")]
+        for _ in range(3):
+            coordinator._merge_round_robin_batteries(INV, no_serial)
+
+        result = coordinator._merge_round_robin_batteries(
+            INV, [_transport_battery(1, "Battery_ID_01")]
+        )
+
+        assert set(result) == {f"{INV}-01"}
+        assert coordinator._battery_fallback_keys[INV] == set()
+        assert coordinator._battery_noserial_polls[INV] == {}
+
+    async def test_shifted_retirement_unblocks_registry_migration(
+        self, hass, mock_config_entry
+    ):
+        """The #252 migration fires despite the shift.
+
+        Pre-fix, the un-retired positional key stayed in the rr-cache and its
+        stale counter in active_keys, permanently skipping the one-shot
+        legacy→canonical registry rename.
+        """
+        mock_config_entry.add_to_hass(hass)
+        old_key = f"{INV}-01"
+        new_key = f"{INV}-{BAT_SN_1}"
+        _, entity_ids = _seed_positional_battery(
+            hass, mock_config_entry, old_key, sensor_suffixes=("battery_soc",)
+        )
+
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        no_serial = [_transport_battery(0, "")]
+        for _ in range(3):
+            coordinator._merge_round_robin_batteries(INV, no_serial)
+        coordinator._merge_round_robin_batteries(INV, [_transport_battery(1, BAT_SN_1)])
+
+        entity_registry = er.async_get(hass)
+        for entity_id in entity_ids:
+            entry_ = entity_registry.async_get(entity_id)
+            assert entry_ is not None
+            assert new_key in entry_.unique_id
+        device_registry = dr.async_get(hass)
+        assert device_registry.async_get_device({(DOMAIN, old_key)}) is None
+        assert device_registry.async_get_device({(DOMAIN, new_key)}) is not None
+
+
 # ── Rotation trust guard (third review, LOCAL only) ───────────────────
 
 


### PR DESCRIPTION
Fixes #302.

## Bug

When a battery's serial registers read all-zero for >= 3 polls (`_NO_SERIAL_EXPOSE_POLLS`), the integration exposes a positional key (e.g. `{inv}-01`). Since pylxpweb#204, the moment that position's serial becomes readable, pylxpweb evicts its `pos:N` accumulator entry and mints the real serial a NEW virtual slot (the old slot stays a reservation hole by design) — so `battery_index` shifts. The rr-merge's positional retirement keyed off the CURRENT `batt.battery_index`, so post-shift it looked for the wrong positional key:

- the exposed positional twin stayed frozen in the rr-cache (self-healing only via the 6h `BATTERY_CARRY_FORWARD_MAX_AGE` bound since #300),
- the stale `noserial_polls` counter for the old slot was never popped, and
- both kept the positional key "active", permanently skipping the one-shot #252 legacy-to-canonical registry migration for that battery.

## Fix

Retirement now keys off what the integration actually **exposed**, not the shifted index:

- The merge records, per poll, which positional keys were re-claimed by serial-less batteries (`positional_keys_this_poll`, including collision-disambiguation keys) and which slots reported serial-less data (`noserial_slots_this_poll`).
- On reconciliation polls (a serial seen for the first time — `new_serials`), any exposed positional key **absent** from that record is retired immediately from `fallback_keys`, the rr-cache, and the carry-forward layer, and stale debounce counters for absent slots are popped — before `active_keys` is computed, so the #252 migration proceeds.

**Position-matching choice (documented per pylxpweb#204 review):** `BatteryData` carries no bank-position metadata that survives the upstream eviction, so exact position matching is impossible from the integration side. Absence-matching is the equivalent exact signal in practice: the transport serves its full accumulator on every poll, so an exposed positional key not re-claimed this poll has been evicted upstream — precisely the `pos:N` entries the arriving serial(s) reconciled. A still-serial-less sibling re-claims its key on the same poll and is never touched.

**Non-shifted common case is byte-identical:** the in-loop same-slot retirement is unchanged, and the sweep is a no-op when every exposed key was re-claimed (it is also gated on `new_serials`, so steady-state polls and transient ghost reads never enter it). A placeholder serial (`Battery_ID_NN`) that canonically claims the very key it was exposed under keeps its mapping — only the exposure record is cleared.

## Tests

New `TestShiftedSlotRetirement` (4 regressions, all fail pre-fix):
- shift scenario: >= 3 serial-less polls → positional exposed → serial arrives at SHIFTED index → exposed key retires immediately (rr-cache + carry-forward), counter popped, no 6h wait, stays gone
- still-serial-less sibling's key and debounce counter are spared
- shifted placeholder serial (`Battery_ID_01` → canonical `{inv}-01`) keeps the claimed mapping while the exposure record clears
- the #252 registry migration is no longer permanently blocked by the orphaned key/counter

Existing non-shift retirement tests (`TestNoSerialThenSerialSequence`, carry-forward resurrection guard) stay green.

## Gates

- `ruff check` + `ruff format`: clean
- `mypy --config-file tests/mypy.ini`: no issues in 40 source files
- `pytest tests/`: **1789 passed, 3 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (Codex pass, a400058)

- **Retirement is user-visible**: the shifted-slot retirement now logs at **INFO** (one-shot per key via `_battery_shift_retire_logged`, mirroring the `_suppress_battery_migration` precedent; flapping-serial repeats fall back to DEBUG), naming the stale positional key — the #252 migration renames first-seen-order legacy keys, which need not match the slot-position fallback, so the retired key's HA device/entities can survive as registry orphans the user must remove manually.
- **Tighter counter sweep**: stale `noserial_polls` counters are popped only for slots the transport did not serve **at all** this poll (true upstream reservation holes). A sibling served as a ghost (voltage=0/soc=0) or with a truncated serial keeps its pending debounce progress.
- Tests: +2 (one-shot log dedup, ghost-read sibling counter retention) plus an INFO-record assertion in the shift regression. Full suite now **1791 passed, 3 skipped**.
