### PR TITLE
fix: seed parameter cache after switch cloud-fallback writes (#310)

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -1197,14 +1197,40 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                     turn_on=value,
                     refresh_params=True,
                 )
+                # The write landed via the cloud: seed the parameter cache so
+                # the switch converges on the acknowledged value even when the
+                # post-write local parameter refresh is skipped (#310). Every
+                # ``parameter`` reaching this wrapper is a named local bit
+                # param, i.e. exactly the parameter-cache key ``is_on`` reads.
+                self._seed_cloud_written_parameter(parameter, value)
             else:
                 await self._execute_cloud_function_action(
                     action_name=action_name,
                     parameter=parameter,
                     value=value,
+                    seed_param_key=parameter,
                 )
         else:
             raise HomeAssistantError(f"No transport available for {action_name}")
+
+    def _seed_cloud_written_parameter(self, param_key: str, value: bool) -> None:
+        """Seed an acknowledged cloud-written FUNC_ bit into the parameter cache.
+
+        Convergence for cloud-fallback writes while a local transport is
+        attached (GH #310, the switch counterpart of
+        :func:`utils.async_write_with_cloud_fallback` seeding): under a down
+        local link the post-write parameter refresh is skipped
+        (``_refresh_device_parameters``), so without the seed ``is_on`` would
+        revert to the stale pre-write cache value once the optimistic state
+        clears, until link recovery. The seed is the local-raw representation
+        (bit params read back as ``bool``), and a later successful parameter
+        read overwrites it with fresh device data.
+
+        Never fires for pure-cloud installs (no transport attached): their
+        parameter cache is cloud-fed and refreshes normally.
+        """
+        if self.coordinator.has_local_transport(self._serial):
+            self.coordinator.note_parameters_written(self._serial, {param_key: value})
 
     async def _execute_cloud_function_action(
         self,
@@ -1212,6 +1238,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         parameter: str,
         value: bool,
         api_delay: float = 1.0,
+        seed_param_key: str | None = None,
     ) -> None:
         """Execute a switch action via the cloud function-control API.
 
@@ -1227,6 +1254,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             parameter: Cloud function parameter name (e.g., "FUNC_CHARGE_LAST").
             value: True to enable, False to disable.
             api_delay: Seconds to wait for the API to propagate changes.
+            seed_param_key: Parameter-cache key to seed with the acknowledged
+                ``value`` when a local transport is attached (#310) — pass
+                only for parameter-backed switches whose ``is_on`` reads this
+                key; leave ``None`` for actions whose state is not parameter
+                cache backed (e.g. status-based quick charge).
 
         Raises:
             HomeAssistantError: If no cloud client exists or the write fails.
@@ -1263,6 +1295,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 action_name,
                 self._serial,
             )
+
+            # Seed the acknowledged value BEFORE the refresh/optimistic-clear:
+            # under a down local link the parameter refresh below is skipped,
+            # and is_on would otherwise revert to the stale pre-write cache
+            # value once the optimistic state clears (#310).
+            if seed_param_key is not None:
+                self._seed_cloud_written_parameter(seed_param_key, value)
 
             # Wait for API to propagate changes before refreshing parameters
             await asyncio.sleep(api_delay)

--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -360,8 +360,10 @@ def _apply_sensor_config(
             else EntityCategory.DIAGNOSTIC
         )
 
-    # Allow sensors to be disabled by default (e.g. noisy last_polled timestamps)
-    if sensor_config.get("enabled_default") is False:
+    # Allow sensors to be disabled by default (e.g. noisy last_polled
+    # timestamps). Truthiness, not an ``is False`` identity check, so a
+    # non-bool falsy value can't silently ship the entity enabled (#310).
+    if not sensor_config.get("enabled_default", True):
         entity._attr_entity_registry_enabled_default = False
 
     return sensor_config
@@ -1007,6 +1009,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         refresh_params: bool = False,
         api_delay: float = 1.0,
         enable_kwargs: dict[str, Any] | None = None,
+        seed_param_key: str | None = None,
     ) -> None:
         """Execute a switch action with optimistic state handling.
 
@@ -1032,6 +1035,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             enable_kwargs: Optional keyword arguments passed to the enable method
                 on the turn-on path only (the disable method is always called with
                 no arguments).
+            seed_param_key: Parameter-cache key to seed with the acknowledged
+                ``turn_on`` boolean when a local transport is attached (#310).
+                Pass only for parameter-backed switches whose ``is_on`` reads
+                this key; leave ``None`` for status-based actions (e.g. quick
+                charge) and pure-cloud-only callers.
 
         Raises:
             HomeAssistantError: If the action fails.
@@ -1078,6 +1086,15 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 action_name,
                 self._serial,
             )
+
+            # Seed the acknowledged value BEFORE the refresh/optimistic-clear
+            # (#310): under a down local link the parameter refresh below is a
+            # no-op, so without the seed this method would publish the STALE
+            # pre-write state when it clears the optimistic value — a
+            # wrong-then-corrected double transition (recorder pollution,
+            # automation misfires on the intermediate value).
+            if seed_param_key is not None:
+                self._seed_cloud_written_parameter(seed_param_key, turn_on)
 
             # Refresh inverter data from API
             await inverter.refresh()
@@ -1171,10 +1188,17 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
 
         if not cloud_only and self.coordinator.has_local_transport(self._serial):
             try:
+                # When a cloud fallback exists, keep the optimistic state on
+                # local failure: clearing it there would publish the stale
+                # pre-write value for one transition before the cloud retry
+                # re-asserts it (#310 review — recorder pollution/automation
+                # misfire). The cloud path's own error handling clears it if
+                # the retry fails too.
                 await self._execute_named_parameter_action(
                     action_name=action_name,
                     parameter=parameter,
                     value=value,
+                    clear_optimistic_on_error=not self.coordinator.has_http_api(),
                 )
                 return
             except HomeAssistantError:
@@ -1189,6 +1213,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                     raise
 
         if self.coordinator.has_http_api():
+            # The write lands via the cloud: seed the parameter cache with
+            # the acknowledged value so the switch converges even when the
+            # post-write local parameter refresh is skipped (#310). Every
+            # ``parameter`` reaching this wrapper is a named local bit
+            # param, i.e. exactly the parameter-cache key ``is_on`` reads.
             if cloud_enable_method and cloud_disable_method:
                 await self._execute_switch_action(
                     action_name=action_name,
@@ -1196,13 +1225,8 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                     disable_method=cloud_disable_method,
                     turn_on=value,
                     refresh_params=True,
+                    seed_param_key=parameter,
                 )
-                # The write landed via the cloud: seed the parameter cache so
-                # the switch converges on the acknowledged value even when the
-                # post-write local parameter refresh is skipped (#310). Every
-                # ``parameter`` reaching this wrapper is a named local bit
-                # param, i.e. exactly the parameter-cache key ``is_on`` reads.
-                self._seed_cloud_written_parameter(parameter, value)
             else:
                 await self._execute_cloud_function_action(
                     action_name=action_name,
@@ -1336,6 +1360,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         action_name: str,
         parameter: str,
         value: bool,
+        clear_optimistic_on_error: bool = True,
     ) -> None:
         """Execute a switch action by writing a named parameter.
 
@@ -1346,6 +1371,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             action_name: Human-readable name of the action for logging.
             parameter: HTTP API-style parameter name (e.g., "FUNC_EPS_EN").
             value: True to enable, False to disable.
+            clear_optimistic_on_error: Whether a failed write clears the
+                optimistic state (and publishes). The fallback wrapper passes
+                False when a cloud retry follows, so the entity never
+                publishes the stale pre-write value between the local failure
+                and the cloud attempt (#310 review).
 
         Raises:
             HomeAssistantError: If the parameter write fails.
@@ -1395,8 +1425,9 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             self.async_write_ha_state()
 
         except HomeAssistantError:
-            self._optimistic_state = None
-            self.async_write_ha_state()
+            if clear_optimistic_on_error:
+                self._optimistic_state = None
+                self.async_write_ha_state()
             raise
         except Exception as e:
             _LOGGER.error(
@@ -1406,8 +1437,9 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 self._serial,
                 e,
             )
-            self._optimistic_state = None
-            self.async_write_ha_state()
+            if clear_optimistic_on_error:
+                self._optimistic_state = None
+                self.async_write_ha_state()
             raise HomeAssistantError(
                 f"Failed to {action_verb.lower()} {action_name}: {e}"
             ) from e

--- a/custom_components/eg4_web_monitor/sensor.py
+++ b/custom_components/eg4_web_monitor/sensor.py
@@ -715,8 +715,10 @@ class EG4StationSensor(EG4StationEntity, SensorEntity):
         if uom := sensor_config.get("unit_of_measurement"):
             self._attr_native_unit_of_measurement = uom
 
-        # Allow sensors to be disabled by default (e.g. noisy last_polled timestamps)
-        if sensor_config.get("enabled_default") is False:
+        # Allow sensors to be disabled by default (e.g. noisy last_polled
+        # timestamps). Truthiness, not an ``is False`` identity check, so a
+        # non-bool falsy value can't silently ship the entity enabled (#310).
+        if not sensor_config.get("enabled_default", True):
             self._attr_entity_registry_enabled_default = False
 
         # Build unique ID

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -733,8 +733,10 @@ class EG4WorkingModeSwitch(EG4BaseSwitch):
         )
 
         # Niche modes register disabled by default (e.g. Share Battery,
-        # GH #288 — multi-inverter shared-bank setups only).
-        if mode_config.get("enabled_default") is False:
+        # GH #288 — multi-inverter shared-bank setups only). Truthiness (not
+        # an ``is False`` identity check) so a future non-bool falsy value
+        # (0, None, "") can't silently ship the entity enabled (#310).
+        if not mode_config.get("enabled_default", True):
             self._attr_entity_registry_enabled_default = False
 
     @property

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -851,13 +851,20 @@ class EG4WorkingModeSwitch(EG4BaseSwitch):
                 value=turn_on,
             )
         elif self.coordinator.has_http_api() and methods:
-            # Cloud-only, no local parameter mapping
+            # Cloud-only, no local parameter mapping. A transport can still
+            # be attached here (the version guard above degrades legacy
+            # flat-HYBRID installs to this branch), so seed the parameter
+            # cache with the acknowledged value like the fallback path —
+            # otherwise a link-down write reverts to the stale pre-write
+            # state until link recovery (#310). Pure-cloud stays unseeded
+            # via the has_local_transport guard in the seeding helper.
             await self._execute_switch_action(
                 action_name=f"working mode {param}",
                 enable_method=methods[0],
                 disable_method=methods[1],
                 turn_on=turn_on,
                 refresh_params=True,
+                seed_param_key=FUNCTION_PARAM_MAPPING.get(param),
             )
         else:
             raise HomeAssistantError(

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -520,13 +520,25 @@ class EG4OffGridModeSwitch(EG4BaseSwitch):
 
     @property
     def is_on(self) -> bool | None:
-        """Return True if off-grid mode is enabled."""
+        """Return True if off-grid mode is enabled, None when unknown.
+
+        An absent FUNC_GREEN_EN key means UNKNOWN, not off: EG4_OFFGRID
+        local reads deliberately omit the key (the SNA register-110 bit
+        for green is unverified — pylxpweb #210), and a successful local
+        parameter refresh replaces the serial's parameter dict wholesale
+        (coordinator_mixins._refresh_device_parameters). Returning False
+        for the absent key would silently flip a cloud-confirmed/seeded
+        "on" to "off" after any local refresh on that family.
+        """
         # Use optimistic state if available (for immediate UI feedback)
         if self._optimistic_state is not None:
             return self._optimistic_state
 
         # Check parameter data from coordinator
-        return bool(self._parameter_data.get("FUNC_GREEN_EN", False))
+        value = self._parameter_data.get(PARAM_FUNC_GREEN_EN)
+        if value is None:
+            return None
+        return bool(value)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -606,11 +606,46 @@ class TestOffGridModeSwitch:
         switch = EG4OffGridModeSwitch(coordinator, "1234567890")
         assert switch.is_on is True
 
-    def test_is_on_false_default(self):
-        """Default state should be False when param missing."""
+    def test_is_on_unknown_when_param_missing(self):
+        """Absent FUNC_GREEN_EN = UNKNOWN (None), never off (#310 round 2).
+
+        EG4_OFFGRID local reads deliberately omit the key (unverified SNA
+        bit, pylxpweb #210) and the local param refresh replaces the
+        serial's parameters wholesale — False here would flip a
+        cloud-confirmed "on" to "off" after any local refresh.
+        """
         coordinator = _mock_coordinator()
         switch = EG4OffGridModeSwitch(coordinator, "1234567890")
+        assert switch.is_on is None
+
+    def test_is_on_false_when_param_present_false(self):
+        """A present falsy value is a real 'disabled' (bool or raw 0)."""
+        coordinator = _mock_coordinator(parameters={"FUNC_GREEN_EN": False})
+        switch = EG4OffGridModeSwitch(coordinator, "1234567890")
         assert switch.is_on is False
+        coordinator.data["parameters"]["1234567890"]["FUNC_GREEN_EN"] = 0
+        assert switch.is_on is False
+
+    def test_offgrid_local_refresh_without_key_goes_unknown_not_off(self):
+        """Offgrid: cloud-seeded True, then a local param refresh replaces
+        the params wholesale WITHOUT the key -> state becomes unknown,
+        not a silent revert to off."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            parameters={"FUNC_GREEN_EN": True},  # cloud-read/seeded value
+            device_data={"features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}},
+        )
+        switch = EG4OffGridModeSwitch(coordinator, "1234567890")
+        assert switch.is_on is True
+
+        # Wholesale replace, as _refresh_device_parameters does after a
+        # successful offgrid local read (no FUNC_GREEN_EN served).
+        coordinator.data["parameters"]["1234567890"] = {
+            "FUNC_BUZZER_EN": True,
+            "FUNC_CHARGE_LAST": False,
+        }
+        assert switch.is_on is None
 
     @pytest.mark.asyncio
     async def test_turn_on_local(self):

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -1048,14 +1048,26 @@ class TestCloudFallbackParameterSeeding:
         assert switch.is_on is True
 
     @pytest.mark.asyncio
-    async def test_named_method_fallback_seeds_parameter_cache(self):
-        """HYBRID local-fail -> cloud named-method route (EPS) seeds too."""
-        coordinator = _mock_coordinator(has_local=True, has_http=True)
+    async def test_named_method_fallback_seeds_without_stale_publish(self):
+        """HYBRID local-fail -> cloud named-method route (EPS) seeds BEFORE
+        the optimistic clear: every published state carries the written
+        value — no wrong-then-corrected double transition (recorder
+        pollution, automation misfire on the intermediate stale value)."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            parameters={PARAM_FUNC_EPS_EN: False},
+        )
         coordinator.write_named_parameter = AsyncMock(
             side_effect=HomeAssistantError("Modbus timeout")
         )
+        self._wire_note_parameters_written(coordinator)
         switch = EG4BatteryBackupSwitch(coordinator, "1234567890")
         _prep(switch)
+        published: list[bool | None] = []
+        switch.async_write_ha_state = MagicMock(
+            side_effect=lambda: published.append(switch.is_on)
+        )
 
         await switch.async_turn_on()
 
@@ -1063,6 +1075,35 @@ class TestCloudFallbackParameterSeeding:
         inverter.enable_battery_backup.assert_called_once()
         coordinator.note_parameters_written.assert_called_once_with(
             "1234567890", {PARAM_FUNC_EPS_EN: True}
+        )
+        # The link-down refresh is a no-op (AsyncMock, like the skipped
+        # real refresh): the final publish must come from the seeded cache
+        # and NO intermediate publish may carry the stale pre-write value.
+        assert published and all(state is True for state in published)
+        assert switch._optimistic_state is None
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_version_degraded_cloud_branch_seeds(self, monkeypatch):
+        """The cloud-only-because-version-guard branch (transport attached,
+        param name unresolvable by legacy pylxpweb) seeds too — the
+        pre-#310 stale-until-recovery bug must not survive there."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        monkeypatch.setattr(
+            switch_module, "_local_params_can_carry", lambda name: False
+        )
+        switch = EG4WorkingModeSwitch(
+            coordinator, "1234567890", WORKING_MODES["ac_charge_mode"]
+        )
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        coordinator.write_named_parameter.assert_not_called()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_ac_charge_mode.assert_called_once()
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {"FUNC_AC_CHARGE": True}
         )
 
     @pytest.mark.asyncio

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -1001,6 +1001,155 @@ class TestCloudFallback:
         inverter.enable_peak_shaving_mode.assert_called_once()
 
 
+class TestCloudFallbackParameterSeeding:
+    """Cloud-fallback writes seed the parameter cache (GH #310).
+
+    Under HYBRID link-down the post-write local parameter refresh is
+    skipped (``_refresh_device_parameters``), so without seeding the
+    acknowledged value via ``note_parameters_written()`` the switch
+    reverts to the stale pre-write cache value once its optimistic state
+    clears. Mirrors ``utils.async_write_with_cloud_fallback``: seed only
+    when a local transport is attached, never for pure-cloud.
+    """
+
+    @staticmethod
+    def _wire_note_parameters_written(coordinator) -> None:
+        """Make the mocked seed actually merge into the parameter cache."""
+
+        def _merge(serial: str, values: dict) -> None:
+            coordinator.data["parameters"].setdefault(serial, {}).update(values)
+
+        coordinator.note_parameters_written = MagicMock(side_effect=_merge)
+
+    @pytest.mark.asyncio
+    async def test_function_control_fallback_seeds_and_converges(self):
+        """HYBRID local-fail -> cloud function control seeds the cache and
+        the switch converges on the written value without a local read."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            parameters={PARAM_FUNC_CHARGE_LAST: False},
+        )
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Modbus timeout")
+        )
+        self._wire_note_parameters_written(coordinator)
+        switch = EG4ChargeLastSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {PARAM_FUNC_CHARGE_LAST: True}
+        )
+        # The link-down refresh is a no-op (AsyncMock, like the skipped
+        # real refresh): state must come from the seeded cache value.
+        assert switch._optimistic_state is None
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_named_method_fallback_seeds_parameter_cache(self):
+        """HYBRID local-fail -> cloud named-method route (EPS) seeds too."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Modbus timeout")
+        )
+        switch = EG4BatteryBackupSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_battery_backup.assert_called_once()
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {PARAM_FUNC_EPS_EN: True}
+        )
+
+    @pytest.mark.asyncio
+    async def test_working_mode_function_route_seeds_off_value(self):
+        """Share Battery (generic function-control route) seeds False on
+        turn-off — the seed carries the written boolean, not just True."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            parameters={"FUNC_BAT_SHARED": True},
+        )
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=HomeAssistantError("Modbus timeout")
+        )
+        switch = EG4WorkingModeSwitch(
+            coordinator, "1234567890", WORKING_MODES["share_battery_mode"]
+        )
+        _prep(switch)
+
+        await switch.async_turn_off()
+
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {"FUNC_BAT_SHARED": False}
+        )
+
+    @pytest.mark.asyncio
+    async def test_pure_cloud_function_write_not_seeded(self):
+        """CLOUD-only (no transport attached): the cloud parameter cache
+        refreshes normally — no seeding."""
+        coordinator = _mock_coordinator(has_local=False, has_http=True)
+        switch = EG4ChargeLastSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        coordinator.client.api.control.control_function.assert_called_once()
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pure_cloud_named_method_write_not_seeded(self):
+        coordinator = _mock_coordinator(has_local=False, has_http=True)
+        switch = EG4BatteryBackupSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_battery_backup.assert_called_once()
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_local_success_path_not_seeded(self):
+        """Local write succeeds: no cloud write, no seed — the existing
+        optimistic in-place parameter update already covers it."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        switch = EG4ChargeLastSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        coordinator.write_named_parameter.assert_called_once()
+        coordinator.client.api.control.control_function.assert_not_called()
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cloud_only_green_mode_with_transport_seeds(self):
+        """cloud_only actions (off-grid green mode) with a transport
+        attached are cloud-preferred writes — they seed as well."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            device_data={"features": {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}},
+        )
+        switch = EG4OffGridModeSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        # Local write withheld (unverified SNA bit), cloud method used
+        coordinator.write_named_parameter.assert_not_called()
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.enable_green_mode.assert_called_once()
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {PARAM_FUNC_GREEN_EN: True}
+        )
+
+
 # ── DSTSwitch ────────────────────────────────────────────────────────
 
 
@@ -1797,6 +1946,18 @@ class TestShareBatteryGating:
         coordinator = _mock_coordinator()
         switch = _make_fast_zero_export_switch(coordinator)
         assert switch.entity_registry_enabled_default is True
+
+    @pytest.mark.parametrize("falsy", [0, None, ""])
+    def test_falsy_non_bool_enabled_default_disables(self, falsy):
+        """Truthiness, not an ``is False`` identity check (GH #310): a
+        future non-bool falsy value must not silently ship enabled."""
+        coordinator = _mock_coordinator()
+        mode_config = {
+            **WORKING_MODES["share_battery_mode"],
+            "enabled_default": falsy,
+        }
+        switch = EG4WorkingModeSwitch(coordinator, "1234567890", mode_config)
+        assert switch.entity_registry_enabled_default is False
 
 
 class TestShareBatterySwitchBehavior:


### PR DESCRIPTION
Fixes #310 (found during the PR #306 Codex adversarial pass; pre-existing, cross-cutting across the working-mode switch family).

## Problem
PR #301 gave number/select/time entities `note_parameters_written()` seeding after cloud-fallback writes, but switches never migrated. `_execute_local_with_fallback` → cloud route sleeps, calls `async_refresh_device_parameters`, and clears optimistic state — but under HYBRID link-down `_refresh_device_parameters` skips the local read, so a switch flipped while the link is down reverted to the stale pre-write cache value once optimistic state cleared, until link recovery.

## Fix
- **`_execute_local_with_fallback`** (base_entity.py): after a successful CLOUD write on *either* cloud route — named-method (`_execute_switch_action`, e.g. EPS/Green Mode/AC Charge) or generic function-control (`_execute_cloud_function_action`, e.g. Charge Last/Fast Zero Export/Share Battery) — seed the acknowledged boolean into the parameter cache via the new `_seed_cloud_written_parameter()` helper.
- **Guard mirrors `utils.async_write_with_cloud_fallback` (#301)**: seed only when a local transport is attached (`has_local_transport`), never for pure-cloud. Covers attempt-then-fallback, and the cloud-preferred `cloud_only` case (off-grid Green Mode).
- **`_execute_cloud_function_action`** takes an explicit `seed_param_key` (default `None` = never seed) so seeding only applies to parameter-backed working-mode switches — status-based actions (quick charge, PR #308 pending) are unaffected. The seed fires *before* the optimistic state clears, so there is no stale-state blip.
- **Value domain**: FUNC_ bit params read back as `bool` from pylxpweb's named-parameter decode — the seed is `{FUNC_KEY: bool}`, exactly what `is_on` reads (directly or via the identity `FUNCTION_PARAM_MAPPING`).
- **Pure-cloud and local-success paths unchanged.**
- **switch.py `enabled_default`**: `mode_config.get("enabled_default") is False` → `not mode_config.get("enabled_default", True)` so a future non-bool falsy value can't silently ship an entity enabled.

## Tests
- HYBRID local-fail → cloud function-control write seeds `{FUNC_CHARGE_LAST: True}` and the switch **converges without a local read** (refresh is a no-op, state comes from the seeded cache; optimistic cleared)
- Named-method route (EPS) seeds `{FUNC_EPS_EN: True}`
- Function route carries the written boolean (Share Battery turn-off seeds `False`)
- Pure-cloud writes (both routes) NOT seeded
- Local-success path unchanged (no cloud call, no seed)
- `cloud_only` Green Mode on EG4_OFFGRID with a transport attached seeds
- `enabled_default` falsy non-bool (`0`, `None`, `""`) disables the entity

**Suite: 1810 passed, 3 skipped.** ruff + mypy strict clean. `git merge-tree` vs `origin/fix/issue-296-quickcharge-xp` (PR #308): clean, 0 conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Codex round 2 (coupled with pylxpweb #210)

- **Off-grid switch absent-key semantics**: with pylxpweb #210, EG4_OFFGRID local reads omit `FUNC_GREEN_EN` entirely, and `_refresh_device_parameters` replaces the serial's parameter dict **wholesale** — the old `get("FUNC_GREEN_EN", False)` silently flipped a cloud-confirmed/seeded "on" to "off" after any successful local param refresh. `is_on` now returns `None` (HA `unknown`) for the absent key; a present falsy value stays a real "disabled". Regression test: cloud-seeded True + wholesale local replace without the key → unknown, not off.
- **General pattern note**: the wholesale replace drops *any* cloud-only parameter key after a local param read. Green mode is the only current instance (the only key deliberately absent from one family's local map while cloud-served), so it's handled at the consumer here; a generic cloud-key carry-forward across local refreshes belongs to the #304 availability/fallback design discussion.
