### PR TITLE
test: CLOUD family-gated entity gap refuted (stale checkout) + #313/#312 merge-skew fix

### DIFF
--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -649,6 +649,15 @@ class TestStickyParameterCarryForward:
         assert coordinator._param_retry_pending == set()
 
 
+# Targeted parameter reads per cycle for the seeded FlexBOSS21 (model-fallback
+# family EG4_HYBRID): 13 base ranges in _read_modbus_parameters() plus the 3
+# family-gated schedule ranges — Peak Shaving (209,4), Generator (256,4) and
+# Off-Grid (269,6) — added by the beta.22 schedule families (GH #295 / PR
+# #312).  PR #313 landed these tests with the pre-#312 count of 13; both PRs
+# were green alone but the merged branch reads 16 (merge skew, not a bug).
+_EXPECTED_HYBRID_READS = 16
+
+
 class TestLinkDownParameterGateCycle:
     """Full-cycle behavior of the targeted-read link-down gate.
 
@@ -751,7 +760,7 @@ class TestLinkDownParameterGateCycle:
         # Cycle 2: retry-due — the targeted read runs and drains the queue.
         result = await self._run_cycle(coordinator)
 
-        assert inv._transport.read_named_parameters.call_count == 13
+        assert inv._transport.read_named_parameters.call_count == _EXPECTED_HYBRID_READS
         assert result["parameters"][self.SERIAL] == {"PARAM": 1}
         assert coordinator._param_retry_pending == set()
         assert coordinator._last_param_read_complete is True
@@ -766,7 +775,7 @@ class TestLinkDownParameterGateCycle:
 
         result = await self._run_cycle(coordinator)
 
-        assert inv._transport.read_named_parameters.call_count == 13
+        assert inv._transport.read_named_parameters.call_count == _EXPECTED_HYBRID_READS
         assert result["parameters"][self.SERIAL] == {"PARAM": 1}
         assert coordinator._param_retry_pending == set()
         assert coordinator._last_parameter_refresh is not None

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -450,6 +450,11 @@ class TestSwitchPlatformSetup:
         # Grid sell controls (GH #135): both available with cloud parameters
         assert "FUNC_FEED_IN_GRID_EN" in working_mode_params
         assert "FUNC_PV_SELL_TO_GRID_EN" in working_mode_params
+        # Share Battery (#306): no transport/family gate beyond the control
+        # model check, so CLOUD mode (no local transport) must create it too.
+        # A beta.22 live validation ran the cloud container against a stale
+        # pre-beta.22 checkout and reported it missing — lock the contract.
+        assert "FUNC_BAT_SHARED" in working_mode_params
 
     @pytest.mark.asyncio
     async def test_setup_never_writes_to_inverter(self, hass):


### PR DESCRIPTION
## Verdict: reported bug REFUTED — no production change needed

The reported beta.22 CLOUD gap (zero generator_charge/off_grid/peak_shaving time entities, no share_battery switches, while HYBRID/LOCAL register all 64) is **not a family-gating bug**. The cloud validation run that produced the observation was executing a **stale pre-beta.22 checkout** of the bind-mounted integration.

### Evidence (file:line)

**The failing cloud run itself proves the family gates work in CLOUD:**
- `config/home-assistant.log.1` (cloud run, content ts 01:33): `Switch setup for 4512670118: model=18KPV ... family=EG4_HYBRID` and the full features dict (incl. `inverter_family: 'EG4_HYBRID'`) logged **at platform-setup time** (log.1:424-427). `device_data["features"]` is populated in the first refresh — `_process_inverter_object()` awaits `inverter.detect_features()` before publishing (`coordinator_mixins.py:996-1010`), and `async_config_entry_first_refresh()` (`__init__.py:479`) completes before platform forwarding (`__init__.py:683-684`). CLOUD `detect_features()` resolves family from `HOLD_DEVICE_TYPE_CODE` via cloud `read_parameters` (`pylxpweb base.py:3820-3837`), with the model-name fallback (`coordinator_mappings.py:1551`) as backstop.
- Same run: `Setup complete: 36 time entities created` (log.1:448) and **zero** `share_battery` mentions, **zero** "lacks write_time_parameter" info line — the running `time.py` had no writeTime specs and `working_modes.py` had no share_battery entry.

**The checkout was stale:**
- `git reflog` of the bind-mounted repo: during that run HEAD was on the beta.21 line; the beta.22 merge `7a98ebb` was only pulled at 08:16 the next morning. `git show <beta.21>:.../const/working_modes.py | grep -c share_battery` → 0; same for `write_time_parameter` in `time.py`. 36 = beta.21's HYBRID count (3 classic families × 3 windows × 2 boundaries × 2 inverters).

**Post-pull cloud rerun (beta.22, same `./config`):**
- `config/home-assistant.log` (content ts 11:24): `Setup complete: 64 time entities created`, all 28 new-family time registrations (`peak_shaving`/`generator_charge`/`off_grid`, log:451-478) and both `switch.*_share_battery` registrations (log:437, 446) — in pure CLOUD mode (`Fetching HTTP data`, no transports).

The deliberate fail-closed `is_hybrid_family` gates are correct and untouched.

### Changes (tests only)

1. **`tests/test_switch_entities.py`** — `test_cloud_mode_includes_all_working_modes` now asserts `FUNC_BAT_SHARED` is created in CLOUD mode (no local transport). This was the one reported scenario without existing coverage; the EG4_HYBRID→writeTime-families and unknown-family-fail-closed regressions already exist in `test_time_entities.py` (`test_setup_hybrid_family_gets_writetime_families`, `test_setup_offgrid_model_without_family_features`, `test_setup_unsupported_model_creates_nothing`) with a cloud-shaped mock.

2. **`tests/test_coordinator_local.py`** — fixes a REAL pre-existing failure on `integration/3.4.0`: PR #313's `TestLinkDownParameterGateCycle` tests hardcode 13 targeted parameter reads, but PR #312 (merged ~4h later) added 3 family-gated schedule ranges — Peak Shaving (209,4), Generator (256,4), Off-Grid (269,6) — for EG4_HYBRID, so the merged branch performs 16. Each PR was green alone; the combined branch was never run. Without this the base suite is red (2 failures).

### Validation
- `uv run ruff check` / `ruff format` — clean
- `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — clean
- `uv run pytest tests/` — **1909 passed, 3 skipped, 0 failed** (base was 1907 passed / 2 failed)

Note: the repo venv had a stray pylxpweb build (0.9.36b23 from another agent's scratchpad worktree); it was realigned to the manifest floor `pylxpweb>=0.9.36b24` (editable install of the local b24 source).

Do NOT merge — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)