### PR TITLE
fix: DST switch pinned off + summer DST sync skip (#323)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -706,9 +706,9 @@ class HTTPUpdateMixin(_MixinBase):
         }
 
         # DST flag consumed by the Daylight Saving Time switch. Refreshes at
-        # station load, on HA-side writes (set_daylight_saving_time), and on
-        # the hourly DST sync — a portal-side toggle is picked up at the next
-        # config entry reload or DST sync.
+        # station load, on HA-side writes (set_daylight_saving_time), and is
+        # re-read from the cloud during each hourly DST sync — with DST sync
+        # disabled, portal-side toggles are only picked up on entry reload.
         processed["station"]["daylightSavingTime"] = bool(
             getattr(self.station, "daylight_saving_time", False)
         )

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -705,6 +705,14 @@ class HTTPUpdateMixin(_MixinBase):
             "station_last_polled": dt_util.utcnow(),
         }
 
+        # DST flag consumed by the Daylight Saving Time switch. Refreshes at
+        # station load, on HA-side writes (set_daylight_saving_time), and on
+        # the hourly DST sync — a portal-side toggle is picked up at the next
+        # config entry reload or DST sync.
+        processed["station"]["daylightSavingTime"] = bool(
+            getattr(self.station, "daylight_saving_time", False)
+        )
+
         if timezone := getattr(self.station, "timezone", None):
             processed["station"]["timezone"] = timezone
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -2688,36 +2688,33 @@ class DSTSyncMixin(_MixinBase):
             return
 
         try:
+            # detect_dst_status() returns the ACTUAL DST state for the
+            # configured IANA timezone (True=DST in effect, False=not,
+            # None=cannot determine). It says nothing about whether the
+            # API flag matches — sync_dst_setting() performs that
+            # comparison itself and no-ops when already correct.
             dst_status = self.station.detect_dst_status()
-            if dst_status is False:
-                _LOGGER.info(
-                    "DST mismatch detected for station %s, syncing DST setting",
-                    self.plant_id,
-                )
-                sync_result = await self.station.sync_dst_setting()
-                if sync_result:
-                    _LOGGER.info(
-                        "DST setting synchronized successfully for station %s",
-                        self.plant_id,
-                    )
-                else:
-                    _LOGGER.warning(
-                        "Failed to synchronize DST setting for station %s",
-                        self.plant_id,
-                    )
-                self._last_dst_sync = dt_util.utcnow()
-            elif dst_status is True:
-                _LOGGER.debug(
-                    "DST setting is already correct for station %s",
-                    self.plant_id,
-                )
-                self._last_dst_sync = dt_util.utcnow()
-            else:
+            if dst_status is None:
                 _LOGGER.debug(
                     "DST status could not be determined for station %s",
                     self.plant_id,
                 )
                 self._last_dst_sync = dt_util.utcnow()
+                return
+
+            sync_result = await self.station.sync_dst_setting()
+            if sync_result:
+                _LOGGER.debug(
+                    "DST setting verified/synchronized for station %s (actual DST: %s)",
+                    self.plant_id,
+                    dst_status,
+                )
+            else:
+                _LOGGER.warning(
+                    "Failed to synchronize DST setting for station %s",
+                    self.plant_id,
+                )
+            self._last_dst_sync = dt_util.utcnow()
         except Exception as e:
             _LOGGER.warning(
                 "Error during DST sync for station %s: %s", self.plant_id, e

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -2702,6 +2702,24 @@ class DSTSyncMixin(_MixinBase):
                 self._last_dst_sync = dt_util.utcnow()
                 return
 
+            # Re-read the cloud-side DST flag before syncing.
+            # sync_dst_setting() compares the detected status against the
+            # CACHED daylight_saving_time flag, which is otherwise only set
+            # at Station.load and by our own writes — without this refresh
+            # a portal-side toggle would leave the cache (and the HA
+            # switch) stale forever and turn the sync into a no-op. On
+            # fetch failure, proceed with the cached value.
+            try:
+                self.station.daylight_saving_time = bool(
+                    await self.station.get_daylight_saving_time_enabled()
+                )
+            except Exception as err:
+                _LOGGER.debug(
+                    "Could not refresh DST flag for station %s: %s",
+                    self.plant_id,
+                    err,
+                )
+
             sync_result = await self.station.sync_dst_setting()
             if sync_result:
                 _LOGGER.debug(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -331,6 +331,92 @@ class TestDSTSynchronization:
         ):
             assert coordinator._should_sync_dst() is False
 
+    async def test_perform_dst_sync_syncs_when_dst_active(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """detect_dst_status()=True must still call sync_dst_setting (#323).
+
+        The old code treated True as "already correct" and never synced,
+        leaving an API flag stuck at False all summer.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.detect_dst_status = MagicMock(return_value=True)
+        mock_station_object.sync_dst_setting = AsyncMock(return_value=True)
+        # Reporter's state: API flag stuck at False during summer
+        mock_station_object.daylight_saving_time = False
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_awaited_once()
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_syncs_when_dst_inactive(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """detect_dst_status()=False also calls sync_dst_setting."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.detect_dst_status = MagicMock(return_value=False)
+        mock_station_object.sync_dst_setting = AsyncMock(return_value=True)
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_awaited_once()
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_skips_when_undeterminable(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """detect_dst_status()=None skips sync but stamps the timestamp."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.detect_dst_status = MagicMock(return_value=None)
+        mock_station_object.sync_dst_setting = AsyncMock(return_value=True)
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_not_awaited()
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_failure_still_stamps(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """A failed sync (returns False) still stamps _last_dst_sync."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.detect_dst_status = MagicMock(return_value=True)
+        mock_station_object.sync_dst_setting = AsyncMock(return_value=False)
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_awaited_once()
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_exception_still_stamps(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """An exception during sync still stamps _last_dst_sync (no hot loop)."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.detect_dst_status = MagicMock(return_value=True)
+        mock_station_object.sync_dst_setting = AsyncMock(
+            side_effect=RuntimeError("api error")
+        )
+
+        await coordinator._perform_dst_sync()
+
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_noop_when_no_station(self, hass, mock_config_entry):
+        """No station loaded -> no sync attempt, no timestamp."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = None
+
+        await coordinator._perform_dst_sync()
+
+        assert coordinator._last_dst_sync is None
+
 
 class TestParameterRefresh:
     """Test hourly parameter refresh."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -149,6 +149,8 @@ def mock_station_object(mock_inverter):
     mock.refresh_all_data = AsyncMock()
     mock.detect_dst_status = MagicMock(return_value=True)
     mock.sync_dst_setting = AsyncMock(return_value=True)
+    mock.daylight_saving_time = True
+    mock.get_daylight_saving_time_enabled = AsyncMock(return_value=True)
     return mock
 
 
@@ -416,6 +418,81 @@ class TestDSTSynchronization:
         await coordinator._perform_dst_sync()
 
         assert coordinator._last_dst_sync is None
+
+    async def test_perform_dst_sync_noop_when_disabled(self, hass, mock_station_object):
+        """DST sync disabled -> immediate return, no sync, no timestamp."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EG4 Web Monitor - Test Plant",
+            data={
+                CONF_USERNAME: "test_user",
+                CONF_PASSWORD: "test_pass",
+                CONF_BASE_URL: "https://monitor.eg4electronics.com",
+                CONF_VERIFY_SSL: True,
+                CONF_DST_SYNC: False,
+                CONF_LIBRARY_DEBUG: False,
+                CONF_PLANT_ID: "12345",
+                CONF_PLANT_NAME: "Test Plant",
+            },
+            entry_id="dst_disabled_test",
+        )
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator.station = mock_station_object
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_not_awaited()
+        mock_station_object.get_daylight_saving_time_enabled.assert_not_awaited()
+        assert coordinator._last_dst_sync is None
+
+    async def test_perform_dst_sync_refreshes_cached_flag_from_cloud(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """Cached flag True, cloud says False -> flag updated BEFORE sync (#323).
+
+        The cached daylight_saving_time flag is otherwise only set at
+        Station.load and by our own writes, so portal-side toggles would
+        stay invisible forever without this re-read.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.daylight_saving_time = True
+        mock_station_object.get_daylight_saving_time_enabled = AsyncMock(
+            return_value=False
+        )
+
+        flag_at_sync_time: list[bool] = []
+
+        async def record_sync() -> bool:
+            flag_at_sync_time.append(mock_station_object.daylight_saving_time)
+            return True
+
+        mock_station_object.sync_dst_setting = AsyncMock(side_effect=record_sync)
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.get_daylight_saving_time_enabled.assert_awaited_once()
+        # Flag was refreshed from the cloud before sync_dst_setting ran
+        assert mock_station_object.daylight_saving_time is False
+        assert flag_at_sync_time == [False]
+        assert coordinator._last_dst_sync is not None
+
+    async def test_perform_dst_sync_flag_fetch_failure_uses_cached(
+        self, hass, mock_config_entry, mock_station_object
+    ):
+        """Cloud flag fetch failure -> proceed with cached value, still sync."""
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.station = mock_station_object
+        mock_station_object.daylight_saving_time = True
+        mock_station_object.get_daylight_saving_time_enabled = AsyncMock(
+            side_effect=RuntimeError("api error")
+        )
+
+        await coordinator._perform_dst_sync()
+
+        mock_station_object.sync_dst_setting.assert_awaited_once()
+        assert mock_station_object.daylight_saving_time is True
+        assert coordinator._last_dst_sync is not None
 
 
 class TestParameterRefresh:

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -360,6 +360,36 @@ class TestProcessStationData:
 
     @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
     @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_station_dst_flag_true(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Station dict mirrors station.daylight_saving_time=True (#323)."""
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+        coordinator.station = _mock_station()
+        coordinator.station.daylight_saving_time = True
+
+        result = await coordinator._process_station_data()
+
+        assert result["station"]["daylightSavingTime"] is True
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_station_dst_flag_false(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """Station dict mirrors station.daylight_saving_time=False (#323)."""
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+        coordinator.station = _mock_station()
+        coordinator.station.daylight_saving_time = False
+
+        result = await coordinator._process_station_data()
+
+        assert result["station"]["daylightSavingTime"] is False
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
     async def test_no_station_raises(
         self, mock_aiohttp, mock_client_cls, hass, http_config_entry
     ):


### PR DESCRIPTION
Fixes #323 (reporter brendonlobo123, cloud mode, 12000XP: HA shows the Daylight Saving Time switch OFF while the EG4 portal shows DST ON).

## Root cause

**Bug 1 — the switch reads a key that was never populated.** `EG4DSTSwitch.is_on` reads `coordinator.data["station"]["daylightSavingTime"]`, but `_process_station_data` (coordinator_http.py) never set that key — git history confirms it was never wired. The switch was hard-pinned OFF regardless of portal state (not "inverted", just always False).

**Bug 2 — hourly DST sync misread `detect_dst_status()` semantics.** The pylxpweb method returns the ACTUAL DST state for the configured IANA timezone (`True` = DST currently in effect, `False` = not, `None` = cannot determine). `_perform_dst_sync` treated `False` as "mismatch detected" and only called `station.sync_dst_setting()` in that branch; when `detect_dst_status()` returned `True` (i.e. all summer) it logged "already correct" and never synced. An API flag stuck at False during summer — exactly the reporter's state — was never corrected, and with Fix 1 alone the switch would now display that stale False.

**Bug 3 (adversarial review P1) — portal-side toggles were invisible forever.** `station.daylight_saving_time` is only set at `Station.load` and by our own writes; `refresh_all_data()` never re-reads plant config, and `sync_dst_setting()` compares detected status against that CACHED flag. A portal-side toggle would leave the HA switch stale indefinitely and make the hourly sync no-op (detected==cached).

## Fix

- `_process_station_data` now populates `station["daylightSavingTime"]` from the pylxpweb Station's `daylight_saving_time` flag.
- `_perform_dst_sync` restructured: `None` → debug log + stamp `_last_dst_sync` (no hot loop); any determinate status → **re-read the cloud-side flag via `station.get_daylight_saving_time_enabled()`** (live plant-details fetch, one extra API call per hourly window; on fetch failure proceed with the cached value), then call `await station.sync_dst_setting()` unconditionally. That method internally compares detected status vs the stored flag and no-ops (returns True) when already correct. Both the switch and the sync now converge on portal-side changes within ≤1h; with DST sync disabled, portal-side toggles are only picked up on entry reload. Existing try/except shape and percent-format logging kept.

## Tests

- `_process_station_data` mirrors `station.daylight_saving_time` into `daylightSavingTime` (True and False).
- `_perform_dst_sync`: summer case (`detect=True`, API flag False) now calls `sync_dst_setting`; `detect=False` also syncs; `detect=None` skips; cloud re-read updates the cached flag BEFORE sync runs; flag-fetch failure falls back to the cached value and still syncs; `dst_sync_enabled=False` returns immediately (no sync, no fetch, no timestamp); failed sync / exception / all determinate branches stamp `_last_dst_sync`; no station → no-op.
- Existing `EG4DSTSwitch.is_on` tests already cover the switch reflecting the station key.

Full suite: **1922 passed, 3 skipped**. ruff + mypy (strict, tests/mypy.ini) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)