### PR TITLE
fix: refresh buttons force full data + parameter refresh (#322)

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -1102,11 +1102,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             )
 
             # Seed the acknowledged value BEFORE the refresh/optimistic-clear
-            # (#310): under a down local link the parameter refresh below is a
-            # no-op, so without the seed this method would publish the STALE
-            # pre-write state when it clears the optimistic value — a
-            # wrong-then-corrected double transition (recorder pollution,
-            # automation misfires on the intermediate value).
+            # (#310): under a down local link the parameter refresh below
+            # cannot read the device locally (LOCAL-only: no data at all;
+            # HYBRID: cloud re-read can lag or fail), so without the seed
+            # this method could publish the STALE pre-write state when it
+            # clears the optimistic value — a wrong-then-corrected double
+            # transition (recorder pollution, automation misfires on the
+            # intermediate value).
             if seed_param_key is not None:
                 self._seed_cloud_written_parameter(seed_param_key, turn_on)
 
@@ -1257,10 +1259,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         Convergence for cloud-fallback writes while a local transport is
         attached (GH #310, the switch counterpart of
         :func:`utils.async_write_with_cloud_fallback` seeding): under a down
-        local link the post-write parameter refresh is skipped
-        (``_refresh_device_parameters``), so without the seed ``is_on`` would
-        revert to the stale pre-write cache value once the optimistic state
-        clears, until link recovery. The seed is the local-raw representation
+        local link the post-write parameter refresh cannot read the device
+        locally (pylxpweb skips the local read — LOCAL-only installs get no
+        data at all, and a HYBRID cloud re-read can lag or fail), so without
+        the seed ``is_on`` could revert to the stale pre-write cache value
+        once the optimistic state clears. The seed is the local-raw representation
         (bit params read back as ``bool``), and a later successful parameter
         read overwrites it with fresh device data.
 
@@ -1335,9 +1338,10 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             )
 
             # Seed the acknowledged value BEFORE the refresh/optimistic-clear:
-            # under a down local link the parameter refresh below is skipped,
-            # and is_on would otherwise revert to the stale pre-write cache
-            # value once the optimistic state clears (#310).
+            # under a down local link the parameter refresh below cannot read
+            # the device locally (LOCAL-only: skipped; HYBRID: cloud re-read
+            # can lag or fail), and is_on would otherwise revert to the stale
+            # pre-write cache value once the optimistic state clears (#310).
             if seed_param_key is not None:
                 self._seed_cloud_written_parameter(seed_param_key, value)
 

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -240,16 +240,25 @@ class EG4RefreshButton(EG4DeviceEntity, ButtonEntity):
             device_type = device_data.get("type", "unknown")
 
             if device_type == "inverter":
-                # Get inverter object and refresh
-                inverter = self.coordinator.get_inverter_object(self._serial)
-                if inverter:
-                    _LOGGER.debug(
-                        "Refreshing inverter device object for %s", self._serial
-                    )
-                    await inverter.refresh()
-                    _LOGGER.debug("Successfully refreshed inverter %s", self._serial)
-                else:
-                    _LOGGER.warning("Inverter object not found for %s", self._serial)
+                # Force a full refresh INCLUDING parameters (holding
+                # registers).  A bare refresh() respects pylxpweb cache TTLs
+                # (re-reads nothing shortly after a poll) and never touches
+                # parameters, so control values changed outside HA (e.g. on
+                # the EG4 portal) took until the hourly parameter cycle to
+                # appear (#322).  The coordinator helper calls
+                # inverter.refresh(force=True, include_parameters=True),
+                # stores the fresh parameters, and is gated on
+                # is_transport_link_down (a dead local link would otherwise
+                # hang uninterruptibly).  The private method is used instead
+                # of async_refresh_device_parameters() because the public
+                # wrapper swallows exceptions (this button must log + raise)
+                # and triggers its own coordinator refresh (double-read).
+                _LOGGER.debug(
+                    "Force-refreshing inverter %s including parameters",
+                    self._serial,
+                )
+                await self.coordinator._refresh_device_parameters(self._serial)
+                _LOGGER.debug("Successfully refreshed inverter %s", self._serial)
 
             # For other device types or as fallback, trigger coordinator refresh
             await self.coordinator.async_request_refresh()
@@ -317,10 +326,14 @@ class EG4BatteryRefreshButton(EG4BatteryEntity, ButtonEntity):
                 self._battery_key,
             )
 
-            # Get parent inverter object and refresh (which refreshes all batteries)
+            # Get parent inverter object and refresh (which refreshes all
+            # batteries).  force=True bypasses the pylxpweb cache TTLs so a
+            # press actually re-reads instead of serving cached data (#322);
+            # parameters are not needed here (battery data lives in input
+            # registers).
             inverter = self.coordinator.get_inverter_object(self._parent_serial)
             if inverter:
-                await inverter.refresh()
+                await inverter.refresh(force=True)
             else:
                 _LOGGER.warning(
                     "Parent inverter object not found for %s", self._parent_serial

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 if TYPE_CHECKING:
@@ -239,6 +240,7 @@ class EG4RefreshButton(EG4DeviceEntity, ButtonEntity):
             )
             device_type = device_data.get("type", "unknown")
 
+            incomplete = False
             if device_type == "inverter":
                 # Force a full refresh INCLUDING parameters (holding
                 # registers).  A bare refresh() respects pylxpweb cache TTLs
@@ -246,22 +248,38 @@ class EG4RefreshButton(EG4DeviceEntity, ButtonEntity):
                 # parameters, so control values changed outside HA (e.g. on
                 # the EG4 portal) took until the hourly parameter cycle to
                 # appear (#322).  The coordinator helper calls
-                # inverter.refresh(force=True, include_parameters=True),
-                # stores the fresh parameters, and is gated on
-                # is_transport_link_down (a dead local link would otherwise
-                # hang uninterruptibly).  The private method is used instead
-                # of async_refresh_device_parameters() because the public
-                # wrapper swallows exceptions (this button must log + raise)
-                # and triggers its own coordinator refresh (double-read).
+                # inverter.refresh(force=True, include_parameters=True) and
+                # stores the fresh parameters; link-down handling lives in
+                # pylxpweb's _fetch_parameters guard (cloud fallback in
+                # HYBRID, clean skip in LOCAL — no hang risk).  The private
+                # method is used instead of async_refresh_device_parameters()
+                # because the public wrapper triggers its own coordinator
+                # refresh (double-read) and this button does its own
+                # completeness check: refresh() gathers its fetch tasks with
+                # return_exceptions=True, so read failures never raise — they
+                # surface only as parameters_complete=False.
                 _LOGGER.debug(
                     "Force-refreshing inverter %s including parameters",
                     self._serial,
                 )
                 await self.coordinator._refresh_device_parameters(self._serial)
-                _LOGGER.debug("Successfully refreshed inverter %s", self._serial)
+                inverter = self.coordinator.get_inverter_object(self._serial)
+                incomplete = inverter is not None and not getattr(
+                    inverter, "parameters_complete", True
+                )
 
-            # For other device types or as fallback, trigger coordinator refresh
+            # Publish whatever was read (partial data plus sticky
+            # carry-forward); also the fallback path for other device types.
             await self.coordinator.async_request_refresh()
+
+            if incomplete:
+                # The device read silently came up short (dead link with no
+                # cloud fallback, failed register ranges, ...) — surface it
+                # in the UI instead of reporting a successful refresh.
+                raise HomeAssistantError(
+                    f"Parameter refresh incomplete for {self._serial}: device"
+                    " unreachable or link degraded; showing last known values"
+                )
             _LOGGER.debug("Successfully refreshed data for device %s", self._serial)
 
         except Exception as e:

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -1088,12 +1088,13 @@ class EG4DataUpdateCoordinator(
         179 holds a MIXED regime (same convergence pattern as the schedule
         time entities' partial hour/minute cloud writes). A best-effort
         parameter refresh re-reads the device so entities reflect the actual
-        state. When the local link is DOWN the re-read is impossible
-        (``_refresh_device_parameters`` skips it), so the KNOWN-succeeded
-        charge bit is seeded into the cache instead — the failed discharge
-        bit is left untouched (the device still holds its previous value) —
-        so the cache converges on what actually landed while the error still
-        surfaces.
+        state. When the local link is DOWN the KNOWN-succeeded charge bit is
+        seeded into the cache instead of a full re-read (pylxpweb would route
+        the re-read via its cloud fallback, but this write just came over the
+        cloud path anyway — seeding the acknowledged bit converges instantly
+        without a 3-range cloud read) — the failed discharge bit is left
+        untouched (the device still holds its previous value) — so the cache
+        converges on what actually landed while the error still surfaces.
         """
         _LOGGER.warning(
             "Battery control mode write for %s partially applied (discharge "

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -786,10 +786,11 @@ class DeviceProcessingMixin(_MixinBase):
 
         Skipped while the transport link is down: a raw ``read_parameters``
         on an attached-but-dead link is the multi-minute pymodbus hang class
-        that Python 3.11's ``asyncio.wait_for`` cannot interrupt (same gate
-        as ``_refresh_device_parameters``) — and this read fires on every
-        30s-throttled status poll, in exactly the HYBRID configuration where
-        the link can be down. Degrades to None like a failed read.
+        that Python 3.11's ``asyncio.wait_for`` cannot interrupt (pylxpweb's
+        ``_fetch_parameters`` link-down guard does not cover raw transport
+        reads like this one) — and this read fires on every 30s-throttled
+        status poll, in exactly the HYBRID configuration where the link can
+        be down. Degrades to None like a failed read.
         """
         transport = getattr(inverter, "transport", None)
         if transport is None:
@@ -2524,26 +2525,19 @@ class ParameterManagementMixin(_MixinBase):
     async def _refresh_device_parameters(self, serial: str) -> None:
         """Refresh parameters for a specific device using device object.
 
-        Skipped while the device's local transport link is down: pylxpweb's
-        parameter fetch has no ``transport_link_down`` gate (unlike its
-        runtime/energy/battery reads), so an attached-but-dead link would
-        attempt local Modbus reads that Python 3.11's ``asyncio.wait_for``
-        cannot interrupt (multi-minute hangs). The regular poll re-probes
-        the link every cycle and parameters refresh on recovery; entities
-        converge on written values via ``note_parameters_written()``.
+        Link-down handling is delegated to pylxpweb's ``_fetch_parameters``
+        guard (pylxpweb#206, shipped in the 0.9.36b24 floor pinned by
+        manifest.json): while the local transport link is down it skips the
+        local Modbus read (no uninterruptible pymodbus hang) and falls back
+        to cloud named-parameter reads in HYBRID, or skips cleanly in LOCAL
+        with ``parameters_complete`` set False.  Gating here would BLOCK
+        that cloud fallback — in HYBRID with a dead link parameters could
+        refresh via cloud but never would (#322 review).
         """
         try:
             inverter = self.get_inverter_object(serial)
             if not inverter:
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
-                return
-
-            if is_transport_link_down(inverter):
-                _LOGGER.debug(
-                    "Skipping parameter refresh for %s: local transport link "
-                    "is down (re-probed by the regular poll cycle)",
-                    serial,
-                )
                 return
 
             # Use force=True to bypass cache when refreshing parameters after changes

--- a/custom_components/eg4_web_monitor/utils.py
+++ b/custom_components/eg4_web_monitor/utils.py
@@ -151,10 +151,11 @@ async def async_write_with_cloud_fallback(
             cloud path while a local transport is attached, these are merged
             into the coordinator's parameter cache
             (:meth:`EG4DataUpdateCoordinator.note_parameters_written`) so the
-            entity converges on the written value — the follow-up local
-            parameter refresh is skipped on a down link, and without the
-            seed the entity would revert to the stale pre-write cache value
-            once its optimistic state clears.
+            entity converges on the written value — the follow-up parameter
+            refresh cannot read locally on a down link (LOCAL-only: skipped
+            by pylxpweb; HYBRID: cloud re-read can lag or fail), and without
+            the seed the entity would revert to the stale pre-write cache
+            value once its optimistic state clears.
 
     Raises:
         HomeAssistantError: If all available write paths fail, or none exist.

--- a/tests/test_button_entities.py
+++ b/tests/test_button_entities.py
@@ -5,6 +5,8 @@ import types
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.eg4_web_monitor.button import (
     EG4RefreshButton,
     EG4BatteryRefreshButton,
@@ -67,8 +69,8 @@ class TestEG4RefreshButton:
 
         await entity.async_press()
 
-        # The inverter path delegates to the coordinator's link-down-gated
-        # force refresh (which includes holding-register parameters).
+        # The inverter path delegates to the coordinator's force refresh
+        # (which includes holding-register parameters).
         coordinator._refresh_device_parameters.assert_awaited_once_with("1234567890")
         coordinator.async_request_refresh.assert_awaited_once()
 
@@ -92,6 +94,7 @@ class TestEG4RefreshButton:
         mock_inverter.transport = None  # no local transport -> link not down
         mock_inverter.refresh = AsyncMock()
         mock_inverter.parameters = {"HOLD_110": 8}
+        mock_inverter.parameters_complete = True
         coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
 
         entity = EG4RefreshButton(
@@ -111,12 +114,15 @@ class TestEG4RefreshButton:
         coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_async_press_link_down_skips_device_read(self):
-        """With the local transport link down, no device read is attempted.
+    async def test_async_press_link_down_still_refreshes(self):
+        """A down local link does NOT block the button refresh.
 
-        The is_transport_link_down gate in _refresh_device_parameters must
-        short-circuit (Python 3.11 asyncio.wait_for cannot interrupt in-flight
-        pymodbus reads on a dead link); the coordinator refresh still runs.
+        Link-down handling is delegated to pylxpweb's _fetch_parameters
+        guard (pylxpweb#206, in the b24 floor pinned by manifest.json):
+        it skips the local Modbus read (no hang risk) and falls back to
+        cloud named-parameter reads in HYBRID.  A coordinator-side gate
+        would block exactly that fallback, so refresh() must still be
+        awaited with force + parameters even when the link is down.
         """
         coordinator = MagicMock()
         coordinator.data = {"devices": {"1234567890": {"type": "inverter"}}}
@@ -130,6 +136,8 @@ class TestEG4RefreshButton:
         mock_inverter.transport = MagicMock()  # attached...
         mock_inverter.transport_link_down = True  # ...but dead link
         mock_inverter.refresh = AsyncMock()
+        mock_inverter.parameters = {"HOLD_110": 8}  # served via cloud fallback
+        mock_inverter.parameters_complete = True
         coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
 
         entity = EG4RefreshButton(
@@ -141,7 +149,42 @@ class TestEG4RefreshButton:
 
         await entity.async_press()
 
-        mock_inverter.refresh.assert_not_awaited()
+        mock_inverter.refresh.assert_awaited_once_with(
+            force=True, include_parameters=True
+        )
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_press_incomplete_parameters_raises(self):
+        """A silently-failed read surfaces as HomeAssistantError.
+
+        refresh() gathers its fetch tasks with return_exceptions=True and
+        _fetch_parameters records failures only as parameters_complete=False,
+        so the button must check completeness itself: partial data is still
+        published (coordinator refresh runs) but the press reports failure
+        instead of pretending the values are fresh.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {"devices": {"1234567890": {"type": "inverter"}}}
+        coordinator.get_device_info.return_value = {}
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator._refresh_device_parameters = AsyncMock()
+
+        mock_inverter = MagicMock()
+        mock_inverter.parameters_complete = False
+        coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
+
+        entity = EG4RefreshButton(
+            coordinator=coordinator,
+            serial="1234567890",
+            device_data={"type": "inverter"},
+            model="FlexBOSS21",
+        )
+
+        with pytest.raises(HomeAssistantError, match="incomplete"):
+            await entity.async_press()
+
+        # Partial data + sticky carry-forward still published first
         coordinator.async_request_refresh.assert_awaited_once()
 
     def test_device_info(self):

--- a/tests/test_button_entities.py
+++ b/tests/test_button_entities.py
@@ -1,5 +1,7 @@
 """Unit tests for button entity logic without HA instance."""
 
+import types
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -7,6 +9,9 @@ from custom_components.eg4_web_monitor.button import (
     EG4RefreshButton,
     EG4BatteryRefreshButton,
     EG4StationRefreshButton,
+)
+from custom_components.eg4_web_monitor.coordinator_mixins import (
+    ParameterManagementMixin,
 )
 
 
@@ -44,16 +49,12 @@ class TestEG4RefreshButton:
 
     @pytest.mark.asyncio
     async def test_async_press_refreshes_coordinator(self):
-        """Test pressing button refreshes coordinator."""
+        """Pressing the button runs the gated parameter refresh path (#322)."""
         coordinator = MagicMock()
         coordinator.data = {"devices": {"1234567890": {"type": "inverter"}}}
         coordinator.get_device_info.return_value = {}
         coordinator.async_request_refresh = AsyncMock()
-
-        # Mock inverter object with async refresh method
-        mock_inverter = MagicMock()
-        mock_inverter.refresh = AsyncMock()
-        coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
+        coordinator._refresh_device_parameters = AsyncMock()
 
         device_data = {"type": "inverter"}
 
@@ -66,9 +67,82 @@ class TestEG4RefreshButton:
 
         await entity.async_press()
 
-        # Verify inverter refresh was called
-        mock_inverter.refresh.assert_called_once()
-        coordinator.async_request_refresh.assert_called_once()
+        # The inverter path delegates to the coordinator's link-down-gated
+        # force refresh (which includes holding-register parameters).
+        coordinator._refresh_device_parameters.assert_awaited_once_with("1234567890")
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_press_forces_refresh_with_parameters(self):
+        """The button press force-refreshes the device INCLUDING parameters.
+
+        Uses the real ParameterManagementMixin._refresh_device_parameters so
+        the assertion covers the actual pylxpweb call: a bare refresh() would
+        serve cached TTL data and never read holding registers (#322).
+        """
+        coordinator = MagicMock()
+        coordinator.data = {"devices": {"1234567890": {"type": "inverter"}}}
+        coordinator.get_device_info.return_value = {}
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator._refresh_device_parameters = types.MethodType(
+            ParameterManagementMixin._refresh_device_parameters, coordinator
+        )
+
+        mock_inverter = MagicMock()
+        mock_inverter.transport = None  # no local transport -> link not down
+        mock_inverter.refresh = AsyncMock()
+        mock_inverter.parameters = {"HOLD_110": 8}
+        coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
+
+        entity = EG4RefreshButton(
+            coordinator=coordinator,
+            serial="1234567890",
+            device_data={"type": "inverter"},
+            model="FlexBOSS21",
+        )
+
+        await entity.async_press()
+
+        mock_inverter.refresh.assert_awaited_once_with(
+            force=True, include_parameters=True
+        )
+        # Fresh parameters are stored for entity consumption
+        assert coordinator.data["parameters"]["1234567890"] == {"HOLD_110": 8}
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_press_link_down_skips_device_read(self):
+        """With the local transport link down, no device read is attempted.
+
+        The is_transport_link_down gate in _refresh_device_parameters must
+        short-circuit (Python 3.11 asyncio.wait_for cannot interrupt in-flight
+        pymodbus reads on a dead link); the coordinator refresh still runs.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {"devices": {"1234567890": {"type": "inverter"}}}
+        coordinator.get_device_info.return_value = {}
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator._refresh_device_parameters = types.MethodType(
+            ParameterManagementMixin._refresh_device_parameters, coordinator
+        )
+
+        mock_inverter = MagicMock()
+        mock_inverter.transport = MagicMock()  # attached...
+        mock_inverter.transport_link_down = True  # ...but dead link
+        mock_inverter.refresh = AsyncMock()
+        coordinator.get_inverter_object = MagicMock(return_value=mock_inverter)
+
+        entity = EG4RefreshButton(
+            coordinator=coordinator,
+            serial="1234567890",
+            device_data={"type": "inverter"},
+            model="FlexBOSS21",
+        )
+
+        await entity.async_press()
+
+        mock_inverter.refresh.assert_not_awaited()
+        coordinator.async_request_refresh.assert_awaited_once()
 
     def test_device_info(self):
         """Test device info is correctly set."""
@@ -137,9 +211,9 @@ class TestEG4BatteryRefreshButton:
 
         await entity.async_press()
 
-        # Verify parent inverter refresh was called (which refreshes batteries)
-        mock_inverter.refresh.assert_called_once()
-        coordinator.async_request_refresh.assert_called_once()
+        # Parent inverter refresh must bypass the pylxpweb cache TTLs (#322)
+        mock_inverter.refresh.assert_awaited_once_with(force=True)
+        coordinator.async_request_refresh.assert_awaited_once()
 
     def test_unique_id(self):
         """Test unique ID includes battery key."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7065,8 +7065,9 @@ class TestQuickChargeOffgridCloudStatus:
     ):
         """Codex round-3: an attached-but-dead transport link must not be
         touched — a raw read_parameters on it is the uninterruptible
-        multi-minute pymodbus hang class (same gate as
-        _refresh_device_parameters). No transport read is attempted; minute
+        multi-minute pymodbus hang class (not covered by pylxpweb's
+        _fetch_parameters link-down guard). No transport read is attempted;
+        minute
         degrades to None (stored-preference fallback); the cloud active flag
         is unaffected."""
         mock_config_entry.add_to_hass(hass)

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -3344,11 +3344,14 @@ class TestBatteryControlModeMethods:
 
 
 class TestLinkDownParameterRefreshGate:
-    """Parameter refreshes must skip attached-but-dead links (codex P1 on
-    PR #301): pylxpweb's parameter fetch has no transport_link_down gate
-    (unlike runtime/energy/battery), so a local param read on a down link
-    hangs for minutes (Python 3.11 asyncio.wait_for cannot interrupt
-    in-flight pymodbus reads)."""
+    """Link-down handling is delegated to pylxpweb's _fetch_parameters guard
+    (pylxpweb#206, in the 0.9.36b24 floor pinned by manifest.json): it skips
+    the local Modbus read on a dead link (no uninterruptible pymodbus hang)
+    and falls back to cloud named-parameter reads in HYBRID, or skips
+    cleanly in LOCAL (parameters_complete=False).  The coordinator-side hard
+    skip that preceded it (codex P1 on PR #301) blocked exactly that cloud
+    fallback and was removed in #322 — down-link serials must still be
+    refreshed with force + parameters."""
 
     @staticmethod
     def _fake_inverter(*, link_down: bool, parameters: dict | None = None):
@@ -3359,14 +3362,15 @@ class TestLinkDownParameterRefreshGate:
         inv.parameters = parameters or {}
         return inv
 
-    async def test_refresh_all_skips_only_down_link_serials(
+    async def test_refresh_all_includes_down_link_serials(
         self, hass, local_config_entry
     ):
-        """refresh_all_device_parameters: the down serial is skipped, the
-        healthy sibling is still refreshed."""
+        """refresh_all_device_parameters: the down serial is refreshed too —
+        pylxpweb routes it via cloud fallback (HYBRID) or skips internally
+        (LOCAL); the healthy sibling refreshes as before."""
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
-        down = self._fake_inverter(link_down=True)
+        down = self._fake_inverter(link_down=True, parameters={"HOLD_Y": 2})
         up = self._fake_inverter(link_down=False, parameters={"HOLD_X": 1})
         coordinator._inverter_cache = {"DOWN1": down, "UP1": up}
         coordinator.data = {
@@ -3378,14 +3382,15 @@ class TestLinkDownParameterRefreshGate:
 
         await coordinator.refresh_all_device_parameters()
 
-        down.refresh.assert_not_awaited()
+        down.refresh.assert_awaited_once_with(force=True, include_parameters=True)
         up.refresh.assert_awaited_once_with(force=True, include_parameters=True)
         assert coordinator.data["parameters"]["UP1"] == {"HOLD_X": 1}
+        assert coordinator.data["parameters"]["DOWN1"] == {"HOLD_Y": 2}
 
-    async def test_async_refresh_device_parameters_skips_down_link(
+    async def test_async_refresh_device_parameters_refreshes_down_link(
         self, hass, local_config_entry
     ):
-        """The single-serial public refresh path is gated the same way."""
+        """The single-serial public refresh path delegates the same way."""
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
         down = self._fake_inverter(link_down=True)
@@ -3395,7 +3400,7 @@ class TestLinkDownParameterRefreshGate:
 
         await coordinator.async_refresh_device_parameters("DOWN1")
 
-        down.refresh.assert_not_awaited()
+        down.refresh.assert_awaited_once_with(force=True, include_parameters=True)
 
     async def test_note_parameters_written_merges_and_notifies(
         self, hass, local_config_entry


### PR DESCRIPTION
Fixes #322

## Root cause

`EG4RefreshDataButton.async_press` (button.py) called `await inverter.refresh()` with no arguments. Two problems:

1. **`refresh(force=False)` respects the pylxpweb cache TTLs** (~30 s for runtime/energy/battery on dongle transports), so a press shortly after a poll re-read nothing — matching the reporter's "goes fast when it is near the time to update".
2. **It never refreshed parameters** (holding registers), which is where control values like Share Battery live. Parameters only refresh on the hourly cycle — hence values changed on the EG4 portal taking 4+ minutes to appear in HA.

`EG4BatteryRefreshButton.async_press` had the same unforced `refresh()`.

## Fix

- **Inverter refresh button**: the inverter path now delegates to the coordinator's existing `_refresh_device_parameters(serial)` machinery, which calls `inverter.refresh(force=True, include_parameters=True)` and stores the fresh parameters into coordinator data. The button keeps a single trailing `coordinator.async_request_refresh()` to publish the data (no double-read).
- **Battery refresh button**: `await inverter.refresh(force=True)` to actually bypass the TTL cache. Parameters aren't needed there — battery data lives in input registers.

## Adversarial review round (2 confirmed P1s, fixed)

- **P1-1 — coordinator link-down gate removed from `_refresh_device_parameters`**: since pylxpweb 0.9.36b24 (the floor pinned by manifest.json), `_fetch_parameters` carries its own link-down guard (pylxpweb#206): it skips the local Modbus read on a dead link (no uninterruptible pymodbus hang) and **falls back to cloud named-parameter reads in HYBRID**, or skips cleanly in LOCAL with `parameters_complete=False`. The coordinator-side hard skip predated that guard and now blocked exactly the button's purpose in HYBRID-with-dead-link — parameters could refresh via cloud but never did. Link-down handling is now delegated to pylxpweb.
- **P1-2 — silent failures now surface**: `inverter.refresh()` runs its fetch tasks via `asyncio.gather(..., return_exceptions=True)` and `_fetch_parameters` records failures only as `parameters_complete=False`, so device-read failures never raise — a press that read nothing reported success. The button now checks `parameters_complete` after the refresh: partial data + sticky carry-forward is still published (the coordinator refresh runs first), then `HomeAssistantError("Parameter refresh incomplete for <serial>: device unreachable or link degraded; showing last known values")` surfaces the failure in the HA UI.
- The **private** `_refresh_device_parameters` is called rather than the public `async_refresh_device_parameters` wrapper because the wrapper triggers its own `async_request_refresh()` (double-read) and the button performs its own completeness check + error surfacing (the wrapper cannot — and per P1-2, exception propagation from `refresh()` itself is a fiction). Cross-module private coordinator access has precedent (`number.py`/`switch.py` use `coordinator._quick_charge_minutes`).
- Stale comments referencing the removed gate were corrected (coordinator.py partial-write seeding, base_entity.py seed docs, utils.py cloud-fallback docs, test_coordinator.py reg-234 test docstring). The raw-transport-read gates (reg-234 quick-charge read, targeted param reads) are untouched — pylxpweb's guard does not cover raw `transport.read_parameters` calls.

## Tests (`tests/test_button_entities.py`, `tests/test_coordinator_local.py`)

- `test_async_press_refreshes_coordinator` — inverter button delegates to `coordinator._refresh_device_parameters` with the right serial and still triggers the coordinator refresh.
- `test_async_press_forces_refresh_with_parameters` — binds the **real** `ParameterManagementMixin._refresh_device_parameters` and asserts the actual device call is `refresh(force=True, include_parameters=True)` and fresh parameters land in `coordinator.data["parameters"]`.
- `test_async_press_link_down_still_refreshes` — with an attached-but-dead transport link, `refresh(force=True, include_parameters=True)` is still awaited (pylxpweb routes via cloud fallback / skips internally); no coordinator-side block.
- `test_async_press_incomplete_parameters_raises` — `parameters_complete=False` → `HomeAssistantError` raised AND the coordinator refresh still ran first.
- `TestLinkDownParameterRefreshGate` updated to the delegation contract: down-link serials are refreshed with force+parameters in both the refresh-all and single-serial paths.
- Battery button test asserts `refresh(force=True)`.

## Validation

- `ruff check --fix` + `ruff format`: clean (40 files)
- `mypy --config-file tests/mypy.ini` (strict): no issues in 40 source files
- `pytest tests/ -x`: **1914 passed, 3 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)