### PR TITLE
fix: Grid Peak Shaving Power write pre-checks mode enable (#328)

### DIFF
--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -52,6 +52,7 @@ from .const import (
     GRID_SELL_BACK_POWER_MAX,
     GRID_SELL_BACK_POWER_MIN,
     GRID_SELL_BACK_POWER_STEP,
+    PARAM_FUNC_GRID_PEAK_SHAVING,
     PARAM_HOLD_AC_CHARGE_END_VOLTAGE,
     PARAM_HOLD_AC_CHARGE_POWER,
     PARAM_HOLD_AC_CHARGE_SOC_LIMIT,
@@ -1106,6 +1107,14 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
     register encoding (presumed deci-kW) is unverified. The cloud write goes
     by parameter NAME, so the server resolves the true register and accepts
     float kW — local transport name-writes are never used for this control.
+
+    Firmware coupling to Peak Shaving mode (#328, live-verified 2026-07):
+    the inverter only accepts this setpoint while Peak Shaving mode
+    (FUNC_GRID_PEAK_SHAVING, reg 179 bit 7) is enabled — writes with the
+    mode off fail param-specifically with DATAFRAME_TIMEOUT — and the
+    firmware ZEROES the stored setpoint whenever the mode deactivates. A
+    0 readback right after the mode turns off is therefore firmware
+    behavior, not a read bug.
     """
 
     def __init__(self, coordinator: EG4DataUpdateCoordinator, serial: str) -> None:
@@ -1151,6 +1160,13 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
         unverified, so local raw writes cannot be constructed safely. The
         cloud name-write works in CLOUD and HYBRID modes; in pure-LOCAL mode
         this control cannot be written.
+
+        Pre-check (#328): the firmware rejects this write (DATAFRAME_TIMEOUT)
+        while Peak Shaving mode is disabled, and clears the setpoint whenever
+        the mode deactivates — so a write with the mode known-off is refused
+        up front with a clear message. When the mode state is unknown (the
+        parameter is absent from coordinator data) the write proceeds
+        fail-open rather than blocking on missing data.
         """
         if value < 0.0 or value > 25.5:
             raise HomeAssistantError(
@@ -1162,6 +1178,14 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
                 "register encoding is unverified (the previous local write "
                 "path targeted the wrong register). Add cloud credentials to "
                 "this integration entry to use this control."
+            )
+        mode_state = self._parameter_data.get(PARAM_FUNC_GRID_PEAK_SHAVING)
+        if mode_state is not None and not mode_state:
+            raise ServiceValidationError(
+                "Peak Shaving mode is disabled — enable it first: the "
+                "inverter rejects the power setpoint while the mode is off, "
+                "and the firmware clears the setpoint whenever the mode "
+                "deactivates."
             )
         _LOGGER.info(
             "Setting grid peak shaving power to %.1f kW for %s", value, self.serial

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -1164,15 +1164,19 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
         Pre-check (#328): the firmware rejects this write (DATAFRAME_TIMEOUT)
         while Peak Shaving mode is disabled, and clears the setpoint whenever
         the mode deactivates — so a write with the mode known-off is refused
-        up front with a clear message. When the mode state is unknown (the
-        parameter is absent from coordinator data) the write proceeds
+        up front with a clear message. Because the parameter cache refreshes
+        ~hourly, a cached False is confirmed with a live reg-179 cloud read
+        before blocking (verify-then-block) so a mode just enabled on the
+        portal/LCD isn't wrongly refused. When the mode state is unknown
+        (parameter absent, or the live read fails) the write proceeds
         fail-open rather than blocking on missing data.
         """
         if value < 0.0 or value > 25.5:
             raise HomeAssistantError(
                 f"Grid peak shaving power must be between 0.0-25.5 kW, got {value}"
             )
-        if self.coordinator.client is None:
+        client = self.coordinator.client
+        if client is None:
             raise HomeAssistantError(
                 "Grid peak shaving power requires the cloud API: the local "
                 "register encoding is unverified (the previous local write "
@@ -1181,12 +1185,40 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
             )
         mode_state = self._parameter_data.get(PARAM_FUNC_GRID_PEAK_SHAVING)
         if mode_state is not None and not mode_state:
-            raise ServiceValidationError(
-                "Peak Shaving mode is disabled — enable it first: the "
-                "inverter rejects the power setpoint while the mode is off, "
-                "and the firmware clears the setpoint whenever the mode "
-                "deactivates."
-            )
+            # Verify-then-block: the parameter cache refreshes ~hourly, so a
+            # user who just enabled Peak Shaving mode on the EG4 portal or
+            # the inverter LCD would otherwise be locked out by a stale
+            # cached False until the next refresh. Confirm with a live
+            # single-register cloud read (reg 179 carries the FUNC bit)
+            # before refusing; if the read fails or omits the bit, fail
+            # open — the firmware is the final arbiter of the write.
+            try:
+                response = await client.api.control.read_parameters(
+                    self.serial, start_register=179, point_number=1
+                )
+                mode_state = response.parameters.get(PARAM_FUNC_GRID_PEAK_SHAVING)
+            except Exception as err:
+                _LOGGER.debug(
+                    "Live Peak Shaving mode check for %s failed (%s); "
+                    "proceeding fail-open",
+                    self.serial,
+                    err,
+                )
+                mode_state = None
+            if mode_state is not None and not mode_state:
+                raise ServiceValidationError(
+                    "Peak Shaving mode is disabled — enable it first: the "
+                    "inverter rejects the power setpoint while the mode is "
+                    "off, and the firmware clears the setpoint whenever the "
+                    "mode deactivates."
+                )
+            if mode_state:
+                # The cache said off but the device says ON — seed the
+                # fresh truth so the mode switch stops showing stale state
+                # until the next scheduled parameter refresh.
+                self.coordinator.note_parameters_written(
+                    self.serial, {PARAM_FUNC_GRID_PEAK_SHAVING: True}
+                )
         _LOGGER.info(
             "Setting grid peak shaving power to %.1f kW for %s", value, self.serial
         )

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -1234,6 +1234,73 @@ class TestGridPeakShavingPowerNumber:
         inverter = coordinator.get_inverter_object("1234567890")
         inverter.set_grid_peak_shaving_power.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_write_mode_disabled_raises(self):
+        """#328: Peak Shaving mode known-OFF refuses the write up front —
+        the firmware rejects it (DATAFRAME_TIMEOUT) and clears the setpoint
+        while the mode is off, so a silent attempt would misreport success."""
+        coordinator = _mock_coordinator(
+            has_local=False,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": False},
+        )
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        with pytest.raises(ServiceValidationError, match="Peak Shaving mode"):
+            await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_mode_disabled_int_zero_raises(self):
+        """#328: local param refreshes report FUNC bits as 0/1 ints — a raw
+        0 must gate exactly like False."""
+        coordinator = _mock_coordinator(
+            has_local=True,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": 0},
+        )
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        with pytest.raises(ServiceValidationError, match="Peak Shaving mode"):
+            await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_mode_enabled_proceeds(self):
+        """#328: Peak Shaving mode ON — the write goes through normally."""
+        coordinator = _mock_coordinator(
+            has_local=False,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": True},
+        )
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
+
+    @pytest.mark.asyncio
+    async def test_write_mode_unknown_fails_open(self):
+        """#328: mode param absent from coordinator data (e.g. params not
+        yet fetched) — proceed with the write rather than blocking on
+        missing data (fail-open)."""
+        coordinator = _mock_coordinator(has_local=False, has_http=True)
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
+
     def test_native_value_from_inverter_attr(self):
         """Cloud modes read the kW value from the pylxpweb property."""
         coordinator = _mock_coordinator(

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -7,6 +7,7 @@ from homeassistant.components.number import RestoreNumber
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.eg4_web_monitor.const import (
+    PARAM_FUNC_GRID_PEAK_SHAVING,
     PARAM_HOLD_AC_CHARGE_POWER,
     PARAM_HOLD_FORCED_CHG_POWER,
 )
@@ -1234,15 +1235,28 @@ class TestGridPeakShavingPowerNumber:
         inverter = coordinator.get_inverter_object("1234567890")
         inverter.set_grid_peak_shaving_power.assert_not_called()
 
+    @staticmethod
+    def _mock_live_mode_read(coordinator, parameters: dict) -> AsyncMock:
+        """Mock the live reg-179 cloud read used by verify-then-block."""
+        response = MagicMock()
+        response.parameters = parameters
+        read = AsyncMock(return_value=response)
+        coordinator.client.api.control.read_parameters = read
+        return read
+
     @pytest.mark.asyncio
     async def test_write_mode_disabled_raises(self):
         """#328: Peak Shaving mode known-OFF refuses the write up front —
         the firmware rejects it (DATAFRAME_TIMEOUT) and clears the setpoint
-        while the mode is off, so a silent attempt would misreport success."""
+        while the mode is off, so a silent attempt would misreport success.
+        The cached False is confirmed by the live reg-179 read first."""
         coordinator = _mock_coordinator(
             has_local=False,
             has_http=True,
             parameters={"FUNC_GRID_PEAK_SHAVING": False},
+        )
+        live_read = self._mock_live_mode_read(
+            coordinator, {"FUNC_GRID_PEAK_SHAVING": False}
         )
         entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
         _prep(entity)
@@ -1250,6 +1264,9 @@ class TestGridPeakShavingPowerNumber:
         with pytest.raises(ServiceValidationError, match="Peak Shaving mode"):
             await entity.async_set_native_value(5.0)
 
+        live_read.assert_awaited_once_with(
+            "1234567890", start_register=179, point_number=1
+        )
         inverter = coordinator.get_inverter_object("1234567890")
         inverter.set_grid_peak_shaving_power.assert_not_called()
 
@@ -1262,6 +1279,7 @@ class TestGridPeakShavingPowerNumber:
             has_http=True,
             parameters={"FUNC_GRID_PEAK_SHAVING": 0},
         )
+        self._mock_live_mode_read(coordinator, {"FUNC_GRID_PEAK_SHAVING": 0})
         entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
         _prep(entity)
 
@@ -1272,18 +1290,84 @@ class TestGridPeakShavingPowerNumber:
         inverter.set_grid_peak_shaving_power.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_write_mode_enabled_proceeds(self):
-        """#328: Peak Shaving mode ON — the write goes through normally."""
+    async def test_write_stale_cache_live_mode_on_proceeds(self):
+        """#328 review P2 (stale-cache lockout): the cache refreshes ~hourly,
+        so a mode just enabled on the portal/LCD can be cached False. The
+        live reg-179 read says ON — the write proceeds and the fresh truth
+        is seeded into the coordinator cache."""
         coordinator = _mock_coordinator(
             has_local=False,
             has_http=True,
-            parameters={"FUNC_GRID_PEAK_SHAVING": True},
+            parameters={"FUNC_GRID_PEAK_SHAVING": False},
+        )
+        self._mock_live_mode_read(coordinator, {"FUNC_GRID_PEAK_SHAVING": True})
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
+        coordinator.note_parameters_written.assert_called_once_with(
+            "1234567890", {PARAM_FUNC_GRID_PEAK_SHAVING: True}
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_cached_false_live_read_fails_open(self):
+        """#328: the live confirmation read failing must NOT block the write
+        — the firmware is the final arbiter (fail-open)."""
+        coordinator = _mock_coordinator(
+            has_local=False,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": False},
+        )
+        coordinator.client.api.control.read_parameters = AsyncMock(
+            side_effect=TimeoutError("cloud read failed")
         )
         entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
         _prep(entity)
 
         await entity.async_set_native_value(5.0)
 
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_cached_false_live_read_omits_bit_fails_open(self):
+        """#328: a live response without the FUNC bit is unknown state —
+        proceed fail-open, and don't seed anything into the cache."""
+        coordinator = _mock_coordinator(
+            has_local=False,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": False},
+        )
+        self._mock_live_mode_read(coordinator, {})
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(5.0)
+
+        inverter = coordinator.get_inverter_object("1234567890")
+        inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
+        coordinator.note_parameters_written.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_mode_enabled_proceeds(self):
+        """#328: Peak Shaving mode ON — the write goes through normally,
+        with NO extra live read on the happy path."""
+        coordinator = _mock_coordinator(
+            has_local=False,
+            has_http=True,
+            parameters={"FUNC_GRID_PEAK_SHAVING": True},
+        )
+        live_read = self._mock_live_mode_read(coordinator, {})
+        entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(5.0)
+
+        live_read.assert_not_awaited()
         inverter = coordinator.get_inverter_object("1234567890")
         inverter.set_grid_peak_shaving_power.assert_called_once_with(power_kw=5.0)
 


### PR DESCRIPTION
## Summary

Integration half of #328 (Grid Peak Shaving Power UX). Hardware facts (live-verified + DoubleDoc's pylxpweb#158 test):

- Cloud writes to the PS1 power param **succeed while Peak Shaving mode** (`FUNC_GRID_PEAK_SHAVING`, reg 179 bit 7) is enabled, and **fail param-specifically with `DATAFRAME_TIMEOUT`** while it is off.
- The firmware **zeroes the PS power setpoint** whenever the mode deactivates.

### Changes

- `GridPeakShavingPowerNumber.async_set_native_value` now pre-checks the device's parameter data for `FUNC_GRID_PEAK_SHAVING` before writing:
  - **present and falsy** → `ServiceValidationError` ("Peak Shaving mode is disabled — enable it first…"), no write attempted;
  - **present and truthy** → write proceeds as before;
  - **absent (unknown)** → write proceeds (fail-open; never blocks on missing data).
- Class + method docstrings document the firmware clear-on-deactivate behavior so a `0` readback right after mode-off reads as firmware behavior, not a read bug.

Out of scope (deliberate): the readback-blanking half of #328 is fixed in pylxpweb (local register map for HR206); PS2/SOC/VOLT windows remain deferred — no new entities.

### Tests

4 new tests in `tests/test_number_entities.py::TestGridPeakShavingPowerNumber`:
- mode param `False` → `ServiceValidationError`, setter not called
- mode param `0` (local int-form FUNC bit) → same gate
- mode param `True` → setter called
- mode param absent → setter called (fail-open)

### Gates

- `ruff check --fix` + `ruff format`: clean
- `mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/`: Success, no issues in 40 files
- `pytest tests/`: **1929 passed, 3 skipped**

Fixes the write-UX half of #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)