### PR TITLE
fix: LOCAL mode never read the Grid Peak Shaving Power register (#328 gap)

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -553,6 +553,16 @@ class LocalTransportMixin(_MixinBase):
                 hybrid_schedule_ranges.append((256, 4))  # Generator charge
             if is_hybrid:
                 hybrid_schedule_ranges.append((269, 6))  # Off-Grid
+                # Grid Peak Shaving Power (PS1, reg 206, deci-kW — encoding
+                # hardware-verified in #328): consumed by the Grid Peak
+                # Shaving Power number, which was cloud/hybrid-only until
+                # pylxpweb 0.9.36b27 mapped the register; without this read
+                # the entity sat unknown in LOCAL mode (3.4.0-final sweep).
+                # Family-gated like the (209, 4) schedule read above — the
+                # SNA probe shows the PS params absent from the offgrid
+                # template. Older pylxpweb surfaces the raw "206" key,
+                # which nothing consumes until the pin bump.
+                hybrid_schedule_ranges.append((206, 1))
 
             # Read all parameter ranges using library's register-to-name mapping
             # The library handles bit field extraction automatically
@@ -608,11 +618,11 @@ class LocalTransportMixin(_MixinBase):
                 # mapping surfaces this read under the raw key "202" (unused).
                 (202, 1),
                 (227, 2),  # System charge SOC limit (227) + voltage limit (228)
-                # Registers 231-232 were read here as "grid peak shaving power"
-                # — removed (eg4-gfu5): PS1 actually lives at reg 206 (231 is an
-                # unknown, unnamed register) and the PS power raw encoding is
-                # unverified, so there is nothing useful to read locally yet.
-                # Grid Peak Shaving Power is cloud-sourced only.
+                # Registers 231-232 were once read here as "grid peak shaving
+                # power" — removed (eg4-gfu5): PS1 actually lives at reg 206
+                # (231 is an unknown, unnamed register). Since #328 verified
+                # the deci-kW encoding, reg 206 is read via the family-gated
+                # (206, 1) entry in hybrid_schedule_ranges above.
                 (233, 1),  # Extended functions 2 (FUNC_BATTERY_BACKUP_CTRL, etc.)
                 # Peak Shaving / Generator / Off-Grid schedules — EG4_HYBRID
                 # only (209-212, 256-274). See hybrid_schedule_ranges above.

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -1157,10 +1157,11 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:chart-bell-curve-cumulative"
         self._attr_native_precision = 1
         if coordinator.is_local_only():
-            # Pure-LOCAL can neither read nor write this control (cloud-only
-            # until the reg-206 raw encoding is verified) — register it
-            # disabled instead of shipping a permanently-dead config entity.
-            # Users who later attach cloud credentials can enable it.
+            # Pure-LOCAL reads this control since #328 (reg 206, deci-kW
+            # encoding verified; hybrid-family-gated targeted read) but the
+            # write path is still cloud-routed — register it disabled so a
+            # write-less config entity is opt-in. Users who attach cloud
+            # credentials (or want the read-only view) can enable it.
             self._attr_entity_registry_enabled_default = False
 
     def _get_related_entity_types(self) -> tuple[type, ...]:

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -186,8 +186,9 @@ class TestReadModbusParameters:
             (227, 2),
             # (231, 2) removed: PS1 is reg 206, reg 231 unknown (eg4-gfu5)
             (233, 1),
-            # (209, 4)/(256, 4)/(269, 6) absent: Peak Shaving/Generator/Off-Grid
-            # are EG4_HYBRID/OFFGRID-gated (pylxpweb #209).
+            # (209, 4)/(256, 4)/(269, 6)/(206, 1) absent: Peak Shaving/
+            # Generator/Off-Grid schedules and the PS power register are
+            # EG4_HYBRID/OFFGRID-gated (pylxpweb #209, #328).
         ]
         assert "PARAM_A" in result
 
@@ -214,6 +215,9 @@ class TestReadModbusParameters:
         assert (209, 4) in called_ranges
         assert (256, 4) in called_ranges
         assert (269, 6) in called_ranges
+        # Grid Peak Shaving Power (reg 206, #328): without this read the
+        # PS power number sat unknown in LOCAL mode (3.4.0-final sweep).
+        assert (206, 1) in called_ranges
         # Never a span that crosses the unmapped 260-268 zone.
         assert (256, 19) not in called_ranges
         assert (152, 6) not in called_ranges
@@ -241,6 +245,8 @@ class TestReadModbusParameters:
         assert (256, 4) in called_ranges
         assert (209, 4) not in called_ranges
         assert (269, 6) not in called_ranges
+        # PS power (206) params are likewise absent on the SNA probe.
+        assert (206, 1) not in called_ranges
 
     async def test_offgrid_device_reads_ac_first_range(self, hass, local_config_entry):
         """EG4_OFFGRID devices additionally poll the AC First schedule
@@ -701,7 +707,9 @@ class TestStickyParameterCarryForward:
 # Off-Grid (269,6) — added by the beta.22 schedule families (GH #295 / PR
 # #312).  PR #313 landed these tests with the pre-#312 count of 13; both PRs
 # were green alone but the merged branch reads 16 (merge skew, not a bug).
-_EXPECTED_HYBRID_READS = 16
+# 17th read: Grid Peak Shaving Power (206,1), hybrid-family-gated (#328 —
+# the 3.4.0-final sweep found the PS number unknown in LOCAL mode).
+_EXPECTED_HYBRID_READS = 17
 
 
 class TestLinkDownParameterGateCycle:


### PR DESCRIPTION
Found by the 3.4.0-final three-mode validation sweep: `number.*_grid_peak_shaving_power` read **unknown in LOCAL mode** while cloud and hybrid read real values.

**Root cause**: beta.25 (#328) verified the deci-kW encoding and mapped reg 206 in pylxpweb b27, and validated in cloud + hybrid — but those modes source entity parameter data from the full 250-register refresh / cloud ranges. LOCAL-mode entities feed from `_read_modbus_parameters`' targeted range list, which still carried the June-era comment *"PS power raw encoding is unverified... Grid Peak Shaving Power is cloud-sourced only"* and deliberately skipped reg 206.

**Fix**: add a `(206, 1)` read, family-gated on EG4_HYBRID with the same predicate and rationale as the `(209, 4)` Peak Shaving schedule read (SNA probe shows the PS params absent from the offgrid template — an ungated read would NAK and loop the #282 early retry). Stale comment corrected; hardcoded hybrid read-count test bumped 16→17 with provenance.

**Live-verified in LOCAL mode**: both rig inverters read 0.0 after restart (were unknown).

Gates: ruff clean, mypy strict clean, **1957 passed / 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)