### PR TITLE
fix: EPS Load Power reads the real epsLoadPower field — was an alias of combined EPS output (#335)

### DIFF
--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -88,18 +88,30 @@ _DEPRECATED_CHARGE_DISCHARGE_SUFFIXES: frozenset[str] = frozenset(
     }
 )
 
+# Sensor keys removed because they duplicated another sensor's value; the
+# suffixes purge their orphaned registry entries at setup.  Matching uses the
+# literal ``_{sensor_key}`` unique_id tail so surviving keys are never touched.
+#
 # Issue #253: the per-inverter "Has Runtime Data" sensor was created twice —
 # from the inverter ``has_data`` property (key ``has_data``) and from the
 # redundant ``has_runtime_data``/cloud ``hasRuntimeData`` field (key
 # ``inverter_has_runtime_data``).  Both rendered the identical name and
 # collided onto one entity_id slug, so installs accumulated two active
-# entities per inverter.  The duplicate key has been removed; this suffix
-# purges its orphaned registry entries.  Matching requires the literal
-# ``_inverter_has_runtime_data`` tail so the surviving ``_has_data`` entity
-# (and any ``_runtime_..._has_data`` variant) is never touched.
+# entities per inverter.  The ``_inverter_has_runtime_data`` tail never
+# matches the surviving ``_has_data`` entity (or any ``_runtime_..._has_data``
+# variant).
+#
+# Issue #335: the EG4_OFFGRID "EPS Load Power L1/L2" sensors (#197) aliased
+# the eps_power_l1/l2 values (regs 129/130 / cloud pEpsL1N/L2N — the COMBINED
+# backup-path legs), so they were exact duplicates of "EPS Power L1/L2".  The
+# keys are retired: no per-leg source for the EPS-loads subset exists.  The
+# ``..._l1``/``..._l2`` tails never match the surviving ``_eps_load_power``
+# (total) entity, which now carries the real cloud ``epsLoadPower`` field.
 _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES: frozenset[str] = frozenset(
     {
         "_inverter_has_runtime_data",
+        "_eps_load_power_l1",
+        "_eps_load_power_l2",
     }
 )
 
@@ -307,15 +319,14 @@ def _async_cleanup_duplicate_runtime_data_entities(
     hass: HomeAssistant,
     entry: EG4ConfigEntry,
 ) -> None:
-    """Remove orphaned duplicate "Has Runtime Data" sensor entities (#253).
+    """Remove orphaned entities of retired duplicate sensor keys (#253, #335).
 
-    Earlier versions exposed the same inverter runtime-data flag as two
-    sensors sharing the name "Has Runtime Data": the canonical ``has_data``
-    key and the redundant ``inverter_has_runtime_data`` key.  Both mapped the
-    identical underlying value and collided onto one entity_id slug, so
-    installs accumulated two active entities per inverter.  The
-    ``inverter_has_runtime_data`` sensor has been removed; purge its stale
-    registry entries so the duplicate disappears without manual deletion.
+    Earlier versions exposed the same underlying value under two sensor keys
+    (see ``_DEPRECATED_DUPLICATE_SENSOR_SUFFIXES``): the redundant
+    ``inverter_has_runtime_data`` twin of ``has_data`` (#253) and the
+    ``eps_load_power_l1``/``_l2`` aliases of ``eps_power_l1``/``_l2`` (#335).
+    The duplicate keys have been removed; purge their stale registry entries
+    so the dead entities disappear without manual deletion.
     """
     entity_registry = er.async_get(hass)
     for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
@@ -327,7 +338,7 @@ def _async_cleanup_duplicate_runtime_data_entities(
         ):
             entity_registry.async_remove(entity.entity_id)
             _LOGGER.info(
-                "Removed duplicate Has Runtime Data sensor (#253): %s",
+                "Removed retired duplicate sensor (#253/#335): %s",
                 entity.entity_id,
             )
 
@@ -603,7 +614,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
             entity_registry.async_remove(entity.entity_id)
             _LOGGER.info("Removed deprecated sensor: %s", entity.entity_id)
 
-    # One-time cleanup: remove the duplicate "Has Runtime Data" sensor (#253).
+    # One-time cleanup: purge retired duplicate sensor keys — the "Has
+    # Runtime Data" twin (#253) and the fabricated EPS Load Power L1/L2
+    # aliases of EPS Power L1/L2 (#335).
     _async_cleanup_duplicate_runtime_data_entities(hass, entry)
 
     # Conditional cleanup: per-inverter "_battery_discharge_power" was

--- a/custom_components/eg4_web_monitor/const/device_types.py
+++ b/custom_components/eg4_web_monitor/const/device_types.py
@@ -191,33 +191,31 @@ DISCHARGE_RECOVERY_SENSORS: frozenset[str] = frozenset(
     }
 )
 
-# Sensors backed by registers confirmed working on EG4_OFFGRID hardware only
-# (12000XP/6000XP — live Modbus sweep + cloud cross-reference, issue #197):
-#   - eps_load_power_l1/_l2: input regs 129/130 (per-phase EPS load, W)
-#   - eps_load_power: L1+L2 sum.  NOTE: regs 129/130 carry the COMBINED
-#     backup-path output — when a GEN-port smart load is active this sum is
-#     smart load + EPS loads, NOT the cloud epsLoadPower field, which is the
-#     EPS-only split (6000XP live evidence, issue #222: L1+L2 = 3371 W =
-#     smartLoadPower 2999 W + epsLoadPower 365 W).  With no smart load active
-#     it matches cloud epsLoadPower within timing skew (12000XP, issue #197).
+# Sensors confirmed meaningful on EG4_OFFGRID hardware only (12000XP/6000XP —
+# live Modbus sweep + cloud cross-reference, issues #197/#222/#335):
 #   - load_power: input reg 170 ("Pload" in the 6kXP Modbus PDF, W).  The cloud
 #     zeroes its reg-170 mirror for EG4_OFFGRID, so the value comes from the
 #     LOCAL register only (LOCAL mapping + HYBRID transport overlay).
 #   - battery_discharge_power: input reg 11 / cloud pDisCharge (W)
-#   - smart_load_power / grid_load_power: cloud smartLoadPower /
-#     gridLoadPower fields (W) — the GEN-port smart load + grid-side split of
-#     the backup output (issue #222).  CLOUD/HYBRID supplemental only: no
-#     validated local register on this family (the 18kPV firmware RE names
-#     input reg 232 "smart_load_power" but it is unvalidated on EG4_OFFGRID
-#     hardware), so these keys are intentionally absent from
-#     ALL_INVERTER_SENSOR_KEYS and the LOCAL mapping.
+#   - smart_load_power / grid_load_power / eps_load_power: the cloud
+#     smartLoadPower / gridLoadPower / epsLoadPower fields (W) — the GEN-port
+#     smart load + grid-side + EPS-loads split of the backup output (issue
+#     #222: consumption = epsLoadPower + smartLoadPower + gridLoadPower).
+#     CLOUD/HYBRID supplemental only: no validated local register on this
+#     family (the 18kPV firmware RE names input reg 232 "smart_load_power"
+#     but it is unvalidated on EG4_OFFGRID hardware, and regs 129/130 are the
+#     COMBINED backup legs, not the epsLoadPower subset), so these keys are
+#     intentionally absent from ALL_INVERTER_SENSOR_KEYS and the LOCAL
+#     mapping.
+#   - The former eps_load_power_l1/_l2 sensors (#197) were RETIRED (#335):
+#     they aliased the combined regs 129/130 / pEpsL1N/L2N values and so
+#     duplicated eps_power_l1/l2 — no per-leg source for the EPS-loads
+#     subset exists on any path.
 # NOTE: "load_power" is also a GridBOSS/parallel-group sensor key — this gate
 # only applies to inverter entities (GridBOSS devices carry no inverter
 # features, so _should_create_sensor passes them through).
 OFFGRID_ONLY_SENSORS: frozenset[str] = frozenset(
     {
-        "eps_load_power_l1",
-        "eps_load_power_l2",
         "eps_load_power",
         "load_power",
         "battery_discharge_power",

--- a/custom_components/eg4_web_monitor/const/sensors/inverter.py
+++ b/custom_components/eg4_web_monitor/const/sensors/inverter.py
@@ -144,23 +144,13 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "icon": "mdi:power-plug",
     },
-    # Per-phase EPS load power (input regs 129/130, W) + L1+L2 sum.
-    # EG4_OFFGRID only (12000XP/6000XP) — confirmed via live Modbus sweep,
-    # matches the cloud epsLoadPower field within timing skew (issue #197).
-    "eps_load_power_l1": {
-        "name": "EPS Load Power L1",
-        "unit": UnitOfPower.WATT,
-        "device_class": "power",
-        "state_class": "measurement",
-        "icon": "mdi:home-lightning-bolt",
-    },
-    "eps_load_power_l2": {
-        "name": "EPS Load Power L2",
-        "unit": UnitOfPower.WATT,
-        "device_class": "power",
-        "state_class": "measurement",
-        "icon": "mdi:home-lightning-bolt",
-    },
+    # EPS-loads subset of the backup output — cloud epsLoadPower field (W),
+    # the EPS leg of the 6000XP/12000XP load split (#222: consumption =
+    # epsLoadPower + smartLoadPower + gridLoadPower).  EG4_OFFGRID only,
+    # CLOUD/HYBRID supplemental — regs 129/130 are the COMBINED backup legs
+    # (eps_power_l1/l2), NOT this subset, and no per-leg epsLoad fields exist;
+    # the former eps_load_power_l1/l2 sensors fabricated from them duplicated
+    # eps_power_l1/l2 and were retired (#335).
     "eps_load_power": {
         "name": "EPS Load Power",
         "unit": UnitOfPower.WATT,

--- a/custom_components/eg4_web_monitor/coordinator_mappings.py
+++ b/custom_components/eg4_web_monitor/coordinator_mappings.py
@@ -149,50 +149,14 @@ def alias_common_voltage_sensors(
         sensors["eps_voltage"] = v
 
 
-def _sum_optional_watts(l1: Any, l2: Any) -> int | None:
-    """Sum two optional per-leg watt values (L1+L2 pattern).
-
-    Returns ``None`` only when BOTH legs are ``None`` (no data); a single
-    available leg carries the total — the same semantics as the GridBOSS
-    ``sum_l1_l2`` aggregation.
-    """
-    if l1 is None and l2 is None:
-        return None
-    return int(l1 or 0) + int(l2 or 0)
-
-
-def apply_eps_load_power_sensors(sensors: dict[str, Any]) -> None:
-    """Populate per-phase EPS load power sensors + L1+L2 sum (issue #197).
-
-    Input regs 129/130 (LOCAL/HYBRID transport) and the cloud pEpsL1N/pEpsL2N
-    fields land on the ``eps_power_l1``/``eps_power_l2`` keys in both data
-    paths.  This aliases them onto the EG4_OFFGRID ``eps_load_power_*`` keys
-    and computes the combined ``eps_load_power`` following the existing
-    L1+L2 sum pattern.  Live-validated on 12000XP: L1=1031 + L2=296 = 1327 W
-    vs cloud epsLoadPower=1338 W (timing skew).
-
-    Called from BOTH the LOCAL runtime mapping and the cloud/hybrid device
-    processing path so the sum logic cannot drift between modes.
-
-    Args:
-        sensors: Mutable sensor dict to update.
-    """
-    # Presence means a NON-None VALUE (review round 2): the LOCAL runtime
-    # mapping materializes eps_power_l1/l2 keys unconditionally (values may
-    # be None), while pure-CLOUD responses omit the keys entirely — value
-    # presence is the only test that means the same thing on both paths.
-    # A single available phase aliases alone; the combined sum requires
-    # BOTH phases so a lone leg can never publish a half-truth total.
-    l1 = sensors.get("eps_power_l1")
-    l2 = sensors.get("eps_power_l2")
-    if l1 is None and l2 is None:
-        return
-    if l1 is not None:
-        sensors["eps_load_power_l1"] = l1
-    if l2 is not None:
-        sensors["eps_load_power_l2"] = l2
-    if l1 is not None and l2 is not None:
-        sensors["eps_load_power"] = _sum_optional_watts(l1, l2)
+# NOTE (#335): the former apply_eps_load_power_sensors() helper (#197) that
+# aliased eps_power_l1/l2 onto eps_load_power_l1/l2 and summed them into
+# eps_load_power was DELETED.  Regs 129/130 / cloud pEpsL1N/pEpsL2N are the
+# COMBINED backup-path output (smart load + EPS loads) — the #197 "sum matches
+# cloud epsLoadPower" validation was a coincidence (smart load idle).  The
+# eps_load_power_l1/l2 keys are retired (no per-leg EPS-load source exists on
+# any path) and eps_load_power now maps the real cloud epsLoadPower field via
+# the HTTP property map (cloud-only; see _get_inverter_property_map()).
 
 
 # Families whose cloud pLoad170 mirror is trustworthy for output_power:
@@ -323,13 +287,15 @@ INVERTER_RUNTIME_KEYS: frozenset[str] = frozenset(
         "eps_power_l2",
         "eps_apparent_power_l1",
         "eps_apparent_power_l2",
-        # EG4_OFFGRID confirmed registers (issue #197): per-phase EPS load
-        # power (regs 129/130 + L1+L2 sum), load power (reg 170) and battery
-        # discharge power (reg 11).  Entity creation is family-gated via
-        # OFFGRID_ONLY_SENSORS in sensor.py.
-        "eps_load_power_l1",
-        "eps_load_power_l2",
-        "eps_load_power",
+        # EG4_OFFGRID confirmed registers (issue #197): load power (reg 170)
+        # and battery discharge power (reg 11).  Entity creation is
+        # family-gated via OFFGRID_ONLY_SENSORS in sensor.py.
+        # NOTE (#335): eps_load_power is NOT here — it is a CLOUD-ONLY sensor
+        # (cloud epsLoadPower field) like smart_load_power/grid_load_power;
+        # regs 129/130 carry the COMBINED backup output (eps_power_l1/l2
+        # above), and no local register for the EPS-loads subset is known
+        # (needs XP hardware probing).  The former eps_load_power_l1/l2
+        # aliases were retired for the same reason.
         "load_power",
         "battery_discharge_power",
         # US split-phase per-leg power (regs 195-204)
@@ -828,9 +794,14 @@ def _build_runtime_sensor_mapping(
         "max_charge_current": runtime_data.bms_charge_current_limit,
         "max_discharge_current": runtime_data.bms_discharge_current_limit,
     }
-    # Per-phase EPS load power (regs 129/130) + L1+L2 sum — shared helper so
-    # the LOCAL and cloud/hybrid paths cannot drift (issue #197).
-    apply_eps_load_power_sensors(mapping)
+    # NOTE (#335): eps_load_power (the EPS-loads subset of the backup output)
+    # is deliberately NOT mapped here.  Regs 129/130 are the COMBINED
+    # backup-path legs (already on eps_power_l1/l2 above) — with a GEN-port
+    # smart load active they include the smart-load draw (#222: 6000XP live,
+    # L1+L2 3371 W = smartLoadPower 2999 + epsLoadPower 365).  No local
+    # register for the subset is validated (needs XP hardware probing), so
+    # the sensor is CLOUD-ONLY for now: absent in pure LOCAL, populated in
+    # CLOUD/HYBRID whenever cloud runtime is fetched (HTTP property map).
     return mapping
 
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -52,7 +52,6 @@ from .coordinator_mappings import (
     _safe_float,
     _write_charge_rate,
     alias_common_voltage_sensors,
-    apply_eps_load_power_sensors,
     build_battery_bank_sensors,
     compute_bank_charge_rate,
     drop_offgrid_cloud_output_power,
@@ -1110,12 +1109,6 @@ class DeviceProcessingMixin(_MixinBase):
             inverter.transport_runtime is not None,
         )
 
-        # Per-phase EPS load power (regs 129/130 / cloud pEpsL1N/pEpsL2N) +
-        # L1+L2 sum — same shared helper as the LOCAL mapping (issue #197).
-        # The eps_power_l1/_l2 properties prefer the transport registers in
-        # HYBRID and fall back to the cloud fields in pure CLOUD.
-        apply_eps_load_power_sensors(processed["sensors"])
-
         # Load Energy (Eload, regs 171/172) — the inverter-served load.  This is
         # a SEPARATE meter from whole-home `consumption` (overridden below).
         # energy_today_usage/energy_lifetime_usage return the transport register
@@ -1447,6 +1440,18 @@ class DeviceProcessingMixin(_MixinBase):
             # source (no validated register) and never creates the keys.
             "smart_load_power": "smart_load_power",
             "grid_load_power": "grid_load_power",
+            # EPS-loads subset of the backup output — cloud-only epsLoadPower
+            # field, the third leg of the #222 split (consumption =
+            # epsLoadPower + smartLoadPower + gridLoadPower).  NOT the same
+            # quantity as eps_power/peps/pEpsL1N, which carry the COMBINED
+            # backup output — the former eps_power_l1+l2 aliasing was a #197
+            # coincidence (smart load idle) and produced duplicate sensors
+            # (#335).  No per-leg epsLoad fields exist, and regs 129/130 are
+            # the combined legs, so there is no LOCAL source (needs XP
+            # hardware probing).  Same HYBRID cloud-supplemental behavior as
+            # its siblings above.  Requires a pylxpweb eps_load_power
+            # property (getattr resolves None → key absent until then).
+            "eps_load_power": "eps_load_power",
             # US split-phase per-leg power
             "inverter_power_l1": "inverter_power_l1",
             "inverter_power_l2": "inverter_power_l2",

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -1449,8 +1449,8 @@ class DeviceProcessingMixin(_MixinBase):
             # (#335).  No per-leg epsLoad fields exist, and regs 129/130 are
             # the combined legs, so there is no LOCAL source (needs XP
             # hardware probing).  Same HYBRID cloud-supplemental behavior as
-            # its siblings above.  Requires a pylxpweb eps_load_power
-            # property (getattr resolves None → key absent until then).
+            # its siblings above.  Backed by the pylxpweb eps_load_power
+            # property (>=0.9.36); no cloud runtime → None → key absent.
             "eps_load_power": "eps_load_power",
             # US split-phase per-leg power
             "inverter_power_l1": "inverter_power_l1",

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.36b28", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.36", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.4.0-beta.26"
 }

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -182,7 +182,7 @@ Mapping chain: Register → `_canonical_reader.read_scaled()` → `InverterRunti
 > combined regs 129/130 values and so exactly duplicated `eps_power_l1/l2` —
 > the #197 "sum ≈ cloud epsLoadPower" validation was a smart-load-idle
 > coincidence.  `eps_load_power` now maps the real cloud `epsLoadPower`
-> field (pending a pylxpweb `eps_load_power` property).
+> field via the pylxpweb `eps_load_power` property (pylxpweb ≥0.9.36).
 
 > **Note:** Regs 193-204 (grid/generator per-leg voltage + per-leg power) are
 > firmware-zero on EG4 US split-phase inverters — confirmed live across the full
@@ -1364,7 +1364,7 @@ value; the `status_code` sensor retains it for diagnosis).
 | Smart port power | Modbus regs 34-41 | API fields | Both | Filtered by port status |
 | `load_power` (inverter) | Yes | No | Yes (overlay) | Reg 170; EG4_OFFGRID-only — cloud zeroes its mirror field (#197) |
 | `battery_discharge_power` | Yes | API (pDisCharge) | Yes (transport) | Reg 11; EG4_OFFGRID-only entities (#197) |
-| `smart_load_power` / `grid_load_power` / `eps_load_power` | No | API (smartLoadPower/gridLoadPower/epsLoadPower) | API (cloud supplemental) | Cloud-only backup-output split; EG4_OFFGRID-only entities (#222/#335); `eps_load_power` pending a pylxpweb property. The former `eps_load_power_l1/_l2` (#197) were retired duplicates of `eps_power_l1/l2` (#335) |
+| `smart_load_power` / `grid_load_power` / `eps_load_power` | No | API (smartLoadPower/gridLoadPower/epsLoadPower) | API (cloud supplemental) | Cloud-only backup-output split; EG4_OFFGRID-only entities (#222/#335); pylxpweb ≥0.9.36 properties. The former `eps_load_power_l1/_l2` (#197) were retired duplicates of `eps_power_l1/l2` (#335) |
 | `fault_code` / `warning_code` | Yes | No | Yes (overlay) | Regs 60-63 (32-bit, BMS fallback merge); no cloud field (eg4-23a6) |
 
 ---
@@ -1762,11 +1762,10 @@ at setup (`_DEPRECATED_DUPLICATE_SENSOR_SUFFIXES` in `__init__.py`).
 #### `smart_load_power` / `grid_load_power` / `eps_load_power` (Inverter, EG4_OFFGRID only, #222/#335)
 
 Cloud-only backup-output split, mapped from the pylxpweb `smart_load_power` /
-`grid_load_power` properties (cloud `smartLoadPower` / `gridLoadPower`
-runtime fields, raw W) — plus `eps_load_power` for the cloud `epsLoadPower`
-(EPS-loads subset) field, wired in the HTTP property map but **pending a
-pylxpweb `eps_load_power` property** (the map's getattr resolves None → key
-absent until the library exposes it):
+`grid_load_power` / `eps_load_power` properties (cloud `smartLoadPower` /
+`gridLoadPower` / `epsLoadPower` runtime fields, raw W; `eps_load_power`
+shipped in pylxpweb 0.9.36, pylxpweb #219 — the property returns None when no
+cloud runtime is attached, so the key stays absent in pure-LOCAL operation):
 
 | Mode | Source |
 |------|--------|

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -151,37 +151,38 @@ Mapping chain: Register → `_canonical_reader.read_scaled()` → `InverterRunti
 |-----|----------------|-------|------|----------------|---------------|
 | 127 | `eps_l1_voltage` | ÷10 | V | `eps_l1_voltage` | `eps_voltage_l1` |
 | 128 | `eps_l2_voltage` | ÷10 | V | `eps_l2_voltage` | `eps_voltage_l2` |
-| 129 | `eps_l1_power` | 1 | W | `eps_l1_power` | `eps_power_l1`; also `eps_load_power_l1` (EG4_OFFGRID-only, #197) |
-| 130 | `eps_l2_power` | 1 | W | `eps_l2_power` | `eps_power_l2`; also `eps_load_power_l2` (EG4_OFFGRID-only, #197) |
+| 129 | `eps_l1_power` | 1 | W | `eps_l1_power` | `eps_power_l1` (COMBINED backup-path leg — see #335 note) |
+| 130 | `eps_l2_power` | 1 | W | `eps_l2_power` | `eps_power_l2` (COMBINED backup-path leg — see #335 note) |
 | 170 | `output_power` | 1 | W | `output_power` | `output_power`; also `load_power` (EG4_OFFGRID-only, #197) |
 | 193 | `grid_l1_voltage` | ÷10 | V | `grid_l1_voltage` | `grid_voltage_l1` (suppressed when 0) |
 | 194 | `grid_l2_voltage` | ÷10 | V | `grid_l2_voltage` | `grid_voltage_l2` (suppressed when 0) |
 
 > **EG4_OFFGRID confirmed registers (issue #197):** live Modbus sweep + cloud
-> cross-reference on a 12000XP (device type 54) validated regs 129/130 as
-> per-phase EPS load power (zero grid-tied, non-zero in EPS mode; L1+L2 sum
-> matches cloud `epsLoadPower` within timing skew) and reg 170 as load power
-> (`Pload` in the 6kXP Modbus PDF — valid both grid-tied AND in EPS mode).
-> The cloud zeroes its reg-170 mirror for EG4_OFFGRID, so `load_power` comes
-> from the LOCAL register only (LOCAL mapping + HYBRID `_TRANSPORT_OVERLAY`;
-> absent in pure CLOUD).  The derived `eps_load_power` sensor is the L1+L2 sum
-> (`apply_eps_load_power_sensors()` in `coordinator_mappings.py`, shared by
-> both data paths).  All `eps_load_power_*`, `load_power` and
-> `battery_discharge_power` inverter entities are gated to EG4_OFFGRID via
-> `OFFGRID_ONLY_SENSORS` in `const/device_types.py`.
+> cross-reference on a 12000XP (device type 54) validated reg 170 as load
+> power (`Pload` in the 6kXP Modbus PDF — valid both grid-tied AND in EPS
+> mode).  The cloud zeroes its reg-170 mirror for EG4_OFFGRID, so
+> `load_power` comes from the LOCAL register only (LOCAL mapping + HYBRID
+> `_TRANSPORT_OVERLAY`; absent in pure CLOUD).  `load_power`,
+> `battery_discharge_power` and the backup-output-split sensors below are
+> gated to EG4_OFFGRID via `OFFGRID_ONLY_SENSORS` in
+> `const/device_types.py`.
 >
-> **GEN-port smart load caveat (issue #222):** on the 6000XP the GEN terminal
-> can be a smart-load output, and regs 129/130 then carry the COMBINED
-> backup-path output (smart load + EPS loads) — live evidence: L1+L2 = 3371 W
-> = cloud `smartLoadPower` 2999 W + `epsLoadPower` 365 W.  The cloud-only
-> split is exposed as `smart_load_power` / `grid_load_power` sensors
+> **Backup-output split (issues #222/#335):** on the 6000XP/12000XP the GEN
+> terminal can be a smart-load output, and `peps`/`pEpsL1N`/`pEpsL2N` (regs
+> 129/130 locally) carry the COMBINED backup-path output (smart load + EPS
+> loads) — live evidence: L1+L2 = 3371 W = cloud `smartLoadPower` 2999 W +
+> `epsLoadPower` 365 W.  The cloud-only split is exposed as
+> `smart_load_power` / `grid_load_power` / `eps_load_power` sensors
 > (CLOUD/HYBRID supplemental, EG4_OFFGRID-gated; no validated local register
 > — the 18kPV firmware RE names input reg 232 `smart_load_power` but it has
-> never been observed non-zero and is unvalidated on off-grid hardware).
-> The cloud `epsLoadPower` (EPS-only) field is intentionally NOT given its
-> own sensor: the `eps_load_power` key already carries the combined L1+L2
-> semantics and renaming/repurposing it would break entity stability —
-> EPS-only load = `eps_load_power` − `smart_load_power`.
+> never been observed non-zero and is unvalidated on off-grid hardware, and
+> regs 129/130 are the combined legs, not the `epsLoadPower` subset).
+> The former `eps_load_power_l1/_l2` sensors and the L1+L2
+> `eps_load_power` sum (#197) were RETIRED in #335: they aliased the
+> combined regs 129/130 values and so exactly duplicated `eps_power_l1/l2` —
+> the #197 "sum ≈ cloud epsLoadPower" validation was a smart-load-idle
+> coincidence.  `eps_load_power` now maps the real cloud `epsLoadPower`
+> field (pending a pylxpweb `eps_load_power` property).
 
 > **Note:** Regs 193-204 (grid/generator per-leg voltage + per-leg power) are
 > firmware-zero on EG4 US split-phase inverters — confirmed live across the full
@@ -1233,8 +1234,11 @@ From `INVERTER_COMPUTED_KEYS` frozenset in `coordinator_mappings.py`:
 | `grid_import_power` | From register 27 (`power_to_user`) | coordinator_local.py |
 | `eps_power_l1` | Direct reg 129 (pylxpweb ≥0.9.36b1); voltage-ratio split `eps_power * (V_l1 / (V_l1 + V_l2))` as fallback | pylxpweb `eps_power_l1` |
 | `eps_power_l2` | Direct reg 130 (pylxpweb ≥0.9.36b1); voltage-ratio split as fallback | pylxpweb `eps_power_l2` |
-| `eps_load_power` | `eps_load_power_l1 + eps_load_power_l2` (None only when both legs None) | `apply_eps_load_power_sensors()` in coordinator_mappings.py (#197) |
 | `operating_state` | Friendly decode of `status_code` (see below) | `operating_state_slug()` in `const/operating_state.py`; injected in both paths |
+
+> `eps_load_power` is no longer computed: the former L1+L2 sum (#197) was the
+> COMBINED backup output and duplicated `eps_power` (#335).  It now maps the
+> cloud `epsLoadPower` field via the HTTP property map (cloud-only).
 
 ### Operating State Decode (Table 9, issue #262)
 
@@ -1359,9 +1363,8 @@ value; the `status_code` sensor retains it for diagnosis).
 | `consumption` (energy) | Computed | API (÷10) | API (÷10) | `_energy_balance()` vs `todayLoad` |
 | Smart port power | Modbus regs 34-41 | API fields | Both | Filtered by port status |
 | `load_power` (inverter) | Yes | No | Yes (overlay) | Reg 170; EG4_OFFGRID-only — cloud zeroes its mirror field (#197) |
-| `eps_load_power_l1/_l2/` sum | Yes | API (pEpsL1N/L2N) | Yes (transport) | Regs 129/130; EG4_OFFGRID-only entities (#197) |
 | `battery_discharge_power` | Yes | API (pDisCharge) | Yes (transport) | Reg 11; EG4_OFFGRID-only entities (#197) |
-| `smart_load_power` / `grid_load_power` | No | API (smartLoadPower/gridLoadPower) | API (cloud supplemental) | Cloud-only GEN-port smart-load split; EG4_OFFGRID-only entities (#222) |
+| `smart_load_power` / `grid_load_power` / `eps_load_power` | No | API (smartLoadPower/gridLoadPower/epsLoadPower) | API (cloud supplemental) | Cloud-only backup-output split; EG4_OFFGRID-only entities (#222/#335); `eps_load_power` pending a pylxpweb property. The former `eps_load_power_l1/_l2` (#197) were retired duplicates of `eps_power_l1/l2` (#335) |
 | `fault_code` / `warning_code` | Yes | No | Yes (overlay) | Regs 60-63 (32-bit, BMS fallback merge); no cloud field (eg4-23a6) |
 
 ---
@@ -1743,32 +1746,27 @@ CLOUD mode reads the `pEpsL1N` / `pEpsL2N` API fields.
 **Source:** `inverter.eps_power_l1` / `inverter.eps_power_l2` properties in
 pylxpweb. Set in `coordinator_local.py` `_build_local_device_data()`.
 
-#### `eps_load_power_l1` / `eps_load_power_l2` / `eps_load_power` (Inverter, EG4_OFFGRID only, #197)
+#### `eps_load_power_l1` / `eps_load_power_l2` — RETIRED (#335)
 
-Per-phase EPS load power aliased from the reg-129/130 values plus the L1+L2
-sum, populated by `apply_eps_load_power_sensors()` in
-`coordinator_mappings.py` (shared by the LOCAL mapping and the cloud/hybrid
-device path):
+The #197 sensors aliased `eps_power_l1`/`eps_power_l2` (regs 129/130 / cloud
+`pEpsL1N`/`pEpsL2N`) onto `eps_load_power_l1/_l2` and published the L1+L2 sum
+as `eps_load_power`.  Those source values are the COMBINED backup-path output
+(smart load + EPS loads), so the sensors were exact duplicates of
+`eps_power_l1/l2` — the #197 "sum 1327 ≈ cloud `epsLoadPower` 1338"
+validation was a smart-load-idle coincidence (#222 evidence: with the GEN
+port active, L1+L2 = 3371 W = `smartLoadPower` 2999 + `epsLoadPower` 365).
+No per-leg fields for the EPS-loads subset exist on any path.  The keys were
+removed from `SENSOR_TYPES`/key sets and orphaned registry entries are purged
+at setup (`_DEPRECATED_DUPLICATE_SENSOR_SUFFIXES` in `__init__.py`).
 
-```python
-eps_load_power_l1 = eps_power_l1          # reg 129 / pEpsL1N
-eps_load_power_l2 = eps_power_l2          # reg 130 / pEpsL2N
-eps_load_power    = l1 + l2               # None only when BOTH legs are None
-```
+#### `smart_load_power` / `grid_load_power` / `eps_load_power` (Inverter, EG4_OFFGRID only, #222/#335)
 
-Entities are created only for EG4_OFFGRID (`OFFGRID_ONLY_SENSORS`).
-Live-validated on 12000XP: 1031 + 296 = 1327 W vs cloud `epsLoadPower`
-1338 W (timing skew).
-
-**Smart-load caveat (#222):** with a GEN-port smart load active (6000XP) the
-reg-129/130 values include the smart-load draw, so `eps_load_power` is the
-combined backup output, not the cloud `epsLoadPower` (EPS-only) field.
-
-#### `smart_load_power` / `grid_load_power` (Inverter, EG4_OFFGRID only, #222)
-
-Cloud-only GEN-port smart-load split, mapped from the pylxpweb
-`smart_load_power` / `grid_load_power` properties (cloud `smartLoadPower` /
-`gridLoadPower` runtime fields, raw W):
+Cloud-only backup-output split, mapped from the pylxpweb `smart_load_power` /
+`grid_load_power` properties (cloud `smartLoadPower` / `gridLoadPower`
+runtime fields, raw W) — plus `eps_load_power` for the cloud `epsLoadPower`
+(EPS-loads subset) field, wired in the HTTP property map but **pending a
+pylxpweb `eps_load_power` property** (the map's getattr resolves None → key
+absent until the library exposes it):
 
 | Mode | Source |
 |------|--------|

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1985,13 +1985,10 @@ class TestStaticLocalData:
     def test_static_keys_match_runtime_mapping(self):
         """INVERTER_RUNTIME_KEYS matches _build_runtime_sensor_mapping keys.
 
-        The EPS load aliases are value-conditional (#197 review round 2):
-        they only materialize when regs 129/130 carry non-None values, so
-        the drift guard feeds both legs to exercise the full key surface.
+        The mapping's key surface is unconditional since the #197 EPS load
+        aliases were retired (#335) — an empty runtime exercises it fully.
         """
-        mapping = _build_runtime_sensor_mapping(
-            InverterRuntimeData(eps_l1_power=0, eps_l2_power=0)
-        )
+        mapping = _build_runtime_sensor_mapping(InverterRuntimeData())
         assert set(mapping.keys()) == INVERTER_RUNTIME_KEYS
 
     def test_static_keys_match_energy_mapping(self):
@@ -4246,11 +4243,13 @@ class TestMappingKeyConsistency:
             "ac_couple_power",
             "max_charge_current",
             "max_discharge_current",
-            # Smart load split (#222): cloud smartLoadPower/gridLoadPower —
-            # no validated local register on EG4_OFFGRID, so deliberately
-            # absent from the LOCAL static set (CLOUD/HYBRID supplemental).
+            # Backup-output split (#222/#335): cloud smartLoadPower/
+            # gridLoadPower/epsLoadPower — no validated local register on
+            # EG4_OFFGRID, so deliberately absent from the LOCAL static set
+            # (CLOUD/HYBRID supplemental).
             "smart_load_power",
             "grid_load_power",
+            "eps_load_power",
         }
 
         property_map = DeviceProcessingMixin._get_inverter_property_map()

--- a/tests/test_offgrid_registers.py
+++ b/tests/test_offgrid_registers.py
@@ -1,22 +1,32 @@
-"""Confirmed EG4_OFFGRID registers (issue #197).
+"""Confirmed EG4_OFFGRID registers and the backup-output split (#197/#222/#335).
 
 Live-validated on a 12000XP (EG4_OFFGRID, device type 54) via Modbus sweep +
 cloud cross-reference (see GH issue #197 for the reporter's tables):
 
-  * Input regs 129/130 — per-phase EPS load power (W, SCALE_NONE).  Zero when
-    grid-tied, non-zero in EPS/discharge mode (L1=1031 / L2=296 vs cloud
-    epsLoadPower=1338, 11 W timing skew).
   * Input reg 170 — load power (W, SCALE_NONE).  The 6kXP Modbus PDF labels it
     ``Pload``; valid grid-tied (3788 W) AND in EPS mode (1324 W).  The cloud
     zeroes its mirror field for EG4_OFFGRID, so the LOCAL register is the only
     trustworthy source — never the cloud.
   * Input reg 11 — battery discharge power (W, SCALE_NONE).  Already mapped in
     cloud as ``pDisCharge``; the LOCAL register agrees (1415 vs 1401, timing).
+  * Input regs 129/130 — per-leg COMBINED backup-path output (W, SCALE_NONE),
+    the local mirror of cloud pEpsL1N/pEpsL2N → ``eps_power_l1/l2`` ONLY.
 
-These tests pin the issue-#197 contract: sensor keys exist in SENSOR_TYPES and
-the static key set, both data paths (LOCAL mapping + cloud/hybrid property map
-or transport overlay) populate them, and entity creation is gated to the
-EG4_OFFGRID family.
+CORRECTED by #335: the former ``eps_load_power_l1/_l2`` sensors (#197) aliased
+regs 129/130 and the L1+L2 sum masqueraded as ``eps_load_power`` — but those
+values are the COMBINED backup output (smart load + EPS loads), so the
+sensors duplicated ``eps_power_l1/l2`` exactly.  The #197 "sum 1327 ≈ cloud
+epsLoadPower 1338" validation was a smart-load-idle coincidence (#222
+evidence: GEN port active → L1+L2 3371 W = smartLoadPower 2999 +
+epsLoadPower 365).  The per-leg keys are RETIRED (no per-leg EPS-loads
+source exists) and ``eps_load_power`` now maps the real cloud
+``epsLoadPower`` field — CLOUD-ONLY like its #222 siblings
+smart_load_power/grid_load_power, pending a pylxpweb ``eps_load_power``
+property (absent until then).
+
+These tests pin that contract: sensor keys in SENSOR_TYPES and the static
+key sets, both data paths, EG4_OFFGRID entity gating, and the retirement of
+the fabricated per-leg keys.
 """
 
 from __future__ import annotations
@@ -50,7 +60,6 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
     ALL_INVERTER_SENSOR_KEYS,
     INVERTER_RUNTIME_KEYS,
     _build_runtime_sensor_mapping,
-    apply_eps_load_power_sensors,
     drop_offgrid_cloud_output_power,
 )
 from custom_components.eg4_web_monitor.sensor import _should_create_sensor
@@ -80,19 +89,35 @@ def mock_config_entry():
     )
 
 
-# The five sensor keys introduced/enabled by issue #197.
-_NEW_KEYS = (
-    "eps_load_power_l1",
-    "eps_load_power_l2",
-    "eps_load_power",
+# The LOCAL-register-backed keys introduced by issue #197 (regs 170 / 11).
+_LOCAL_KEYS = (
     "load_power",
     "battery_discharge_power",
 )
 
-# The two CLOUD-ONLY smart-load split keys introduced by issue #222
-# (6000XP GEN-port smart load).  Unlike the #197 keys these have NO local
-# register source, so they are deliberately absent from the LOCAL static
-# key sets and flow exclusively through the HTTP property map.
+# The CLOUD-ONLY backup-output split keys (#222/#335: consumption =
+# epsLoadPower + smartLoadPower + gridLoadPower on this family).  These have
+# NO validated local register source, so they are deliberately absent from
+# the LOCAL static key sets and flow exclusively through the HTTP property
+# map.  eps_load_power additionally awaits a pylxpweb ``eps_load_power``
+# property — the map entry resolves to None (key absent) until it ships.
+_CLOUD_ONLY_KEYS = (
+    "smart_load_power",
+    "grid_load_power",
+    "eps_load_power",
+)
+
+# Retired by #335: fabricated aliases of eps_power_l1/l2 (regs 129/130 /
+# cloud pEpsL1N/L2N carry the COMBINED backup output — no per-leg source
+# for the EPS-loads subset exists on any path).
+_RETIRED_KEYS = (
+    "eps_load_power_l1",
+    "eps_load_power_l2",
+)
+
+# The #222 GEN-port subset of _CLOUD_ONLY_KEYS whose pylxpweb properties
+# already SHIPPED (eps_load_power's is still pending, #335) — used by the
+# TestSmartLoadSensors specifics below.
 _SMART_LOAD_KEYS = (
     "smart_load_power",
     "grid_load_power",
@@ -105,26 +130,50 @@ _SMART_LOAD_KEYS = (
 
 
 class TestSensorDefinitions:
-    """SENSOR_TYPES and static key-set membership for the #197 keys."""
+    """SENSOR_TYPES and static key-set membership for the offgrid keys."""
 
-    @pytest.mark.parametrize("key", _NEW_KEYS)
+    @pytest.mark.parametrize("key", _LOCAL_KEYS + _CLOUD_ONLY_KEYS)
     def test_sensor_types_defined_as_power(self, key: str) -> None:
-        """Every #197 key is a W power measurement sensor."""
+        """Every surviving offgrid key is a W power measurement sensor."""
         assert key in SENSOR_TYPES, f"{key} missing from SENSOR_TYPES"
         assert SENSOR_TYPES[key]["device_class"] == "power"
         assert SENSOR_TYPES[key]["state_class"] == "measurement"
         assert SENSOR_TYPES[key]["unit"] == "W"
 
-    @pytest.mark.parametrize("key", _NEW_KEYS)
-    def test_keys_in_static_sets(self, key: str) -> None:
-        """#197 keys are in the static key sets (zero-read first refresh)."""
+    @pytest.mark.parametrize("key", _LOCAL_KEYS)
+    def test_local_keys_in_static_sets(self, key: str) -> None:
+        """Register-backed keys are in the static sets (zero-read refresh)."""
         assert key in INVERTER_RUNTIME_KEYS, f"{key} missing from runtime keys"
         assert key in ALL_INVERTER_SENSOR_KEYS, f"{key} missing from static set"
 
+    @pytest.mark.parametrize("key", _CLOUD_ONLY_KEYS + _RETIRED_KEYS)
+    def test_cloud_only_and_retired_keys_not_in_static_sets(self, key: str) -> None:
+        """Cloud-only + retired keys must NOT be statically created in LOCAL.
+
+        There is no local source for any of them; pre-creating the entities
+        would leave them permanently unknown in pure-LOCAL mode (#335).
+        """
+        assert key not in INVERTER_RUNTIME_KEYS, f"{key} leaked into runtime keys"
+        assert key not in ALL_INVERTER_SENSOR_KEYS, f"{key} leaked into static set"
+
+    @pytest.mark.parametrize("key", _RETIRED_KEYS)
+    def test_retired_keys_fully_removed(self, key: str) -> None:
+        """The fabricated per-leg keys are gone from every creation surface
+        and their orphaned registry entries are covered by the setup purge
+        (#335)."""
+        from custom_components.eg4_web_monitor import (
+            _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES,
+        )
+
+        assert key not in SENSOR_TYPES
+        property_map = EG4DataUpdateCoordinator._get_inverter_property_map()
+        assert key not in property_map.values()
+        assert f"_{key}" in _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES
+
     def test_offgrid_only_set_matches_issue_scope(self) -> None:
-        """OFFGRID_ONLY_SENSORS is exactly the #197 + #222 key set (drift guard)."""
-        assert OFFGRID_ONLY_SENSORS == frozenset(_NEW_KEYS) | frozenset(
-            _SMART_LOAD_KEYS
+        """OFFGRID_ONLY_SENSORS is exactly the surviving key set (drift guard)."""
+        assert OFFGRID_ONLY_SENSORS == frozenset(_LOCAL_KEYS) | frozenset(
+            _CLOUD_ONLY_KEYS
         )
 
 
@@ -134,14 +183,14 @@ class TestSensorDefinitions:
 
 
 class TestOffgridGating:
-    """#197 sensors are created for EG4_OFFGRID only."""
+    """Offgrid-only sensors are created for EG4_OFFGRID only."""
 
-    @pytest.mark.parametrize("key", _NEW_KEYS)
+    @pytest.mark.parametrize("key", _LOCAL_KEYS + _CLOUD_ONLY_KEYS)
     def test_created_for_offgrid(self, key: str) -> None:
         features = {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
         assert _should_create_sensor(key, features) is True
 
-    @pytest.mark.parametrize("key", _NEW_KEYS)
+    @pytest.mark.parametrize("key", _LOCAL_KEYS + _CLOUD_ONLY_KEYS)
     @pytest.mark.parametrize(
         "family", [INVERTER_FAMILY_EG4_HYBRID, INVERTER_FAMILY_LXP]
     )
@@ -149,7 +198,7 @@ class TestOffgridGating:
         features = {"inverter_family": family}
         assert _should_create_sensor(key, features) is False
 
-    @pytest.mark.parametrize("key", _NEW_KEYS)
+    @pytest.mark.parametrize("key", _LOCAL_KEYS + _CLOUD_ONLY_KEYS)
     def test_no_features_is_fail_closed(self, key: str) -> None:
         """No detected features → DO NOT create (review: fail-closed).
 
@@ -170,14 +219,14 @@ class TestOffgridGating:
         assert _should_create_sensor("load_power", None, "parallel_group") is True
 
     def test_static_path_gating_offgrid_vs_hybrid(self) -> None:
-        """Static-config features gate the 5 keys per family (review F5)."""
+        """Static-config features gate the offgrid keys per family (review F5)."""
         from custom_components.eg4_web_monitor.coordinator_mappings import (
             _features_from_family,
         )
 
         offgrid = _features_from_family("EG4_OFFGRID", None)
         hybrid = _features_from_family("EG4_HYBRID", None)
-        for key in _NEW_KEYS:
+        for key in _LOCAL_KEYS + _CLOUD_ONLY_KEYS:
             assert _should_create_sensor(key, offgrid) is True
             assert _should_create_sensor(key, hybrid) is False
 
@@ -190,40 +239,33 @@ class TestOffgridGating:
 class TestLocalRuntimeMapping:
     """_build_runtime_sensor_mapping carries the #197 register values."""
 
-    def test_eps_load_power_per_leg_and_sum(self) -> None:
-        """Regs 129/130 → eps_load_power_l1/_l2 + L1+L2 sum.
+    def test_regs_129_130_map_to_eps_power_legs_only(self) -> None:
+        """Regs 129/130 → eps_power_l1/_l2 and NOTHING else (#335).
 
-        Values from the reporter's EPS-discharge sweep: L1=1031, L2=296,
-        sum=1327 (cloud epsLoadPower read 1338 — 11 W timing skew).
+        The registers carry the COMBINED backup-path legs; the former
+        eps_load_power_l1/_l2 aliases and the L1+L2 eps_load_power sum
+        fabricated duplicates of eps_power_l1/l2 and are retired.  There is
+        no LOCAL source for the cloud epsLoadPower (EPS-loads subset) field.
         """
         runtime = InverterRuntimeData(eps_l1_power=1031, eps_l2_power=296)
         mapping = _build_runtime_sensor_mapping(runtime)
-        assert mapping["eps_load_power_l1"] == 1031
-        assert mapping["eps_load_power_l2"] == 296
-        assert mapping["eps_load_power"] == 1327
+        assert mapping["eps_power_l1"] == 1031
+        assert mapping["eps_power_l2"] == 296
+        assert "eps_load_power_l1" not in mapping
+        assert "eps_load_power_l2" not in mapping
+        assert "eps_load_power" not in mapping
 
-    def test_eps_load_power_sum_none_semantics(self) -> None:
-        """No leg values → no derived keys; one leg aliases alone, no sum.
-
-        The runtime mapping always materializes eps_power_l1/l2 KEYS (values
-        may be None) — presence for the derived keys means a non-None VALUE
-        (review round 2), so a lone leg can never publish a one-leg total.
-        """
-        empty = _build_runtime_sensor_mapping(InverterRuntimeData())
-        assert "eps_load_power_l1" not in empty
-        assert "eps_load_power_l2" not in empty
-        assert "eps_load_power" not in empty
-
-        l1_only = _build_runtime_sensor_mapping(InverterRuntimeData(eps_l1_power=1031))
-        assert l1_only["eps_load_power_l1"] == 1031
-        assert "eps_load_power_l2" not in l1_only
-        assert "eps_load_power" not in l1_only
-
-    def test_eps_load_power_zero_when_grid_tied(self) -> None:
-        """Grid-tied: regs 129/130 read 0 — the sum is 0, not None."""
-        runtime = InverterRuntimeData(eps_l1_power=0, eps_l2_power=0)
-        mapping = _build_runtime_sensor_mapping(runtime)
-        assert mapping["eps_load_power"] == 0
+    def test_no_eps_load_keys_even_when_legs_zero_or_absent(self) -> None:
+        """The retired keys never materialize, whatever regs 129/130 read."""
+        for runtime in (
+            InverterRuntimeData(),
+            InverterRuntimeData(eps_l1_power=0, eps_l2_power=0),
+            InverterRuntimeData(eps_l1_power=1031),
+        ):
+            mapping = _build_runtime_sensor_mapping(runtime)
+            assert "eps_load_power_l1" not in mapping
+            assert "eps_load_power_l2" not in mapping
+            assert "eps_load_power" not in mapping
 
     def test_load_power_from_reg_170(self) -> None:
         """Reg 170 (output_power field) feeds load_power — grid-tied 3788 W."""
@@ -264,60 +306,88 @@ class TestCloudHybridPath:
         assert "load_power" not in property_map
         assert "load_power" not in property_map.values()
 
-    def test_apply_eps_load_power_sensors_aliases_and_sums(self) -> None:
-        sensors = {"eps_power_l1": 1031, "eps_power_l2": 296}
-        apply_eps_load_power_sensors(sensors)
-        assert sensors["eps_load_power_l1"] == 1031
-        assert sensors["eps_load_power_l2"] == 296
-        assert sensors["eps_load_power"] == 1327
+    def test_eps_load_power_in_property_map(self) -> None:
+        """CLOUD maps eps_load_power from the pylxpweb ``eps_load_power``
+        property (cloud epsLoadPower — the EPS-loads subset, #335).  The
+        property does not exist in pylxpweb yet; until it ships, the map's
+        getattr resolves None and the key stays absent (fail-closed)."""
+        property_map = EG4DataUpdateCoordinator._get_inverter_property_map()
+        assert property_map.get("eps_load_power") == "eps_load_power"
 
-    def test_apply_eps_load_power_sensors_absent_sources_write_nothing(
-        self,
+    async def test_cloud_eps_load_power_is_the_subset_not_the_combined_legs(
+        self, hass, mock_config_entry
     ) -> None:
-        """No source keys → no derived keys (review: presence semantics).
+        """#335 contract: epsLoadPower=365 / pEpsL1N=1000 / pEpsL2N=300 →
+        eps_power legs 1000/300, eps_load_power=365, and NO fabricated
+        eps_load_power_l1/_l2 keys (they were duplicates of the legs).
 
-        Fabricating None keys here would create permanently-unknown entities
-        for cloud responses that lack pEpsL1N/pEpsL2N entirely.
+        The eps_load_power property is patched onto the class with
+        ``create=True`` because pylxpweb does not expose it yet — this pins
+        the integration's mapping contract for when the library ships it.
         """
-        sensors: dict[str, object] = {"pv1_power": 100}
-        apply_eps_load_power_sensors(sensors)
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+
+        inverter = make_real_inverter("1111111111", "12000XP")
+        inverter.refresh = AsyncMock()
+        inverter.detect_features = AsyncMock()
+        cls = type(inverter)
+        with (
+            patch.object(cls, "has_data", property(lambda s: True)),
+            patch.object(cls, "eps_power_l1", property(lambda s: 1000)),
+            patch.object(cls, "eps_power_l2", property(lambda s: 300)),
+            patch.object(cls, "eps_load_power", property(lambda s: 365), create=True),
+        ):
+            result = await coordinator._process_inverter_object(inverter)
+        sensors = result["sensors"]
+
+        assert sensors["eps_power_l1"] == 1000
+        assert sensors["eps_power_l2"] == 300
+        assert sensors["eps_load_power"] == 365
         assert "eps_load_power_l1" not in sensors
         assert "eps_load_power_l2" not in sensors
-        assert "eps_load_power" not in sensors
 
-    def test_apply_eps_load_power_sensors_single_phase_no_sum(self) -> None:
-        """One phase present → that alias only; no half-truth sum."""
-        sensors: dict[str, object] = {"eps_power_l1": 1031}
-        apply_eps_load_power_sensors(sensors)
-        assert sensors["eps_load_power_l1"] == 1031
-        assert "eps_load_power_l2" not in sensors
-        assert "eps_load_power" not in sensors
+    async def test_cloud_without_eps_load_power_leaves_key_absent(
+        self, hass, mock_config_entry
+    ) -> None:
+        """No epsLoadPower source → no eps_load_power key (and never the
+        fabricated legs/sum) even with pEpsL1N/pEpsL2N present.
 
-    def test_apply_eps_none_valued_keys_are_not_presence(self) -> None:
-        """A key carrying None (LOCAL mapping shape) is NOT presence.
-
-        The LOCAL runtime mapping materializes eps_power_l1/l2 keys
-        unconditionally; only non-None VALUES may alias or contribute to
-        the sum (review round 2 MAJOR).
+        This is also the CURRENT pylxpweb behavior: the class has no
+        ``eps_load_power`` property, so the sensor stays absent — never
+        wrong — until the library exposes the field.
         """
-        sensors: dict[str, object] = {"eps_power_l1": 1031, "eps_power_l2": None}
-        apply_eps_load_power_sensors(sensors)
-        assert sensors["eps_load_power_l1"] == 1031
-        assert "eps_load_power_l2" not in sensors
-        assert "eps_load_power" not in sensors
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
-        both_none: dict[str, object] = {"eps_power_l1": None, "eps_power_l2": None}
-        apply_eps_load_power_sensors(both_none)
-        assert "eps_load_power_l1" not in both_none
-        assert "eps_load_power_l2" not in both_none
-        assert "eps_load_power" not in both_none
+        inverter = make_real_inverter("1111111111", "12000XP")
+        inverter.refresh = AsyncMock()
+        inverter.detect_features = AsyncMock()
+        cls = type(inverter)
+        with (
+            patch.object(cls, "has_data", property(lambda s: True)),
+            patch.object(cls, "eps_power_l1", property(lambda s: 1000)),
+            patch.object(cls, "eps_power_l2", property(lambda s: 300)),
+        ):
+            result = await coordinator._process_inverter_object(inverter)
+        sensors = result["sensors"]
+
+        assert sensors["eps_power_l1"] == 1000
+        assert sensors["eps_power_l2"] == 300
+        assert "eps_load_power" not in sensors
+        assert "eps_load_power_l1" not in sensors
+        assert "eps_load_power_l2" not in sensors
 
     async def test_hybrid_overlay_populates_offgrid_sensors(
         self, hass, mock_config_entry
     ) -> None:
         """HYBRID trusts the local registers: reg 170 → load_power via the
-        transport overlay, regs 129/130 → eps_load_power_* via the property
-        map alias, reg 11 → battery_discharge_power via the property map."""
+        transport overlay, regs 129/130 → eps_power_l1/_l2 via the property
+        map, reg 11 → battery_discharge_power via the property map.  The
+        transport carries NO EPS-loads-subset value, so eps_load_power and
+        the retired per-leg keys stay absent (#335) — in a real HYBRID
+        session the key populates only from cloud-supplemental runtime once
+        pylxpweb exposes the property."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
@@ -336,10 +406,12 @@ class TestCloudHybridPath:
         sensors = result["sensors"]
 
         assert sensors["load_power"] == 1324.0
-        assert sensors["eps_load_power_l1"] == 1031
-        assert sensors["eps_load_power_l2"] == 296
-        assert sensors["eps_load_power"] == 1327
+        assert sensors["eps_power_l1"] == 1031
+        assert sensors["eps_power_l2"] == 296
         assert sensors["battery_discharge_power"] == 1415
+        assert "eps_load_power" not in sensors
+        assert "eps_load_power_l1" not in sensors
+        assert "eps_load_power_l2" not in sensors
 
     async def test_pure_cloud_has_no_load_power(self, hass, mock_config_entry) -> None:
         """No transport → no load_power key (cloud zero is never trusted).
@@ -373,10 +445,12 @@ class TestCloudHybridPath:
             result = await coordinator._process_inverter_object(inverter)
         sensors = result["sensors"]
         assert "load_power" not in sensors
-        # The legitimately cloud-mapped #197 sensors still flow with data.
+        # The legitimately cloud-mapped sensors still flow with data.
         assert sensors["battery_discharge_power"] == 1415
-        assert sensors["eps_load_power_l1"] == 1031
-        assert sensors["eps_load_power"] == 1327
+        assert sensors["eps_power_l1"] == 1031
+        # The fabricated #197 aliases are retired (#335).
+        assert "eps_load_power_l1" not in sensors
+        assert "eps_load_power" not in sensors
 
 
 # =========================================================================
@@ -574,6 +648,59 @@ class TestDeprecatedCleanupSuffixes:
             new_uid.endswith(suffix) for suffix in _DEPRECATED_CHARGE_DISCHARGE_SUFFIXES
         )
 
+    def test_eps_load_purge_suffixes_spare_surviving_keys(self) -> None:
+        """#335: the retired-leg suffixes never match the surviving
+        eps_load_power (total) or eps_power_l1/l2 unique_ids."""
+        from custom_components.eg4_web_monitor import (
+            _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES,
+        )
+
+        assert "_eps_load_power_l1" in _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES
+        assert "_eps_load_power_l2" in _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES
+        for surviving_uid in (
+            "1111111111_runtime_eps_load_power",
+            "1111111111_runtime_eps_power_l1",
+            "1111111111_runtime_eps_power_l2",
+            # GridBOSS per-leg load keys share the ..._load_power_l1 shape.
+            "4524850115_midbox_runtime_load_power_l1",
+        ):
+            assert not any(
+                surviving_uid.endswith(suffix)
+                for suffix in _DEPRECATED_DUPLICATE_SENSOR_SUFFIXES
+            ), surviving_uid
+
+    async def test_retired_eps_load_leg_entities_purged(
+        self, hass, mock_config_entry
+    ) -> None:
+        """#335: orphaned eps_load_power_l1/_l2 registry entries are removed
+        by the duplicate-sensor cleanup; the eps_load_power (total) entry —
+        which now carries the real cloud epsLoadPower field — survives."""
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.eg4_web_monitor import (
+            _async_cleanup_duplicate_runtime_data_entities,
+        )
+
+        mock_config_entry.add_to_hass(hass)
+        registry = er.async_get(hass)
+
+        uid_l1 = "1111111111_runtime_eps_load_power_l1"
+        uid_l2 = "1111111111_runtime_eps_load_power_l2"
+        uid_total = "1111111111_runtime_eps_load_power"
+        uid_leg = "1111111111_runtime_eps_power_l1"
+        for uid in (uid_l1, uid_l2, uid_total, uid_leg):
+            registry.async_get_or_create(
+                "sensor", DOMAIN, uid, config_entry=mock_config_entry
+            )
+
+        _async_cleanup_duplicate_runtime_data_entities(hass, mock_config_entry)
+
+        get_eid = registry.async_get_entity_id
+        assert get_eid("sensor", DOMAIN, uid_l1) is None
+        assert get_eid("sensor", DOMAIN, uid_l2) is None
+        assert get_eid("sensor", DOMAIN, uid_total) is not None
+        assert get_eid("sensor", DOMAIN, uid_leg) is not None
+
     async def test_conditional_cleanup_by_family(self, hass, mock_config_entry) -> None:
         """The conditional registry cleanup removes stale per-inverter
         _battery_discharge_power entries ONLY for known non-OFFGRID families.
@@ -648,44 +775,12 @@ class TestSmartLoadSensors:
     on the off-grid family — so the keys flow exclusively through the HTTP
     property map (CLOUD + HYBRID supplemental) and must stay out of the
     LOCAL static key sets.
+
+    SENSOR_TYPES shape, static-set exclusion and family gating for these
+    keys are covered generically above (they parametrize _CLOUD_ONLY_KEYS,
+    which #335 extended with eps_load_power); this class keeps the
+    GEN-port-specific contracts.
     """
-
-    @pytest.mark.parametrize("key", _SMART_LOAD_KEYS)
-    def test_sensor_types_defined_as_power(self, key: str) -> None:
-        """Every #222 key is a W power measurement sensor."""
-        assert key in SENSOR_TYPES, f"{key} missing from SENSOR_TYPES"
-        assert SENSOR_TYPES[key]["device_class"] == "power"
-        assert SENSOR_TYPES[key]["state_class"] == "measurement"
-        assert SENSOR_TYPES[key]["unit"] == "W"
-
-    @pytest.mark.parametrize("key", _SMART_LOAD_KEYS)
-    def test_keys_not_in_local_static_sets(self, key: str) -> None:
-        """Cloud-only contract: NOT in the LOCAL static/runtime key sets.
-
-        Putting these in ALL_INVERTER_SENSOR_KEYS would create permanently
-        unavailable entities in pure-LOCAL mode, where no data source exists.
-        """
-        assert key not in ALL_INVERTER_SENSOR_KEYS, f"{key} leaked into static set"
-        assert key not in INVERTER_RUNTIME_KEYS, f"{key} leaked into runtime keys"
-
-    @pytest.mark.parametrize("key", _SMART_LOAD_KEYS)
-    def test_created_for_offgrid(self, key: str) -> None:
-        features = {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
-        assert _should_create_sensor(key, features) is True
-
-    @pytest.mark.parametrize("key", _SMART_LOAD_KEYS)
-    @pytest.mark.parametrize(
-        "family", [INVERTER_FAMILY_EG4_HYBRID, INVERTER_FAMILY_LXP]
-    )
-    def test_not_created_for_other_families(self, key: str, family: str) -> None:
-        features = {"inverter_family": family}
-        assert _should_create_sensor(key, features) is False
-
-    @pytest.mark.parametrize("key", _SMART_LOAD_KEYS)
-    def test_no_features_is_fail_closed(self, key: str) -> None:
-        """No detected features → DO NOT create (same rule as the #197 set)."""
-        assert _should_create_sensor(key, None) is False
-        assert _should_create_sensor(key, {}) is False
 
     def test_gridboss_smart_load_power_unaffected(self) -> None:
         """ "smart_load_power" is a SHARED key (like "load_power"): GridBOSS
@@ -707,12 +802,15 @@ class TestSmartLoadSensors:
         self, hass, mock_config_entry
     ) -> None:
         """HYBRID: transport regs feed the #197 sensors while the cloud-only
-        smart-load split flows through the property map — and the existing
-        eps sensors keep their combined-output semantics (entity stability).
+        smart-load split flows through the property map — and the eps_power
+        sensors keep their combined-output semantics.
 
         The smart-load properties land in pylxpweb (cloud-read even when a
         transport is attached); they are patched onto the real class here so
         the integration contract is testable against the released library.
+        The fabricated eps_load_* duplicates of the combined legs are gone
+        (#335): this very scenario (GEN port active) is where the old L1+L2
+        "EPS load" sum diverged from the cloud epsLoadPower subset.
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
@@ -737,14 +835,18 @@ class TestSmartLoadSensors:
             result = await coordinator._process_inverter_object(inverter)
         sensors = result["sensors"]
 
-        # New cloud-supplemental split (#222)
+        # Cloud-supplemental split (#222)
         assert sensors["smart_load_power"] == 2999
         assert sensors["grid_load_power"] == 0
-        # Existing eps sensors unchanged: combined backup output from the
-        # per-leg registers (1590 + 1740 = 3330 ≈ web UI 3371 W timing skew).
-        assert sensors["eps_load_power_l1"] == 1590
-        assert sensors["eps_load_power_l2"] == 1740
-        assert sensors["eps_load_power"] == 3330
+        # eps_power legs: combined backup output from the per-leg registers
+        # (1590 + 1740 = 3330 ≈ web UI 3371 W timing skew).
+        assert sensors["eps_power_l1"] == 1590
+        assert sensors["eps_power_l2"] == 1740
+        # The fabricated aliases/sum no longer exist; eps_load_power would
+        # only appear from the cloud epsLoadPower field (property pending).
+        assert "eps_load_power_l1" not in sensors
+        assert "eps_load_power_l2" not in sensors
+        assert "eps_load_power" not in sensors
 
     @pytest.mark.asyncio
     async def test_smart_port_cleanup_spares_inverter_entity(

--- a/tests/test_offgrid_registers.py
+++ b/tests/test_offgrid_registers.py
@@ -21,8 +21,9 @@ evidence: GEN port active → L1+L2 3371 W = smartLoadPower 2999 +
 epsLoadPower 365).  The per-leg keys are RETIRED (no per-leg EPS-loads
 source exists) and ``eps_load_power`` now maps the real cloud
 ``epsLoadPower`` field — CLOUD-ONLY like its #222 siblings
-smart_load_power/grid_load_power, pending a pylxpweb ``eps_load_power``
-property (absent until then).
+smart_load_power/grid_load_power, via the pylxpweb ``eps_load_power``
+property (shipped in 0.9.36, pylxpweb #219; returns None when no cloud
+runtime is attached, so the key stays absent in pure-LOCAL operation).
 
 These tests pin that contract: sensor keys in SENSOR_TYPES and the static
 key sets, both data paths, EG4_OFFGRID entity gating, and the retirement of
@@ -99,8 +100,8 @@ _LOCAL_KEYS = (
 # epsLoadPower + smartLoadPower + gridLoadPower on this family).  These have
 # NO validated local register source, so they are deliberately absent from
 # the LOCAL static key sets and flow exclusively through the HTTP property
-# map.  eps_load_power additionally awaits a pylxpweb ``eps_load_power``
-# property — the map entry resolves to None (key absent) until it ships.
+# map — all three pylxpweb properties shipped as of 0.9.36 (eps_load_power
+# via pylxpweb #219) and return None without cloud runtime data.
 _CLOUD_ONLY_KEYS = (
     "smart_load_power",
     "grid_load_power",
@@ -115,9 +116,8 @@ _RETIRED_KEYS = (
     "eps_load_power_l2",
 )
 
-# The #222 GEN-port subset of _CLOUD_ONLY_KEYS whose pylxpweb properties
-# already SHIPPED (eps_load_power's is still pending, #335) — used by the
-# TestSmartLoadSensors specifics below.
+# The #222 GEN-port subset of _CLOUD_ONLY_KEYS — used by the
+# TestSmartLoadSensors specifics below (eps_load_power is the #335 member).
 _SMART_LOAD_KEYS = (
     "smart_load_power",
     "grid_load_power",
@@ -308,9 +308,10 @@ class TestCloudHybridPath:
 
     def test_eps_load_power_in_property_map(self) -> None:
         """CLOUD maps eps_load_power from the pylxpweb ``eps_load_power``
-        property (cloud epsLoadPower — the EPS-loads subset, #335).  The
-        property does not exist in pylxpweb yet; until it ships, the map's
-        getattr resolves None and the key stays absent (fail-closed)."""
+        property (cloud epsLoadPower — the EPS-loads subset, #335; shipped
+        in pylxpweb 0.9.36, #219).  The property returns None when no cloud
+        runtime is attached, so the key stays absent in pure-LOCAL
+        operation (fail-closed)."""
         property_map = EG4DataUpdateCoordinator._get_inverter_property_map()
         assert property_map.get("eps_load_power") == "eps_load_power"
 
@@ -321,9 +322,10 @@ class TestCloudHybridPath:
         eps_power legs 1000/300, eps_load_power=365, and NO fabricated
         eps_load_power_l1/_l2 keys (they were duplicates of the legs).
 
-        The eps_load_power property is patched onto the class with
-        ``create=True`` because pylxpweb does not expose it yet — this pins
-        the integration's mapping contract for when the library ships it.
+        Exercises the REAL resolution path end-to-end: a genuine cloud
+        runtime payload on the real pylxpweb class — pEpsL1N/pEpsL2N via
+        the eps_power_l1/_l2 properties and epsLoadPower via the
+        eps_load_power property (pylxpweb >=0.9.36) — no property patches.
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
@@ -331,14 +333,13 @@ class TestCloudHybridPath:
         inverter = make_real_inverter("1111111111", "12000XP")
         inverter.refresh = AsyncMock()
         inverter.detect_features = AsyncMock()
-        cls = type(inverter)
-        with (
-            patch.object(cls, "has_data", property(lambda s: True)),
-            patch.object(cls, "eps_power_l1", property(lambda s: 1000)),
-            patch.object(cls, "eps_power_l2", property(lambda s: 300)),
-            patch.object(cls, "eps_load_power", property(lambda s: 365), create=True),
-        ):
-            result = await coordinator._process_inverter_object(inverter)
+        inverter._runtime = InverterRuntime.model_construct(
+            epsLoadPower=365,
+            pEpsL1N=1000,
+            pEpsL2N=300,
+        )
+
+        result = await coordinator._process_inverter_object(inverter)
         sensors = result["sensors"]
 
         assert sensors["eps_power_l1"] == 1000
@@ -347,15 +348,17 @@ class TestCloudHybridPath:
         assert "eps_load_power_l1" not in sensors
         assert "eps_load_power_l2" not in sensors
 
-    async def test_cloud_without_eps_load_power_leaves_key_absent(
+    async def test_no_cloud_runtime_leaves_eps_load_power_absent(
         self, hass, mock_config_entry
     ) -> None:
-        """No epsLoadPower source → no eps_load_power key (and never the
-        fabricated legs/sum) even with pEpsL1N/pEpsL2N present.
+        """No cloud runtime → no eps_load_power key (and never the
+        fabricated legs/sum) even with the combined legs present.
 
-        This is also the CURRENT pylxpweb behavior: the class has no
-        ``eps_load_power`` property, so the sensor stays absent — never
-        wrong — until the library exposes the field.
+        The shipped pylxpweb eps_load_power property returns None when
+        ``_runtime`` is unset — the transport carries no EPS-loads-subset
+        register — so the sensor stays absent (never wrong) whenever the
+        cloud payload is unavailable.  The eps_power legs are patched to
+        prove their presence alone can no longer fabricate anything.
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
@@ -384,10 +387,10 @@ class TestCloudHybridPath:
         """HYBRID trusts the local registers: reg 170 → load_power via the
         transport overlay, regs 129/130 → eps_power_l1/_l2 via the property
         map, reg 11 → battery_discharge_power via the property map.  The
-        transport carries NO EPS-loads-subset value, so eps_load_power and
-        the retired per-leg keys stay absent (#335) — in a real HYBRID
-        session the key populates only from cloud-supplemental runtime once
-        pylxpweb exposes the property."""
+        transport carries NO EPS-loads-subset value, so with no cloud
+        runtime attached the real eps_load_power property returns None and
+        the key (plus the retired per-leg keys) stays absent (#335) — in a
+        real HYBRID session it populates from cloud-supplemental runtime."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
@@ -802,15 +805,15 @@ class TestSmartLoadSensors:
         self, hass, mock_config_entry
     ) -> None:
         """HYBRID: transport regs feed the #197 sensors while the cloud-only
-        smart-load split flows through the property map — and the eps_power
-        sensors keep their combined-output semantics.
+        backup-output split flows through the property map — and the
+        eps_power sensors keep their combined-output semantics.
 
-        The smart-load properties land in pylxpweb (cloud-read even when a
-        transport is attached); they are patched onto the real class here so
-        the integration contract is testable against the released library.
-        The fabricated eps_load_* duplicates of the combined legs are gone
-        (#335): this very scenario (GEN port active) is where the old L1+L2
-        "EPS load" sum diverged from the cloud epsLoadPower subset.
+        Fully-real resolution path (pylxpweb >=0.9.36, no property patches):
+        the smart_load_power / grid_load_power / eps_load_power properties
+        read the attached cloud runtime even with a transport present
+        (HYBRID cloud-supplemental).  This very scenario (GEN port active)
+        is where the old fabricated L1+L2 "EPS load" sum (3330 W) diverged
+        from the real cloud epsLoadPower subset (365 W) — the #335 bug.
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
@@ -825,28 +828,27 @@ class TestSmartLoadSensors:
         inverter.refresh = AsyncMock()
         inverter.detect_features = AsyncMock()
         inverter._transport = make_transport_spec()
-        cls = type(inverter)
-        with (
-            patch.object(
-                cls, "smart_load_power", property(lambda s: 2999), create=True
-            ),
-            patch.object(cls, "grid_load_power", property(lambda s: 0), create=True),
-        ):
-            result = await coordinator._process_inverter_object(inverter)
+        inverter._runtime = InverterRuntime.model_construct(
+            smartLoadPower=2999,
+            gridLoadPower=0,
+            epsLoadPower=365,
+        )
+
+        result = await coordinator._process_inverter_object(inverter)
         sensors = result["sensors"]
 
-        # Cloud-supplemental split (#222)
+        # Cloud-supplemental split (#222/#335)
         assert sensors["smart_load_power"] == 2999
         assert sensors["grid_load_power"] == 0
+        assert sensors["eps_load_power"] == 365
         # eps_power legs: combined backup output from the per-leg registers
-        # (1590 + 1740 = 3330 ≈ web UI 3371 W timing skew).
+        # (1590 + 1740 = 3330 ≈ web UI 3371 W timing skew) — NOT the 365 W
+        # EPS-loads subset.
         assert sensors["eps_power_l1"] == 1590
         assert sensors["eps_power_l2"] == 1740
-        # The fabricated aliases/sum no longer exist; eps_load_power would
-        # only appear from the cloud epsLoadPower field (property pending).
+        # The fabricated per-leg aliases no longer exist.
         assert "eps_load_power_l1" not in sensors
         assert "eps_load_power_l2" not in sensors
-        assert "eps_load_power" not in sensors
 
     @pytest.mark.asyncio
     async def test_smart_port_cleanup_spares_inverter_entity(

--- a/tests/test_register_contract.py
+++ b/tests/test_register_contract.py
@@ -44,6 +44,18 @@ KNOWN_SEAM_GAPS: dict[tuple[str, str], str] = {
     # entry only with a tracking issue, and
     # `test_known_seam_gaps_are_still_gaps` guards against stale entries
     # pylxpweb has since provided.
+    #
+    # GH #335: eps_load_power maps the cloud epsLoadPower field (the
+    # EPS-loads subset of the off-grid backup output; the InverterRuntime
+    # model already carries it) but pylxpweb does not yet expose an
+    # ``eps_load_power`` property mirroring its shipped smart_load_power /
+    # grid_load_power siblings.  Until it ships, the map entry resolves
+    # None and the sensor stays absent — never wrong.  The staleness guard
+    # below forces this entry's removal the moment the property lands.
+    ("inverter", "eps_load_power"): (
+        "GH #335: awaiting pylxpweb eps_load_power property "
+        "(cloud epsLoadPower, sibling of smart_load_power/grid_load_power)"
+    ),
 }
 
 # (label, property_map, target pylxpweb class the map is applied to)

--- a/tests/test_register_contract.py
+++ b/tests/test_register_contract.py
@@ -40,22 +40,12 @@ KNOWN_SEAM_GAPS: dict[tuple[str, str], str] = {
     # battery_bank.cycle_count) were closed in eg4-ohz by exposing honest
     # device properties on pylxpweb, so the device-object path now resolves
     # them for real — as were the eg4-1d0 smart-load split properties once
-    # the type-38 pylxpweb branch merged.  Keep this set SHRINKING — add an
-    # entry only with a tracking issue, and
+    # the type-38 pylxpweb branch merged, and the GH #335 eps_load_power
+    # property (cloud epsLoadPower, sibling of smart_load_power /
+    # grid_load_power) once pylxpweb #219 shipped in 0.9.36.  Keep this set
+    # SHRINKING — add an entry only with a tracking issue, and
     # `test_known_seam_gaps_are_still_gaps` guards against stale entries
     # pylxpweb has since provided.
-    #
-    # GH #335: eps_load_power maps the cloud epsLoadPower field (the
-    # EPS-loads subset of the off-grid backup output; the InverterRuntime
-    # model already carries it) but pylxpweb does not yet expose an
-    # ``eps_load_power`` property mirroring its shipped smart_load_power /
-    # grid_load_power siblings.  Until it ships, the map entry resolves
-    # None and the sensor stays absent — never wrong.  The staleness guard
-    # below forces this entry's removal the moment the property lands.
-    ("inverter", "eps_load_power"): (
-        "GH #335: awaiting pylxpweb eps_load_power property "
-        "(cloud epsLoadPower, sibling of smart_load_power/grid_load_power)"
-    ),
 }
 
 # (label, property_map, target pylxpweb class the map is applied to)

--- a/tests/test_register_contract_harness.py
+++ b/tests/test_register_contract_harness.py
@@ -609,10 +609,9 @@ _METADATA_INVERTER_PROPERTIES: frozenset[str] = frozenset(
         # 232 but it is unvalidated on EG4_OFFGRID hardware, and regs
         # 129/130 are the COMBINED backup legs, not the epsLoadPower
         # subset), so there is no canonical triangle to compare.  The
-        # pylxpweb properties read the HTTP runtime even in HYBRID by
-        # design (cloud-supplemental data); the eps_load_power property is
-        # still PENDING in pylxpweb (#335) — the map entry resolves None
-        # until it ships.
+        # pylxpweb properties (all three shipped as of 0.9.36; eps_load_power
+        # via pylxpweb #219 for #335) read the HTTP runtime even in HYBRID
+        # by design (cloud-supplemental data).
         "smart_load_power",
         "grid_load_power",
         "eps_load_power",

--- a/tests/test_register_contract_harness.py
+++ b/tests/test_register_contract_harness.py
@@ -603,14 +603,19 @@ _METADATA_INVERTER_PROPERTIES: frozenset[str] = frozenset(
         # (identical value + display name) and is no longer in the property map.
         "ac_couple_power",  # cloud acCouplePower; transport field is
         # populated only via the canonical ac_couple_power register on LXP
-        # Smart-load split (eg4-1d0 / GH #222): cloud smartLoadPower /
-        # gridLoadPower only — NO register exists on the off-grid family
-        # (18kPV firmware RE names input reg 232 but it is unvalidated on
-        # EG4_OFFGRID hardware), so there is no canonical triangle to
-        # compare.  The pylxpweb properties read the HTTP runtime even in
-        # HYBRID by design (cloud-supplemental data).
+        # Backup-output split (eg4-1d0 / GH #222, #335): cloud
+        # smartLoadPower / gridLoadPower / epsLoadPower only — NO register
+        # exists on the off-grid family (18kPV firmware RE names input reg
+        # 232 but it is unvalidated on EG4_OFFGRID hardware, and regs
+        # 129/130 are the COMBINED backup legs, not the epsLoadPower
+        # subset), so there is no canonical triangle to compare.  The
+        # pylxpweb properties read the HTTP runtime even in HYBRID by
+        # design (cloud-supplemental data); the eps_load_power property is
+        # still PENDING in pylxpweb (#335) — the map entry resolves None
+        # until it ships.
         "smart_load_power",
         "grid_load_power",
+        "eps_load_power",
     }
 )
 
@@ -637,18 +642,20 @@ def test_inverter_triangle_exclusion_lists_are_current() -> None:
     assert not overlap, (
         "Property classified as BOTH derived and metadata: " + ", ".join(overlap)
     )
-    # Anchored counts: 9 derived + 8 metadata = 17 excluded entries today.
+    # Anchored counts: 9 derived + 9 metadata = 18 excluded entries today.
     # (metadata dropped from 9 to 8 in #253 — duplicate ``has_runtime_data``
-    # removed.)  A failure here means triangle coverage changed — verify the
-    # new classification is correct, then update the anchor.
+    # removed — and grew back to 9 in #335: cloud-only ``eps_load_power``
+    # joined the backup-output split.)  A failure here means triangle
+    # coverage changed — verify the new classification is correct, then
+    # update the anchor.
     assert len(_DERIVED_INVERTER_PROPERTIES) == 9, (
         f"derived exclusion list changed size "
         f"({len(_DERIVED_INVERTER_PROPERTIES)} != 9) — triangle coverage "
         f"shrinks/grows with it; re-verify and update this anchor"
     )
-    assert len(_METADATA_INVERTER_PROPERTIES) == 8, (
+    assert len(_METADATA_INVERTER_PROPERTIES) == 9, (
         f"metadata exclusion list changed size "
-        f"({len(_METADATA_INVERTER_PROPERTIES)} != 8) — triangle coverage "
+        f"({len(_METADATA_INVERTER_PROPERTIES)} != 9) — triangle coverage "
         f"shrinks/grows with it; re-verify and update this anchor"
     )
 
@@ -768,13 +775,9 @@ _LOCAL_ONLY_KEY_EXCEPTIONS: dict[str, str] = {
     # NOTE: inverter_energy/_lifetime need no entry either — regs 31/46 carry
     # no cloud_api_field anymore (todayYielding/totalYielding are PV yield,
     # not Einv; eg4-bc0), so the keys are cloud-impossible by table.
-    # DELIBERATE (#197): the eps_load_power_* aliases are populated by the
-    # SHARED apply_eps_load_power_sensors() helper on BOTH paths (called
-    # inside the LOCAL runtime table AND in _process_inverter_object), not by
-    # the cloud property map — the helper exists precisely so the alias+sum
-    # logic cannot drift between modes.
-    "eps_load_power_l1": "deliberate (#197): shared helper feeds both paths",
-    "eps_load_power_l2": "deliberate (#197): shared helper feeds both paths",
+    # NOTE: eps_load_power_l1/_l2 need no entry anymore — the #197 aliases of
+    # the combined regs 129/130 legs were RETIRED in #335 (they duplicated
+    # eps_power_l1/l2; the cloud epsLoadPower subset has no per-leg fields).
 }
 
 


### PR DESCRIPTION
Fixes #335 (brendonlobo123, 12000XP EG4_OFFGRID, CLOUD mode): "EPS Power L1" and "EPS Load Power L1" were identical sensors.

## Root cause — a coincidental validation

The cloud runtime carries **three distinct quantities** on the off-grid family (pylxpweb `models.py`):

| Field | Meaning |
|---|---|
| `peps` + `pEpsL1N`/`pEpsL2N` | **COMBINED** backup output (total + per-leg) |
| `epsLoadPower` | the **EPS-loads subset** (total only — no per-leg fields) |
| `smartLoadPower` / `gridLoadPower` | GEN-port smart load / grid-side legs |

`apply_eps_load_power_sensors()` (#197) aliased `eps_power_l1/l2` (regs 129/130 / `pEpsL1N`/`pEpsL2N`) onto `eps_load_power_l1/l2` and summed them into `eps_load_power`. The #197 live validation — sum 1327 W ≈ cloud `epsLoadPower` 1338 W — held only because the smart load was **idle**, so combined == subset. The #222 evidence shows the divergence: GEN port active → L1+L2 = 3371 W = `smartLoadPower` 2999 + `epsLoadPower` 365 (and pylxpweb's consumption identity: `consumption = epsLoadPower + smartLoadPower + gridLoadPower`). So our `eps_load_*` sensors were duplicates of `eps_power_*`, wrong for the quantity they were named after.

## Changes

- **`eps_load_power` ← the real cloud field**: added to the HTTP property map next to its #222 siblings `smart_load_power`/`grid_load_power` (cloud-only, EG4_OFFGRID-gated via `OFFGRID_ONLY_SENSORS`, HYBRID cloud-supplemental — pylxpweb keeps `_runtime` fresh for EG4_OFFGRID via the supplemental fetch). Backed by the pylxpweb `eps_load_power` property (**shipped in pylxpweb 0.9.36**, pylxpweb #219); the property returns None when no cloud runtime is attached, so the key stays absent in pure-LOCAL operation (existing presence semantics — absent, never wrong).
- **Fabricated per-leg sensors retired**: `apply_eps_load_power_sensors()` deleted; `eps_load_power_l1/l2` removed from `SENSOR_TYPES`, `INVERTER_RUNTIME_KEYS`/`ALL_INVERTER_SENSOR_KEYS` and `OFFGRID_ONLY_SENSORS`; orphaned registry entries purged at setup via the established #253 duplicate-sensor suffix cleanup (`_DEPRECATED_DUPLICATE_SENSOR_SUFFIXES`). The suffixes can't match the surviving `_eps_load_power` (total), `_eps_power_l*`, or GridBOSS `_load_power_l*` uids (test-pinned).
- **No LOCAL source invented**: regs 129/130 are the combined legs (pylxpweb `inverter_input.py` → `eps_l1_power`, same key as `pEpsL1N`). No register for the EPS-loads subset is validated — needs XP hardware probing (documented in the LOCAL mapping comment + `DATA_MAPPING.md`). Pure LOCAL: sensor absent (also dropped from the static key sets, matching how the #222 cloud-only keys are handled).
- **Lockstep with pylxpweb 0.9.36**: manifest pin bumped to `pylxpweb>=0.9.36`; the temporary `KNOWN_SEAM_GAPS` debt entry was removed once pylxpweb #219 merged — `test_property_map_sources_exist_on_pylxpweb_class` now enforces the real contract (the property resolves on `BaseInverter`).
- **docs/DATA_MAPPING.md** updated (register rows, #197/#222 note, computed-sensor table, mode matrix, per-sensor sections) — including retracting the old "#222 decision" note that deliberately kept `eps_load_power` on combined semantics.

## Entity migration notes

- **Retired**: "EPS Load Power L1" (`eps_load_power_l1`) and "EPS Load Power L2" (`eps_load_power_l2`) — registry entries auto-purged at setup (they were exact duplicates of "EPS Power L1/L2").
- **Kept**: "EPS Load Power" (`eps_load_power`) — same unique_id (`{serial}_{data_type}_eps_load_power`) and entity_id, so statistics continuity is preserved; the value semantics change from the fabricated combined L1+L2 sum to the real EPS-loads subset.

## Tests

1949 passed, 3 skipped. Coverage now exercises the **real resolution path** (no property patches, pylxpweb ≥0.9.36):
- Cloud contract: genuine `InverterRuntime` payload `epsLoadPower=365`, `pEpsL1N=1000`, `pEpsL2N=300` → `eps_power_l1/l2` = 1000/300, `eps_load_power` = 365, **no** `eps_load_power_l1/l2` keys.
- #222 GEN-port divergence end-to-end (the exact #335 bug scenario): transport legs 1590/1740 (combined 3330 W) alongside cloud split 2999/0/**365** → `eps_load_power` = 365, not 3330.
- No cloud runtime → the shipped property returns None → no `eps_load_power` key (pure-LOCAL / transport-only behavior).
- Registry purge: `_eps_load_power_l1/_l2` entries removed, `_eps_load_power`/`_eps_power_l1` survive; suffix non-collision pins.
- Key-set drift tests + register-contract harness (`eps_load_power` classified metadata/cloud-only; stale `_LOCAL_ONLY_KEY_EXCEPTIONS` pruned; seam guards enforce the shipped property).

## Gates

- `ruff check --fix` + `ruff format`: clean
- `mypy --config-file tests/mypy.ini` (strict): clean
- `pytest tests/`: 1949 passed, 3 skipped (including both seam-contract guards against live pylxpweb 0.9.36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)