### PR TITLE
docs: catch documentation up to v3.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,8 @@ Connection type (http/local/hybrid) is **auto-derived** from configured data, no
 Release notes should follow the CHANGELOG.md format. See `CHANGELOG.md` for detailed release history.
 
 ### Current Version
-- **v3.4.0-rc.1** — RELEASE CANDIDATE: identical source to beta.27, version promotion only (semver orders beta.27 < rc.1 < final). pylxpweb 0.9.36 stable pin unchanged. Cut after the three-mode sweep passed + #334/#335/#336 landed. Remaining to final: reporter confirms (#331 automation, #335 divergence), consolidated 3.4.0 changelog, integration/3.4.0→main merge, non-prerelease tag, prod roll.
+- **v3.4.0** — STABLE (2026-07-07): consolidates the beta.1–beta.27 + rc.1 cycle; requires **pylxpweb>=0.9.37**. The final tri-vendor review (Codex GPT-5.5 + Gemini 3.1 Pro + Claude, 3 rounds, both repos against v3.3.0/v0.9.35 baselines) found and fixed pre-ship: pylxpweb's cloud raw-register write NEVER worked (nested-dict form-encoding dropped the values on the wire — root cause of the historical param-specific cloud write failures; the five 3.4.0 voltage-limit numbers were dead in pure-CLOUD until 0.9.37's live-validated named-write rewrite), a `_read_modbus_parameters` completeness-flag race across concurrently-polled endpoint groups (#282 regression class), options-flow battery-control-mode writes firing on any options save, partial reg-179 write convergence, and pylxpweb `set_ac_charge_voltage_limits` ×10/÷10 inversion. DRY items 1–4 applied (−79 lines); deferred simplifier items → #342, pylxpweb follow-ups → pylxpweb#223. Merged to main (PR #341), tagged latest, prod rolled via HACS (605 entities / 0 unavailable).
+- **v3.4.0-rc.1** — RELEASE CANDIDATE: identical source to beta.27, version promotion only (semver orders beta.27 < rc.1 < final). pylxpweb 0.9.36 stable pin unchanged. Cut after the three-mode sweep passed + #334/#335/#336 landed.
 - **v3.4.0-beta.27** — EPS Load un-aliased (#335, brendonlobo123: EPS/EPS Load identical on XP): #197's off-grid enablement aliased combined pEpsL1N/L2N onto eps_load_* — validated while smart load idle (the one matching state); #222 consumption identity = the proof (peps/pEpsL1N/L2N combined, epsLoadPower subset, smartLoadPower GEN port). eps_load_power → real epsLoadPower via NEW pylxpweb 0.9.36-STABLE property (#219, cut as first non-beta of the line: also #217 log dedup + #218 transports README); per-leg eps_load L1/L2 RETIRED (no per-leg cloud field; #253 suffix purge, changelog breaking-note per agy P2); statistics carry over on unchanged total unique_id, semantic level-shift documented; pure-LOCAL total = unknown (no local subset register — probe = follow-up). LOCAL PS-power sweep fix #334 rides too. Review: Opus CLEAN + agy P1 = the seam-gap/pin lockstep (property merged mid-review — KNOWN_SEAM_GAPS tripwire worked exactly as designed), agy P2s → changelog notes + real-resolution-path tests (upgraded #222 e2e now pins combined-3330 vs subset-365 divergence). 1949 tests, requires pylxpweb>=0.9.36 (stable).
 - **v3.4.0-beta.26** — off-grid AC Charge SOC fix (#331, brendonlobo123's nightly REMOTE_SET_ERROR): reg 67 SOC Limit is grid-tied-only (offgrid firmware-rejects, portal-absent, reads 0 on XP-v2 dump) -> gated off EG4_OFFGRID w/ one-shot Repairs; NEW AC Charge Start/End Battery SOC numbers (regs 160/161, portal-verified, enabled-default, offgrid-only); reg 161 = pinned SOC-101 top-balance candidate; pylxpweb b28 maps 161 (only unmapped family member, historical accident) + family-scopes the old "161 read-only" FlexBOSS note (grid-tied observation preserved; offgrid local write UNVERIFIED, readback-verify covers) + #215 [serial]+frame-context dongle logs (#213); Repairs suffix serial-boundary hardened all callers. Review: Opus refuted agy's cache-incoherence P1 (wholesale param replace), Opus found the read-only-note contradiction; raw-161 dual-key workaround DELETED for named path per both reviewers. 1957 tests, requires pylxpweb>=0.9.36b28.
 - **v3.4.0-beta.25** — Grid Peak Shaving complete (#328, DoubleDoc's pylxpweb#158 hardware test + live cloud correlation): reg 206 = 0.1 kW CONFIRMED, PS family (206/232 power deci-kW, 207/218 SOC, 208/219 volt decivolts) mapped for local reads w/ cloud-identical strings + direct local writes (pylxpweb b27 #214, dual-CLEAN review); number entity pre-checks FUNC_GRID_PEAK_SHAVING with verify-then-block (live reg-179 read on stale-falsy cache — portal-side enable honored immediately) (#329); firmware NAKs PS writes + zeroes setpoint while mode off (live-verified). Pin bump also delivers b26 proven-capable Fast-mode (ivanfmartinez: >40-reg success ever → cooldown never permanent latch). 1932 tests, requires pylxpweb>=0.9.36b27.
@@ -441,8 +442,24 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
 | PV Charge Power | 74 | 100 W units (reg 64 is the legacy percent command; the entity reads/writes 74) |
 | Discharge Power | 65 | 0-100% |
 | AC Charge Power | 66 | 0-100% |
-| AC Charge SOC Limit | 67 | 0-100% |
+| AC Charge SOC Limit | 67 | 0-100% (grid-tied families only; removed on EG4_OFFGRID, #331/#332) |
+| AC Charge Start / End Battery SOC | 160 / 161 | 0-100% (EG4_OFFGRID family only, #332) |
 | Charge Current | 101 | Amps |
 | Discharge Current | 102 | Amps |
 | On-Grid SOC Cutoff | 105 | 10-90% |
 | Off-Grid SOC Cutoff | 125 | 0-100% |
+| Battery Charge / Discharge Control | 179, bit 9 / bit 10 | Bit field (0=SOC, 1=Voltage; #48) |
+| System Charge Voltage Limit | 228 | Decivolts |
+| On-Grid / Off-Grid Cut-Off Voltage | 169 / 100 | Decivolts |
+| AC Charge Start / End Voltage | 158 / 159 | Decivolts |
+| Stop Discharge Voltage | 202 | Decivolts |
+| Grid Sell Back | 21, bit 15 | Bit field (#135) |
+| Export PV Only | 179, bit 3 | Bit field (#135) |
+| Grid Sell Back Power | 103 | 100 W units, kW cap (#135) |
+| Fast Zero Export | 110, bit 1 | Bit field (#274) |
+| Share Battery | 110, bit 3 | Bit field (#306) |
+| Start Discharge Power Threshold | 116 | Whole watts (#272) |
+| Start Charge Power Threshold | 117 | Signed watts, LOCAL/HYBRID only (#272) |
+| Grid Peak Shaving Power | 206 | 0.1 kW units (#328) |
+| Forced Discharge Power / SOC Limit | 82 / 83 | kW / % (grid-tied only, #207) |
+| Schedule time windows | 68-73 (AC Charge), 76-81 (Forced Charge), 84-89 (Forced Discharge), 152-157 (AC First), 209-212 (Peak Shaving), 256-259 (Generator), 269-274 (Off-Grid) | Packed hour (low byte) + minute (high byte); #277/#295/#312 |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ required — if you can use the EG4 Monitor app, you can use this integration.
 - **Fast local polling:** 5-second updates over Modbus, dongle, or serial — no
   internet dependency.
 - **Hybrid mode:** enrich local data with cloud-only features such as DST
-  auto-sync and quick charge control.
+  auto-sync, and fall back to the cloud for control writes when the local link
+  is down.
 - **Data integrity:** WiFi dongle cross-request validation, canary checks, and
   energy monotonicity guards protect against corrupt readings.
 - **Control & automation:** quick charge, battery backup (EPS), operating modes,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,9 @@ WiFi dongle, and serial RS485). A single config entry maps to one station/plant.
 - **Base entities** (`base_entity.py`) — shared base classes for device,
   battery, station, sensor, switch, and battery-bank entities to eliminate
   duplication.
-- **Entity platforms** — `sensor.py`, `switch.py`, `number.py`, `select.py`,
-  `button.py`, and `update.py`.
+- **Entity platforms** — `sensor.py`, `binary_sensor.py`, `switch.py`,
+  `number.py`, `select.py`, `button.py`, `time.py` (schedule windows), and
+  `update.py`, plus service actions in `services.py`.
 - **Constants** (`const/`) — typed configuration (e.g. `SensorConfig`),
   `SENSOR_TYPES`, and config keys.
 
@@ -54,8 +55,9 @@ SoC/SoH, temperature, cycle count, and per-cell metrics.
   from config metadata (zero Modbus reads); real values fill in on the next
   refresh.
 - **Hybrid:** local transports drive fast sensor updates while the cloud API
-  supplies cloud-only features (DST sync, quick charge) and any
-  transport-exclusive overlays. pylxpweb handles transport routing.
+  supplies cloud-only features (DST sync) and any transport-exclusive overlays.
+  Controls fall back to the cloud when the local link is down. pylxpweb handles
+  transport routing.
 
 ## Key Design Decisions
 

--- a/docs/BATTERY_CURRENT_CONTROL.md
+++ b/docs/BATTERY_CURRENT_CONTROL.md
@@ -369,6 +369,9 @@ Then use in automations to select appropriate charge rates.
 - **Operating Mode Control**: `select.eg4_{model}_{serial}_operating_mode`
 - **AC Charge Power**: `number.eg4_{model}_{serial}_ac_charge_power`
 - **Battery SOC Limits**: Various battery parameter sensors
+- **Battery Control Mode (SOC vs Voltage)**: regulate the battery by State of
+  Charge or Voltage — see
+  [CONFIGURATION.md → Battery control mode](CONFIGURATION.md#battery-control-mode-soc-vs-voltage)
 - **Grid Export Control**: Via operating mode and power settings
 
 ## Support

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,6 +158,15 @@ After setup, click **Configure** on the integration to customize:
   Default: 5 seconds for local connections, 30 seconds for HTTP.
 - **Parameter Refresh Interval** — how often to sync configuration settings
   (5–1440 minutes). Default: 60 minutes.
+- **Data Validation** — toggle canary checks and energy-monotonicity guards on
+  incoming readings. Default: on. Shown for all connection types.
+- **Modbus Read Block Size** — shown when a local (Modbus/dongle/serial)
+  transport is configured. **Conservative** (default) keeps the small grouped
+  register reads every dongle and firmware supports; **Fast** reads up to 120
+  registers per request (~4 fewer round-trips per poll) for tooling that polls
+  at 15 s. Older dongle firmware that only supports ~40-register reads
+  automatically latches back to conservative reads without interrupting polling
+  (#254).
 
 > Lower sensor intervals give faster updates but increase network/API load. For
 > local connections, 5 seconds is recommended; for the cloud API, 30 seconds
@@ -172,17 +181,25 @@ parameter sync.
 
 ### Switches
 
-- **Quick Charge** — start/stop battery quick charging (Cloud API / Hybrid only,
-  as it is a cloud-scheduled task).
+- **Quick Charge** — start/stop battery quick charging. Works in all modes
+  (local, hybrid, and cloud) since #251.
 - **Battery Backup (EPS)** — enable/disable emergency power supply mode.
 - **Daylight Saving Time** — enable/disable DST for station time sync.
+- **Charge Last** — flip PV surplus to charge the battery last (register 110
+  bit 4, all modes; #177).
+- **Share Battery** — per-inverter shared-bank toggle for multi-inverter systems
+  (register 110 bit 3; disabled by default as a niche feature; #306).
 - **Working modes** — AC Charge, PV Charge Priority, Forced Discharge, Peak
   Shaving, Battery Backup Control.
-  > **EG4 Off-Grid family (12000XP/6000XP):** the **Forced Discharge** and
-  > **Peak Shaving** switches are not created — these grid-parallel functions
-  > are inert on the no-sellback SNA platform (PR #220 / #197 adjudication).
-  > If you had them from an earlier version, a Repairs issue explains the
-  > removal.
+- **Grid sell-back controls** (grid-tied families only — EG4_HYBRID / LXP) —
+  **Grid Sell Back** and **Export PV Only** (#135), and **Fast Zero Export**
+  (#274). Off-grid XP units have no export to suppress, so these are not created
+  there.
+  > **EG4 Off-Grid family (12000XP/6000XP):** the **Forced Discharge**,
+  > **Peak Shaving**, **Grid Sell Back**, **Export PV Only**, and **Fast Zero
+  > Export** switches are not created — these grid-parallel functions are inert
+  > on the no-sellback SNA platform (PR #220 / #197 adjudication). If you had
+  > them from an earlier version, a Repairs issue explains the removal.
 
 ### Selects
 
@@ -195,16 +212,27 @@ parameter sync.
 ### Numbers
 
 - System Charge SOC Limit (%)
-- AC Charge SOC Limit (%), On-Grid SOC Cut-Off (%), Off-Grid SOC Cut-Off (%)
+- AC Charge SOC Limit (%) — grid-tied families only; on the EG4 Off-Grid family
+  it is replaced by **AC Charge Start Battery SOC** and **AC Charge End Battery
+  SOC** (%) (registers 160/161, enabled by default; #332)
+- On-Grid SOC Cut-Off (%), Off-Grid SOC Cut-Off (%)
 - System Charge Voltage Limit (V), AC Charge Start / End Voltage (V),
   On-Grid / Off-Grid Cut-Off Voltage (V) — voltage-mode limits (see below)
+- Stop Discharge Voltage (V) — the voltage-regime counterpart of the Forced
+  Discharge SOC Limit (register 202; all modes)
 - AC Charge Power (0.1 kW increments)
 - PV Charge Power
 - PV Start Voltage threshold
+- Grid Sell Back Power (kW cap) — grid-tied families only (register 103; #135)
 - Grid Peak Shaving Power (not on the EG4 Off-Grid family — see the working
   modes note above)
 - Forced Discharge Power (kW) and Forced Discharge SOC Limit (%) (not on the
   EG4 Off-Grid family)
+- Start Discharge Power Threshold (W) — CT-equipped grid-tied inverters, all
+  modes; and **Start Charge Power Threshold** (W) — LOCAL/HYBRID only, disabled
+  by default (the cloud has no parameter name for it) (#272)
+- Quick Charge Duration (minutes) — mirrors register 234 live in LOCAL/HYBRID;
+  a cloud-only install keeps it as a start-minute preference (#251)
 - Battery Charge Current
 - Battery Discharge Current
 
@@ -248,19 +276,69 @@ then raise **System Charge Voltage Limit** (the absorption/balance target) and
 **AC Charge End Voltage** — EG4's *"Back Up Volt(V)"*, the battery voltage at which
 grid/AC charging stops. Both are writable and automatable from Home Assistant.
 
+### Time entities (schedule windows)
+
+Native Home Assistant **time** entities expose the portal's working-mode schedule
+windows, so automations can reshape charging/discharging windows instead of
+editing them in the EG4 web portal. Seven schedule families are supported, each
+with up to three windows × (start, end):
+
+| Schedule | Windows | Availability |
+|---|---|---|
+| **AC Charge** | 3 | all control-capable families (#277) |
+| **AC First** | 3 | EG4 Off-Grid (SNA) family only |
+| **Forced Charge** | 3 | grid-tied families |
+| **Forced Discharge** | 3 | grid-tied families |
+| **Peak Shaving** | 2 | EG4_HYBRID family |
+| **Generator Charge** | 2 | EG4_HYBRID and EG4 Off-Grid families |
+| **Off-Grid** | 3 | EG4_HYBRID family |
+
+Values follow parameter polling, so changes made in the EG4 portal appear in
+Home Assistant; LOCAL/HYBRID write the packed register directly while cloud uses
+the portal's named parameters. Whether a schedule is *honored* is still governed
+by the matching enable switch (e.g. the AC Charge switch, register 21 bit 7).
+
+> **All schedule time entities are created disabled by default** (#312). They
+> serve a limited automation use case and add entity noise for most installs.
+> Enable the specific windows you automate from **Settings → Devices & Services
+> → Entities**. Entities you have already enabled keep their state.
+
+### Notable sensors
+
+Beyond the standard power/voltage/current/energy sensors, 3.4.0 adds:
+
+- **Operating State** — the operating-mode code decoded into a friendly enum
+  (e.g. `Battery → Grid`, `Off-Grid (Battery)`), all modes (#262).
+- **Off-Grid** (binary sensor) — whether the inverter is running disconnected
+  from the grid, all modes (#262).
+- **Fault Code** / **Warning Code** (diagnostic) — per inverter in LOCAL and
+  HYBRID modes (the cloud API doesn't carry these fields).
+- **Quick Charge Remaining** — the live quick-charge countdown in **seconds**
+  (#251).
+- **Smart Load Power** / **Grid Load Power** — the off-grid family's GEN-terminal
+  split, surfaced in Cloud and Hybrid modes (#222).
+
+The **Cloud Status** sensor (formerly "Status") reports the cloud
+connection/health string; its entity ID is unchanged.
+
 ### Buttons
 
 - **Refresh Data** — force a refresh for devices and batteries.
 
-### Service action: `eg4_web_monitor.refresh_data`
+### Service actions
 
-Force an immediate refresh of device data, bypassing the normal polling interval.
+The integration registers three service actions (callable from **Developer
+Tools → Actions** or automations). See each service's fields in the UI (defined
+in `services.yaml`).
 
-| Parameter | Type | Description |
-|---|---|---|
-| `entry_id` | string (optional) | The config entry to refresh. If omitted, all EG4 Web Monitor integrations refresh. |
+| Service | Description |
+|---|---|
+| `eg4_web_monitor.refresh_data` | Force an immediate refresh of all device data, bypassing the polling interval. Optional `entry_id` targets a single config entry (default: all). |
+| `eg4_web_monitor.reconcile_history` | Backfill missing energy statistics from the EG4 cloud for gaps in your energy-sensor history (requires cloud/hybrid mode). Accepts `lookback_hours` or an explicit `start_date`/`end_date`, and an optional `entry_id`. |
+| `eg4_web_monitor.import_historical_data` | Import plant-level daily energy history (PV yield, consumption, grid import/export, battery charge/discharge) from the EG4 cloud into Home Assistant long-term statistics as external statistics, selectable in the Energy dashboard. Idempotent, bounded to 2 years per call, with a `dry_run` preview. Requires cloud/hybrid mode (#73). See the README for a full walkthrough. |
 
 ```yaml
+# Force an immediate data refresh
 service: eg4_web_monitor.refresh_data
 data:
   entry_id: "abc123def456"

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -521,28 +521,36 @@ if reg1 & 0x100:
 > `str(addr)` for unmapped registers); writes use the raw register address
 > with two's-complement masking (-50 → 65486).
 
-### Schedule Time Window Registers ([#277](https://github.com/joyfulhouse/eg4_web_monitor/issues/277) + [#295](https://github.com/joyfulhouse/eg4_web_monitor/issues/295))
+### Schedule Time Window Registers ([#277](https://github.com/joyfulhouse/eg4_web_monitor/issues/277) + [#295](https://github.com/joyfulhouse/eg4_web_monitor/issues/295) + [#312](https://github.com/joyfulhouse/eg4_web_monitor/pull/312))
 
-Four schedule types share one packed-time layout, declared once in the
+Seven schedule types share one packed-time layout, declared once in the
 `SCHEDULE_TIME_TYPES` table (const/modbus.py, mirroring pylxpweb's
 `SCHEDULE_CONFIGS`) and consumed by a single `time` entity class
-(`EG4ScheduleTimeEntity`). Per type: three daily windows × (start, end) =
-six consecutive holding registers from the base. Each 16-bit register
-**packs both time fields**: hour in the **low byte**, minute in the **high
-byte** (`value = hour | (minute << 8)`, pylxpweb
-`pack_time()`/`unpack_time()`; e.g. 23:30 → `7703`).
+(`EG4ScheduleTimeEntity`). Per type: up to three daily windows × (start, end) =
+two consecutive holding registers per window from the base (AC Charge, AC First,
+Forced Charge, Forced Discharge, Off-Grid expose 3 windows; Peak Shaving and
+Generator Charge expose 2). Each 16-bit register **packs both time fields**:
+hour in the **low byte**, minute in the **high byte** (`value = hour | (minute
+<< 8)`, pylxpweb `pack_time()`/`unpack_time()`; e.g. 23:30 → `7703`).
 
-| Schedule | Regs | Cloud param prefix | Entities (gating) |
-|----------|------|--------------------|-------------------|
-| AC Charge | 68-73 | `HOLD_AC_CHARGE` | all control-capable families (#277) |
-| AC First | 152-157 | `HOLD_AC_FIRST` | **EG4_OFFGRID (SNA) only** — the portal shows the AC First section only on the SNA working-mode page (`/WManage/web/maintain/workingMode/sna`) |
-| Forced Charge | 76-81 | `HOLD_FORCED_CHARGE` | all control-capable families |
-| Forced Discharge | 84-89 | `HOLD_FORCED_DISCHARGE` | control-capable **grid-tied** families — suppressed on EG4_OFFGRID like the forced discharge power/SOC numbers (PR #220 / #197) |
+| Schedule | Regs | Windows | Cloud param prefix | Entities (gating) |
+|----------|------|---------|--------------------|-------------------|
+| AC Charge | 68-73 | 3 | `HOLD_AC_CHARGE` | all control-capable families (#277) |
+| AC First | 152-157 | 3 | `HOLD_AC_FIRST` | **EG4_OFFGRID (SNA) only** — the portal shows the AC First section only on the SNA working-mode page (`/WManage/web/maintain/workingMode/sna`) |
+| Forced Charge | 76-81 | 3 | `HOLD_FORCED_CHARGE` | control-capable **grid-tied** families — suppressed on EG4_OFFGRID (cloud rejects `HOLD_FORCED_CHARGE_*`, no portal params on the SNA page; #316) |
+| Forced Discharge | 84-89 | 3 | `HOLD_FORCED_DISCHARGE` | control-capable **grid-tied** families — suppressed on EG4_OFFGRID like the forced discharge power/SOC numbers (PR #220 / #197) |
+| Peak Shaving | 209-212 | 2 | `HOLD_PEAK_SHAVING` (cloud reads via interleaved `LSP_HOLD_DIS_CHG_POWER_TIME_37..44`) | EG4_HYBRID only (absent on the SNA probe); #312 |
+| Generator Charge | 256-259 | 2 | `HOLD_GEN` | EG4_HYBRID **and** EG4_OFFGRID (SNA probe carries the same names); #312 |
+| Off-Grid | 269-274 | 3 | `HOLD_OFF_GRID` | EG4_HYBRID only; #312 |
 
 Within each block: reg base+0/1 = window 1 start/end, +2/3 = window 2,
 +4/5 = window 3. HA entity keys are `{schedule}_{start|end}_time_{1|2|3}`
-(e.g. `ac_first_start_time_1`); window 1 is enabled by default, windows 2/3
-are created registry-disabled. Cloud param names take the window suffix
+(e.g. `ac_first_start_time_1`); **all schedule time windows are created
+disabled by default** (changed in #312 / beta.22 — beta.18–.20 created window 1
+enabled; already-enabled entities keep their state, the default only affects new
+registrations). Peak Shaving, Generator Charge and Off-Grid write their windows
+through the portal's atomic writeTime endpoint (`write_via_time_api`; one call
+per boundary). Cloud param names take the window suffix
 `""`/`_1`/`_2`: e.g. reg 72 (AC charge window 3 start) ↔
 `HOLD_AC_CHARGE_START_HOUR_2` + `HOLD_AC_CHARGE_START_MINUTE_2`.
 
@@ -554,9 +562,12 @@ are created registry-disabled. Cloud param names take the window suffix
 > suffixed `_1`/`_2`. This matches pylxpweb's `SCHEDULE_CONFIGS` (bases
 > 68/76/84/152) and its Modbus schedule helpers, which write
 > `pack_time(hour, minute)` per register. All probed families (12kPV,
-> FlexBOSS18/21, LXP-US, SNA12K-US) report the named cloud params for all
-> four schedules; the family gates above reflect the portal UI (which page
-> shows the section) and the #197 off-grid adjudication, not param absence.
+> FlexBOSS18/21, LXP-US, SNA12K-US) report the named cloud params for the
+> AC Charge, AC First and Forced Charge/Discharge schedules; the Peak Shaving,
+> Generator Charge and Off-Grid families (bases 209/256/269) were pinned by the
+> #312 live cloud-write ↔ local-register correlation on a FlexBOSS21. The family
+> gates above reflect the portal UI (which page shows the section) and the #197
+> off-grid adjudication, not param absence.
 >
 > **LOCAL parameter-cache naming caveat (AC charge only)**: pylxpweb's
 > `REGISTER_TO_PARAM_KEYS` still carries a stale pre-probe interpretation of

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -111,10 +111,11 @@ station and select a different station each time.
 dongle: yes. Hybrid: sensor and battery data work locally, but cloud features
 (DST sync, quick charge) need internet.
 
-**Does it control my inverter?** Yes, for supported features: quick charge (Cloud
-API only), battery backup (EPS), operating mode, SOC limits, AC/PV charge power,
-and charge/discharge currents. Cloud/Hybrid send commands through EG4's cloud
-API; local modes write registers directly.
+**Does it control my inverter?** Yes, for supported features: quick charge,
+battery backup (EPS), operating mode, SOC and voltage limits, AC/PV charge power,
+charge/discharge currents, grid sell-back, and schedule windows. Cloud mode sends
+commands through EG4's cloud API; local modes write registers directly; hybrid
+writes locally and falls back to the cloud when the local link is down.
 
 **Is it secure?** Yes — encrypted HTTPS to EG4's servers, credentials stored in
 Home Assistant's encrypted storage, communication only with official EG4


### PR DESCRIPTION
Post-release documentation audit against the shipped v3.4.0 feature set (source of truth: the consolidated CHANGELOG section + entity platforms).

The two files that actually misled a 3.4.0 user: **CONFIGURATION.md** (the entire schedule time-entity feature was undocumented, plus ~10 new controls, two options, two services, and a stale "Quick Charge is cloud-only" claim) and the **CLAUDE.md register table** (frozen pre-3.4.0). Contained fixes in DATA_MAPPING (schedule section said 4 families / window-1-enabled), ARCHITECTURE, TROUBLESHOOTING, README; CLAUDE.md Current Version updated to the v3.4.0 final ship.

Docs-only — no code changes. Translation-completeness test still passes (39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)