### PR TITLE
fix(scripts): resolve Bandit security-scan findings in dev tooling

### DIFF
--- a/scripts/capture_mode_data.py
+++ b/scripts/capture_mode_data.py
@@ -8,7 +8,8 @@ Outputs JSON to stdout for piping/comparison.
 import json
 import os
 import sys
-from urllib.request import Request, urlopen
+
+import httpx
 
 MODE = sys.argv[1] if len(sys.argv) > 1 else "unknown"
 TOKEN = os.environ.get("HA_LONG_LIVED_TOKEN", "")
@@ -18,12 +19,14 @@ if not TOKEN:
     print("ERROR: Set HA_LONG_LIVED_TOKEN", file=sys.stderr)
     sys.exit(1)
 
-req = Request(
+resp = httpx.get(
     f"{BASE_URL}/api/states",
     headers={"Authorization": f"Bearer {TOKEN}"},
+    timeout=15,
+    follow_redirects=True,
 )
-with urlopen(req, timeout=15) as resp:
-    states = json.loads(resp.read())
+resp.raise_for_status()
+states = resp.json()
 
 PREFIXES = ["flexboss", "18kpv", "12kpv", "gridboss", "parallel_group", "station_"]
 eg4_all = [s for s in states if any(p in s["entity_id"].lower() for p in PREFIXES)]

--- a/scripts/download_dongle_firmware.py
+++ b/scripts/download_dongle_firmware.py
@@ -67,6 +67,14 @@ def parse_args() -> argparse.Namespace:
         default=30,
         help="HTTP timeout in seconds (default: 30)",
     )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help=(
+            "Disable TLS certificate verification (opt-in; some LuxPower "
+            "servers present invalid certificates)"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -237,8 +245,8 @@ def analyze_firmware(filepath: Path) -> None:
     print(f"\n    --- Analysis of {filepath.name} ---")
     print(f"    Size: {size:,} bytes ({size / 1024:.1f} KB)")
 
-    # Hashes
-    md5 = hashlib.md5(data).hexdigest()
+    # Hashes (checksums for firmware identification, not security)
+    md5 = hashlib.md5(data, usedforsecurity=False).hexdigest()
     sha256 = hashlib.sha256(data).hexdigest()
     print(f"    MD5:    {md5}")
     print(f"    SHA256: {sha256}")
@@ -440,9 +448,15 @@ def main() -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     print(f"[*] Output directory: {args.output_dir.resolve()}")
 
+    # Verify TLS by default; only skip when the operator opts in via --insecure
+    # (some LuxPower servers present invalid certificates).
+    verify_tls = not args.insecure
+    if not verify_tls:
+        print("[!] WARNING: TLS certificate verification disabled (--insecure)")
+
     with httpx.Client(
         timeout=args.timeout,
-        verify=False,  # Some LuxPower servers have cert issues
+        verify=verify_tls,
         follow_redirects=True,
     ) as client:
         # Step 1: Fetch firmware list

--- a/scripts/ghidra_extract.py
+++ b/scripts/ghidra_extract.py
@@ -12,6 +12,7 @@ Run via Ghidra headless:
 # This script runs inside Ghidra's Jython environment
 # pylint: disable=undefined-variable
 import os
+import tempfile
 
 from ghidra.app.decompiler import DecompInterface, DecompileOptions
 from ghidra.util.task import ConsoleTaskMonitor
@@ -22,7 +23,7 @@ def get_output_dir():
     args = getScriptArgs()  # noqa: F821
     if args:
         return args[0]
-    return "/tmp/ghidra_esp32_output"
+    return os.path.join(tempfile.gettempdir(), "ghidra_esp32_output")
 
 
 def setup_decompiler(program):

--- a/scripts/monitor_spikes.py
+++ b/scripts/monitor_spikes.py
@@ -5,12 +5,12 @@ Polls HA API every 30 seconds, records values for key sensors,
 and flags any readings that look like spikes (sudden large jumps).
 """
 
-import json
 import os
 import sys
 import time
-import urllib.request
 from datetime import datetime
+
+import httpx
 
 # Force unbuffered output
 sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
@@ -101,12 +101,14 @@ def get_threshold(entity_id: str) -> float:
 
 
 def fetch_states() -> dict[str, str]:
-    req = urllib.request.Request(
+    resp = httpx.get(
         f"{BASE_URL}/api/states",
         headers={"Authorization": f"Bearer {TOKEN}"},
+        timeout=10,
+        follow_redirects=True,
     )
-    with urllib.request.urlopen(req, timeout=10) as resp:
-        data = json.loads(resp.read())
+    resp.raise_for_status()
+    data = resp.json()
     return {s["entity_id"]: s["state"] for s in data}
 
 


### PR DESCRIPTION
## Problem

The **Bronze - Security Scan** CI job (Bandit, medium+ severity) has been failing on pre-existing findings in `scripts/` dev tooling — unrelated to any feature work, but red on every PR (surfaced while shipping #345/#349). Five findings across four scripts.

## Fixes (root cause — no `# nosec` suppressions)

| Bandit | File | Fix |
|--------|------|-----|
| **B310** url-open scheme | `capture_mode_data.py`, `monitor_spikes.py` | Replace `urllib.request.urlopen` with `httpx.get` + `raise_for_status()`; `follow_redirects=True` preserves prior redirect behavior. `httpx` is already a `scripts/` dependency (`download_dongle_firmware.py`). |
| **B324** weak MD5 | `download_dongle_firmware.py` | `hashlib.md5(data, usedforsecurity=False)` — it's a firmware-identification checksum, not security. |
| **B501** `verify=False` | `download_dongle_firmware.py` | TLS verification is now **on by default**; disabling is opt-in via a new `--insecure` flag (prints a warning), replacing the hardcoded `verify=False`. |
| **B108** hardcoded `/tmp` | `ghidra_extract.py` | Default output dir from `tempfile.gettempdir()` (Jython-2.7 safe, runs inside Ghidra). |

## Verification

- `bandit -r -ll -i -x ./test_env,./venv,./tests .` → **No issues identified** (was 5).
- `ruff check`/`ruff format` clean; `py_compile` passes on all three CPython scripts; `ghidra_extract.py` parses; `--help` renders the new `--insecure` flag.
- Scope is **dev scripts only** — the integration and its test suite are untouched.

## Behavior notes

- `download_dongle_firmware.py` now verifies TLS by default. Against LuxPower servers with invalid certs, pass `--insecure` (documented in `--help`).
- The two monitoring scripts now raise on non-2xx HA API responses (`raise_for_status`) instead of blindly parsing — a strict improvement for dev diagnostics.

## Review

Tri-vendor adversarial gate (Codex GPT-5.5/xhigh + Gemini 3.1 Pro): Codex flagged the httpx redirect-default gap (fixed with `follow_redirects=True`); both then returned **NO BLOCKING ISSUES**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)