### PR TITLE
refactor(342) PR A: coordinator write-helper tests + low-risk DRY consolidations

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -682,6 +682,33 @@ class HTTPUpdateMixin(_MixinBase):
         device_data["batteries"] = current
         self._battery_carry_forward[inverter_serial] = dict(current)
 
+    def _resolve_cloud_battery_key(
+        self, serial: str, battery: Any, seen_keys: dict[str, int]
+    ) -> tuple[str, str, tuple[str, str] | None]:
+        """Return (resolved_key, identity_key, migration_pair | None).
+
+        ``identity_key`` is the pre-disambiguation cloud ``batteryKey`` — the
+        caller needs it to format the collision warning (``{identity_key!r}``)
+        and to look up ``seen_keys[identity_key]`` (the index of the battery
+        that first claimed the identity). On collision ``resolved_key`` is the
+        positional key (``f"{serial}-{c_idx+1:02d}"``) and ``migration_pair``
+        is ``None``; otherwise ``resolved_key == identity_key`` and
+        ``migration_pair`` is ``(legacy_positional_key, canonical_key)`` to
+        record. Side-effect free: does NOT mutate ``seen_keys``, register
+        migrations, or suppress.
+        """
+        identity_key = cloud_battery_key(serial, battery)
+        c_idx = getattr(battery, "battery_index", None)
+        if c_idx is None:
+            return identity_key, identity_key, None
+        if identity_key in seen_keys:
+            return f"{serial}-{c_idx + 1:02d}", identity_key, None
+        return (
+            identity_key,
+            identity_key,
+            (f"{serial}-{c_idx + 1:02d}", identity_key),
+        )
+
     async def _process_station_data(self) -> dict[str, Any]:
         """Process station data using device objects."""
         if not self.station:
@@ -1013,8 +1040,12 @@ class HTTPUpdateMixin(_MixinBase):
                     c_idx = getattr(cloud_batt, "battery_index", None)
                     if c_idx is None:
                         continue
-                    battery_key = cloud_battery_key(serial, cloud_batt)
-                    if battery_key in baseline_keys:
+                    battery_key, identity_key, migration_pair = (
+                        self._resolve_cloud_battery_key(
+                            serial, cloud_batt, baseline_keys
+                        )
+                    )
+                    if migration_pair is None:
                         # Duplicate battery identity in one payload: keep
                         # positional disambiguation for the colliding battery
                         # and stop trusting registry migration for this
@@ -1022,16 +1053,15 @@ class HTTPUpdateMixin(_MixinBase):
                         # the migration could misbind history).
                         self._suppress_battery_migration(
                             serial,
-                            f"cloud batteries {baseline_keys[battery_key]} "
+                            f"cloud batteries {baseline_keys[identity_key]} "
                             f"and {c_idx} both resolve to identity "
-                            f"{battery_key!r}",
+                            f"{identity_key!r}",
                             level=logging.WARNING,
                         )
-                        battery_key = f"{serial}-{c_idx + 1:02d}"
                     else:
-                        baseline_keys[battery_key] = c_idx
-                        # Legacy positional key the pre-#252 HYBRID path used.
-                        key_migrations[f"{serial}-{c_idx + 1:02d}"] = battery_key
+                        baseline_keys[identity_key] = c_idx
+                        legacy_key, canonical_key = migration_pair
+                        key_migrations[legacy_key] = canonical_key
                     device_data["batteries"][battery_key] = (
                         _build_individual_battery_mapping(cloud_batt)
                     )
@@ -1167,25 +1197,30 @@ class HTTPUpdateMixin(_MixinBase):
             cloud_seen_keys: dict[str, int] = {}
             for battery in batteries:
                 try:
-                    battery_key = cloud_battery_key(serial, battery)
                     c_idx = getattr(battery, "battery_index", None)
-                    if c_idx is not None and battery_key in cloud_seen_keys:
-                        # Duplicate battery identity in one payload — keep
-                        # positional disambiguation and stop trusting registry
-                        # migration for this inverter (#252).
-                        self._suppress_battery_migration(
-                            serial,
-                            f"cloud batteries {cloud_seen_keys[battery_key]} "
-                            f"and {c_idx} both resolve to identity "
-                            f"{battery_key!r}",
-                            level=logging.WARNING,
+                    battery_key, identity_key, migration_pair = (
+                        self._resolve_cloud_battery_key(
+                            serial, battery, cloud_seen_keys
                         )
-                        battery_key = f"{serial}-{c_idx + 1:02d}"
-                    elif c_idx is not None:
-                        cloud_seen_keys[battery_key] = c_idx
-                        # Legacy positional key a pre-#252 HYBRID/LOCAL install
-                        # would have used for this battery.
-                        cloud_key_migrations[f"{serial}-{c_idx + 1:02d}"] = battery_key
+                    )
+                    if c_idx is not None:
+                        if migration_pair is None:
+                            # Duplicate battery identity in one payload — keep
+                            # positional disambiguation and stop trusting
+                            # registry migration for this inverter (#252).
+                            self._suppress_battery_migration(
+                                serial,
+                                f"cloud batteries {cloud_seen_keys[identity_key]} "
+                                f"and {c_idx} both resolve to identity "
+                                f"{identity_key!r}",
+                                level=logging.WARNING,
+                            )
+                        else:
+                            cloud_seen_keys[identity_key] = c_idx
+                            # Legacy positional key a pre-#252 HYBRID/LOCAL
+                            # install would have used for this battery.
+                            legacy_key, canonical_key = migration_pair
+                            cloud_key_migrations[legacy_key] = canonical_key
                     battery_sensors = self._extract_battery_from_object(battery)
                     battery_sensors["battery_last_polled"] = dt_util.utcnow()
                     battery_sensors["battery_last_seen"] = dt_util.utcnow()

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -136,6 +136,26 @@ _LOGGER = logging.getLogger(__name__)
 MAX_PARALLEL_UPDATES = 3
 
 
+def _coerce_int_in_range(
+    value: float,
+    *,
+    min_v: int,
+    max_v: int,
+    label: str,
+    unit: str = "%",
+    require_integer: bool = False,
+) -> int:
+    """Coerce ``value`` to int, validating range (and optionally integer-ness)."""
+    int_value = int(value)
+    if int_value < min_v or int_value > max_v:
+        raise HomeAssistantError(
+            f"{label} must be between {min_v}-{max_v}{unit}, got {int_value}"
+        )
+    if require_integer and abs(value - int_value) > 0.01:
+        raise HomeAssistantError(f"{label} must be an integer value, got {value}")
+    return int_value
+
+
 class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
     """Base class for EG4 number entities with shared read/write helpers.
 
@@ -1270,16 +1290,13 @@ class ACChargeSOCLimitNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the AC charge SOC limit."""
-        int_value = int(value)
-        if int_value < AC_CHARGE_SOC_LIMIT_MIN or int_value > AC_CHARGE_SOC_LIMIT_MAX:
-            raise HomeAssistantError(
-                f"AC charge SOC limit must be between "
-                f"{AC_CHARGE_SOC_LIMIT_MIN}-{AC_CHARGE_SOC_LIMIT_MAX}%, got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"AC charge SOC limit must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=AC_CHARGE_SOC_LIMIT_MIN,
+            max_v=AC_CHARGE_SOC_LIMIT_MAX,
+            label="AC charge SOC limit",
+            require_integer=True,
+        )
         await self._write_parameter(
             value,
             local_param=PARAM_HOLD_AC_CHARGE_SOC_LIMIT,
@@ -1331,20 +1348,13 @@ class ACChargeStartBatterySOCNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the SOC that starts AC charging (local named write or cloud)."""
-        int_value = int(value)
-        if (
-            int_value < AC_CHARGE_BATTERY_SOC_MIN
-            or int_value > AC_CHARGE_BATTERY_SOC_MAX
-        ):
-            raise HomeAssistantError(
-                f"AC charge start battery SOC must be between "
-                f"{AC_CHARGE_BATTERY_SOC_MIN}-{AC_CHARGE_BATTERY_SOC_MAX}%, "
-                f"got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"AC charge start battery SOC must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=AC_CHARGE_BATTERY_SOC_MIN,
+            max_v=AC_CHARGE_BATTERY_SOC_MAX,
+            label="AC charge start battery SOC",
+            require_integer=True,
+        )
         await self._write_parameter(
             value,
             local_param=PARAM_HOLD_AC_CHARGE_START_BATTERY_SOC,
@@ -1410,20 +1420,13 @@ class ACChargeEndBatterySOCNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the SOC that stops AC charging (local named write or cloud)."""
-        int_value = int(value)
-        if (
-            int_value < AC_CHARGE_BATTERY_SOC_MIN
-            or int_value > AC_CHARGE_BATTERY_SOC_MAX
-        ):
-            raise HomeAssistantError(
-                f"AC charge end battery SOC must be between "
-                f"{AC_CHARGE_BATTERY_SOC_MIN}-{AC_CHARGE_BATTERY_SOC_MAX}%, "
-                f"got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"AC charge end battery SOC must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=AC_CHARGE_BATTERY_SOC_MIN,
+            max_v=AC_CHARGE_BATTERY_SOC_MAX,
+            label="AC charge end battery SOC",
+            require_integer=True,
+        )
         await self._write_parameter(
             value,
             local_param=PARAM_HOLD_AC_CHARGE_END_BATTERY_SOC,
@@ -1891,15 +1894,13 @@ class ForcedDischargeSOCLimitNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the forced discharge SOC limit."""
-        int_value = int(value)
-        if int_value < 0 or int_value > 100:
-            raise HomeAssistantError(
-                f"Forced discharge SOC limit must be between 0-100%, got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"Forced discharge SOC limit must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=0,
+            max_v=100,
+            label="Forced discharge SOC limit",
+            require_integer=True,
+        )
         # Cloud setter ships with pylxpweb > 0.9.36b3 — see the power
         # entity above for rationale.
         inverter = self.coordinator.get_inverter_object(self.serial)
@@ -2040,15 +2041,13 @@ class OnGridSOCCutoffNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the on-grid SOC cutoff."""
-        int_value = int(value)
-        if int_value < 0 or int_value > 100:
-            raise HomeAssistantError(
-                f"On-grid SOC cutoff must be between 0-100%, got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"On-grid SOC cutoff must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=0,
+            max_v=100,
+            label="On-grid SOC cutoff",
+            require_integer=True,
+        )
         await self._write_parameter(
             value,
             local_param=PARAM_HOLD_ONGRID_DISCHG_SOC,
@@ -2093,15 +2092,13 @@ class OffGridSOCCutoffNumber(EG4BaseNumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the off-grid SOC cutoff."""
-        int_value = int(value)
-        if int_value < 0 or int_value > 100:
-            raise HomeAssistantError(
-                f"Off-grid SOC cutoff must be between 0-100%, got {int_value}"
-            )
-        if abs(value - int_value) > 0.01:
-            raise HomeAssistantError(
-                f"Off-grid SOC cutoff must be an integer value, got {value}"
-            )
+        int_value = _coerce_int_in_range(
+            value,
+            min_v=0,
+            max_v=100,
+            label="Off-grid SOC cutoff",
+            require_integer=True,
+        )
         await self._write_parameter(
             value,
             local_param=PARAM_HOLD_OFFGRID_DISCHG_SOC,

--- a/tests/test_coordinator_write_helpers.py
+++ b/tests/test_coordinator_write_helpers.py
@@ -73,6 +73,8 @@ async def test_refresh_if_linked_calls_refresh_when_linked(real_coordinator):
     real_coordinator.is_transport_link_down = MagicMock(return_value=False)
     await real_coordinator.refresh_inverter_params_if_linked("123")
     inv.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+    real_coordinator.get_inverter_object.assert_called_once_with("123")
+    real_coordinator.is_transport_link_down.assert_called_once_with("123")
 
 
 async def test_refresh_if_linked_skips_when_link_down(real_coordinator):
@@ -95,6 +97,18 @@ def test_params_local_raw_local_only_short_circuits(real_coordinator):
     assert real_coordinator.params_are_local_raw("123") is True
 
 
+def test_params_local_raw_local_only_wins_regardless_of_flag(real_coordinator):
+    """local-only returns True unconditionally — include_configured must not
+    weaken it (a wrong `is_local_only() and not include_configured` impl
+    would fail here; switch setup calls with include_configured=True)."""
+    real_coordinator.is_local_only = MagicMock(return_value=True)
+    real_coordinator.has_configured_local_transport = MagicMock(return_value=False)
+    real_coordinator.get_inverter_object = MagicMock(return_value=None)
+    assert real_coordinator.params_are_local_raw("123", include_configured=True) is True
+    real_coordinator.has_configured_local_transport.assert_not_called()
+    real_coordinator.get_inverter_object.assert_not_called()
+
+
 def test_params_local_raw_include_configured_branch(real_coordinator):
     real_coordinator.is_local_only = MagicMock(return_value=False)
     real_coordinator.has_configured_local_transport = MagicMock(return_value=True)
@@ -105,6 +119,7 @@ def test_params_local_raw_include_configured_branch(real_coordinator):
     assert real_coordinator.params_are_local_raw("123") is False
     # flag on -> configured transport counts -> True
     assert real_coordinator.params_are_local_raw("123", include_configured=True) is True
+    real_coordinator.has_configured_local_transport.assert_called_with("123")
 
 
 def test_params_local_raw_configured_flag_without_configured_transport(
@@ -133,6 +148,7 @@ def test_params_local_raw_live_transport_present(real_coordinator):
         return_value=MagicMock(transport=object())
     )
     assert real_coordinator.params_are_local_raw("123") is True
+    real_coordinator.get_inverter_object.assert_called_once_with("123")
 
 
 def test_params_local_raw_no_inverter_on_live_path(real_coordinator):

--- a/tests/test_coordinator_write_helpers.py
+++ b/tests/test_coordinator_write_helpers.py
@@ -1,0 +1,115 @@
+"""Unit tests for the coordinator write helpers (require_client,
+refresh_inverter_params_if_linked, params_are_local_raw) against the REAL
+EG4DataUpdateCoordinator — conftest.wire_coordinator_write_helpers only
+re-implements these on a MagicMock and cannot catch drift."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from homeassistant.exceptions import HomeAssistantError
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.eg4_web_monitor.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_DST_SYNC,
+    CONF_LIBRARY_DEBUG,
+    CONF_LOCAL_TRANSPORTS,
+    CONNECTION_TYPE_LOCAL,
+    DOMAIN,
+)
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
+
+
+@pytest.fixture
+def local_config_entry():
+    """Create a config entry for LOCAL connection mode."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EG4 Electronics - FlexBOSS21",
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+            CONF_DST_SYNC: False,
+            CONF_LIBRARY_DEBUG: False,
+            CONF_LOCAL_TRANSPORTS: [
+                {
+                    "serial": "1234567890",
+                    "host": "192.168.1.100",
+                    "port": 502,
+                    "transport_type": "modbus_tcp",
+                    "inverter_family": "EG4_HYBRID",
+                    "model": "FlexBOSS21",
+                },
+            ],
+        },
+        entry_id="local_write_helpers_test_entry",
+    )
+
+
+@pytest.fixture
+def real_coordinator(hass, local_config_entry):
+    """Create a real coordinator without replacing its write helpers."""
+    return EG4DataUpdateCoordinator(hass, local_config_entry)
+
+
+def test_require_client_returns_client(real_coordinator):
+    real_coordinator.client = MagicMock()
+    assert real_coordinator.require_client() is real_coordinator.client
+
+
+def test_require_client_raises_exact_message(real_coordinator):
+    real_coordinator.client = None
+    with pytest.raises(HomeAssistantError) as exc:
+        real_coordinator.require_client()
+    assert str(exc.value) == (
+        "No local transport or cloud API available for parameter write."
+    )
+
+
+async def test_refresh_if_linked_calls_refresh_when_linked(real_coordinator):
+    inv = MagicMock()
+    inv.refresh = AsyncMock()
+    real_coordinator.get_inverter_object = MagicMock(return_value=inv)
+    real_coordinator.is_transport_link_down = MagicMock(return_value=False)
+    await real_coordinator.refresh_inverter_params_if_linked("123")
+    inv.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+
+
+async def test_refresh_if_linked_skips_when_link_down(real_coordinator):
+    inv = MagicMock()
+    inv.refresh = AsyncMock()
+    real_coordinator.get_inverter_object = MagicMock(return_value=inv)
+    real_coordinator.is_transport_link_down = MagicMock(return_value=True)
+    await real_coordinator.refresh_inverter_params_if_linked("123")
+    inv.refresh.assert_not_awaited()
+
+
+async def test_refresh_if_linked_skips_when_no_inverter(real_coordinator):
+    real_coordinator.get_inverter_object = MagicMock(return_value=None)
+    real_coordinator.is_transport_link_down = MagicMock(return_value=False)
+    await real_coordinator.refresh_inverter_params_if_linked("123")  # no raise
+
+
+def test_params_local_raw_local_only_short_circuits(real_coordinator):
+    real_coordinator.is_local_only = MagicMock(return_value=True)
+    assert real_coordinator.params_are_local_raw("123") is True
+
+
+def test_params_local_raw_include_configured_branch(real_coordinator):
+    real_coordinator.is_local_only = MagicMock(return_value=False)
+    real_coordinator.has_configured_local_transport = MagicMock(return_value=True)
+    real_coordinator.get_inverter_object = MagicMock(
+        return_value=MagicMock(transport=None)
+    )
+    # flag off -> falls through to live transport (None) -> False
+    assert real_coordinator.params_are_local_raw("123") is False
+    # flag on -> configured transport counts -> True
+    assert real_coordinator.params_are_local_raw("123", include_configured=True) is True
+
+
+def test_params_local_raw_live_transport_present(real_coordinator):
+    real_coordinator.is_local_only = MagicMock(return_value=False)
+    real_coordinator.has_configured_local_transport = MagicMock(return_value=False)
+    real_coordinator.get_inverter_object = MagicMock(
+        return_value=MagicMock(transport=object())
+    )
+    assert real_coordinator.params_are_local_raw("123") is True

--- a/tests/test_coordinator_write_helpers.py
+++ b/tests/test_coordinator_write_helpers.py
@@ -48,6 +48,7 @@ def local_config_entry():
 @pytest.fixture
 def real_coordinator(hass, local_config_entry):
     """Create a real coordinator without replacing its write helpers."""
+    local_config_entry.add_to_hass(hass)
     return EG4DataUpdateCoordinator(hass, local_config_entry)
 
 
@@ -106,6 +107,25 @@ def test_params_local_raw_include_configured_branch(real_coordinator):
     assert real_coordinator.params_are_local_raw("123", include_configured=True) is True
 
 
+def test_params_local_raw_configured_flag_without_configured_transport(
+    real_coordinator,
+):
+    """include_configured=True alone must NOT short-circuit: with no configured
+    transport it falls through to the live-transport check."""
+    real_coordinator.is_local_only = MagicMock(return_value=False)
+    real_coordinator.has_configured_local_transport = MagicMock(return_value=False)
+    real_coordinator.get_inverter_object = MagicMock(
+        return_value=MagicMock(transport=None)
+    )
+    assert (
+        real_coordinator.params_are_local_raw("123", include_configured=True) is False
+    )
+    real_coordinator.get_inverter_object = MagicMock(
+        return_value=MagicMock(transport=object())
+    )
+    assert real_coordinator.params_are_local_raw("123", include_configured=True) is True
+
+
 def test_params_local_raw_live_transport_present(real_coordinator):
     real_coordinator.is_local_only = MagicMock(return_value=False)
     real_coordinator.has_configured_local_transport = MagicMock(return_value=False)
@@ -113,3 +133,11 @@ def test_params_local_raw_live_transport_present(real_coordinator):
         return_value=MagicMock(transport=object())
     )
     assert real_coordinator.params_are_local_raw("123") is True
+
+
+def test_params_local_raw_no_inverter_on_live_path(real_coordinator):
+    """A missing inverter object resolves False (getattr fallback, no raise)."""
+    real_coordinator.is_local_only = MagicMock(return_value=False)
+    real_coordinator.has_configured_local_transport = MagicMock(return_value=False)
+    real_coordinator.get_inverter_object = MagicMock(return_value=None)
+    assert real_coordinator.params_are_local_raw("123") is False

--- a/tests/test_issue_252_battery_identity.py
+++ b/tests/test_issue_252_battery_identity.py
@@ -1412,6 +1412,31 @@ class TestCloudBatteryKeyResolverCharacterization:
             f"{f'{INV}-{BAT_SN_1}'!r}" in caplog.text
         )
 
+    async def test_cloud_indexless_collision_publishes_under_identity_without_suppression(
+        self, hass, mock_config_entry, caplog
+    ):
+        """Index-less CLOUD collision: last-write-wins, no suppress/warn.
+
+        A battery with ``battery_index is None`` sharing an identity key with
+        an earlier indexed battery skips the collision-detection branch
+        entirely (it is gated on ``c_idx is not None``), so it silently
+        overwrites the earlier entry instead of being disambiguated.
+        """
+        mock_config_entry.add_to_hass(hass)
+        indexless = _cloud_battery(1, BAT_SN_1)
+        indexless.battery_index = None
+        cloud = [_cloud_battery(0, BAT_SN_1), indexless]
+        coordinator = _make_coordinator(hass, mock_config_entry, cloud=cloud)
+
+        with caplog.at_level(logging.WARNING):
+            result = await _process(coordinator)
+        batteries = result["devices"][INV]["batteries"]
+
+        # Published under the shared identity key; nothing disambiguated.
+        assert set(batteries) == {f"{INV}-{BAT_SN_1}"}
+        assert INV not in coordinator._battery_migration_suppressed
+        assert "both resolve to identity" not in caplog.text
+
 
 class TestResolveCloudBatteryKey:
     """Direct unit tests for the extracted ``_resolve_cloud_battery_key``."""

--- a/tests/test_issue_252_battery_identity.py
+++ b/tests/test_issue_252_battery_identity.py
@@ -1323,3 +1323,150 @@ class TestSetupOrderingInvariant:
 
             await hass.config_entries.async_unload(mock_config_entry.entry_id)
             await hass.async_block_till_done()
+
+
+# ── #342 resolver extraction — characterization + unit tests ──────────
+
+
+class TestCloudBatteryKeyResolverCharacterization:
+    """Behavior of the HYBRID/CLOUD collision + migration paths.
+
+    These pin the observable behavior of the (currently inline) key
+    resolution logic in both call sites before it is extracted into
+    ``_resolve_cloud_battery_key`` (#342), so the refactor cannot silently
+    change the collision-warning text, the disambiguated key, or the
+    migration-suppression side effect.
+    """
+
+    async def test_hybrid_distinct_index_batteries_get_canonical_keys(
+        self, hass, mock_config_entry
+    ):
+        """No collision: both batteries keep their canonical identity keys."""
+        mock_config_entry.add_to_hass(hass)
+        cloud = [_cloud_battery(0, BAT_SN_1), _cloud_battery(1, BAT_SN_2)]
+        coordinator = _make_coordinator(
+            hass, mock_config_entry, cloud=cloud, transport=[]
+        )
+
+        result = await _process(coordinator)
+        batteries = result["devices"][INV]["batteries"]
+
+        assert set(batteries) == {f"{INV}-{BAT_SN_1}", f"{INV}-{BAT_SN_2}"}
+        assert INV not in coordinator._battery_migration_suppressed
+
+    async def test_hybrid_colliding_identity_disambiguated_and_suppressed(
+        self, hass, mock_config_entry, caplog
+    ):
+        """Two cloud batteries sharing an identity: positional split + warn."""
+        mock_config_entry.add_to_hass(hass)
+        cloud = [_cloud_battery(0, BAT_SN_1), _cloud_battery(1, BAT_SN_1)]
+        coordinator = _make_coordinator(
+            hass, mock_config_entry, cloud=cloud, transport=[]
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = await _process(coordinator)
+        batteries = result["devices"][INV]["batteries"]
+
+        # First battery keeps the canonical identity key; the collider is
+        # disambiguated positionally.
+        assert f"{INV}-{BAT_SN_1}" in batteries
+        assert f"{INV}-02" in batteries
+        assert INV in coordinator._battery_migration_suppressed
+        assert (
+            f"cloud batteries 0 and 1 both resolve to identity "
+            f"{f'{INV}-{BAT_SN_1}'!r}" in caplog.text
+        )
+
+    async def test_cloud_distinct_index_batteries_get_canonical_keys(
+        self, hass, mock_config_entry
+    ):
+        """CLOUD-only path: no collision, canonical keys used."""
+        mock_config_entry.add_to_hass(hass)
+        cloud = [_cloud_battery(0, BAT_SN_1), _cloud_battery(1, BAT_SN_2)]
+        coordinator = _make_coordinator(hass, mock_config_entry, cloud=cloud)
+
+        result = await _process(coordinator)
+        batteries = result["devices"][INV]["batteries"]
+
+        assert set(batteries) == {f"{INV}-{BAT_SN_1}", f"{INV}-{BAT_SN_2}"}
+        assert INV not in coordinator._battery_migration_suppressed
+
+    async def test_cloud_colliding_identity_disambiguated_and_suppressed(
+        self, hass, mock_config_entry, caplog
+    ):
+        """CLOUD-only path: colliding identity disambiguated + suppressed."""
+        mock_config_entry.add_to_hass(hass)
+        cloud = [_cloud_battery(0, BAT_SN_1), _cloud_battery(1, BAT_SN_1)]
+        coordinator = _make_coordinator(hass, mock_config_entry, cloud=cloud)
+
+        with caplog.at_level(logging.WARNING):
+            result = await _process(coordinator)
+        batteries = result["devices"][INV]["batteries"]
+
+        assert f"{INV}-{BAT_SN_1}" in batteries
+        assert f"{INV}-02" in batteries
+        assert INV in coordinator._battery_migration_suppressed
+        assert (
+            f"cloud batteries 0 and 1 both resolve to identity "
+            f"{f'{INV}-{BAT_SN_1}'!r}" in caplog.text
+        )
+
+
+class TestResolveCloudBatteryKey:
+    """Direct unit tests for the extracted ``_resolve_cloud_battery_key``."""
+
+    async def test_distinct_index_returns_migration_pair(self, hass, mock_config_entry):
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        battery = _cloud_battery(0, BAT_SN_1)
+
+        resolved_key, identity_key, migration_pair = (
+            coordinator._resolve_cloud_battery_key(INV, battery, seen_keys={})
+        )
+
+        assert resolved_key == identity_key == f"{INV}-{BAT_SN_1}"
+        assert migration_pair == (f"{INV}-01", f"{INV}-{BAT_SN_1}")
+
+    async def test_colliding_index_returns_positional_key_and_no_migration(
+        self, hass, mock_config_entry
+    ):
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        battery = _cloud_battery(1, BAT_SN_1)
+        identity = f"{INV}-{BAT_SN_1}"
+
+        resolved_key, identity_key, migration_pair = (
+            coordinator._resolve_cloud_battery_key(
+                INV, battery, seen_keys={identity: 0}
+            )
+        )
+
+        assert resolved_key == f"{INV}-02"
+        assert identity_key == identity
+        assert migration_pair is None
+
+    async def test_no_index_returns_identity_with_no_migration(
+        self, hass, mock_config_entry
+    ):
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        battery = _cloud_battery(0, BAT_SN_1)
+        battery.battery_index = None
+
+        resolved_key, identity_key, migration_pair = (
+            coordinator._resolve_cloud_battery_key(INV, battery, seen_keys={})
+        )
+
+        assert resolved_key == identity_key == f"{INV}-{BAT_SN_1}"
+        assert migration_pair is None
+
+    async def test_does_not_mutate_seen_keys(self, hass, mock_config_entry):
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        battery = _cloud_battery(0, BAT_SN_1)
+        seen_keys: dict[str, int] = {}
+
+        coordinator._resolve_cloud_battery_key(INV, battery, seen_keys=seen_keys)
+
+        assert seen_keys == {}

--- a/tests/test_number_coerce_int.py
+++ b/tests/test_number_coerce_int.py
@@ -89,14 +89,16 @@ async def test_out_of_range_message_is_exact(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(("entity_type", "min_v", "max_v", "label"), ENTITY_CASES)
+@pytest.mark.parametrize("side", ("low", "high"))
 async def test_non_integer_message_is_exact(
     entity_type: type[EG4BaseNumberEntity],
     min_v: int,
     max_v: int,
     label: str,
+    side: str,
 ) -> None:
     """In-range fractional values preserve the exact validation message."""
-    value = min_v + 0.5
+    value = min_v + 0.5 if side == "low" else max_v - 0.5
     coordinator = _mock_coordinator(has_local=True)
     entity = entity_type(coordinator, "1234567890")
     _prep(entity)
@@ -109,15 +111,18 @@ async def test_non_integer_message_is_exact(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(("entity_type", "min_v", "max_v", "label"), ENTITY_CASES)
+@pytest.mark.parametrize("bound", ("min", "max"))
 async def test_in_range_integer_succeeds(
     entity_type: type[EG4BaseNumberEntity],
     min_v: int,
     max_v: int,
     label: str,
+    bound: str,
 ) -> None:
-    """An in-range integer reaches the mocked write successfully."""
+    """Exact boundary integers reach the mocked write successfully."""
+    value = float(min_v) if bound == "min" else float(max_v)
     coordinator = _mock_coordinator(has_local=True)
     entity = entity_type(coordinator, "1234567890")
     _prep(entity)
 
-    await entity.async_set_native_value(float(min_v))
+    await entity.async_set_native_value(value)

--- a/tests/test_number_coerce_int.py
+++ b/tests/test_number_coerce_int.py
@@ -1,0 +1,123 @@
+"""Characterization tests for SOC integer validation messages."""
+
+from collections.abc import Sequence
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.eg4_web_monitor.number import (
+    ACChargeEndBatterySOCNumber,
+    ACChargeSOCLimitNumber,
+    ACChargeStartBatterySOCNumber,
+    EG4BaseNumberEntity,
+    ForcedDischargeSOCLimitNumber,
+    OffGridSOCCutoffNumber,
+    OnGridSOCCutoffNumber,
+)
+from tests.test_number_entities import _mock_coordinator, _prep
+
+
+ENTITY_CASES: Sequence = (
+    pytest.param(
+        ACChargeSOCLimitNumber,
+        0,
+        101,
+        "AC charge SOC limit",
+        id="ac-charge-soc-limit",
+    ),
+    pytest.param(
+        ACChargeStartBatterySOCNumber,
+        0,
+        100,
+        "AC charge start battery SOC",
+        id="ac-charge-start-battery-soc",
+    ),
+    pytest.param(
+        ACChargeEndBatterySOCNumber,
+        0,
+        100,
+        "AC charge end battery SOC",
+        id="ac-charge-end-battery-soc",
+    ),
+    pytest.param(
+        ForcedDischargeSOCLimitNumber,
+        0,
+        100,
+        "Forced discharge SOC limit",
+        id="forced-discharge-soc-limit",
+    ),
+    pytest.param(
+        OnGridSOCCutoffNumber,
+        0,
+        100,
+        "On-grid SOC cutoff",
+        id="on-grid-soc-cutoff",
+    ),
+    pytest.param(
+        OffGridSOCCutoffNumber,
+        0,
+        100,
+        "Off-grid SOC cutoff",
+        id="off-grid-soc-cutoff",
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("entity_type", "min_v", "max_v", "label"), ENTITY_CASES)
+@pytest.mark.parametrize("bound", ("min", "max"))
+async def test_out_of_range_message_is_exact(
+    entity_type: type[EG4BaseNumberEntity],
+    min_v: int,
+    max_v: int,
+    label: str,
+    bound: str,
+) -> None:
+    """Out-of-range values preserve the exact validation message."""
+    value = min_v - 1 if bound == "min" else max_v + 1
+    coordinator = _mock_coordinator(has_local=True)
+    entity = entity_type(coordinator, "1234567890")
+    _prep(entity)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await entity.async_set_native_value(value)
+
+    assert str(exc_info.value) == (
+        f"{label} must be between {min_v}-{max_v}%, got {value}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("entity_type", "min_v", "max_v", "label"), ENTITY_CASES)
+async def test_non_integer_message_is_exact(
+    entity_type: type[EG4BaseNumberEntity],
+    min_v: int,
+    max_v: int,
+    label: str,
+) -> None:
+    """In-range fractional values preserve the exact validation message."""
+    value = min_v + 0.5
+    coordinator = _mock_coordinator(has_local=True)
+    entity = entity_type(coordinator, "1234567890")
+    _prep(entity)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await entity.async_set_native_value(value)
+
+    assert str(exc_info.value) == f"{label} must be an integer value, got {value}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("entity_type", "min_v", "max_v", "label"), ENTITY_CASES)
+async def test_in_range_integer_succeeds(
+    entity_type: type[EG4BaseNumberEntity],
+    min_v: int,
+    max_v: int,
+    label: str,
+) -> None:
+    """An in-range integer reaches the mocked write successfully."""
+    coordinator = _mock_coordinator(has_local=True)
+    entity = entity_type(coordinator, "1234567890")
+    _prep(entity)
+
+    await entity.async_set_native_value(float(min_v))


### PR DESCRIPTION
Part 1 of 2 for #342 (3.5.0 deferred DRY consolidation). PR A carries the mechanical/low-risk bucket; the behavior-risk refactors (time.py per-device refresh, history_import tz idempotency, ChargeLast→WORKING_MODES, VoltageNumberSpec, optimistic-write envelope) follow in PR B after this merges.

## What's in here

**U1 — real unit tests for the coordinator write helpers** (`3ccc1c4`, `9cffb03`, `5989f4b`)
`require_client()`, `refresh_inverter_params_if_linked()`, `params_are_local_raw()` were only exercised through `tests/conftest.py::wire_coordinator_write_helpers`, which re-implements their logic on a MagicMock — real-implementation drift was invisible. New `tests/test_coordinator_write_helpers.py` pins the real `EG4DataUpdateCoordinator`: exact error message, refresh kwargs, link-down/no-inverter skips, the full `params_are_local_raw` truth table (including local-only precedence over `include_configured=True` — the combination switch setup actually uses), and collaborator serial forwarding. 11 tests. Result: no drift found today; the hole is closed going forward.

**U3 — `_resolve_cloud_battery_key()`** (`c31d84f`, `5eb6cfb`)
The HYBRID and CLOUD battery blocks in `coordinator_http.py` duplicated the collision-detect/migration-key logic (the #252/#258 divergence bug class). Extracted a side-effect-free resolver returning `(resolved_key, identity_key, migration_pair | None)`; the deliberate per-branch divergences stay at the call sites (HYBRID skips index-less batteries; CLOUD publishes them), suppression messages render byte-identically, and suppression stickiness is unchanged. Characterization tests pin both paths including the index-less CLOUD collision edge (last-write-wins, no suppression).

**U4 — `_coerce_int_in_range()`** (`d5804f2`, `1c03c11`)
Six SOC-percent number entities repeated the int-coercion + range + integer-check boilerplate. One module helper now serves all six; every `HomeAssistantError` message renders byte-for-byte identically (AST-verified in review), range-check-first ordering and the `abs(value-int)>0.01` threshold are preserved, and the original float still flows to the write path. Excluded by design: peak shaving, power thresholds, PV charge power, and all voltage sites (different message shapes — voltage consolidation is PR B's U7). 36 characterization tests with hardcoded per-site literals.

## Review process
Every commit went through: implementer (Codex gpt-5.6-sol) → independent Claude diff review → code-simplifier pass (verdict: already-minimal ×3) → adversarial reviews by Codex gpt-5.6-sol and Antigravity, findings adjudicated and fixed in-branch (5 accepted findings became the follow-up test commits; false positives documented in the session ledger).

## Gate
- `pytest tests/` — **2008 passed, 3 skipped** (baseline 1952/3; +56 tests)
- `ruff check` / `ruff format` — clean
- `mypy --strict` (tests/mypy.ini) — clean, no suppressions

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)