### PR TITLE
fix(security): resolve bandit findings in dev scripts

### DIFF
--- a/scripts/capture_mode_data.py
+++ b/scripts/capture_mode_data.py
@@ -8,7 +8,8 @@ Outputs JSON to stdout for piping/comparison.
 import json
 import os
 import sys
-from urllib.request import Request, urlopen
+
+import httpx
 
 MODE = sys.argv[1] if len(sys.argv) > 1 else "unknown"
 TOKEN = os.environ.get("HA_LONG_LIVED_TOKEN", "")
@@ -18,12 +19,14 @@ if not TOKEN:
     print("ERROR: Set HA_LONG_LIVED_TOKEN", file=sys.stderr)
     sys.exit(1)
 
-req = Request(
+resp = httpx.get(
     f"{BASE_URL}/api/states",
     headers={"Authorization": f"Bearer {TOKEN}"},
+    timeout=15,
+    follow_redirects=True,
 )
-with urlopen(req, timeout=15) as resp:
-    states = json.loads(resp.read())
+resp.raise_for_status()
+states = resp.json()
 
 PREFIXES = ["flexboss", "18kpv", "12kpv", "gridboss", "parallel_group", "station_"]
 eg4_all = [s for s in states if any(p in s["entity_id"].lower() for p in PREFIXES)]

--- a/scripts/download_dongle_firmware.py
+++ b/scripts/download_dongle_firmware.py
@@ -67,6 +67,11 @@ def parse_args() -> argparse.Namespace:
         default=30,
         help="HTTP timeout in seconds (default: 30)",
     )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification (some LuxPower servers have certificate issues)",
+    )
     return parser.parse_args()
 
 
@@ -238,7 +243,7 @@ def analyze_firmware(filepath: Path) -> None:
     print(f"    Size: {size:,} bytes ({size / 1024:.1f} KB)")
 
     # Hashes
-    md5 = hashlib.md5(data).hexdigest()
+    md5 = hashlib.md5(data, usedforsecurity=False).hexdigest()
     sha256 = hashlib.sha256(data).hexdigest()
     print(f"    MD5:    {md5}")
     print(f"    SHA256: {sha256}")
@@ -442,7 +447,7 @@ def main() -> None:
 
     with httpx.Client(
         timeout=args.timeout,
-        verify=False,  # Some LuxPower servers have cert issues
+        verify=not args.insecure,  # TLS verified by default; opt out with --insecure
         follow_redirects=True,
     ) as client:
         # Step 1: Fetch firmware list

--- a/scripts/ghidra_extract.py
+++ b/scripts/ghidra_extract.py
@@ -12,6 +12,7 @@ Run via Ghidra headless:
 # This script runs inside Ghidra's Jython environment
 # pylint: disable=undefined-variable
 import os
+import tempfile
 
 from ghidra.app.decompiler import DecompInterface, DecompileOptions
 from ghidra.util.task import ConsoleTaskMonitor
@@ -22,7 +23,7 @@ def get_output_dir():
     args = getScriptArgs()  # noqa: F821
     if args:
         return args[0]
-    return "/tmp/ghidra_esp32_output"
+    return os.path.join(tempfile.gettempdir(), "ghidra_esp32_output")
 
 
 def setup_decompiler(program):

--- a/scripts/monitor_spikes.py
+++ b/scripts/monitor_spikes.py
@@ -5,12 +5,12 @@ Polls HA API every 30 seconds, records values for key sensors,
 and flags any readings that look like spikes (sudden large jumps).
 """
 
-import json
 import os
 import sys
 import time
-import urllib.request
 from datetime import datetime
+
+import httpx
 
 # Force unbuffered output
 sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
@@ -101,12 +101,14 @@ def get_threshold(entity_id: str) -> float:
 
 
 def fetch_states() -> dict[str, str]:
-    req = urllib.request.Request(
+    resp = httpx.get(
         f"{BASE_URL}/api/states",
         headers={"Authorization": f"Bearer {TOKEN}"},
+        timeout=10,
+        follow_redirects=True,
     )
-    with urllib.request.urlopen(req, timeout=10) as resp:
-        data = json.loads(resp.read())
+    resp.raise_for_status()
+    data = resp.json()
     return {s["entity_id"]: s["state"] for s in data}
 
 


### PR DESCRIPTION
Fixes the 5 bandit findings (from 4812f03's firmware-RE tooling) that fail the Bronze security scan on every PR, blocking #354 and all future PRs. Dev tooling only — no integration code touched.

- B310 ×2: `urlopen` → `httpx.get` with `raise_for_status()` + `follow_redirects=True` (capture_mode_data, monitor_spikes)
- B324: `hashlib.md5(data, usedforsecurity=False)` — firmware fingerprint, not a security control
- B501: `verify=False` → TLS verified by default, explicit `--insecure` opt-out flag (LuxPower cert-issue workflow documented in `--help`)
- B108: hardcoded `/tmp` → `tempfile.gettempdir()` (Jython-safe)

No `# nosec`/suppressions. Bandit (CI's exact invocation `bandit -r . -ll -i -x ./test_env,./venv,./tests`): 5 findings → 0. Reviewed by Fable 5, Codex gpt-5.6-sol, and Antigravity (findings adjudicated; redirect-drift fix folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)