### PR TITLE
chore(342): post-merge review nits

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -1020,7 +1020,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         action_name: str,
         value: bool,
         *,
-        do_write: Callable[[], Awaitable[bool]],
+        do_write: Callable[[], Awaitable[None]],
         do_refresh: Callable[[], Awaitable[None]],
         pre_delay_refresh: Callable[[], Awaitable[None]] | None = None,
         api_delay: float = 1.0,
@@ -1036,6 +1036,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         The optimistic state is cleared AFTER ``do_refresh`` completes to
         prevent the "bounce" effect where the entity briefly shows the wrong
         state while waiting for API data to propagate.
+
+        Callers emit their path-specific debug log BEFORE invoking this
+        envelope — the pinned log ordering is debug → optimistic publish →
+        write. A logging handler that itself raises therefore escapes
+        unwrapped (no optimistic state exists yet to clear); accepted, since
+        wrapping it would require moving the log after the optimistic
+        publish and changing the documented ordering.
         """
         action_verb = "Enabling" if value else "Disabling"
 
@@ -1150,7 +1157,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
 
         inverter: Any = None
 
-        async def do_write() -> bool:
+        async def do_write() -> None:
             nonlocal inverter
             inverter = self._get_inverter_or_raise()
 
@@ -1180,7 +1187,6 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 action_name,
                 self._serial,
             )
-            return True
 
         async def pre_delay_refresh() -> None:
             await inverter.refresh()
@@ -1370,7 +1376,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             parameter,
         )
 
-        async def do_write() -> bool:
+        async def do_write() -> None:
             response = await client.api.control.control_function(
                 self._serial, parameter, value
             )
@@ -1385,7 +1391,6 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 action_name,
                 self._serial,
             )
-            return True
 
         async def do_refresh() -> None:
             await self.coordinator.async_refresh_device_parameters(self._serial)

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -2377,6 +2377,10 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
         self._attr_native_precision = spec.precision
 
     def _get_related_entity_types(self) -> tuple[type, ...]:
+        # Contract-only: satisfies the base class's abstract method but is
+        # never consulted — _refresh_related_entities below is fully
+        # overridden to filter by spec.related_group instead (an isinstance
+        # check alone would over-refresh all four voltage specs at once).
         return (EG4VoltageNumber,)
 
     @property

--- a/tests/test_base_entity_envelope.py
+++ b/tests/test_base_entity_envelope.py
@@ -201,6 +201,30 @@ async def test_switch_false_success_clears_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_switch_write_failure_never_seeds() -> None:
+    """A failed write must not seed the parameter cache (#310 seed is
+    an acknowledgement of a SUCCESSFUL write; seeding on failure would
+    publish a state the device never confirmed)."""
+    events: list[str] = []
+    entity, _coordinator, inverter = _make_entity(events)
+    inverter.enable_test = AsyncMock(
+        side_effect=lambda: events.append("write") or False
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await entity._execute_switch_action(
+            "test action",
+            "enable_test",
+            "disable_test",
+            True,
+            seed_param_key="FUNC_TEST",
+        )
+
+    entity._seed_cloud_written_parameter.assert_not_called()
+    assert events == ["optimistic-set", "write", "clear"]
+
+
+@pytest.mark.asyncio
 async def test_switch_plain_exception_is_wrapped() -> None:
     """Plain switch write exceptions become HomeAssistantError failures."""
     events: list[str] = []
@@ -301,6 +325,26 @@ async def test_cloud_function_false_success_clears_once() -> None:
 
     assert events == ["optimistic-set", "write", "clear"]
     _assert_state_write_counts(entity, optimistic_value=False, clear_count=1)
+
+
+@pytest.mark.asyncio
+async def test_cloud_function_write_failure_never_seeds() -> None:
+    """A failed cloud function write must not seed the parameter cache."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    coordinator.client.api.control.control_function.side_effect = (
+        lambda _serial, _parameter, _value: (
+            events.append("write") or SimpleNamespace(success=False)
+        )
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await entity._execute_cloud_function_action(
+            "test action", "FUNC_TEST", False, seed_param_key="FUNC_TEST"
+        )
+
+    entity._seed_cloud_written_parameter.assert_not_called()
+    assert events == ["optimistic-set", "write", "clear"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_number_coerce_int.py
+++ b/tests/test_number_coerce_int.py
@@ -1,8 +1,12 @@
 """Characterization tests for SOC integer validation messages."""
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from _pytest.mark import ParameterSet
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.eg4_web_monitor.number import (
@@ -17,7 +21,7 @@ from custom_components.eg4_web_monitor.number import (
 from tests.test_number_entities import _mock_coordinator, _prep
 
 
-ENTITY_CASES: Sequence = (
+ENTITY_CASES: "Sequence[ParameterSet]" = (
     pytest.param(
         ACChargeSOCLimitNumber,
         0,


### PR DESCRIPTION
Follow-ups from the #354/#357 review threads (the LOW/minor findings deferred at merge time):

- **Envelope signature honesty**: `_optimistic_write_envelope`'s `do_write` is now `Awaitable[None]` and the two wrapper closures drop their discarded `return True` — the contract is raise-on-failure and the envelope never consumed the bool (the falsy-success checks inside the closures are untouched).
- **Contract-only stub annotated**: `EG4VoltageNumber._get_related_entity_types` documents that it exists to satisfy the abstract contract and is never consulted (the pair-scoped `_refresh_related_entities` override is the real mechanism).
- **Debug-log placement documented**: the envelope docstring records the pinned debug→optimistic→write ordering and the accepted trade-off (a raising log handler escapes unwrapped, before any optimistic state exists).
- **Seeded-failure tests**: both write paths now assert a failed write never seeds the parameter cache — the #310 seed is an acknowledgement of success, so seeding on failure would publish a state the device never confirmed.
- **Typing**: `ENTITY_CASES` tightened to `"Sequence[ParameterSet]"` with the pytest-internal import behind `TYPE_CHECKING` (type-check-time-only exposure to pytest internals).

Gate: 2065 passed / 3 skipped, ruff clean, mypy strict clean. Reviewed by Fable 5, Codex gpt-5.6-sol (CLEAN), and Antigravity (one accepted finding — the TYPE_CHECKING import — folded in; one refuted on code evidence).

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)