### PR TITLE
fix: firmware install runs multi-step chains and surfaces failures (#353)

### DIFF
--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -787,12 +787,14 @@ jobs:
 
       - name: Install mypy and dependencies with uv
         run: |
-          # Match tests/requirements-test.txt's pre-release pin so mypy
-          # type-checks against the SAME pylxpweb the tests use, not the older
-          # stable (bare "pylxpweb" -> 0.9.35, which lacks new attributes such
-          # as InverterRuntimeData.rectifier_power). The pre-release marker lets
-          # uv resolve the latest 0.9.36 beta.
-          uv pip install --system 'homeassistant>=2025.11.0' mypy 'pylxpweb>=0.9.37'
+          # Read the pylxpweb pin from tests/requirements-test.txt so mypy
+          # type-checks against the SAME pylxpweb the tests use. A hardcoded
+          # ">=stable" specifier here resolved the latest stable and missed
+          # pre-release-only attributes (bit us on 0.9.37 -> 0.9.38b1: mypy
+          # couldn't see run_firmware_update_to_completion).
+          PYLXPWEB_PIN=$(grep -oE '^pylxpweb[><=!~]+[0-9a-zA-Z.]+' tests/requirements-test.txt)
+          echo "Using pin: $PYLXPWEB_PIN"
+          uv pip install --system 'homeassistant>=2025.11.0' mypy "$PYLXPWEB_PIN"
 
       - name: Verify strict typing configuration
         run: |

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.37", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.38b1", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.4.0"
 }

--- a/custom_components/eg4_web_monitor/update.py
+++ b/custom_components/eg4_web_monitor/update.py
@@ -9,6 +9,7 @@ from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -182,25 +183,44 @@ class EG4FirmwareUpdateEntity(
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
-        """Install firmware update."""
+        """Install firmware update, running multi-step chains to completion.
+
+        Some devices (e.g. 6000XP) require the cloud update call once per
+        firmware component — a single call leaves them on a partial version
+        (issue #353). ``run_firmware_update_to_completion`` re-checks and
+        re-runs until the device converges, and its result is checked so a
+        refused start or partial chain surfaces as an error instead of
+        logging "initiated" and silently stopping short.
+        """
         _LOGGER.info("Installing firmware update for %s", self._serial)
 
         # Get device object from coordinator
         device = self.coordinator._get_device_object(self._serial)
         if not device:
-            _LOGGER.error("Device %s not found for firmware update", self._serial)
-            return
+            raise HomeAssistantError(
+                f"Device {self._serial} not found for firmware update"
+            )
 
         try:
-            # Start firmware update
-            await device.start_firmware_update()
-            _LOGGER.info("Firmware update initiated for %s", self._serial)
-
-            # Refresh coordinator data to update status
+            result = await device.run_firmware_update_to_completion()
+        except Exception as err:
+            _LOGGER.error("Failed to run firmware update for %s: %s", self._serial, err)
+            raise
+        finally:
+            # Refresh coordinator data so version/progress state updates
+            # regardless of outcome.
             await self.coordinator.async_request_refresh()
 
-        except Exception as err:
-            _LOGGER.error(
-                "Failed to start firmware update for %s: %s", self._serial, err
+        if not result.success:
+            raise HomeAssistantError(
+                f"Firmware update for {self._serial} did not complete: "
+                f"{result.message} (steps run: {result.steps_run}, "
+                f"current version: {result.final_version or 'unknown'})"
             )
-            raise
+
+        _LOGGER.info(
+            "Firmware update for %s complete after %d step(s); version %s",
+            self._serial,
+            result.steps_run,
+            result.final_version,
+        )

--- a/custom_components/eg4_web_monitor/update.py
+++ b/custom_components/eg4_web_monitor/update.py
@@ -191,6 +191,13 @@ class EG4FirmwareUpdateEntity(
         re-runs until the device converges, and its result is checked so a
         refused start or partial chain surfaces as an error instead of
         logging "initiated" and silently stopping short.
+
+        Long-running by design: a step takes 20-40 minutes and chains can
+        double that. HA keeps the service task alive past the 10s service
+        limit and this entity reports progress via in_progress/percentage.
+        If HA restarts mid-chain, the device finishes its current step on
+        its own and pressing Install again resumes from the remaining
+        components (the orchestrator re-checks before every run).
         """
         _LOGGER.info("Installing firmware update for %s", self._serial)
 
@@ -207,9 +214,17 @@ class EG4FirmwareUpdateEntity(
             _LOGGER.error("Failed to run firmware update for %s: %s", self._serial, err)
             raise
         finally:
-            # Refresh coordinator data so version/progress state updates
-            # regardless of outcome.
-            await self.coordinator.async_request_refresh()
+            # Best-effort refresh so entity state reflects reality on every
+            # outcome. Must not raise: an exception here would replace the
+            # orchestrator's exception (or discard its failure result).
+            try:
+                await self.coordinator.async_request_refresh()
+            except Exception:
+                _LOGGER.debug(
+                    "Post-install coordinator refresh failed for %s",
+                    self._serial,
+                    exc_info=True,
+                )
 
         if not result.success:
             raise HomeAssistantError(

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.37  # keep in sync with manifest.json; 3.4.0 cloud raw-register writes need >=0.9.37
+pylxpweb>=0.9.38b1  # keep in sync with manifest.json; #353 needs run_firmware_update_to_completion (>=0.9.38b1)
 
 # Code quality
 ruff>=0.8.0

--- a/tests/test_update_entities.py
+++ b/tests/test_update_entities.py
@@ -504,6 +504,38 @@ class TestAsyncInstall:
         coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_refresh_failure_does_not_mask_success(self):
+        """A failing post-install refresh is swallowed: a successful update
+        must not surface as an installation error (codex P2)."""
+        coordinator = _mock_coordinator(
+            devices={"SN1": {"type": "inverter", "model": "X"}}
+        )
+        coordinator.async_request_refresh = AsyncMock(
+            side_effect=RuntimeError("refresh boom")
+        )
+        entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
+
+        await entity.async_install(version=None, backup=False)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_does_not_mask_orchestrator_error(self):
+        """The orchestrator's exception wins over a refresh exception."""
+        coordinator = _mock_coordinator(
+            devices={"SN1": {"type": "inverter", "model": "X"}}
+        )
+        device = coordinator._get_device_object("SN1")
+        device.run_firmware_update_to_completion = AsyncMock(
+            side_effect=RuntimeError("update boom")
+        )
+        coordinator.async_request_refresh = AsyncMock(
+            side_effect=RuntimeError("refresh boom")
+        )
+        entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
+
+        with pytest.raises(RuntimeError, match="update boom"):
+            await entity.async_install(version=None, backup=False)
+
+    @pytest.mark.asyncio
     async def test_install_reraises_exceptions(self):
         """Exceptions from the orchestrator are re-raised; refresh still runs."""
         coordinator = _mock_coordinator(

--- a/tests/test_update_entities.py
+++ b/tests/test_update_entities.py
@@ -1,10 +1,12 @@
 """Tests for EG4 firmware update entities."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.eg4_web_monitor.const import ENTITY_PREFIX
 from custom_components.eg4_web_monitor.update import (
@@ -39,9 +41,19 @@ def _mock_coordinator(
     else:
         coordinator.data = {"devices": {}}
 
-    # _get_device_object default: returns a mock device
+    # _get_device_object default: returns a mock device whose orchestrated
+    # update converges in one step (issue #353 result contract).
     mock_device = MagicMock()
     mock_device.start_firmware_update = AsyncMock()
+    mock_device.run_firmware_update_to_completion = AsyncMock(
+        return_value=SimpleNamespace(
+            success=True,
+            converged=True,
+            steps_run=1,
+            message="Firmware update complete after 1 step(s)",
+            final_version="ccaa-1E1515",
+        )
+    )
     coordinator._get_device_object = MagicMock(return_value=mock_device)
 
     return coordinator
@@ -438,8 +450,8 @@ class TestAsyncInstall:
     """Test the firmware install action."""
 
     @pytest.mark.asyncio
-    async def test_install_calls_device_and_refreshes(self):
-        """Install triggers start_firmware_update then coordinator refresh."""
+    async def test_install_runs_to_completion_and_refreshes(self):
+        """Install runs the multi-step orchestrator then refreshes (#353)."""
         coordinator = _mock_coordinator(
             devices={"SN1": {"type": "inverter", "model": "X"}}
         )
@@ -448,34 +460,62 @@ class TestAsyncInstall:
         await entity.async_install(version=None, backup=False)
 
         device = coordinator._get_device_object("SN1")
-        device.start_firmware_update.assert_called_once()
+        device.run_firmware_update_to_completion.assert_called_once()
         coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_install_device_not_found(self):
-        """When device object is None, install logs error and returns."""
+    async def test_install_device_not_found_raises(self):
+        """When device object is None, install raises instead of silently
+        returning (#353 — silent no-op looked like success)."""
         coordinator = _mock_coordinator(
             devices={"SN1": {"type": "inverter", "model": "X"}}
         )
         coordinator._get_device_object = MagicMock(return_value=None)
         entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
 
-        # Should not raise
-        await entity.async_install(version=None, backup=False)
+        with pytest.raises(HomeAssistantError, match="not found"):
+            await entity.async_install(version=None, backup=False)
 
         coordinator.async_request_refresh.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_install_reraises_exceptions(self):
-        """Exceptions from start_firmware_update are re-raised."""
+    async def test_install_failure_result_raises(self):
+        """A non-success orchestration result raises with its message —
+        a refused start must not log 'initiated' and vanish (#353)."""
         coordinator = _mock_coordinator(
             devices={"SN1": {"type": "inverter", "model": "X"}}
         )
         device = coordinator._get_device_object("SN1")
-        device.start_firmware_update = AsyncMock(
+        device.run_firmware_update_to_completion = AsyncMock(
+            return_value=SimpleNamespace(
+                success=False,
+                converged=False,
+                steps_run=1,
+                message="API refused to start the firmware update",
+                final_version="ccaa-1E1415",
+            )
+        )
+        entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
+
+        with pytest.raises(HomeAssistantError, match="API refused"):
+            await entity.async_install(version=None, backup=False)
+
+        # Refresh still happens (finally) so state reflects reality.
+        coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_install_reraises_exceptions(self):
+        """Exceptions from the orchestrator are re-raised; refresh still runs."""
+        coordinator = _mock_coordinator(
+            devices={"SN1": {"type": "inverter", "model": "X"}}
+        )
+        device = coordinator._get_device_object("SN1")
+        device.run_firmware_update_to_completion = AsyncMock(
             side_effect=RuntimeError("connection lost")
         )
         entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
 
         with pytest.raises(RuntimeError, match="connection lost"):
             await entity.async_install(version=None, backup=False)
+
+        coordinator.async_request_refresh.assert_called_once()


### PR DESCRIPTION
## Summary
Integration half of #353 (6000XP firmware update landed `1E1415` instead of `1E1515`; the update entity showed target `ccaa-1515` and swallowed failed starts). Pairs with pylxpweb 0.9.38b1 ([pylxpweb#227](https://github.com/joyfulhouse/pylxpweb/pull/227)).

- `async_install` now calls pylxpweb's `run_firmware_update_to_completion()` — check → eligibility → start → poll → re-check until the device converges, with FAILED-step abort, start-visibility grace, settle window, and step budget (details in pylxpweb#227).
- The orchestration **result is checked**: any non-success raises `HomeAssistantError` with the orchestrator's message, steps run, and the device's actual current version. Previously the bool from `start_firmware_update()` was discarded — a refused start logged "initiated" and vanished.
- Device-not-found raises instead of silently returning.
- Post-install coordinator refresh is best-effort in `finally` (a refresh failure can no longer mask the real outcome — codex P2).
- The wrong displayed target (`ccaa-1515` → `ccaa-1E1515`) is fixed in pylxpweb 0.9.38b1's version-prefix construction; pin bumped here.

## Reviews
Codex gpt-5.6-sol + Antigravity adversarial round + codex verify pass — all findings fixed and test-pinned (FAILED terminal handling, prefix-progress key, settle window, refresh masking, sentinel version).

## Testing
2086 passed / 3 skipped, mypy strict clean. New tests: orchestrated install + refresh, failure-result raises with message, device-not-found raises, refresh-failure never masks success or the orchestrator's exception.

## Validation plan
@eode kept his second (un-upgraded) 6000XP as the test case — hardware validation on that inverter gates the 3.5.0-beta.1 tag.

Closes #353 pending hardware confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)