### PR TITLE
refactor(363): DRY batch — 4 safe-mechanical consolidations

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
-from collections.abc import Callable, Collection
+from collections.abc import Awaitable, Callable, Collection
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from homeassistant.config_entries import ConfigEntry
@@ -880,6 +880,38 @@ class EG4DataUpdateCoordinator(
         for old_key in migrated:
             self._battery_key_migrations_done.add((inverter_serial, old_key))
 
+    async def _write_with_local_transport(
+        self,
+        *,
+        serial: str | None,
+        no_transport_message: str,
+        reconnect_message: str,
+        reconnect_args: tuple[Any, ...],
+        write: Callable[[Any], Awaitable[None]],
+        success_message: str,
+        success_args: tuple[Any, ...],
+        failure_message: str,
+        failure_args: tuple[Any, ...],
+        translated_error: Callable[[Exception], str],
+    ) -> bool:
+        """Run the shared local-transport write and error-translation shell."""
+        transport = self.get_local_transport(serial)
+        if not transport:
+            raise HomeAssistantError(no_transport_message)
+
+        try:
+            if not transport.is_connected:
+                _LOGGER.debug(reconnect_message, *reconnect_args)
+                await transport.connect()
+
+            await write(transport)
+            _LOGGER.debug(success_message, *success_args)
+            return True
+
+        except Exception as err:
+            _LOGGER.error(failure_message, *failure_args, err)
+            raise HomeAssistantError(translated_error(err)) from err
+
     async def write_named_parameter(
         self,
         parameter: str,
@@ -911,26 +943,22 @@ class EG4DataUpdateCoordinator(
             # Write an integer value
             await coordinator.write_named_parameter("HOLD_AC_CHARGE_SOC_LIMIT", 95)
         """
-        transport = self.get_local_transport(serial)
-        if not transport:
-            raise HomeAssistantError("No local transport available for parameter write")
-
-        try:
-            if not transport.is_connected:
-                _LOGGER.debug(
-                    "Reconnecting transport for %s before writing %s", serial, parameter
-                )
-                await transport.connect()
-
-            await transport.write_named_parameters({parameter: value})
-            _LOGGER.debug("Wrote parameter %s = %s", parameter, value)
-            return True
-
-        except Exception as err:
-            _LOGGER.error("Failed to write parameter %s: %s", parameter, err)
-            raise HomeAssistantError(
+        return await self._write_with_local_transport(
+            serial=serial,
+            no_transport_message="No local transport available for parameter write",
+            reconnect_message="Reconnecting transport for %s before writing %s",
+            reconnect_args=(serial, parameter),
+            write=lambda transport: transport.write_named_parameters(
+                {parameter: value}
+            ),
+            success_message="Wrote parameter %s = %s",
+            success_args=(parameter, value),
+            failure_message="Failed to write parameter %s: %s",
+            failure_args=(parameter,),
+            translated_error=lambda err: (
                 f"Failed to write parameter {parameter}: {err}"
-            ) from err
+            ),
+        )
 
     async def write_raw_parameter(
         self,
@@ -959,28 +987,18 @@ class EG4DataUpdateCoordinator(
         Raises:
             HomeAssistantError: If no local transport or write fails.
         """
-        transport = self.get_local_transport(serial)
-        if not transport:
-            raise HomeAssistantError("No local transport available for parameter write")
-
-        try:
-            if not transport.is_connected:
-                _LOGGER.debug(
-                    "Reconnecting transport for %s before writing register %d",
-                    serial,
-                    address,
-                )
-                await transport.connect()
-
-            await transport.write_parameters({address: value})
-            _LOGGER.debug("Wrote raw register %d = %s", address, value)
-            return True
-
-        except Exception as err:
-            _LOGGER.error("Failed to write register %d: %s", address, err)
-            raise HomeAssistantError(
-                f"Failed to write register {address}: {err}"
-            ) from err
+        return await self._write_with_local_transport(
+            serial=serial,
+            no_transport_message="No local transport available for parameter write",
+            reconnect_message="Reconnecting transport for %s before writing register %d",
+            reconnect_args=(serial, address),
+            write=lambda transport: transport.write_parameters({address: value}),
+            success_message="Wrote raw register %d = %s",
+            success_args=(address, value),
+            failure_message="Failed to write register %d: %s",
+            failure_args=(address,),
+            translated_error=lambda err: f"Failed to write register {address}: {err}",
+        )
 
     async def write_register(
         self,
@@ -1013,28 +1031,18 @@ class EG4DataUpdateCoordinator(
         Raises:
             HomeAssistantError: If no local transport or write fails.
         """
-        transport = self.get_local_transport(serial)
-        if not transport:
-            raise HomeAssistantError("No local transport available for register write")
-
-        try:
-            if not transport.is_connected:
-                _LOGGER.debug(
-                    "Reconnecting transport for %s before writing register %d",
-                    serial,
-                    register,
-                )
-                await transport.connect()
-
-            await transport.write_parameters({register: value})
-            _LOGGER.debug("Wrote register %d = %s", register, value)
-            return True
-
-        except Exception as err:
-            _LOGGER.error("Failed to write register %d: %s", register, err)
-            raise HomeAssistantError(
-                f"Failed to write register {register}: {err}"
-            ) from err
+        return await self._write_with_local_transport(
+            serial=serial,
+            no_transport_message="No local transport available for register write",
+            reconnect_message="Reconnecting transport for %s before writing register %d",
+            reconnect_args=(serial, register),
+            write=lambda transport: transport.write_parameters({register: value}),
+            success_message="Wrote register %d = %s",
+            success_args=(register, value),
+            failure_message="Failed to write register %d: %s",
+            failure_args=(register,),
+            translated_error=lambda err: f"Failed to write register {register}: {err}",
+        )
 
     # ── Battery control regime (SOC vs Voltage, register 179 bits 9/10) ──────
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -974,6 +974,23 @@ class DeviceProcessingMixin(_MixinBase):
             return None
         return None  # neither read method available -> unknown
 
+    async def _poll_firmware_update_info(self, device: Any) -> dict[str, Any] | None:
+        """Poll and extract firmware update information for a device."""
+        firmware_update_info = None
+        try:
+            if hasattr(device, "check_firmware_updates"):
+                await device.check_firmware_updates()
+                if hasattr(device, "get_firmware_update_progress"):
+                    await device.get_firmware_update_progress()
+                firmware_update_info = self._extract_firmware_update_info(device)
+        except Exception as e:
+            _LOGGER.debug(
+                "Could not check firmware updates for %s: %s",
+                device.serial_number,
+                e,
+            )
+        return firmware_update_info
+
     async def _process_inverter_object(
         self, inverter: "BaseInverter"
     ) -> dict[str, Any]:
@@ -1026,19 +1043,7 @@ class DeviceProcessingMixin(_MixinBase):
         firmware_version = getattr(inverter, "firmware_version", "1.0.0")
 
         # Check for firmware updates (pylxpweb 0.3.7+)
-        firmware_update_info = None
-        try:
-            if hasattr(inverter, "check_firmware_updates"):
-                await inverter.check_firmware_updates()
-                if hasattr(inverter, "get_firmware_update_progress"):
-                    await inverter.get_firmware_update_progress()
-                firmware_update_info = self._extract_firmware_update_info(inverter)
-        except Exception as e:
-            _LOGGER.debug(
-                "Could not check firmware updates for %s: %s",
-                inverter.serial_number,
-                e,
-            )
+        firmware_update_info = await self._poll_firmware_update_info(inverter)
 
         processed: dict[str, Any] = {
             "serial": inverter.serial_number,
@@ -1821,19 +1826,7 @@ class DeviceProcessingMixin(_MixinBase):
         model = getattr(mid_device, "model", "GridBOSS")
         firmware_version = getattr(mid_device, "firmware_version", "1.0.0")
 
-        firmware_update_info = None
-        try:
-            if hasattr(mid_device, "check_firmware_updates"):
-                await mid_device.check_firmware_updates()
-                if hasattr(mid_device, "get_firmware_update_progress"):
-                    await mid_device.get_firmware_update_progress()
-                firmware_update_info = self._extract_firmware_update_info(mid_device)
-        except Exception as e:
-            _LOGGER.debug(
-                "Could not check firmware updates for %s: %s",
-                mid_device.serial_number,
-                e,
-            )
+        firmware_update_info = await self._poll_firmware_update_info(mid_device)
 
         processed: dict[str, Any] = {
             "serial": mid_device.serial_number,

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -258,6 +258,11 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
     def _get_related_entity_types(self) -> tuple[type, ...]:
         """Return tuple of related entity types for parameter refresh."""
 
+    def _related_entity_predicate(self) -> Callable[[Any], bool]:
+        """Return the entity-selection predicate for parameter refreshes."""
+        related_types = self._get_related_entity_types()
+        return lambda entity: isinstance(entity, related_types)
+
     # ── Value read helpers ──────────────────────────────────────────
 
     def _params_are_local_raw(self) -> bool:
@@ -518,11 +523,11 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             await self.coordinator.refresh_all_device_parameters()
             platform = self.platform
             if platform is not None:
-                related_types = self._get_related_entity_types()
+                is_related_entity = self._related_entity_predicate()
                 related_entities = [
                     entity
                     for entity in platform.entities.values()
-                    if isinstance(entity, related_types)
+                    if is_related_entity(entity)
                 ]
                 _LOGGER.info(
                     "Updating %d related entities after parameter refresh",
@@ -1280,8 +1285,12 @@ class ACChargeStartBatterySOCNumber(EG4BaseNumberEntity):
             # The named-param cloud writer is BOTH the cloud-mode path and
             # the HYBRID local-failure fallback — the portal's own
             # holdParam write (GH #331).
-            cloud_write=lambda: _write_cloud_named_soc(
-                self, PARAM_HOLD_AC_CHARGE_START_BATTERY_SOC, int_value
+            cloud_write=lambda: _write_cloud_named_parameter(
+                self,
+                PARAM_HOLD_AC_CHARGE_START_BATTERY_SOC,
+                int_value,
+                f"Failed to set {PARAM_HOLD_AC_CHARGE_START_BATTERY_SOC} "
+                f"to {int_value}%",
             ),
             label=f"AC charge start battery SOC to {int_value}%",
         )
@@ -1352,27 +1361,31 @@ class ACChargeEndBatterySOCNumber(EG4BaseNumberEntity):
             # The named-param cloud writer is BOTH the cloud-mode path and
             # the HYBRID local-failure fallback — the portal's own
             # holdParam write (GH #331).
-            cloud_write=lambda: _write_cloud_named_soc(
-                self, PARAM_HOLD_AC_CHARGE_END_BATTERY_SOC, int_value
+            cloud_write=lambda: _write_cloud_named_parameter(
+                self,
+                PARAM_HOLD_AC_CHARGE_END_BATTERY_SOC,
+                int_value,
+                f"Failed to set {PARAM_HOLD_AC_CHARGE_END_BATTERY_SOC} to {int_value}%",
             ),
             label=f"AC charge end battery SOC to {int_value}%",
         )
 
 
-async def _write_cloud_named_soc(
-    entity: EG4BaseNumberEntity, param: str, soc: int
+async def _write_cloud_named_parameter(
+    entity: EG4BaseNumberEntity,
+    param: str,
+    value: int,
+    error_message: str,
 ) -> None:
-    """Write an off-grid AC-charge SOC holdParam via the cloud named write.
+    """Write a cloud holdParam value through the generic named-write API.
 
-    The portal's own call for the off-grid working-mode page (GH #331):
-    remoteSet/write with the holdParam name and the whole-percent value as
-    text. Bare writer — logging, optimistic state and the related-entity
-    refresh are provided by the callers' write wrappers.
+    Bare writer — logging, optimistic state and the related-entity refresh are
+    provided by the callers' write wrappers.
     """
     client = entity.coordinator.require_client()
-    result = await client.api.control.write_parameter(entity.serial, param, str(soc))
+    result = await client.api.control.write_parameter(entity.serial, param, str(value))
     if not result.success:
-        raise HomeAssistantError(f"Failed to set {param} to {soc}%")
+        raise HomeAssistantError(error_message)
     await entity.coordinator.refresh_inverter_params_if_linked(entity.serial)
 
 
@@ -1570,38 +1583,20 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
             local_param=PARAM_HOLD_PTOUSER_START_DISCHARGE,
             local_value=int_value,
             # The named-param cloud writer is BOTH the cloud-mode path and
-            # the HYBRID local-failure fallback; pylxpweb's
-            # set_start_discharge_power is deliberately bypassed (see
-            # _write_cloud_named_parameter).
-            cloud_write=lambda: self._write_cloud_named_parameter(int_value),
+            # the HYBRID local-failure fallback. The website's own call
+            # (reporter-verified in the GH #272 browser console) is
+            # remoteSet/write with holdParam HOLD_P_TO_USER_START_DISCHG;
+            # pylxpweb's set_start_discharge_power is deliberately bypassed —
+            # its cloud leg writes the raw register by address and its read
+            # leg looks up a key that never exists on the server.
+            cloud_write=lambda: _write_cloud_named_parameter(
+                self,
+                PARAM_HOLD_P_TO_USER_START_DISCHG,
+                int_value,
+                f"Failed to set start discharge power threshold to {int_value} W",
+            ),
             label=f"start discharge power threshold to {int_value} W",
         )
-
-    async def _write_cloud_named_parameter(self, watts: int) -> None:
-        """Write the threshold via the generic cloud named-parameter API.
-
-        The website's own call (reporter-verified in the GH #272 browser
-        console): remoteSet/write with holdParam HOLD_P_TO_USER_START_DISCHG
-        and the watt value as text. pylxpweb's ``set_start_discharge_power``
-        is deliberately NOT used for cloud writes — its cloud leg writes the
-        raw register by address, and its cloud read leg looks up the wrong
-        key (the guessed HOLD_PTOUSER_START_DISCHARGE never exists on the
-        server), so the named-param call is the only website-verified path.
-
-        Bare writer: logging, ineffective-regime warning, optimistic state
-        and the related-entity refresh are provided by ``_write_parameter``.
-        """
-        client = self.coordinator.require_client()
-        result = await client.api.control.write_parameter(
-            self.serial,
-            PARAM_HOLD_P_TO_USER_START_DISCHG,
-            str(watts),
-        )
-        if not result.success:
-            raise HomeAssistantError(
-                f"Failed to set start discharge power threshold to {watts} W"
-            )
-        await self.coordinator.refresh_inverter_params_if_linked(self.serial)
 
 
 class StartChargePowerNumber(EG4BaseNumberEntity):
@@ -2344,9 +2339,9 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
 
     def _get_related_entity_types(self) -> tuple[type, ...]:
         # Contract-only: satisfies the base class's abstract method but is
-        # never consulted — _refresh_related_entities below is fully
-        # overridden to filter by spec.related_group instead (an isinstance
-        # check alone would over-refresh every voltage spec at once).
+        # never consulted — _related_entity_predicate below narrows the
+        # refresh to spec.related_group instead (an isinstance check alone
+        # would over-refresh every voltage spec at once).
         return (EG4VoltageNumber,)
 
     def _volts_from_spec_param(self, raw: Any) -> float:
@@ -2402,15 +2397,12 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
             volts = int(write_value)
 
             async def _cloud_write_named_volts() -> None:
-                client = self.coordinator.require_client()
-                result = await client.api.control.write_parameter(
-                    self.serial, spec.param_key, str(volts)
+                await _write_cloud_named_parameter(
+                    self,
+                    spec.param_key,
+                    volts,
+                    f"Failed to set {spec.message_label} to {volts} V",
                 )
-                if not result.success:
-                    raise HomeAssistantError(
-                        f"Failed to set {spec.message_label} to {volts} V"
-                    )
-                await self.coordinator.refresh_inverter_params_if_linked(self.serial)
 
             cloud_write = _cloud_write_named_volts
 
@@ -2422,24 +2414,9 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
             cloud_write=cloud_write,
         )
 
-    async def _refresh_related_entities(self) -> None:
-        """Refresh only voltage entities in this spec's related group."""
-        try:
-            await self.coordinator.refresh_all_device_parameters()
-            platform = self.platform
-            if platform is not None:
-                related_entities = [
-                    entity
-                    for entity in platform.entities.values()
-                    if isinstance(entity, EG4VoltageNumber)
-                    and entity._spec.key in self._spec.related_group
-                ]
-                _LOGGER.info(
-                    "Updating %d related entities after parameter refresh",
-                    len(related_entities),
-                )
-                update_tasks = [entity.async_update() for entity in related_entities]
-                await asyncio.gather(*update_tasks, return_exceptions=True)
-                await self.coordinator.async_request_refresh()
-        except Exception as e:
-            _LOGGER.error("Failed to refresh parameters and entities: %s", e)
+    def _related_entity_predicate(self) -> Callable[[Any], bool]:
+        """Select voltage entities in this spec's parameter refresh group."""
+        return lambda entity: (
+            isinstance(entity, EG4VoltageNumber)
+            and entity._spec.key in self._spec.related_group
+        )


### PR DESCRIPTION
Items 1–4 of #363 (item 5, the envelope-vs-switch-lifecycle consolidation, stays deferred behind #362's write-refresh semantics decision).

1. `coordinator.py` — one `_write_with_local_transport` shell for the three local-write methods
2. `number.py` — `_write_cloud_named_parameter` generalization (System-SOC excluded: dedicated pylxpweb method; GridSellBack excluded by design)
3. `number.py` — related-entity refresh via overridable `_related_entity_predicate`
4. `coordinator_mixins.py` — shared `_poll_firmware_update_info`

Net −27 lines. Behavior byte-for-byte: existing 2090-test suite passes **unchanged** (characterization net), mypy strict clean, zero suppressions.

Gate: codex gpt-5.6-sol implemented; Fable reviewed (2 doc-fidelity nits fixed in-round); agy adversarial review **CLEAN** (verified log-arg expansion, exception propagation, lambda binding, predicate gating, typing).

Closes #363 (item 5 tracked in #362's follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)