### PR TITLE
docs(api): clarify coverage scope — pylxpweb subset, not full portal

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -27,6 +27,12 @@ mobile app. `pylxpweb` wraps it; this integration (`eg4_web_monitor`) consumes
 | `forecasting` | Solar + weather forecasts |
 | `export` | Historical runtime `.xls` export |
 
+## Coverage & scope
+
+**This spec documents 100% of the endpoints the `pylxpweb` client calls — 44 endpoints, statically verified — but that is *not* the complete EG4 portal API.** It is the client-used subset: the endpoints a Home Assistant integration needs (discovery, runtime/energy, battery, GridBOSS, control/write, firmware, analytics, forecast, export). The coverage was confirmed by a full static sweep of every HTTP call site in `pylxpweb` (including the calls that bypass the generic request wrapper — the `locale/region`/`locale/country` POSTs and the `.xls` export GET — and all CLI collectors): the 44 paths here are exactly the set the client can reach, with none missing and none unused.
+
+The live EG4 portal exposes **more** endpoints that `pylxpweb` never touches and that are therefore **out of scope** here — e.g. account/profile management, password reset & registration, user/installer/customer administration, plant create/delete/share/transfer, device & datalog binding, notification/alarm preferences, reports, and support/admin workflows. Documenting those would require frontend-JavaScript analysis plus authenticated network capture across roles — worthwhile only for broader portal automation, not for integration support.
+
 ## Auth & session model
 
 1. `POST /WManage/api/login` with form fields `account`, `password`, `language=ENGLISH`.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6,11 +6,18 @@ info:
     **Reverse-engineered / UNOFFICIAL** OpenAPI specification for the EG4 Electronics
     monitor cloud API (`https://monitor.eg4electronics.com`).
 
+    SCOPE: this is the **`pylxpweb`-client-used subset** of the portal API — 100% of the
+    44 endpoints the client calls (statically verified), NOT the complete EG4 portal
+    surface. Endpoints the client never calls (account/user administration, registration,
+    plant create/delete/share, device binding, notifications, reports, etc.) are out of
+    scope. See the "Coverage & scope" section of the README.
+
     This spec is derived entirely from the `pylxpweb` Python client
     (`joyfulhouse/pylxpweb`) — its endpoint modules, Pydantic response models, and
-    live read-only validation (auth/plants/devices validated 2026-07-14; control,
-    firmware, and analytics mapped from source). It is **not** published or endorsed
-    by EG4 Electronics and may drift from the real service.
+    live read-only validation (auth/plants/devices validated 2026-07-14; the analytics/
+    forecast/plantOverview response bodies live-validated 2026-07-15; control and firmware
+    mapped from source). It is **not** published or endorsed by EG4 Electronics and may
+    drift from the real service.
 
     ## Cross-cutting conventions
     - **All request bodies are `application/x-www-form-urlencoded`** (NOT JSON). Even


### PR DESCRIPTION
Codex `gpt-5.6-sol` validated the API-coverage claim: the spec documents **100% of the 44 endpoints the `pylxpweb` client calls** (statically verified across `_request`, the direct `session.post` locale calls, the export GET, dynamic role/parallel path selection, and all CLI collectors — none missing, none unused). But that is the **client-used subset**, not the complete EG4 portal API.

This adds an explicit **"Coverage & scope"** section (README) + `info.description` note so "fully mapped" isn't misread as full-portal coverage, and lists the out-of-scope portal families (account/user admin, registration, plant create/delete/share, device binding, notifications, reports). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)