### PR TITLE
docs(api): exhaustive portal endpoint crawl — 251 endpoints, 23 live-validated

### DIFF
--- a/docs/api/PORTAL_ENDPOINTS.md
+++ b/docs/api/PORTAL_ENDPOINTS.md
@@ -1,402 +1,441 @@
 # EG4 Monitor Portal — Full Endpoint Catalog (frontend-discovered)
 
-> **Scope:** this catalogues **every `/WManage/...` endpoint referenced by the EG4 monitor
-> portal's authenticated web frontend** — a much larger surface than the client-used subset
-> documented in [`openapi.yaml`](openapi.yaml). It answers "how much of the real API do we
-> cover?": the OpenAPI spec covers the **44** endpoints the `pylxpweb` client calls; the portal
-> frontend references **186**.
+> **Scope & method.** This catalogues **every `/WManage/...` endpoint referenced by the EG4
+> monitor portal's authenticated web frontend** — a far larger surface than the client-used
+> subset in [`openapi.yaml`](openapi.yaml). The OpenAPI spec is a *validated contract* for the
+> **44** endpoints the `pylxpweb` client calls; this catalog is a *discovery map* of the full
+> frontend surface.
 >
-> **How this was produced:** static, read-only analysis of the portal's HTML pages and ~64
-> jQuery JS files (role: VIEWER), 2026-07-15. Endpoints were catalogued **from JS source**, not
-> invoked — **no write/control/firmware endpoint was ever called**, and no account or device
-> state was changed.
+> **Totals (this exhaustive pass, 2026-07-15):** **251 distinct `/WManage/...` endpoints** —
+> **113 READ**, **89 WRITE**, **49 server-rendered page routes**.
+> 41 map to the validated `openapi.yaml` set; the rest are beyond it. Of the READ
+> endpoints, **23 were live-validated read-only** (2026-07-15) — their captured top-level
+> response fields are listed in the "Live-validated" section below.
 >
-> **Validation status:** the **KNOWN** endpoints (the 35 of the 44 that surface in VIEWER JS)
-> are fully typed in `openapi.yaml`. The **NEW** endpoints here are **inventory only** — path +
-> HTTP method + request-param *names* extracted from the frontend; their request/response
-> **schemas are NOT validated** (and the ~55 write/control ones deliberately were not exercised).
-> Treat this as a discovery map, not a verified contract. Owner/installer/admin sections are
-> absent (VIEWER role), so the true portal surface is larger still.
+> **How produced.** Read-only static analysis (role: VIEWER): fetched the portal's page HTML +
+> **104 jQuery JS files** (auth-free static assets), and extracted endpoints from source — not
+> only quoted literals but also `baseUrl + …` concatenations, **ternary/variable path segments**
+> (e.g. the `*Parallel` chart variants), backtick template URLs, `fetch()`/`downloadFile()`
+> export calls, and HTML form `action=` targets. **No write/control/firmware endpoint was ever
+> invoked**; the ~89 WRITE endpoints are inventoried from source only. Serials/plant-ids/
+> user-ids obfuscated. Owner/installer/admin sections are only partially reachable as VIEWER, so
+> the true portal surface is larger still.
 >
-> Legend: `R/W` — READ (get/list/query/overview/check) vs WRITE (set/save/add/remove/update/run/
-> start/stop/control/bind). `KNOWN` = in the 44-endpoint `pylxpweb` subset; `NEW` = beyond it.
-> `(q)` = query-string param. `?` method = the call site used a wrapper/`$.ajax` where the type
-> was not co-located (server-rendered page routes are GET; JSON data calls are POST unless noted).
+> **Validation status.** The **KNOWN** endpoints are fully typed in `openapi.yaml`. The **NEW**
+> endpoints here are **inventory** (path + method + param names from source); their request/
+> response **schemas are not validated** except the 23 READ endpoints explicitly marked
+> ✅ live-validated. Treat this as a discovery map, not a verified contract.
+>
+> Legend: `R/W` — READ / WRITE / PAGE (server-rendered). `KNOWN` = in the 44-endpoint
+> `pylxpweb` subset; `NEW` = beyond it. `✅` = live-validated read (2026-07-15). `{param}` =
+> path-parameter segment. `(q)` = query-string param.
 
 
-> Static, read-only discovery from the authenticated jQuery frontend (role: VIEWER).
-> Base host `https://monitor.eg4electronics.com`; JS assets on `https://resource.solarcloudsystem.com`.
-> All app paths are prefixed with `baseUrl = /WManage` at runtime (shown here without it).
-> Serials / plant IDs / user IDs obfuscated. `(q)` = query-string param. `?` method = call site used a
-> wrapper/`$.ajax` where type was not co-located (page routes are GET HTML; data calls are POST unless noted).
+## Live-validated READ endpoints (2026-07-15)
 
-**Totals:** 186 distinct `/WManage/...` paths — **35 KNOWN** (in the 44-endpoint pylxpweb subset), **151 NEW**. ~55 write/control, ~52 server-rendered page routes, remainder JSON read endpoints.
+Confirmed to return a real typed JSON body via read-only calls; top-level response fields captured (values obfuscated). 21 are **NEW** (beyond `openapi.yaml`) and are candidates for promotion into the validated spec; the rest are already-KNOWN endpoints re-confirmed.
 
-## api: EV charge point  (2)
+| Endpoint | Top-level response fields (sample) |
+|---|---|
+| `/WManage/api/battery/renon/getRenonBatteryRuntime` | `dormantCount`, `hasRuntimeData`, `lost`, `offlineCount`, `onlineCount`, `serialNum`, `success` |
+| `/WManage/api/battery/renonAio/getRenonAioInfo` | `customVersionText`, `renonInDcdcModuleNumber`, `renonOutDcdcModuleNumber`, `renonSerialNum`, `renonSubBatNum`, `serialNum`, `success` |
+| `/WManage/api/battery/renonAio/getRenonAioRuntime` | `renonSubBatArray`, `serialNum`, `success` |
+| `/WManage/api/gen/exercise/getGenExerciseInfo` | `success`, `timezoneOffset` |
+| `/WManage/api/inverter/getGenResetInfo` | `genWorkTimeText`, `success` |
+| `/WManage/api/inverter/getInverterBatteryInfoParallel` | `batParallelNum`, `batShared`, `deviceArray`, `deviceCount`, `hasRuntimeData`, `lost`, `parallelEnabled`, `parallelGroup`, `parallelIndex`, `parallelModel`, `serialNum`, `success` |
+| `/WManage/api/inverter/getInverterInfo` | `address`, `allowExport2Grid`, `batteryType`, `datalogSn`, `deviceInfo`, `deviceType`, `deviceTypeText`, `dtc`, `fwVersion`, `hardwareVersion`, `inverterDetail`, `lost` |
+| `/WManage/api/inverter/getInverterRuntimeParallel` | `_12KAcCoupleInverterData`, `_12KAcCoupleInverterFlow`, `_12KUsingGenerator`, `_us_type6_phase3`, `batCapacity`, `batParallelNum`, `batPower`, `batShared`, `batteryColor`, `batteryType`, `bmsCharge`, `bmsDischarge` |
+| `/WManage/api/inverter/queryEpsOverloadRecoveryTime` | `msg`, `success` |
+| `/WManage/api/inverterOverview/list` | `rows`, `success`, `total` |
+| `/WManage/api/micro/monitor/getPlantRuntimeInfo` | `powerTotalText`, `rows`, `success`, `totalStationCo2Text`, `totalYieldingStationText` |
+| `/WManage/api/plant/getPlantInfo` | `address`, `continent`, `continentText`, `country`, `countryText`, `countrys`, `createDate`, `currencyUnit`, `currencyUnitSymbol`, `currencyUnitText`, `currentCountryIndex`, `currentRegionIndex` |
+| `/WManage/api/plantOverview/list` | `rows`, `success`, `total` |
+| `/WManage/api/system/cluster/search/findOnlineInverter` | `msg`, `success` |
+| `/WManage/api/system/cluster/search/viewerFindOnlineDevice` | `msg`, `success` |
+| `/WManage/api/tigo/getDeviceTigoInfo` | `success` |
+| `/WManage/web/config/datalog/getDongleInfo` | `datalogType`, `datalogTypeText`, `firmwareVersion`, `success` |
+| `/WManage/web/config/datalog/readInvInfo` | `msg`, `success` |
+| `/WManage/web/config/inverter/list` | `currentPageSize`, `offlineNum`, `onlineNum`, `rows`, `showAutoParallelButton`, `total` |
+| `/WManage/web/maintain/notification/showList` | `rows`, `success`, `total` |
+| `/WManage/web/maintain/remoteSetRecord/list` | `rows`, `success`, `total` |
+| `/WManage/web/maintain/standardUpdate/list` | `rows`, `success`, `total` |
+| `/WManage/web/maintain/template/list` | `rows`, `success`, `total` |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/chargePoint/getChargePointRunTime` | READ | NEW | clientType,inverterSn |
-| POST | `/api/chargePoint/realTime` | READ | NEW | inverterSn |
+## api: analyze  (16)
 
-## api: analyze/chart  (7)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/api/analyze/chart/analyzeParallelChartData` | READ | NEW |  | - |
+| POST | `/WManage/api/analyze/chart/dayLine` | READ | KNOWN |  | attr,dateText,serialNum |
+| POST | `/WManage/api/analyze/chart/dayMultiLine` | READ | NEW |  | - |
+| POST | `/WManage/api/analyze/chart/dayMultiLineParallel` | READ | NEW |  | ternary-concat: baseUrl + '/api/analyze/chart/dayMultiLine' + (showParallelData ? 'Parallel' : '') — js/monito |
+| GET | `/WManage/api/analyze/energy/columnDataExport` | READ | NEW |  | backtick template literal (not a quoted literal): window.open(`${baseUrl}/api/analyze/energy/columnDataExport? |
+| POST | `/WManage/api/analyze/energy/dayColumn` | READ | KNOWN |  |  |
+| POST | `/WManage/api/analyze/energy/monthColumn` | READ | KNOWN |  |  |
+| POST | `/WManage/api/analyze/energy/totalColumn` | READ | KNOWN |  |  |
+| POST | `/WManage/api/analyze/energy/yearColumn` | READ | KNOWN |  |  |
+| ? | `/WManage/api/analyze/event/list` | READ | KNOWN |  | - |
+| POST | `/WManage/api/inverterChart/monthColumn` | READ | KNOWN |  | - |
+| POST | `/WManage/api/inverterChart/monthColumnParallel` | READ | KNOWN |  | ternary-concat: baseUrl + '/api/inverterChart/monthColumn' + (showParallelData ? 'Parallel' : '') — js/monitor |
+| POST | `/WManage/api/inverterChart/totalColumn` | READ | NEW |  | - |
+| POST | `/WManage/api/inverterChart/totalColumnParallel` | READ | NEW |  | ternary-concat: baseUrl + '/api/inverterChart/totalColumn' + (showParallelData ? 'Parallel' : '') — js/monitor |
+| POST | `/WManage/api/inverterChart/yearColumn` | READ | NEW |  | - |
+| POST | `/WManage/api/inverterChart/yearColumnParallel` | READ | NEW |  | ternary-concat: baseUrl + '/api/inverterChart/yearColumn' + (showParallelData ? 'Parallel' : '') — js/monitor/ |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/api/analyze/chart/analyzeParallelChartData` | READ | NEW | - |
-| POST | `/api/analyze/chart/dayLine` | READ | KNOWN | attr,dateText,serialNum |
-| POST | `/api/analyze/chart/dayMultiLine` | READ | NEW | - |
-| ? | `/api/analyze/event/list` | READ | KNOWN | - |
-| POST | `/api/inverterChart/monthColumn` | READ | KNOWN | - |
-| POST | `/api/inverterChart/totalColumn` | READ | NEW | - |
-| POST | `/api/inverterChart/yearColumn` | READ | NEW | - |
+## api: battery  (6)
 
-## api: analyze/chart (predict)  (1)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/battery/getBatteryInfo` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/battery/getBatteryInfoForSet` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/battery/removeBatteryRuntime` | WRITE | NEW |  | batterySn,serialNum |
+| POST | `/WManage/api/battery/renon/getRenonBatteryRuntime` | READ | NEW | ✅ |  |
+| POST | `/WManage/api/battery/renonAio/getRenonAioInfo` | READ | NEW | ✅ |  |
+| POST | `/WManage/api/battery/renonAio/getRenonAioRuntime` | READ | NEW | ✅ |  |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/predict/solar/` | READ | KNOWN | - |
+## api: cluster/system  (5)
 
-## api: battery  (3)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/system/cluster/search` | READ | NEW |  | - |
+| POST | `/WManage/api/system/cluster/search/checkWarranty` | READ | NEW | · | serialNums |
+| POST | `/WManage/api/system/cluster/search/findOnlineDatalog` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/system/cluster/search/findOnlineInverter` | READ | NEW | ✅ | serialNum |
+| POST | `/WManage/api/system/cluster/search/viewerFindOnlineDevice` | READ | NEW | ✅ | plantId |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/battery/getBatteryInfo` | READ | KNOWN | serialNum |
-| POST | `/api/battery/getBatteryInfoForSet` | READ | KNOWN | serialNum |
-| POST | `/api/battery/removeBatteryRuntime` | WRITE | NEW | batterySn,serialNum |
+## api: forecast  (7)
 
-## api: googleHome  (2)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/predict/solar` | READ | NEW |  | - |
+| POST | `/WManage/api/predict/solar/dayPredictColumn` | READ | NEW |  | variable path-segment: const url = showParallelData?'dayPredictColumnParallel':'dayPredictColumn'; $.post(base |
+| POST | `/WManage/api/predict/solar/dayPredictColumnParallel` | READ | KNOWN |  | variable path-segment (parallel branch of the ternary) — js/monitor/inverter/predictionChart.js:57-58 |
+| POST | `/WManage/api/weather/forecast` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/weather/plant/clearLocation` | WRITE | NEW |  | plantId |
+| POST | `/WManage/api/weather/plant/forecast/manual` | READ | NEW |  | country,inputLocation |
+| POST | `/WManage/api/weather/plant/saveLocation` | WRITE | NEW |  | - |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| GET | `/api/googleHome/getDeviceSetting` | READ | NEW | serialNum |
-| POST | `/api/googleHome/saveDeviceSetting` | WRITE | NEW | - |
+## api: generator  (3)
 
-## api: gridboss / midbox  (4)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/gen/exercise/clearGenExerciseInfo` | WRITE | NEW |  | serialNum |
+| POST | `/WManage/api/gen/exercise/getGenExerciseInfo` | READ | NEW | ✅ | serialNum |
+| POST | `/WManage/api/gen/exercise/updateGenExerciseInfo` | WRITE | NEW |  | dayOfWeekLocal,hourMinuteLocal,serialNum |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/midbox/genQuickStart` | READ | NEW | - |
-| GET | `/api/midbox/genStatus` | READ | NEW | serialNum |
-| POST | `/api/midbox/genStop` | WRITE | NEW | clientType,serialNum |
-| POST | `/api/midbox/getMidboxRuntime` | READ | KNOWN | serialNum |
+## api: gridboss  (4)
 
-## api: inverter  (13)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/midbox/genQuickStart` | WRITE | NEW |  | - |
+| GET | `/WManage/api/midbox/genStatus` | READ | NEW |  | serialNum |
+| POST | `/WManage/api/midbox/genStop` | WRITE | NEW |  | clientType,serialNum |
+| POST | `/WManage/api/midbox/getMidboxRuntime` | READ | KNOWN |  | serialNum |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/inverter/autoParallel` | WRITE | KNOWN | plantId |
-| POST | `/api/inverter/ctrlBatteryBackup` | WRITE | NEW | clientType,enable,inverterSn |
-| POST | `/api/inverter/ctrlGenExercise` | WRITE | NEW | clientType,enable,inverterSn |
-| POST | `/api/inverter/ctrlGenResetTime` | WRITE | NEW | clientType,inverterSn |
-| POST | `/api/inverter/getGenResetInfo` | READ | NEW | inverterSn |
-| ? | `/api/inverter/getInverterBatteryInfoParallel` | READ | NEW | - |
-| POST | `/api/inverter/getInverterEnergyInfo` | READ | KNOWN | - |
-| POST | `/api/inverter/getInverterRuntime` | READ | KNOWN | serialNum |
-| POST | `/api/inverter/getInverterRuntimeParallel` | READ | NEW | serialNum |
-| POST | `/api/inverter/queryEpsOverloadRecoveryTime` | READ | NEW | inverterSn |
-| POST | `/api/inverter/transferData` | WRITE | NEW | fromClusterId,inverterSn |
-| POST | `/api/inverter/updateAdvancedSettings` | WRITE | NEW | allowExport2Grid,inverterSn |
-| POST | `/api/inverterOverview/getParallelGroupDetails` | READ | KNOWN | serialNum |
+## api: integrations  (8)
 
-## api: inverter (generator)  (3)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/chargePoint/getChargePointRunTime` | READ | NEW | · | clientType,inverterSn |
+| POST | `/WManage/api/chargePoint/realTime` | READ | NEW | · | inverterSn |
+| GET | `/WManage/api/googleHome/getDeviceSetting` | READ | NEW | · | serialNum |
+| POST | `/WManage/api/googleHome/saveDeviceSetting` | WRITE | NEW |  | - |
+| POST | `/WManage/api/phnix/getData` | READ | NEW |  | - |
+| POST | `/WManage/api/tigo/checkAuth` | READ | NEW |  | serialNum,tigoPassword,tigoUsername |
+| POST | `/WManage/api/tigo/getDeviceTigoInfo` | READ | NEW | ✅ | serialNum |
+| POST | `/WManage/api/tigo/updateDeviceTigoInfo` | WRITE | NEW |  | serialNum,systemId,tigoPassword,tigoUsername |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/gen/exercise/clearGenExerciseInfo` | WRITE | NEW | serialNum |
-| POST | `/api/gen/exercise/getGenExerciseInfo` | READ | NEW | serialNum |
-| POST | `/api/gen/exercise/updateGenExerciseInfo` | WRITE | NEW | dayOfWeekLocal,hourMinuteLocal,serialNum |
+## api: inverter/device  (19)
 
-## api: overview  (2)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/inverter/autoParallel` | WRITE | KNOWN |  | plantId |
+| POST | `/WManage/api/inverter/ctrlBatteryBackup` | WRITE | NEW |  | clientType,enable,inverterSn |
+| POST | `/WManage/api/inverter/ctrlGenExercise` | WRITE | NEW |  | clientType,enable,inverterSn |
+| POST | `/WManage/api/inverter/ctrlGenResetTime` | WRITE | NEW |  | clientType,inverterSn |
+| POST | `/WManage/api/inverter/getGenResetInfo` | READ | NEW | ✅ | inverterSn |
+| ? | `/WManage/api/inverter/getInverterBatteryInfoParallel` | READ | NEW | ✅ | - |
+| POST | `/WManage/api/inverter/getInverterEnergyInfo` | READ | KNOWN |  | - |
+| POST | `/WManage/api/inverter/getInverterEnergyInfoParallel` | READ | KNOWN |  | ternary-concat suffix: baseUrl + '/api/inverter/getInverterEnergyInfo' + (showParallelData ? 'Parallel' : '')  |
+| POST | `/WManage/api/inverter/getInverterInfo` | READ | KNOWN | ✅ |  |
+| POST | `/WManage/api/inverter/getInverterRuntime` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/inverter/getInverterRuntimeParallel` | READ | NEW | ✅ | serialNum |
+| POST | `/WManage/api/inverter/queryEpsOverloadRecoveryTime` | READ | NEW | ✅ | inverterSn |
+| POST | `/WManage/api/inverter/transferData` | WRITE | NEW |  | fromClusterId,inverterSn |
+| POST | `/WManage/api/inverter/updateAdvancedSettings` | WRITE | NEW |  | allowExport2Grid,inverterSn |
+| POST | `/WManage/api/inverterOverview/clearParallel` | WRITE | NEW |  |  |
+| POST | `/WManage/api/inverterOverview/editParallel` | WRITE | NEW |  |  |
+| POST | `/WManage/api/inverterOverview/export` | READ | NEW |  |  |
+| POST | `/WManage/api/inverterOverview/getParallelGroupDetails` | READ | KNOWN |  | serialNum |
+| POST | `/WManage/api/inverterOverview/list` | READ | KNOWN | ✅ |  |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| GET | `/api/plantOverview/export` | READ | NEW | searchText(q) |
-| ? | `/api/plantOverview/list/viewer` | READ | KNOWN | - |
+## api: microinverter  (2)
 
-## api: phnix (heat pump)  (1)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/micro/monitor/getInverterEnergyInfo` | READ | NEW |  |  |
+| POST | `/WManage/api/micro/monitor/getPlantRuntimeInfo` | READ | NEW | ✅ |  |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/phnix/getData` | READ | NEW | - |
+## api: plant  (4)
 
-## api: plant  (1)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/plant/getPlantInfo` | READ | NEW | ✅ | plantId |
+| GET | `/WManage/api/plantOverview/export` | READ | NEW |  | searchText(q) |
+| POST | `/WManage/api/plantOverview/list` | READ | NEW | ✅ |  |
+| ? | `/WManage/api/plantOverview/list/viewer` | READ | KNOWN |  | - |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/plant/getPlantInfo` | READ | NEW | plantId |
+## api: user/prefs  (9)
 
-## api: system / cluster  (5)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/api/user/getUserAppNoticeInfo` | READ | NEW | · |  |
+| POST | `/WManage/api/user/saveUserAppNoticeInfo` | WRITE | NEW |  |  |
+| POST | `/WManage/api/user/transferViewerDeviceData2StandAlone` | WRITE | NEW |  |  |
+| POST | `/WManage/api/userChartRecord/saveOrUpdateChartColor` | WRITE | NEW |  | - |
+| POST | `/WManage/api/userChartRecord/saveUserChartRecord` | WRITE | NEW |  | - |
+| ? | `/WManage/api/userFav/getUserFavPlantRecordList` | READ | NEW |  | clientType(q) |
+| POST | `/WManage/api/userFav/removeUserFavPlantRecord` | WRITE | NEW |  | plantId |
+| POST | `/WManage/api/userFav/saveUserFavPlantRecord` | WRITE | NEW |  | plantId,remarks |
+| POST | `/WManage/api/userVisit/update` | WRITE | NEW |  | plantId,serialNum |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/system/cluster/search/` | READ | NEW | - |
-| POST | `/api/system/cluster/search/checkWarranty` | READ | NEW | serialNums |
-| POST | `/api/system/cluster/search/findOnlineDatalog` | READ | KNOWN | serialNum |
-| POST | `/api/system/cluster/search/findOnlineInverter` | READ | NEW | serialNum |
-| POST | `/api/system/cluster/search/viewerFindOnlineDevice` | READ | NEW | plantId |
+## auth/locale  (4)
 
-## api: tigo (optimizer)  (3)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/authCode` | READ | NEW |  | authCode |
+| POST | `/WManage/locale` | WRITE | NEW |  | language |
+| POST | `/WManage/locale/country` | READ | KNOWN |  | region |
+| POST | `/WManage/locale/region` | READ | KNOWN |  | continent |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/tigo/checkAuth` | READ | NEW | serialNum,tigoPassword,tigoUsername |
-| POST | `/api/tigo/getDeviceTigoInfo` | READ | NEW | serialNum |
-| POST | `/api/tigo/updateDeviceTigoInfo` | WRITE | NEW | serialNum,systemId,tigoPassword,tigoUsername |
+## web: analyze  (18)
 
-## api: user prefs  (6)
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/analyze/battery/renonData` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/chart` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/chartCompare` | PAGE | NEW |  | - |
+| GET | `/WManage/web/analyze/chartCompareMidBox` | PAGE | NEW |  |  |
+| ? | `/WManage/web/analyze/chartMidBox` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/data` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/data/export` | READ | NEW |  | - |
+| GET | `/WManage/web/analyze/data/export/{serialNum}/{date}` | READ | NEW |  | mid-path variable segments passed to downloadFile()->fetch(): baseUrl + '/web/analyze/data/export/' + combogri |
+| ? | `/WManage/web/analyze/data/export1` | READ | NEW |  | - |
+| POST | `/WManage/web/analyze/data/{date}` | READ | NEW |  | mid-path variable segment (EasyUI datagrid url, defaults POST): baseUrl + '/web/analyze/data/' + selectDateTex |
+| ? | `/WManage/web/analyze/energy` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/energy/exportData` | READ | NEW |  | serialNum(q) |
+| ? | `/WManage/web/analyze/event` | PAGE | NEW |  | - |
+| ? | `/WManage/web/analyze/event/export` | READ | NEW |  | eventText(q),plantId(q) |
+| POST | `/WManage/web/analyze/event/remove` | WRITE | NEW |  | recordId |
+| ? | `/WManage/web/analyze/localData` | PAGE | NEW |  | - |
+| GET | `/WManage/web/analyze/localData/export` | READ | NEW |  |  |
+| GET | `/WManage/web/analyze/localData/list` | READ | NEW |  |  |
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/userChartRecord/saveOrUpdateChartColor` | WRITE | NEW | - |
-| POST | `/api/userChartRecord/saveUserChartRecord` | WRITE | NEW | - |
-| ? | `/api/userFav/getUserFavPlantRecordList` | READ | NEW | clientType(q) |
-| POST | `/api/userFav/removeUserFavPlantRecord` | WRITE | NEW | plantId |
-| POST | `/api/userFav/saveUserFavPlantRecord` | WRITE | NEW | plantId,remarks |
-| POST | `/api/userVisit/update` | WRITE | NEW | plantId,serialNum |
+## web: config  (35)
 
-## api: weather  (4)
-
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/api/weather/forecast` | READ | KNOWN | serialNum |
-| POST | `/api/weather/plant/clearLocation` | WRITE | NEW | plantId |
-| POST | `/api/weather/plant/forecast/manual` | READ | NEW | country,inputLocation |
-| POST | `/api/weather/plant/saveLocation` | WRITE | NEW | - |
-
-## web: analyze  (14)
-
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/analyze/battery/renonData` | READ (page) | NEW | - |
-| ? | `/web/analyze/chart` | READ (page) | NEW | - |
-| ? | `/web/analyze/chartCompare` | READ (page) | NEW | - |
-| ? | `/web/analyze/chartMidBox` | READ (page) | NEW | - |
-| ? | `/web/analyze/data` | READ (page) | NEW | - |
-| ? | `/web/analyze/data/` | READ (page) | NEW | - |
-| ? | `/web/analyze/data/export/` | READ | KNOWN | - |
-| ? | `/web/analyze/data/export1/` | READ | NEW | - |
-| ? | `/web/analyze/energy` | READ (page) | NEW | - |
-| ? | `/web/analyze/energy/exportData` | READ | NEW | serialNum(q) |
-| ? | `/web/analyze/event` | READ (page) | NEW | - |
-| ? | `/web/analyze/event/export` | READ | NEW | eventText(q),plantId(q) |
-| POST | `/web/analyze/event/remove` | WRITE | NEW | recordId |
-| ? | `/web/analyze/localData` | READ (page) | NEW | - |
-
-## web: config  (33)
-
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/config/datalog` | READ (page) | NEW | - |
-| POST | `/web/config/datalog/add` | WRITE | NEW | plantId,serialNum,verifyCode |
-| POST | `/web/config/datalog/checkUpdates` | READ | NEW | - |
-| POST | `/web/config/datalog/edit` | WRITE | NEW | plantId,serialNum |
-| ? | `/web/config/datalog/export` | READ | NEW | - |
-| POST | `/web/config/datalog/getAllFirmwares` | READ | NEW | datalogType |
-| POST | `/web/config/datalog/getDongleInfo` | READ | NEW | serialNum |
-| ? | `/web/config/datalog/list` | READ | KNOWN | - |
-| POST | `/web/config/datalog/readInvInfo` | READ | NEW | serialNum |
-| POST | `/web/config/datalog/removeWithPin` | WRITE | NEW | - |
-| POST | `/web/config/datalog/updateFirmware` | WRITE | NEW | dongleFirmware,serialNum |
-| ? | `/web/config/datalog/upload` | READ (page) | NEW | - |
-| ? | `/web/config/inverter` | READ (page) | NEW | - |
-| POST | `/web/config/inverter/bindChargePoint` | WRITE | NEW | chargePointSn,productType,serialNum |
-| ? | `/web/config/inverter/bmsMinCellVoltExport` | READ | NEW | bmsMinCellVoltMin(q) |
-| POST | `/web/config/inverter/clearBindConnection` | WRITE | NEW | serialNum |
-| POST | `/web/config/inverter/getChargePointBySn` | READ | NEW | serialNum |
-| ? | `/web/config/inverter/list` | READ | NEW | - |
-| POST | `/web/config/inverter/remove` | WRITE | NEW | serialNum |
-| POST | `/web/config/inverter/updateUsedAtCustomerDate` | WRITE | NEW | password,serialNum,usedAtCustomerDate |
-| ? | `/web/config/plant` | READ (page) | NEW | - |
-| ? | `/web/config/plant/edit/` | READ (page) | KNOWN | - |
-| POST | `/web/config/plant/editNotice` | WRITE | NEW | noticeEmail,noticeEmail2,noticeType,plantId |
-| ? | `/web/config/plant/editPlantImage/` | READ (page) | NEW | - |
-| ? | `/web/config/plant/export` | READ | NEW | - |
-| ? | `/web/config/plant/exportInverterType` | READ | NEW | page(q) |
-| ? | `/web/config/plant/list/viewer` | READ | KNOWN | - |
-| POST | `/web/config/plant/remove` | WRITE | NEW | plantId |
-| POST | `/web/config/quickCharge/getStatusInfo` | READ | KNOWN | inverterSn |
-| POST | `/web/config/quickCharge/start` | WRITE | KNOWN | - |
-| POST | `/web/config/quickCharge/stop` | WRITE | KNOWN | clientType,inverterSn |
-| POST | `/web/config/quickDischarge/start` | WRITE | KNOWN | clientType,inverterSn |
-| POST | `/web/config/quickDischarge/stop` | WRITE | KNOWN | clientType,inverterSn |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/config/datalog` | PAGE | NEW |  | - |
+| POST | `/WManage/web/config/datalog/add` | WRITE | NEW |  | plantId,serialNum,verifyCode |
+| POST | `/WManage/web/config/datalog/checkUpdates` | READ | NEW |  | - |
+| POST | `/WManage/web/config/datalog/edit` | WRITE | NEW |  | plantId,serialNum |
+| ? | `/WManage/web/config/datalog/export` | READ | NEW |  | - |
+| POST | `/WManage/web/config/datalog/getAllFirmwares` | READ | NEW |  | datalogType |
+| POST | `/WManage/web/config/datalog/getDongleInfo` | READ | NEW | ✅ | serialNum |
+| ? | `/WManage/web/config/datalog/list` | READ | KNOWN |  | - |
+| POST | `/WManage/web/config/datalog/readInvInfo` | READ | NEW | ✅ | serialNum |
+| POST | `/WManage/web/config/datalog/removeWithPin` | WRITE | NEW |  | - |
+| POST | `/WManage/web/config/datalog/updateFirmware` | WRITE | NEW |  | dongleFirmware,serialNum |
+| ? | `/WManage/web/config/datalog/upload` | WRITE | NEW |  | - |
+| ? | `/WManage/web/config/inverter` | PAGE | NEW |  | - |
+| POST | `/WManage/web/config/inverter/bindChargePoint` | WRITE | NEW |  | chargePointSn,productType,serialNum |
+| ? | `/WManage/web/config/inverter/bmsMinCellVoltExport` | READ | NEW |  | bmsMinCellVoltMin(q) |
+| POST | `/WManage/web/config/inverter/clearBindConnection` | WRITE | NEW |  | serialNum |
+| POST | `/WManage/web/config/inverter/getChargePointBySn` | READ | NEW | · | serialNum |
+| ? | `/WManage/web/config/inverter/list` | READ | NEW | ✅ | - |
+| POST | `/WManage/web/config/inverter/remove` | WRITE | NEW |  | serialNum |
+| POST | `/WManage/web/config/inverter/updateUsedAtCustomerDate` | WRITE | NEW |  | password,serialNum,usedAtCustomerDate |
+| ? | `/WManage/web/config/plant` | PAGE | NEW |  | - |
+| ? | `/WManage/web/config/plant/edit` | WRITE | KNOWN |  | - |
+| GET | `/WManage/web/config/plant/edit/{plantId}` | PAGE | NEW |  | dynamic href/window.open baseUrl+ edit page (web_config_plant.html:241,259, web_maintain_weatherSet.html:259) |
+| POST | `/WManage/web/config/plant/editNotice` | WRITE | NEW |  | noticeEmail,noticeEmail2,noticeType,plantId |
+| ? | `/WManage/web/config/plant/editPlantImage` | WRITE | NEW |  | - |
+| GET | `/WManage/web/config/plant/editPlantImage/{plantId}` | PAGE | NEW |  | dynamic href baseUrl+ picture-edit page (web_config_plant.html:240) |
+| ? | `/WManage/web/config/plant/export` | READ | NEW |  | - |
+| ? | `/WManage/web/config/plant/exportInverterType` | READ | NEW |  | page(q) |
+| ? | `/WManage/web/config/plant/list/viewer` | READ | KNOWN |  | - |
+| POST | `/WManage/web/config/plant/remove` | WRITE | NEW |  | plantId |
+| POST | `/WManage/web/config/quickCharge/getStatusInfo` | READ | KNOWN |  | inverterSn |
+| POST | `/WManage/web/config/quickCharge/start` | WRITE | KNOWN |  | - |
+| POST | `/WManage/web/config/quickCharge/stop` | WRITE | KNOWN |  | clientType,inverterSn |
+| POST | `/WManage/web/config/quickDischarge/start` | WRITE | KNOWN |  | clientType,inverterSn |
+| POST | `/WManage/web/config/quickDischarge/stop` | WRITE | KNOWN |  | clientType,inverterSn |
 
 ## web: inverter  (1)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/web/inverter/debugqna/startAnalyse` | WRITE | NEW | - |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/web/inverter/debugqna/startAnalyse` | WRITE | NEW |  | - |
 
 ## web: login  (3)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/login` | READ (page) | KNOWN | - |
-| ? | `/web/login/clusterLoginForward` | READ (page) | NEW | clusterLoginKey(q) |
-| ? | `/web/login/viewDemoPlant` | READ (page) | NEW | customCompany(q) |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/login` | PAGE | NEW |  | - |
+| ? | `/WManage/web/login/clusterLoginForward` | READ | NEW |  | clusterLoginKey(q) |
+| ? | `/WManage/web/login/viewDemoPlant` | PAGE | NEW |  | customCompany(q) |
 
 ## web: logout  (1)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/logout` | READ (page) | NEW | - |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/logout` | PAGE | NEW |  | - |
 
-## web: maintain  (51)
+## web: maintain  (72)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/maintain/battUpdate` | READ (page) | NEW | - |
-| POST | `/web/maintain/notification/showList` | READ | NEW | deviceType,page,rows |
-| POST | `/web/maintain/readDatalogParam/read` | READ | NEW | datalogParam,datalogSn |
-| POST | `/web/maintain/remoteRead/midDiff` | READ | NEW | inverterSn |
-| POST | `/web/maintain/remoteRead/read` | READ | KNOWN | autoRetry,inverterSn,pointNumber,startRegister |
-| POST | `/web/maintain/remoteRead/readInput` | READ | NEW | inverterSn |
-| POST | `/web/maintain/remoteRead/readMultiBitParam` | READ | NEW | inverterSn |
-| ? | `/web/maintain/remoteSet` | READ (page) | NEW | - |
-| POST | `/web/maintain/remoteSet/bitModelParamControl` | READ | NEW | clientType,inverterSn,modelBitParam,remoteSetType,value |
-| POST | `/web/maintain/remoteSet/bitParamControl` | READ | KNOWN | bitParam,clientType,inverterSn,remoteSetType,value |
-| POST | `/web/maintain/remoteSet/functionControl` | READ | KNOWN | clientType,enable,functionParam,inverterSn,remoteSetType |
-| POST | `/web/maintain/remoteSet/reset` | WRITE | NEW | clientType,inverterSn,remoteSetType,resetParam |
-| POST | `/web/maintain/remoteSet/wattNode/read` | READ | NEW | inverterSn |
-| POST | `/web/maintain/remoteSet/wattNode/write` | WRITE | NEW | inverterSn |
-| POST | `/web/maintain/remoteSet/write` | WRITE | KNOWN | clientType,holdParam,inverterSn,remoteSetType,valueText |
-| POST | `/web/maintain/remoteSet/writeG98ValueForINF01` | WRITE | NEW | clientType,inverterSn,remoteSetType |
-| POST | `/web/maintain/remoteSet/writeModel` | WRITE | NEW | batteryType,inverterSn,leadAcidType,measurement,meterBrand,meterType,ruleMask,usVersion,wirelessMeter |
-| POST | `/web/maintain/remoteSet/writeModelByDeviceType` | WRITE | NEW | clientType,deviceType,inverterSn,remoteSetType |
-| POST | `/web/maintain/remoteSet/writeMultiBitParam` | WRITE | NEW | - |
-| POST | `/web/maintain/remoteSet/writeMultiValue` | WRITE | NEW | - |
-| POST | `/web/maintain/remoteSet/writePartModel` | WRITE | NEW | - |
-| POST | `/web/maintain/remoteSet/writeTime` | WRITE | KNOWN | clientType,hour,inverterSn,minute,remoteSetType,timeParam |
-| ? | `/web/maintain/remoteSet12K` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetAllInOne` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetLsp` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetMidbox` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetOffGrid` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetRecord` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteSetWeekly` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteTransfer/export` | READ | NEW | exportType(q),serialNum(q) |
-| POST | `/web/maintain/remoteTransfer/refreshInputData` | WRITE | NEW | inverterSn |
-| POST | `/web/maintain/remoteTransfer/sendReadInputCommand` | WRITE | NEW | index,inverterSn |
-| ? | `/web/maintain/remoteUpdate` | READ (page) | NEW | - |
-| ? | `/web/maintain/remoteUpdate/cancel` | WRITE | NEW | serialNum,userId |
-| ? | `/web/maintain/remoteUpdate/info` | READ | KNOWN | userId |
-| ? | `/web/maintain/remoteUpdate/run` | WRITE | NEW | serialNums,tryFastMode,userId |
-| ? | `/web/maintain/remoteUpdate/upload` | WRITE | NEW | - |
-| ? | `/web/maintain/setupWizard` | READ (page) | NEW | serialNum(q) |
-| ? | `/web/maintain/standardUpdate/check12KParallelStatus` | READ | KNOWN | serialNum,userId |
-| POST | `/web/maintain/standardUpdate/checkUpdates` | READ | KNOWN | serialNum |
-| ? | `/web/maintain/standardUpdate/list` | READ (page) | NEW | - |
-| ? | `/web/maintain/standardUpdate/run` | WRITE | KNOWN | serialNum,tryFastMode,userId |
-| POST | `/web/maintain/template/importTemplate` | WRITE | NEW | inverterSn,templateId |
-| POST | `/web/maintain/template/list` | READ | NEW | deviceType,dtc,machineType,odm,phase,powerRating,usVersion,voltClass |
-| ? | `/web/maintain/weatherSet` | READ (page) | NEW | - |
-| ? | `/web/maintain/workingMode/12k` | READ (page) | NEW | - |
-| ? | `/web/maintain/workingMode/eqb` | READ (page) | NEW | - |
-| ? | `/web/maintain/workingMode/hybrid` | READ (page) | NEW | - |
-| ? | `/web/maintain/workingMode/midbox` | READ (page) | NEW | - |
-| ? | `/web/maintain/workingMode/sna` | READ (page) | NEW | - |
-| POST | `/web/maintain/writeDatalogParam/write` | WRITE | NEW | clientType,datalogParam,datalogSn,remoteSetType,valueText |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| GET | `/WManage/web/maintain` | PAGE | NEW |  |  |
+| ? | `/WManage/web/maintain/battUpdate` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/battUpdate/run` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/notification/showList` | READ | NEW | ✅ | deviceType,page,rows |
+| POST | `/WManage/web/maintain/readDatalogParam/read` | READ | NEW |  | datalogParam,datalogSn |
+| POST | `/WManage/web/maintain/remoteRead/midDiff` | READ | NEW |  | inverterSn |
+| POST | `/WManage/web/maintain/remoteRead/read` | READ | KNOWN |  | autoRetry,inverterSn,pointNumber,startRegister |
+| POST | `/WManage/web/maintain/remoteRead/readInput` | READ | NEW |  | inverterSn |
+| POST | `/WManage/web/maintain/remoteRead/readMultiBitParam` | READ | NEW |  | inverterSn |
+| ? | `/WManage/web/maintain/remoteSet` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSet/bitModelParamControl` | WRITE | NEW |  | clientType,inverterSn,modelBitParam,remoteSetType,value |
+| POST | `/WManage/web/maintain/remoteSet/bitParamControl` | WRITE | KNOWN |  | bitParam,clientType,inverterSn,remoteSetType,value |
+| POST | `/WManage/web/maintain/remoteSet/functionControl` | WRITE | KNOWN |  | clientType,enable,functionParam,inverterSn,remoteSetType |
+| POST | `/WManage/web/maintain/remoteSet/reset` | WRITE | NEW |  | clientType,inverterSn,remoteSetType,resetParam |
+| POST | `/WManage/web/maintain/remoteSet/wattNode/read` | READ | NEW |  | inverterSn |
+| POST | `/WManage/web/maintain/remoteSet/wattNode/write` | WRITE | NEW |  | inverterSn |
+| POST | `/WManage/web/maintain/remoteSet/write` | WRITE | KNOWN |  | clientType,holdParam,inverterSn,remoteSetType,valueText |
+| POST | `/WManage/web/maintain/remoteSet/writeG98ValueForINF01` | WRITE | NEW |  | clientType,inverterSn,remoteSetType |
+| POST | `/WManage/web/maintain/remoteSet/writeModel` | WRITE | NEW |  | batteryType,inverterSn,leadAcidType,measurement,meterBrand,meterType,ruleMask,usVersion,wirelessMeter |
+| POST | `/WManage/web/maintain/remoteSet/writeModelByDeviceType` | WRITE | NEW |  | clientType,deviceType,inverterSn,remoteSetType |
+| POST | `/WManage/web/maintain/remoteSet/writeMultiBitParam` | WRITE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSet/writeMultiValue` | WRITE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSet/writePartModel` | WRITE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSet/writeTime` | WRITE | KNOWN |  | clientType,hour,inverterSn,minute,remoteSetType,timeParam |
+| ? | `/WManage/web/maintain/remoteSet12K` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/remoteSetAllInOne` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSetBatt/multiResetControl` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/remoteSetBatt/writeMultiSocValue` | WRITE | NEW |  |  |
+| ? | `/WManage/web/maintain/remoteSetLsp` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSetLsp/bitHoldControl` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/remoteSetLsp/bitHoldControlLspReg26` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/remoteSetLsp/writeMultiHoldValue` | WRITE | NEW |  |  |
+| ? | `/WManage/web/maintain/remoteSetMidbox` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/remoteSetOffGrid` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/remoteSetRecord` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteSetRecord/export` | READ | NEW |  |  |
+| POST | `/WManage/web/maintain/remoteSetRecord/list` | READ | NEW | ✅ |  |
+| ? | `/WManage/web/maintain/remoteSetWeekly` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/remoteTransfer/export` | READ | NEW |  | exportType(q),serialNum(q) |
+| POST | `/WManage/web/maintain/remoteTransfer/refreshInputData` | WRITE | NEW |  | inverterSn |
+| POST | `/WManage/web/maintain/remoteTransfer/sendReadInputCommand` | WRITE | NEW |  | index,inverterSn |
+| ? | `/WManage/web/maintain/remoteUpdate` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/remoteUpdate/cancel` | WRITE | NEW |  | serialNum,userId |
+| ? | `/WManage/web/maintain/remoteUpdate/info` | READ | KNOWN |  | userId |
+| ? | `/WManage/web/maintain/remoteUpdate/run` | WRITE | NEW |  | serialNums,tryFastMode,userId |
+| ? | `/WManage/web/maintain/remoteUpdate/upload` | WRITE | NEW |  | - |
+| POST | `/WManage/web/maintain/remoteWeeklyOperation/readValues` | READ | NEW |  | dynamic-concat: var urlSuffix='remoteRead/read'; if(startRegister>=500) urlSuffix='remoteWeeklyOperation/readV |
+| POST | `/WManage/web/maintain/remoteWeeklyOperation/setValues` | WRITE | NEW |  |  |
+| ? | `/WManage/web/maintain/setupWizard` | PAGE | NEW |  | serialNum(q) |
+| ? | `/WManage/web/maintain/standardUpdate/check12KParallelStatus` | READ | KNOWN |  | serialNum,userId |
+| POST | `/WManage/web/maintain/standardUpdate/checkUpdates` | READ | KNOWN |  | serialNum |
+| ? | `/WManage/web/maintain/standardUpdate/list` | READ | NEW | ✅ | - |
+| ? | `/WManage/web/maintain/standardUpdate/run` | WRITE | KNOWN |  | serialNum,tryFastMode,userId |
+| POST | `/WManage/web/maintain/template/importTemplate` | WRITE | NEW |  | inverterSn,templateId |
+| POST | `/WManage/web/maintain/template/list` | READ | NEW | ✅ | deviceType,dtc,machineType,odm,phase,powerRating,usVersion,voltClass |
+| ? | `/WManage/web/maintain/weatherSet` | PAGE | NEW |  | - |
+| POST | `/WManage/web/maintain/weatherSet/addDevice` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/weatherSet/disableDevice` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/weatherSet/edit` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/weatherSet/enableDevice` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/weatherSet/inverter/list` | READ | NEW |  | easyui datagrid url= attr (web_maintain_weatherSet.html:641) |
+| POST | `/WManage/web/maintain/weatherSet/removeDevice` | WRITE | NEW |  |  |
+| POST | `/WManage/web/maintain/weatherSet/setDetail/list` | READ | NEW |  | easyui datagrid url= attr (web_maintain_weatherSet.html:1196) |
+| POST | `/WManage/web/maintain/weatherSet/setResult/viewerList` | READ | NEW |  | easyui datagrid url= attr (web_maintain_weatherSet.html:663) |
+| GET | `/WManage/web/maintain/workingMode` | PAGE | NEW |  |  |
+| ? | `/WManage/web/maintain/workingMode/12k` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/workingMode/eqb` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/workingMode/hybrid` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/workingMode/midbox` | PAGE | NEW |  | - |
+| ? | `/WManage/web/maintain/workingMode/sna` | PAGE | NEW |  | - |
+| GET | `/WManage/web/maintain/workingMode?serialNum={sn}` | PAGE | NEW |  | window.open baseUrl+ (web_maintain_remoteSet12K.html:519) |
+| POST | `/WManage/web/maintain/writeDatalogParam/write` | WRITE | NEW |  | clientType,datalogParam,datalogSn,remoteSetType,valueText |
 
-## web: monitor  (5)
+## web: monitor  (7)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/monitor/battery/zrgp` | READ (page) | NEW | - |
-| ? | `/web/monitor/battery/zrgpAio` | READ (page) | NEW | - |
-| ? | `/web/monitor/inverter` | READ (page) | NEW | - |
-| ? | `/web/monitor/lsp/inverter` | READ (page) | NEW | serialNum(q) |
-| ? | `/web/monitor/micro/inverter` | READ (page) | NEW | - |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/monitor/battery/zrgp` | PAGE | NEW |  | - |
+| ? | `/WManage/web/monitor/battery/zrgpAio` | PAGE | NEW |  | - |
+| ? | `/WManage/web/monitor/inverter` | PAGE | NEW |  | - |
+| ? | `/WManage/web/monitor/lsp/inverter` | PAGE | NEW |  | serialNum(q) |
+| ? | `/WManage/web/monitor/micro/inverter` | PAGE | NEW |  | - |
+| POST | `/WManage/web/monitor/micro/inverter/getMicroDeviceLayoutRecordJsonData` | READ | NEW |  |  |
+| POST | `/WManage/web/monitor/micro/inverter/save` | WRITE | NEW |  |  |
 
 ## web: overview  (3)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/overview/global` | READ (page) | NEW | - |
-| ? | `/web/overview/globalPlant` | READ (page) | NEW | - |
-| ? | `/web/overview/plant` | READ (page) | NEW | autoSelectPlant(q) |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/overview/global` | PAGE | NEW |  | - |
+| ? | `/WManage/web/overview/globalPlant` | PAGE | NEW |  | - |
+| ? | `/WManage/web/overview/plant` | PAGE | NEW |  | autoSelectPlant(q) |
 
 ## web: register  (6)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| ? | `/web/register` | READ (page) | NEW | - |
-| POST | `/web/register/checkDatalogSnValidForRegister` | READ | NEW | datalogSn |
-| POST | `/web/register/isAccountExist` | READ | NEW | account |
-| POST | `/web/register/isCheckCodeMatch` | READ | NEW | checkCode,datalogSn |
-| POST | `/web/register/isCustomerCodeExist` | READ | NEW | customerCode |
-| ? | `/web/register/viewer` | READ (page) | NEW | - |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| ? | `/WManage/web/register` | PAGE | NEW |  | - |
+| POST | `/WManage/web/register/checkDatalogSnValidForRegister` | READ | NEW |  | datalogSn |
+| POST | `/WManage/web/register/isAccountExist` | READ | NEW |  | account |
+| POST | `/WManage/web/register/isCheckCodeMatch` | READ | NEW |  | checkCode,datalogSn |
+| POST | `/WManage/web/register/isCustomerCodeExist` | READ | NEW |  | customerCode |
+| ? | `/WManage/web/register/viewer` | WRITE | NEW |  | - |
 
-## web: system  (8)
+## web: system  (18)
 
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/web/system/cluster/buildClusterKey` | WRITE | NEW | serverClusterId |
-| ? | `/web/system/user` | READ (page) | NEW | - |
-| ? | `/web/system/user/center` | READ (page) | NEW | - |
-| POST | `/web/system/user/getUseNewSettingPageValue` | READ | NEW | userId |
-| ? | `/web/system/user/modifyPassword/{userId}` | READ (page) | NEW | - |
-| ? | `/web/system/user/preferences/{userId}` | READ (page) | NEW | - |
-| POST | `/web/system/user/useNewSettingPage` | WRITE | NEW | useWorkingModePage,userId |
-| ? | `/web/system/user/userSet` | READ (page) | NEW | - |
-
-## auth / locale  (4)
-
-| Method | Endpoint (under /WManage) | R/W | Known? | Params |
-|---|---|---|---|---|
-| POST | `/authCode` | READ | NEW | authCode |
-| POST | `/locale` | READ | NEW | language |
-| POST | `/locale/country` | READ | KNOWN | region |
-| POST | `/locale/region` | READ | KNOWN | continent |
+| Method | Endpoint | R/W | Known? | Live | Notes / params |
+|---|---|---|---|---|---|
+| POST | `/WManage/web/system/cluster/buildClusterKey` | WRITE | NEW |  | serverClusterId |
+| POST | `/WManage/web/system/installer/pointDetail/list` | READ | NEW |  | easyui datagrid url= attr (web_system_user_userSet.html:1213) |
+| POST | `/WManage/web/system/installer/revoke` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/serverEvent/save` | WRITE | NEW |  |  |
+| ? | `/WManage/web/system/user` | PAGE | NEW |  | - |
+| ? | `/WManage/web/system/user/center` | PAGE | NEW |  | - |
+| POST | `/WManage/web/system/user/changeUserCustomerCode` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/user/changeUserTargetCluster` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/user/enable` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/user/getUseNewSettingPageValue` | READ | NEW |  | userId |
+| ? | `/WManage/web/system/user/modifyPassword/{userId}` | READ | NEW |  | - |
+| ? | `/WManage/web/system/user/preferences/{userId}` | READ | NEW |  | - |
+| POST | `/WManage/web/system/user/remove` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/user/useNewSettingPage` | WRITE | NEW |  | useWorkingModePage,userId |
+| ? | `/WManage/web/system/user/userSet` | PAGE | NEW |  | - |
+| POST | `/WManage/web/system/userMigration/getRecords` | READ | NEW |  | easyui datagrid url= attr (web_system_user_userSet.html:1082) |
+| POST | `/WManage/web/system/userMigration/save` | WRITE | NEW |  |  |
+| POST | `/WManage/web/system/userQrcode/generate` | WRITE | NEW |  |  |
 
 ---
 
-## Crawl provenance
+## Provenance & completeness
 
-**Authenticated pages fetched (HTTP 200 unless noted), `/WManage/web/...`:**
-monitor/inverter, overview/global, config/plant, config/inverter, config/datalog,
-analyze/chart, analyze/data, analyze/event, maintain/remoteUpdate, system/user/center,
-maintain/workingMode/12k (281 KB — the inverter Remote Set page; `maintain/remoteSet` and
-`maintain/workingMode/hybrid` both **302→ workingMode/12k**), maintain/workingMode/midbox
-(351 KB — the GridBOSS/MID Remote Set page), plus unauthenticated login + register pages.
-
-**404 (route does not exist):** monitor/plantList, config/user, maintain/standardUpdate, manage/user,
-workingMode/{acdc,lv,ac,18k,15k,parallel,gridboss}.
-**405 (POST-only, not GET-reachable):** maintain/notification/showList, system/user/list.
-
-**JavaScript analysed:** 64 app JS files under `/WManage/web/js/` (every `<script src>` referenced by the
-crawled pages), fetched from `resource.solarcloudsystem.com` at `?v=2.7.3.1`. Key files for the control surface:
-`maintain/remoteSet12K/workingMode2/remoteCtrlCommon2.js`, `maintain/remoteSetMidbox/workingMode2/remoteCtrlCommonMidbox.js`,
-`maintain/remoteSet/remoteModelSet.js`, `maintain/remoteUpdate/remoteUpdate.js`, `monitor/inverter/monitor_ctrls.js`,
-`config/device/inverter/modal/inverterConfigModal.js`, `config/device/datalog/modal/datalogConfigModal.js`,
-`login/register.js`, `format/headerMenu.js`.
-
-## KNOWN endpoints NOT surfaced by the VIEWER frontend (used by pylxpweb / admin roles only)
-
-These 9 of the 44 documented endpoints never appear in the VIEWER-role JS (the frontend uses different
-sibling calls, or they are owner/admin/installer-only, or API-client-only):
-
-- `plant/list` — VIEWER frontend only ever calls `config/plant/list/viewer`.
-- `inverterOverview/list` — frontend uses `inverterOverview/getParallelGroupDetails` + `system/cluster/search/viewerFindOnlineDevice`.
-- `inverter/getInverterInfo` — not called; frontend uses `getInverterRuntime`/`getInverterEnergyInfo`.
-- `inverter/getInverterEnergyInfoParallel` — frontend has `getInverterRuntimeParallel` + `getInverterBatteryInfoParallel` instead.
-- `inverterChart/monthColumnParallel` — only non-parallel `monthColumn`/`yearColumn`/`totalColumn` are wired in `tab_chart_*.js`.
-- `analyze/energy/dayColumn`, `analyze/energy/monthColumn`, `analyze/energy/yearColumn`, `analyze/energy/totalColumn`
-  — this portal build routes energy columns through `/api/inverterChart/*Column` instead; the `analyze/energy/*Column`
-  path family is not referenced.
-
-(`/api/login` — pylxpweb's auth path — is not in the JS either; the browser login form POSTs to `/web/login`.
-`locale/region` and `locale/country` DO appear, on the register page, as `baseUrl + /locale/region|country`.)
-
-## Role gating (VIEWER)
-
-The logged-in account is **VIEWER**. Owner/installer-only sections return 404/405 or are absent from the menu
-(no `manage/*`, no `config/user`, no user-admin list). The Remote Set / Working Mode / Remote Update / firmware pages
-ARE reachable and their full write/control JS is present, so the control endpoints below were catalogued from source
-**without being invoked**. Endpoints marked WRITE were NOT exercised.
-
-## Dynamic / concatenated endpoints resolved
-
-- `/api/predict/solar/` + `{dayPredictColumn | dayPredictColumnParallel}` (predictionChart.js).
-- `/api/system/cluster/search/` + `{findOnlineDatalog | findOnlineInverter | viewerFindOnlineDevice | checkWarranty}` (built dynamically in deviceClusterModal.js).
-- `/web/analyze/data/export/` and `/web/analyze/data/export1/` take trailing path segments (export type/format).
-- `/web/config/plant/edit/{plantId}`, `/web/config/plant/editPlantImage/{plantId}`, `/web/system/user/modifyPassword/{userId}`, `/web/system/user/preferences/{userId}` are RESTish path-param routes.
+- Crawl date 2026-07-15, role VIEWER. 251 distinct endpoints from page HTML + 104 JS files.
+- Extraction covered literal paths **and** indirect construction (ternary/variable path
+  segments, backtick templates, `fetch()`/`downloadFile()` exports, form `action=` targets) —
+  a completeness sweep across three independent static-analysis passes surfaced the `*Parallel`
+  chart/energy/runtime variants, `predict/solar/dayPredictColumn(Parallel)`,
+  `remoteWeeklyOperation/readValues`, `analyze/energy/columnDataExport`, and the export GETs
+  that a quoted-literal scan alone missed.
+- **Not covered (would need more roles / capture):** endpoints reachable only from
+  owner/installer/admin pages a VIEWER account cannot load (some `system/*`, `installer/*`,
+  `userMigration/*` write flows are seen in JS but their full param sets are role-gated); the
+  mobile app's API (if it differs); and any endpoint invoked only by server-side redirects.
+- **No write/control/firmware endpoint was invoked at any point.** The 89 WRITE
+  endpoints are inventoried from JS source.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,18 +31,23 @@ mobile app. `pylxpweb` wraps it; this integration (`eg4_web_monitor`) consumes
 
 **This spec documents 100% of the endpoints the `pylxpweb` client calls — 44 endpoints, statically verified — but that is *not* the complete EG4 portal API.** It is the client-used subset: the endpoints a Home Assistant integration needs (discovery, runtime/energy, battery, GridBOSS, control/write, firmware, analytics, forecast, export). The coverage was confirmed by a full static sweep of every HTTP call site in `pylxpweb` (including the calls that bypass the generic request wrapper — the `locale/region`/`locale/country` POSTs and the `.xls` export GET — and all CLI collectors): the 44 paths here are exactly the set the client can reach, with none missing and none unused.
 
-The live EG4 portal exposes **far more** endpoints that `pylxpweb` never touches. A read-only
-static crawl of the portal's authenticated web frontend (VIEWER role, 2026-07-15) found
-**186 distinct `/WManage/...` endpoints** — so this OpenAPI spec's 44 is roughly **a quarter**
-of the frontend-referenced surface, and the true portal (incl. owner/installer/admin sections)
-is larger still. The **151 endpoints beyond the client subset** — EV charge-point control,
-Tigo optimizers, Google Home / Phnix heat-pump integrations, generator-exercise scheduling,
-battery-backup & working-mode control, datalog firmware/config, device cluster transfer,
-account/registration, and a large export family — are catalogued (path + method + param names,
-schemas **not** validated, writes **not** exercised) in **[`PORTAL_ENDPOINTS.md`](PORTAL_ENDPOINTS.md)**.
+The live EG4 portal exposes **far more** endpoints that `pylxpweb` never touches. An exhaustive
+read-only static crawl of the portal's authenticated web frontend (VIEWER role, 2026-07-15 —
+page HTML + 104 jQuery JS files, extracting `baseUrl +` concatenations, ternary/variable path
+segments, backtick templates, `fetch()` exports, and form `action=` targets) found
+**251 distinct `/WManage/...` endpoints** — so this OpenAPI spec's 44 is roughly **a sixth**
+of the frontend-referenced surface, and the true portal (incl. owner/installer/admin sections a
+VIEWER can't fully reach) is larger still. The endpoints beyond the client subset — EV
+charge-point control, Tigo optimizers, Google Home / Phnix heat-pump, generator-exercise
+scheduling, battery-backup & working-mode control, RenON battery & micro-inverter monitoring,
+datalog firmware/config, device-cluster transfer, user/installer administration, and a large
+export family — are catalogued (path + method + param names) in
+**[`PORTAL_ENDPOINTS.md`](PORTAL_ENDPOINTS.md)**, where **23 of the new READ endpoints were
+live-validated** (real response fields captured); the ~89 WRITE endpoints are inventoried from
+source only and were **never invoked**.
 
 **In short: this `openapi.yaml` is a *validated contract* for the 44 endpoints the integration
-uses; `PORTAL_ENDPOINTS.md` is a *discovery map* of the full 186-endpoint frontend surface.**
+uses; `PORTAL_ENDPOINTS.md` is a *discovery map* of the full 251-endpoint frontend surface.**
 Turning the latter into validated schemas would require authenticated capture across roles and
 is only worthwhile for broader portal automation, not integration support.
 


### PR DESCRIPTION
Continuation of the API-coverage research ("make sure we have all endpoints documented"). Deepens the frontend endpoint discovery well beyond the prior 186-endpoint catalog.

## What changed
- **Deeper crawl:** 104 jQuery JS files (vs 66), reached via page HTML + a transitive-JS fixpoint (workingMode/eqb/offgrid/lsp, monitor/micro, monitor/battery/renon, analyze/energy, weatherSet, template trees the first pass never loaded).
- **Completeness sweep (3 independent static-analysis passes):** recovered endpoints that a quoted-literal scan misses — the `*Parallel` chart/energy/runtime variants (ternary concat), `predict/solar/dayPredictColumn(Parallel)` (variable segment), `remoteWeeklyOperation/readValues`, `analyze/energy/columnDataExport` (backtick template), and export GETs via `fetch()`/`downloadFile()` / form `action=` targets.
- **`PORTAL_ENDPOINTS.md` → 251 distinct endpoints** (113 READ / 89 WRITE / 49 page routes), up from 186, grouped by section with method, R/W, KNOWN-vs-client-44, and source provenance.
- **23 NEW READ endpoints live-validated** read-only (real top-level response fields captured) — e.g. `getInverterInfo`, `getInverterRuntimeParallel`, `getInverterBatteryInfoParallel`, RenON battery + micro-inverter monitoring, cluster search, config/datalog reads, and the maintain list endpoints.
- Newly-surfaced families: `remoteSetBatt/*`, `remoteSetLsp/bitHoldControl*`, `weatherSet/*Device`, user/installer administration (`enable`/`remove`/`revoke`/`userMigration`/`userQrcode`), `inverterOverview` parallel edit+export, user app-notice prefs.
- README **Coverage & scope** updated: 44 documented ≈ **a sixth** of the 251 frontend-referenced surface.

## Rigor
- Grounding adversarially verified by **Codex GPT-5.6-sol + Opus 4.8**: **0 hallucinations, 0 missing endpoints**, honest limits; their 34 classification/method corrections were applied.
- **No write/control/firmware endpoint was ever invoked** — the 89 WRITE endpoints are inventoried from JS source only. Read-only, VIEWER role; serials/PII obfuscated. Owner/installer/admin write flows are partially visible in JS but their full param sets are role-gated.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)