### PR TITLE
fix: retain optimistic state when post-write refresh fails (#362)

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from datetime import time as dt_time
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Generator, cast
 
 from homeassistant.const import EntityCategory
@@ -41,6 +42,14 @@ from .utils import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Bound on retained optimistic switch state after a write-ok + refresh-fail
+# (#362). Retention normally ends when fresh device data arrives, but a
+# firmware-silently-NAKed write (#251 reg-233, #331 reg-67 precedent) plus
+# one failed refresh would otherwise wedge it forever: every healthy poll
+# keeps returning the pre-write value, indistinguishable from a stale tick.
+# Follows the QUICK_CHARGE_OPTIMISTIC_TTL precedent (switch.py).
+RETAINED_OPTIMISTIC_TTL: float = 300.0
 
 
 class EG4DeviceEntity(CoordinatorEntity):
@@ -936,11 +945,14 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         # Set when a successful write's post-write refresh failed (#362):
         # the optimistic state is then RETAINED — the acknowledged write IS
         # device truth — until fresh device data arrives
-        # (:meth:`_handle_coordinator_update`). ``_pre_write_state`` remembers
-        # what the cache decoded to before the write so freshness is
-        # detectable (mirrors the schedule time entities' retention).
+        # (:meth:`_handle_coordinator_update`) or the TTL deadline passes
+        # (firmware-NAK escape). ``_pre_write_state`` remembers what the
+        # cache decoded to before the write so freshness is detectable
+        # (mirrors the schedule time entities' retention).
         self._optimistic_retained = False
         self._pre_write_state: bool | None = None
+        self._retention_expires: float = 0.0
+        self._retained_action: str = ""
 
         # Get device model from coordinator data
         self._model = _get_model_from_coordinator(coordinator, serial)
@@ -1031,6 +1043,13 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         decodes the underlying cache/device data (every subclass prefers
         ``_optimistic_state`` when set). Synchronous — the mask never spans
         an await point.
+
+        Contract: this peek must be SIDE-EFFECT-FREE and must read genuine
+        device data. Subclasses whose ``is_on`` consults additional hold
+        state after the optimistic check (e.g. quick charge's #296
+        ``_pending_state``) must override this to mask that state too —
+        otherwise the peek echoes the held command back (false retention
+        convergence) or mutates the hold as a side effect of the read.
         """
         saved = self._optimistic_state
         self._optimistic_state = None
@@ -1039,25 +1058,123 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         finally:
             self._optimistic_state = saved
 
+    def _arm_retention(self, action_name: str, pre_write_state: bool | None) -> None:
+        """Arm bounded optimistic-state retention after write-ok + refresh-fail.
+
+        The retained state ends when fresh device data arrives
+        (:meth:`_handle_coordinator_update`) or, as the firmware-NAK escape
+        (#251/#331 precedent: a silently rejected write means fresh data
+        never stops decoding to the pre-write value), when
+        ``RETAINED_OPTIMISTIC_TTL`` expires.
+        """
+        self._optimistic_retained = True
+        self._pre_write_state = pre_write_state
+        self._retention_expires = time.monotonic() + RETAINED_OPTIMISTIC_TTL
+        self._retained_action = action_name
+        _LOGGER.debug(
+            "Retaining optimistic state for %s on device %s until fresh "
+            "device data arrives (bounded to %.0f s)",
+            action_name,
+            self._serial,
+            RETAINED_OPTIMISTIC_TTL,
+        )
+
+    def _end_retention(self) -> None:
+        """Drop the retained optimistic state and its bookkeeping."""
+        self._optimistic_state = None
+        self._optimistic_retained = False
+        self._pre_write_state = None
+        self._retained_action = ""
+
+    async def _refresh_coordinator_data(self) -> bool:
+        """Run a full coordinator refresh; True only when it produced fresh data.
+
+        ``last_update_success`` alone LIES during the coordinator's 3-strike
+        tolerance window: the first two consecutive ``UpdateFailed`` cycles
+        return the OLD ``self.data`` object unchanged without flipping the
+        flag, so a post-write refresh could serve stale pre-write data as if
+        it were fresh (#362 review). A same-identity data object after the
+        refresh is therefore treated as failure — every genuinely successful
+        cycle builds a new data dict.
+        """
+        data_before = self.coordinator.data
+        await self.coordinator.async_refresh()
+        return bool(self.coordinator.last_update_success) and (
+            self.coordinator.data is not data_before
+        )
+
+    async def _settle_acknowledged_write(
+        self,
+        action_name: str,
+        pre_write_state: bool | None,
+        refresh: Callable[[], Awaitable[bool]],
+    ) -> None:
+        """Run the post-write refresh phase for an ACKNOWLEDGED write (#362).
+
+        Never raises: a successful write must not be converted into a
+        user-facing write failure. On a completed refresh the optimistic
+        state clears (coordinator data is fresh); on a failed refresh
+        (reported False or raised) it is retained via :meth:`_arm_retention`
+        instead of publishing the stale pre-write value.
+        """
+        refresh_ok = False
+        try:
+            refresh_ok = await refresh()
+            if not refresh_ok:
+                _LOGGER.warning(
+                    "Post-write refresh did not complete after %s for device "
+                    "%s (the write itself succeeded)",
+                    action_name,
+                    self._serial,
+                )
+        except Exception as e:
+            _LOGGER.warning(
+                "Post-write refresh failed after %s for device %s "
+                "(the write itself succeeded): %s",
+                action_name,
+                self._serial,
+                e,
+            )
+
+        if refresh_ok:
+            # Coordinator data reflects the new state — publish it.
+            self._optimistic_state = None
+        else:
+            self._arm_retention(action_name, pre_write_state)
+        self.async_write_ha_state()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Clear a retained optimistic state once fresh device data arrives.
 
         A retained state exists only when a successful write's post-write
-        refresh failed (#362, :meth:`_optimistic_write_envelope`). Fresh data
+        refresh failed (#362, :meth:`_settle_acknowledged_write`). Fresh data
         is anything that no longer decodes to the pre-write state — the
         written value coming back, or a newer external change; a coordinator
         tick that still carries the stale pre-write value keeps the
         optimistic state (clearing there would be the silent revert this
         guards against, just delayed one poll). Mirrors the schedule time
         entities' retention semantics.
+
+        TTL escape: a firmware-silently-NAKed write never produces fresh
+        data that differs from the pre-write value, so an unconverged
+        retention expires after ``RETAINED_OPTIMISTIC_TTL`` with a WARNING
+        (observability for the NAK case) and the entity reverts to the
+        reported state.
         """
         if self._optimistic_retained and self._optimistic_state is not None:
             current = self._cache_state()
             if current == self._optimistic_state or current != self._pre_write_state:
-                self._optimistic_state = None
-                self._optimistic_retained = False
-                self._pre_write_state = None
+                self._end_retention()
+            elif time.monotonic() >= self._retention_expires:
+                _LOGGER.warning(
+                    "Optimistic state for %s on device %s expired without "
+                    "device confirmation; reverting to the reported state "
+                    "(the device may have rejected the write)",
+                    self._retained_action or "switch write",
+                    self._serial,
+                )
+                self._end_retention()
         super()._handle_coordinator_update()
 
     async def _optimistic_write_envelope(
@@ -1073,11 +1190,15 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
     ) -> None:
         """Execute a write with optimistic state and post-write refreshes.
 
-        Shared by ``_execute_switch_action`` and ``_execute_cloud_function_action``.
-        ``do_write`` performs its own precondition/success checks and raises
-        ``HomeAssistantError`` on failure — there is no false-return branch
-        here; failure flows through the write exception handlers below.
-        ``do_refresh`` returns whether the refresh completed.
+        Shared by ``_execute_switch_action`` and ``_execute_cloud_function_action``;
+        the LOCAL named-parameter path (``_execute_named_parameter_action``)
+        shares the identical write/refresh semantics through the same
+        :meth:`_settle_acknowledged_write` helper. ``do_write`` performs its
+        own precondition/success checks and raises ``HomeAssistantError`` on
+        failure — there is no false-return branch here; failure flows through
+        the write exception handlers below. ``do_refresh`` returns whether
+        the refresh completed AND produced fresh data (see
+        :meth:`_refresh_coordinator_data` for the tolerated-stale caveat).
 
         Write and refresh sit in SEPARATE exception boundaries (#362):
 
@@ -1086,11 +1207,11 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
           completes, preventing the "bounce" effect where the entity briefly
           shows the wrong state while waiting for API data to propagate.
         - write ok + refresh fails (reported or raised) → RETAIN the
-          optimistic state until fresh device data arrives
-          (:meth:`_handle_coordinator_update`) and log; a successful write
-          is NEVER converted into a user-facing write failure, and the
-          entity never publishes the stale pre-write cache value the device
-          already superseded.
+          optimistic state until fresh device data arrives or the retention
+          TTL expires (:meth:`_handle_coordinator_update`) and log; a
+          successful write is NEVER converted into a user-facing write
+          failure, and the entity never publishes the stale pre-write cache
+          value the device already superseded.
 
         Callers emit their path-specific debug log BEFORE invoking this
         envelope — the pinned log ordering is debug → optimistic publish →
@@ -1142,41 +1263,17 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         if seed_param_key is not None:
             self._seed_cloud_written_parameter(seed_param_key, value)
 
-        refresh_ok = False
-        try:
+        async def refresh_phase() -> bool:
             if pre_delay_refresh is not None:
                 await pre_delay_refresh()
 
             # Wait for API to propagate changes before refreshing.
             await asyncio.sleep(api_delay)
-            refresh_ok = await do_refresh()
-        except Exception as e:
-            _LOGGER.warning(
-                "Post-write refresh failed after %s %s for device %s "
-                "(the write itself succeeded): %s",
-                action_verb.lower(),
-                action_name,
-                self._serial,
-                e,
-            )
+            return await do_refresh()
 
-        if refresh_ok:
-            # Coordinator data reflects the new state — publish it.
-            self._optimistic_state = None
-        else:
-            # Write landed but the refresh did not complete: retain the
-            # optimistic state (the acknowledged write IS device truth)
-            # until fresh data arrives, instead of reverting to the stale
-            # pre-write cache value (#362).
-            self._optimistic_retained = True
-            self._pre_write_state = pre_write_state
-            _LOGGER.debug(
-                "Retaining optimistic state for %s on device %s until fresh "
-                "device data arrives",
-                action_name,
-                self._serial,
-            )
-        self.async_write_ha_state()
+        await self._settle_acknowledged_write(
+            action_name, pre_write_state, refresh_phase
+        )
 
     async def _execute_switch_action(
         self,
@@ -1284,9 +1381,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 return await self.coordinator.async_refresh_device_parameters(
                     self._serial
                 )
-            await self.coordinator.async_refresh()
-            # async_refresh never raises; its outcome is the success flag.
-            return bool(self.coordinator.last_update_success)
+            return await self._refresh_coordinator_data()
 
         await self._optimistic_write_envelope(
             action_name,
@@ -1507,6 +1602,15 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         Uses pylxpweb's write_named_parameters() which handles register mapping
         and bit field combination automatically.
 
+        Shares the #362 write/refresh semantics with the optimistic write
+        envelope (via :meth:`_settle_acknowledged_write`): a failed
+        post-write refresh — including a tolerated-stale one — retains the
+        optimistic state instead of unconditionally clearing it. The
+        in-place parameter update below converges concurrent cycles
+        immediately, but lives on the LIVE dict a full data rebuild replaces
+        wholesale; the retention is what guards the revert when that
+        happens.
+
         Args:
             action_name: Human-readable name of the action for logging.
             parameter: HTTP API-style parameter name (e.g., "FUNC_EPS_EN").
@@ -1522,53 +1626,29 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         """
         action_verb = "Enabling" if value else "Disabling"
 
+        _LOGGER.debug(
+            "%s %s via LOCAL transport for device %s (parameter %s)",
+            action_verb,
+            action_name,
+            self._serial,
+            parameter,
+        )
+
+        # Set optimistic state immediately for UI feedback. Any retained
+        # state from an earlier write (#362) is superseded by this one —
+        # on the HYBRID fallback path the envelope re-arms retention if
+        # the cloud retry's own refresh fails.
+        pre_write_state = self._cache_state()
+        self._optimistic_retained = False
+        self._pre_write_state = None
+        self._optimistic_state = value
+        self.async_write_ha_state()
+
         try:
-            _LOGGER.debug(
-                "%s %s via LOCAL transport for device %s (parameter %s)",
-                action_verb,
-                action_name,
-                self._serial,
-                parameter,
-            )
-
-            # Set optimistic state immediately for UI feedback. Any retained
-            # state from an earlier write (#362) is superseded by this one —
-            # on the HYBRID fallback path the envelope re-arms retention if
-            # the cloud retry's own refresh fails.
-            self._optimistic_retained = False
-            self._pre_write_state = None
-            self._optimistic_state = value
-            self.async_write_ha_state()
-
             # Write the named parameter via coordinator
             await self.coordinator.write_named_parameter(
                 parameter, value, serial=self._serial
             )
-
-            # Optimistically update coordinator parameter data so any
-            # concurrent coordinator cycle sees the new value immediately
-            if self.coordinator.data and "parameters" in self.coordinator.data:
-                params = self.coordinator.data["parameters"].get(self._serial)
-                if params is not None:
-                    params[parameter] = value
-
-            _LOGGER.info(
-                "Successfully %s %s via LOCAL transport for device %s",
-                action_verb.lower()[:-3] + "ed",
-                action_name,
-                self._serial,
-            )
-
-            # Wait briefly for register write to take effect
-            await asyncio.sleep(0.5)
-
-            # Request coordinator refresh
-            await self.coordinator.async_refresh()
-
-            # Clear optimistic state after refresh
-            self._optimistic_state = None
-            self.async_write_ha_state()
-
         except HomeAssistantError:
             if clear_optimistic_on_error:
                 self._optimistic_state = None
@@ -1588,3 +1668,29 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             raise HomeAssistantError(
                 f"Failed to {action_verb.lower()} {action_name}: {e}"
             ) from e
+
+        # Write acknowledged. Optimistically update coordinator parameter
+        # data so any concurrent coordinator cycle sees the new value
+        # immediately (deliberately NOT note_parameters_written: that is the
+        # cloud-fallback seeding channel and notifies all listeners; this
+        # in-place hint needs neither).
+        if self.coordinator.data and "parameters" in self.coordinator.data:
+            params = self.coordinator.data["parameters"].get(self._serial)
+            if params is not None:
+                params[parameter] = value
+
+        _LOGGER.info(
+            "Successfully %s %s via LOCAL transport for device %s",
+            action_verb.lower()[:-3] + "ed",
+            action_name,
+            self._serial,
+        )
+
+        async def refresh_phase() -> bool:
+            # Wait briefly for register write to take effect.
+            await asyncio.sleep(0.5)
+            return await self._refresh_coordinator_data()
+
+        await self._settle_acknowledged_write(
+            action_name, pre_write_state, refresh_phase
+        )

--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -12,6 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Generator, cast
 
 from homeassistant.const import EntityCategory
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -932,6 +933,14 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
 
         # Optimistic state for immediate UI feedback
         self._optimistic_state: bool | None = None
+        # Set when a successful write's post-write refresh failed (#362):
+        # the optimistic state is then RETAINED — the acknowledged write IS
+        # device truth — until fresh device data arrives
+        # (:meth:`_handle_coordinator_update`). ``_pre_write_state`` remembers
+        # what the cache decoded to before the write so freshness is
+        # detectable (mirrors the schedule time entities' retention).
+        self._optimistic_retained = False
+        self._pre_write_state: bool | None = None
 
         # Get device model from coordinator data
         self._model = _get_model_from_coordinator(coordinator, serial)
@@ -1015,13 +1024,49 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             raise HomeAssistantError(f"Inverter {self._serial} not found")
         return inverter
 
+    def _cache_state(self) -> bool | None:
+        """Return ``is_on`` as decoded from coordinator data.
+
+        Temporarily masks the optimistic state so the subclass's ``is_on``
+        decodes the underlying cache/device data (every subclass prefers
+        ``_optimistic_state`` when set). Synchronous — the mask never spans
+        an await point.
+        """
+        saved = self._optimistic_state
+        self._optimistic_state = None
+        try:
+            return self.is_on
+        finally:
+            self._optimistic_state = saved
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear a retained optimistic state once fresh device data arrives.
+
+        A retained state exists only when a successful write's post-write
+        refresh failed (#362, :meth:`_optimistic_write_envelope`). Fresh data
+        is anything that no longer decodes to the pre-write state — the
+        written value coming back, or a newer external change; a coordinator
+        tick that still carries the stale pre-write value keeps the
+        optimistic state (clearing there would be the silent revert this
+        guards against, just delayed one poll). Mirrors the schedule time
+        entities' retention semantics.
+        """
+        if self._optimistic_retained and self._optimistic_state is not None:
+            current = self._cache_state()
+            if current == self._optimistic_state or current != self._pre_write_state:
+                self._optimistic_state = None
+                self._optimistic_retained = False
+                self._pre_write_state = None
+        super()._handle_coordinator_update()
+
     async def _optimistic_write_envelope(
         self,
         action_name: str,
         value: bool,
         *,
         do_write: Callable[[], Awaitable[None]],
-        do_refresh: Callable[[], Awaitable[None]],
+        do_refresh: Callable[[], Awaitable[bool]],
         pre_delay_refresh: Callable[[], Awaitable[None]] | None = None,
         api_delay: float = 1.0,
         seed_param_key: str | None = None,
@@ -1031,50 +1076,40 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         Shared by ``_execute_switch_action`` and ``_execute_cloud_function_action``.
         ``do_write`` performs its own precondition/success checks and raises
         ``HomeAssistantError`` on failure — there is no false-return branch
-        here; failure flows through the single exception handler below.
+        here; failure flows through the write exception handlers below.
+        ``do_refresh`` returns whether the refresh completed.
 
-        The optimistic state is cleared AFTER ``do_refresh`` completes to
-        prevent the "bounce" effect where the entity briefly shows the wrong
-        state while waiting for API data to propagate.
+        Write and refresh sit in SEPARATE exception boundaries (#362):
+
+        - write fails → clear optimistic state, raise (user-facing failure).
+        - write ok + refresh ok → clear optimistic state AFTER the refresh
+          completes, preventing the "bounce" effect where the entity briefly
+          shows the wrong state while waiting for API data to propagate.
+        - write ok + refresh fails (reported or raised) → RETAIN the
+          optimistic state until fresh device data arrives
+          (:meth:`_handle_coordinator_update`) and log; a successful write
+          is NEVER converted into a user-facing write failure, and the
+          entity never publishes the stale pre-write cache value the device
+          already superseded.
 
         Callers emit their path-specific debug log BEFORE invoking this
         envelope — the pinned log ordering is debug → optimistic publish →
-        write. A logging handler that itself raises therefore escapes
-        unwrapped (no optimistic state exists yet to clear); accepted, since
-        wrapping it would require moving the log after the optimistic
-        publish and changing the documented ordering.
+        write.
         """
         action_verb = "Enabling" if value else "Disabling"
 
+        # Capture what the cache decodes to before the write so a retained
+        # optimistic state can later detect fresh data (#362).
+        pre_write_state = self._cache_state()
+        self._optimistic_retained = False
+        self._pre_write_state = None
+
+        # Set optimistic state immediately for UI feedback.
+        self._optimistic_state = value
+        self.async_write_ha_state()
+
         try:
-            # Set optimistic state immediately for UI feedback.
-            self._optimistic_state = value
-            self.async_write_ha_state()
-
             await do_write()
-
-            # Seed the acknowledged value BEFORE the refresh/optimistic-clear
-            # (#310): under a down local link the parameter refresh below
-            # cannot read the device locally (LOCAL-only: no data at all;
-            # HYBRID: cloud re-read can lag or fail), so without the seed
-            # this method could publish the STALE pre-write state when it
-            # clears the optimistic value — a wrong-then-corrected double
-            # transition (recorder pollution, automation misfires on the
-            # intermediate value).
-            if seed_param_key is not None:
-                self._seed_cloud_written_parameter(seed_param_key, value)
-
-            if pre_delay_refresh is not None:
-                await pre_delay_refresh()
-
-            # Wait for API to propagate changes before refreshing.
-            await asyncio.sleep(api_delay)
-            await do_refresh()
-
-            # Clear optimistic state AFTER refresh completes — at this point
-            # coordinator data should reflect the new state.
-            self._optimistic_state = None
-            self.async_write_ha_state()
         except HomeAssistantError:
             self._optimistic_state = None
             self.async_write_ha_state()
@@ -1092,6 +1127,56 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             raise HomeAssistantError(
                 f"Failed to {action_verb.lower()} {action_name}: {e}"
             ) from e
+
+        # The write is acknowledged: from here on nothing may raise a
+        # user-facing write failure or publish the stale pre-write value.
+
+        # Seed the acknowledged value BEFORE the refresh/optimistic-clear
+        # (#310): under a down local link the parameter refresh below
+        # cannot read the device locally (LOCAL-only: no data at all;
+        # HYBRID: cloud re-read can lag or fail), so without the seed
+        # this method could publish the STALE pre-write state when it
+        # clears the optimistic value — a wrong-then-corrected double
+        # transition (recorder pollution, automation misfires on the
+        # intermediate value).
+        if seed_param_key is not None:
+            self._seed_cloud_written_parameter(seed_param_key, value)
+
+        refresh_ok = False
+        try:
+            if pre_delay_refresh is not None:
+                await pre_delay_refresh()
+
+            # Wait for API to propagate changes before refreshing.
+            await asyncio.sleep(api_delay)
+            refresh_ok = await do_refresh()
+        except Exception as e:
+            _LOGGER.warning(
+                "Post-write refresh failed after %s %s for device %s "
+                "(the write itself succeeded): %s",
+                action_verb.lower(),
+                action_name,
+                self._serial,
+                e,
+            )
+
+        if refresh_ok:
+            # Coordinator data reflects the new state — publish it.
+            self._optimistic_state = None
+        else:
+            # Write landed but the refresh did not complete: retain the
+            # optimistic state (the acknowledged write IS device truth)
+            # until fresh data arrives, instead of reverting to the stale
+            # pre-write cache value (#362).
+            self._optimistic_retained = True
+            self._pre_write_state = pre_write_state
+            _LOGGER.debug(
+                "Retaining optimistic state for %s on device %s until fresh "
+                "device data arrives",
+                action_name,
+                self._serial,
+            )
+        self.async_write_ha_state()
 
     async def _execute_switch_action(
         self,
@@ -1194,11 +1279,14 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         async def pre_delay_refresh() -> None:
             await inverter.refresh()
 
-        async def do_refresh() -> None:
+        async def do_refresh() -> bool:
             if refresh_params:
-                await self.coordinator.async_refresh_device_parameters(self._serial)
-            else:
-                await self.coordinator.async_refresh()
+                return await self.coordinator.async_refresh_device_parameters(
+                    self._serial
+                )
+            await self.coordinator.async_refresh()
+            # async_refresh never raises; its outcome is the success flag.
+            return bool(self.coordinator.last_update_success)
 
         await self._optimistic_write_envelope(
             action_name,
@@ -1395,8 +1483,8 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 self._serial,
             )
 
-        async def do_refresh() -> None:
-            await self.coordinator.async_refresh_device_parameters(self._serial)
+        async def do_refresh() -> bool:
+            return await self.coordinator.async_refresh_device_parameters(self._serial)
 
         await self._optimistic_write_envelope(
             action_name,
@@ -1443,7 +1531,12 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
                 parameter,
             )
 
-            # Set optimistic state immediately for UI feedback
+            # Set optimistic state immediately for UI feedback. Any retained
+            # state from an earlier write (#362) is superseded by this one —
+            # on the HYBRID fallback path the envelope re-arms retention if
+            # the cloud retry's own refresh fails.
+            self._optimistic_retained = False
+            self._pre_write_state = None
             self._optimistic_state = value
             self.async_write_ha_state()
 

--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -1086,6 +1086,21 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         self._pre_write_state = None
         self._retained_action = ""
 
+    def _begin_optimistic_write(self, value: bool) -> bool | None:
+        """Publish the optimistic state and capture the pre-write cache state.
+
+        Returns what the cache decodes to BEFORE the write so a later
+        retained optimistic state can detect fresh device data (#362); any
+        retained state from an earlier write is superseded by this one. The
+        "begin" counterpart of :meth:`_settle_acknowledged_write`.
+        """
+        pre_write_state = self._cache_state()
+        self._optimistic_retained = False
+        self._pre_write_state = None
+        self._optimistic_state = value
+        self.async_write_ha_state()
+        return pre_write_state
+
     async def _refresh_coordinator_data(self) -> bool:
         """Run a full coordinator refresh; True only when it produced fresh data.
 
@@ -1219,15 +1234,7 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
         """
         action_verb = "Enabling" if value else "Disabling"
 
-        # Capture what the cache decodes to before the write so a retained
-        # optimistic state can later detect fresh data (#362).
-        pre_write_state = self._cache_state()
-        self._optimistic_retained = False
-        self._pre_write_state = None
-
-        # Set optimistic state immediately for UI feedback.
-        self._optimistic_state = value
-        self.async_write_ha_state()
+        pre_write_state = self._begin_optimistic_write(value)
 
         try:
             await do_write()
@@ -1634,15 +1641,9 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             parameter,
         )
 
-        # Set optimistic state immediately for UI feedback. Any retained
-        # state from an earlier write (#362) is superseded by this one —
-        # on the HYBRID fallback path the envelope re-arms retention if
-        # the cloud retry's own refresh fails.
-        pre_write_state = self._cache_state()
-        self._optimistic_retained = False
-        self._pre_write_state = None
-        self._optimistic_state = value
-        self.async_write_ha_state()
+        # On the HYBRID fallback path the envelope re-arms retention if the
+        # cloud retry's own refresh fails.
+        pre_write_state = self._begin_optimistic_write(value)
 
         try:
             # Write the named parameter via coordinator

--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -48,7 +48,11 @@ _LOGGER = logging.getLogger(__name__)
 # firmware-silently-NAKed write (#251 reg-233, #331 reg-67 precedent) plus
 # one failed refresh would otherwise wedge it forever: every healthy poll
 # keeps returning the pre-write value, indistinguishable from a stale tick.
-# Follows the QUICK_CHARGE_OPTIMISTIC_TTL precedent (switch.py).
+# Follows the QUICK_CHARGE_OPTIMISTIC_TTL precedent (switch.py) and is kept
+# NUMERICALLY EQUAL to it on purpose: after a quick-charge write-ok +
+# refresh-fail BOTH holds arm within the same call, and nothing couples them
+# afterwards — equal TTLs are what keep them expiring together. Change both
+# or neither.
 RETAINED_OPTIMISTIC_TTL: float = 300.0
 
 
@@ -1184,8 +1188,9 @@ class EG4BaseSwitch(CoordinatorEntity, SwitchEntity):
             elif time.monotonic() >= self._retention_expires:
                 _LOGGER.warning(
                     "Optimistic state for %s on device %s expired without "
-                    "device confirmation; reverting to the reported state "
-                    "(the device may have rejected the write)",
+                    "device confirmation; reverting to the reported state, "
+                    "which may decode as unknown (the device may have "
+                    "rejected the write)",
                     self._retained_action or "switch write",
                     self._serial,
                 )

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -2517,14 +2517,26 @@ class ParameterManagementMixin(_MixinBase):
         except Exception as e:
             _LOGGER.error("Error during all-device parameter refresh: %s", e)
 
-    async def async_refresh_device_parameters(self, serial: str) -> None:
-        """Public method to refresh parameters for a specific device."""
+    async def async_refresh_device_parameters(self, serial: str) -> bool:
+        """Public method to refresh parameters for a specific device.
+
+        Returns:
+            True when the refresh completed; False when it failed. Errors
+            are logged, never raised (#362): post-write callers must be able
+            to distinguish "write+refresh ok" from "write ok, refresh
+            failed" — the old swallow-and-return-None contract made a failed
+            refresh indistinguishable from success, so entities cleared
+            their optimistic state onto the stale pre-write cache value and
+            visibly reverted a write the device had acknowledged.
+        """
         try:
             _LOGGER.debug("Refreshing parameters for device %s", serial)
             await self._refresh_device_parameters(serial)
             await self.async_request_refresh()
         except Exception as e:
             _LOGGER.error("Failed to refresh parameters for device %s: %s", serial, e)
+            return False
+        return True
 
     async def _refresh_device_parameters(self, serial: str) -> None:
         """Refresh parameters for a specific device using device object.

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -360,6 +360,9 @@ async def async_setup_entry(
 # indefinitely (the last thing we know the inverter accepted) — this reverses
 # the earlier "a dead status source can never pin state forever" guarantee.
 # Showing the accepted command beats flapping to provably pre-write data.
+# Kept NUMERICALLY EQUAL to base_entity.RETAINED_OPTIMISTIC_TTL on purpose:
+# after a quick-charge write-ok + refresh-fail both holds arm together and
+# only equal TTLs keep them expiring together. Change both or neither.
 QUICK_CHARGE_OPTIMISTIC_TTL = 300.0
 
 

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -420,6 +420,24 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
         result = await client.api.control.stop_quick_charge(self._serial)
         return bool(result.success)
 
+    def _cache_state(self) -> bool | None:
+        """Peek genuine status data: mask the #296 pending-state hold too.
+
+        The base peek masks only ``_optimistic_state``; quick charge's
+        ``is_on`` would then fall through to the ``_pending_state`` hold,
+        which (a) echoes the commanded value back — false convergence for
+        the #362 retention — and (b) can MUTATE ``_pending_state`` as a side
+        effect of the read (the hold is consumed on a fresh confirming or
+        expired read). Masking it keeps the peek side-effect-free and
+        reading actual device/status truth, per the base contract.
+        """
+        saved = self._pending_state
+        self._pending_state = None
+        try:
+            return super()._cache_state()
+        finally:
+            self._pending_state = saved
+
     @property
     def is_on(self) -> bool | None:
         """Return True if quick charge is on."""

--- a/custom_components/eg4_web_monitor/time.py
+++ b/custom_components/eg4_web_monitor/time.py
@@ -512,13 +512,15 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         """Re-read parameters so all schedule entities converge on the write.
 
         Returns:
-            True when the refresh completed; False when it failed (errors
-            are logged, not raised — the write itself already succeeded, or
-            an error is already propagating).
+            True when the refresh completed; False when it failed. The
+            coordinator helper reports failure by returning False (#362 —
+            it logs and swallows its own errors, so before #362 a failed
+            refresh was indistinguishable from success here and the
+            retain-optimistic branch never fired); the try/except is a
+            defensive belt against a raise that cannot occur in production.
         """
         try:
-            await self.coordinator.async_refresh_device_parameters(self.serial)
+            return await self.coordinator.async_refresh_device_parameters(self.serial)
         except Exception as err:
             _LOGGER.error("Failed to refresh parameters after schedule write: %s", err)
             return False
-        return True

--- a/tests/test_base_entity_envelope.py
+++ b/tests/test_base_entity_envelope.py
@@ -1,4 +1,19 @@
-"""Characterization tests for optimistic cloud-write switch actions."""
+"""Golden ordering/error tests for optimistic write envelope semantics (#362).
+
+Pinned contract for every write flowing through
+``EG4BaseSwitch._optimistic_write_envelope`` (switch actions and pure-CLOUD
+function switches):
+
+- write FAILS -> raise HomeAssistantError, clear optimistic state once,
+  never seed the parameter cache.
+- write OK + refresh OK -> publish the fresh coordinator data (optimistic
+  state cleared after the refresh completes).
+- write OK + refresh FAILS (reported failure or raised exception) -> the
+  service call SUCCEEDS (never converted into a user-facing write failure),
+  the optimistic state is RETAINED until fresh device data arrives
+  (:meth:`EG4BaseSwitch._handle_coordinator_update`), matching the schedule
+  time entities' retained-optimistic semantics.
+"""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -17,6 +32,11 @@ SERIAL = "1234567890"
 class EnvelopeTestSwitch(EG4BaseSwitch):
     """Concrete base switch that records optimistic-state assignments."""
 
+    # Canned cache-decoded state; overriding _cache_state keeps the
+    # production peek helper (which toggles _optimistic_state) from
+    # polluting the recorded event stream.
+    _cache_value: bool | None = None
+
     def __init__(self, coordinator: MagicMock, events: list[str]) -> None:
         """Initialize the test switch and attach its event recorder."""
         super().__init__(coordinator, SERIAL, "envelope", "Envelope")
@@ -34,10 +54,16 @@ class EnvelopeTestSwitch(EG4BaseSwitch):
         if events is not None:
             events.append("optimistic-set" if value is not None else "clear")
 
+    def _cache_state(self) -> bool | None:
+        """Return the canned cache-decoded state."""
+        return self._cache_value
+
     @property
     def is_on(self) -> bool:
         """Return the current test state."""
-        return bool(self._optimistic_state)
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        return bool(self._cache_value)
 
 
 def _make_entity(
@@ -54,8 +80,10 @@ def _make_entity(
     coordinator.async_refresh = AsyncMock(
         side_effect=lambda: events.append("coordinator-refresh")
     )
+    # The coordinator refresh helper reports success/failure (#362); the
+    # default harness refresh succeeds.
     coordinator.async_refresh_device_parameters = AsyncMock(
-        side_effect=lambda _serial: events.append("parameter-refresh")
+        side_effect=lambda _serial: events.append("parameter-refresh") or True
     )
 
     inverter = SimpleNamespace(
@@ -385,3 +413,275 @@ async def test_cloud_function_missing_client_fails_before_optimistic_state() -> 
 
     assert events == []
     assert entity.async_write_ha_state.call_count == 0
+
+
+# ── Write-ok + refresh-fail retention (#362) ─────────────────────────
+
+
+def _assert_retained(entity: EnvelopeTestSwitch, *, value: bool) -> None:
+    """Assert the acknowledged write's optimistic state was retained."""
+    assert entity._optimistic_state is value
+    assert entity._optimistic_retained is True
+    assert entity.is_on is value
+
+
+@pytest.mark.asyncio
+async def test_switch_write_ok_refresh_reports_failure_retains_optimistic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reported parameter-refresh failure after an acknowledged write must
+    NOT raise and must retain the optimistic state (#362): the hardware holds
+    the new value; publishing the stale pre-write cache would be a silent
+    revert while the service reported success."""
+    events: list[str] = []
+    entity, coordinator, inverter = _make_entity(events)
+    entity._cache_value = False  # stale pre-write cache value
+    inverter.enable_test = AsyncMock(side_effect=lambda: events.append("write") or True)
+    coordinator.async_refresh_device_parameters = AsyncMock(
+        side_effect=lambda _serial: events.append("parameter-refresh") or False
+    )
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action",
+        "enable_test",
+        "disable_test",
+        True,
+        refresh_params=True,
+        seed_param_key="FUNC_TEST",
+    )
+
+    # No "clear" event: optimistic state survives the failed refresh. The
+    # seed still fires — it acknowledges the WRITE, not the refresh.
+    assert events == [
+        "optimistic-set",
+        "write",
+        "seed",
+        "inverter-refresh",
+        "sleep",
+        "parameter-refresh",
+    ]
+    _assert_retained(entity, value=True)
+    assert entity._pre_write_state is False
+    assert entity._published_states == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_switch_write_ok_coordinator_refresh_unsuccessful_retains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A data refresh that leaves the coordinator unsuccessful retains the
+    optimistic state instead of publishing stale data."""
+    events: list[str] = []
+    entity, coordinator, inverter = _make_entity(events)
+    inverter.enable_test = AsyncMock(side_effect=lambda: events.append("write") or True)
+
+    async def _failing_refresh() -> None:
+        events.append("coordinator-refresh")
+        coordinator.last_update_success = False
+
+    coordinator.async_refresh = AsyncMock(side_effect=_failing_refresh)
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", True
+    )
+
+    assert events == [
+        "optimistic-set",
+        "write",
+        "inverter-refresh",
+        "sleep",
+        "coordinator-refresh",
+    ]
+    _assert_retained(entity, value=True)
+
+
+@pytest.mark.asyncio
+async def test_switch_write_ok_pre_delay_refresh_raises_is_not_a_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #362 point 2: a transient inverter.refresh() error after a
+    successful write must not raise 'Failed to enable X' nor clear the
+    optimistic state — the hardware accepted the command."""
+    events: list[str] = []
+    entity, _coordinator, inverter = _make_entity(events)
+    inverter.enable_test = AsyncMock(side_effect=lambda: events.append("write") or True)
+
+    async def _exploding_refresh() -> None:
+        events.append("inverter-refresh")
+        raise ConnectionError("transient refresh error")
+
+    inverter.refresh = AsyncMock(side_effect=_exploding_refresh)
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", True
+    )
+
+    assert events == ["optimistic-set", "write", "inverter-refresh"]
+    _assert_retained(entity, value=True)
+
+
+@pytest.mark.asyncio
+async def test_switch_write_ok_refresh_raises_retains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising final refresh is treated exactly like a reported failure."""
+    events: list[str] = []
+    entity, coordinator, inverter = _make_entity(events)
+    inverter.disable_test = AsyncMock(
+        side_effect=lambda: events.append("write") or True
+    )
+    coordinator.async_refresh = AsyncMock(side_effect=RuntimeError("refresh died"))
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", False
+    )
+
+    assert events == ["optimistic-set", "write", "inverter-refresh", "sleep"]
+    _assert_retained(entity, value=False)
+
+
+@pytest.mark.asyncio
+async def test_cloud_function_write_ok_refresh_fail_retains_optimistic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pure-CLOUD function switches (not cache-seeded by design) retain the
+    optimistic state on write-ok + refresh-fail instead of reverting to the
+    stale pre-write parameter value (#362 point 1)."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    entity._cache_value = False
+    coordinator.client.api.control.control_function.side_effect = (
+        lambda _serial, _parameter, _value: (
+            events.append("write") or SimpleNamespace(success=True)
+        )
+    )
+    coordinator.async_refresh_device_parameters = AsyncMock(
+        side_effect=lambda _serial: events.append("parameter-refresh") or False
+    )
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_cloud_function_action("test action", "FUNC_TEST", True)
+
+    assert events == ["optimistic-set", "write", "sleep", "parameter-refresh"]
+    _assert_retained(entity, value=True)
+    assert entity._pre_write_state is False
+
+
+@pytest.mark.asyncio
+async def test_write_failure_resets_retention_flags() -> None:
+    """A failed write clears optimistic state and never arms retention."""
+    events: list[str] = []
+    entity, _coordinator, inverter = _make_entity(events)
+    inverter.enable_test = AsyncMock(
+        side_effect=lambda: events.append("write") or False
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await entity._execute_switch_action(
+            "test action", "enable_test", "disable_test", True
+        )
+
+    assert entity._optimistic_state is None
+    assert entity._optimistic_retained is False
+    assert entity._pre_write_state is None
+
+
+# ── Retained-state clearing on coordinator updates (#362) ────────────
+
+
+async def _make_retained_entity(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pre_write: bool | None = False,
+) -> EnvelopeTestSwitch:
+    """Build an entity holding a retained optimistic ON state."""
+    events: list[str] = []
+    entity, coordinator, inverter = _make_entity(events)
+    entity._cache_value = pre_write
+    inverter.enable_test = AsyncMock(return_value=True)
+    coordinator.async_refresh_device_parameters = AsyncMock(return_value=False)
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", True, refresh_params=True
+    )
+    assert entity._optimistic_retained is True
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_retained_state_clears_when_cache_converges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh data carrying the written value ends the retention."""
+    entity = await _make_retained_entity(monkeypatch)
+
+    entity._cache_value = True  # fresh data: the write came back
+    entity._handle_coordinator_update()
+
+    assert entity._optimistic_state is None
+    assert entity._optimistic_retained is False
+    assert entity._pre_write_state is None
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_retained_state_clears_on_other_fresh_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any value that no longer decodes to the pre-write state is fresh
+    data (e.g. the cache key disappearing) and ends the retention."""
+    entity = await _make_retained_entity(monkeypatch, pre_write=False)
+
+    entity._cache_value = None  # no longer the pre-write value
+    entity._handle_coordinator_update()
+
+    assert entity._optimistic_state is None
+    assert entity._optimistic_retained is False
+
+
+@pytest.mark.asyncio
+async def test_retained_state_survives_stale_coordinator_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coordinator ticks still carrying the stale pre-write value must NOT
+    clear the retained state — that would be the #362 revert, delayed one
+    poll tick."""
+    entity = await _make_retained_entity(monkeypatch, pre_write=False)
+
+    entity._cache_value = False  # stale: still the pre-write value
+    entity._handle_coordinator_update()
+
+    assert entity._optimistic_state is True
+    assert entity._optimistic_retained is True
+    assert entity.is_on is True
+
+
+def test_cache_state_peeks_past_optimistic_state() -> None:
+    """The default _cache_state() decodes is_on with the optimistic state
+    masked off, and restores it afterwards."""
+
+    class PeekSwitch(EG4BaseSwitch):
+        @property
+        def is_on(self) -> bool | None:
+            if self._optimistic_state is not None:
+                return self._optimistic_state
+            value = self._parameter_data.get("FUNC_TEST")
+            return None if value is None else bool(value)
+
+    coordinator = MagicMock()
+    coordinator.data = {
+        "devices": {SERIAL: {"type": "inverter", "model": "FlexBOSS21"}},
+        "parameters": {SERIAL: {"FUNC_TEST": False}},
+    }
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    entity = PeekSwitch(coordinator, SERIAL, "peek", "Peek")
+
+    entity._optimistic_state = True
+    assert entity.is_on is True
+    assert entity._cache_state() is False
+    assert entity._optimistic_state is True  # restored after the peek

--- a/tests/test_base_entity_envelope.py
+++ b/tests/test_base_entity_envelope.py
@@ -1,29 +1,52 @@
 """Golden ordering/error tests for optimistic write envelope semantics (#362).
 
-Pinned contract for every write flowing through
-``EG4BaseSwitch._optimistic_write_envelope`` (switch actions and pure-CLOUD
-function switches):
+Pinned contract for every ``EG4BaseSwitch`` write surface — switch actions,
+pure-CLOUD function switches (both via ``_optimistic_write_envelope``), and
+the LOCAL named-parameter path (``_execute_named_parameter_action``, the
+dispatcher behind ``_execute_local_with_fallback``):
 
 - write FAILS -> raise HomeAssistantError, clear optimistic state once,
-  never seed the parameter cache.
+  never seed the parameter cache. Exception (#301): the HYBRID fallback
+  passes ``clear_optimistic_on_error=False`` so the optimistic state
+  survives between the local failure and the cloud retry.
 - write OK + refresh OK -> publish the fresh coordinator data (optimistic
-  state cleared after the refresh completes).
-- write OK + refresh FAILS (reported failure or raised exception) -> the
-  service call SUCCEEDS (never converted into a user-facing write failure),
-  the optimistic state is RETAINED until fresh device data arrives
-  (:meth:`EG4BaseSwitch._handle_coordinator_update`), matching the schedule
-  time entities' retained-optimistic semantics.
+  state cleared after the refresh completes). "Refresh OK" for a full
+  coordinator refresh requires BOTH ``last_update_success`` AND a new data
+  object identity — during the coordinator's 3-strike tolerance window the
+  flag stays True while the refresh served the OLD data object unchanged.
+- write OK + refresh FAILS (reported failure, raised exception, or a
+  tolerated-stale refresh) -> the service call SUCCEEDS (never converted
+  into a user-facing write failure), the optimistic state is RETAINED until
+  fresh device data arrives (:meth:`EG4BaseSwitch._handle_coordinator_update`)
+  or the retention TTL expires (firmware-NAK escape: #251/#331 precedent),
+  matching the schedule time entities' retained-optimistic semantics.
 """
 
+import logging
+import time as time_module
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.eg4_web_monitor.base_entity as base_entity_module
-from custom_components.eg4_web_monitor.base_entity import EG4BaseSwitch
+from custom_components.eg4_web_monitor.base_entity import (
+    RETAINED_OPTIMISTIC_TTL,
+    EG4BaseSwitch,
+)
+from custom_components.eg4_web_monitor.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_DST_SYNC,
+    CONF_LIBRARY_DEBUG,
+    CONF_LOCAL_TRANSPORTS,
+    CONNECTION_TYPE_LOCAL,
+    DOMAIN,
+)
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
 
 
 SERIAL = "1234567890"
@@ -77,13 +100,22 @@ def _make_entity(
     }
     coordinator.last_update_success = True
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
-    coordinator.async_refresh = AsyncMock(
-        side_effect=lambda: events.append("coordinator-refresh")
-    )
+
+    # A genuinely-successful coordinator refresh produces a NEW data object
+    # (the real _async_update_data builds a fresh dict each cycle; only the
+    # 3-strike tolerance window returns the old object unchanged).
+    def _fresh_refresh() -> None:
+        events.append("coordinator-refresh")
+        coordinator.data = dict(coordinator.data)
+
+    coordinator.async_refresh = AsyncMock(side_effect=_fresh_refresh)
     # The coordinator refresh helper reports success/failure (#362); the
     # default harness refresh succeeds.
     coordinator.async_refresh_device_parameters = AsyncMock(
         side_effect=lambda _serial: events.append("parameter-refresh") or True
+    )
+    coordinator.write_named_parameter = AsyncMock(
+        side_effect=lambda *_args, **_kwargs: events.append("write") or None
     )
 
     inverter = SimpleNamespace(
@@ -685,3 +717,261 @@ def test_cache_state_peeks_past_optimistic_state() -> None:
     assert entity.is_on is True
     assert entity._cache_state() is False
     assert entity._optimistic_state is True  # restored after the peek
+
+
+# ── Retention TTL bound (#362 review round) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_arming_retention_sets_bounded_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retention is bounded: arming sets a monotonic TTL deadline."""
+    before = time_module.monotonic()
+    entity = await _make_retained_entity(monkeypatch)
+
+    assert entity._retention_expires > before
+    assert entity._retention_expires <= time_module.monotonic() + (
+        RETAINED_OPTIMISTIC_TTL + 1.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_retained_state_expires_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A firmware-silently-NAKed write (#251/#331 precedent) + one failed
+    refresh must not wedge the entity forever: when every poll keeps
+    returning the pre-write value (indistinguishable from a stale tick),
+    the retention expires after the TTL, logs at WARNING, and the entity
+    reverts to the reported state."""
+    entity = await _make_retained_entity(monkeypatch, pre_write=False)
+    entity._cache_value = False  # device still reports the pre-write value
+
+    # Within the TTL: stale ticks keep the retained state.
+    with caplog.at_level(logging.WARNING):
+        entity._handle_coordinator_update()
+        assert entity._optimistic_retained is True
+
+        # Past the deadline: the retention expires with observability.
+        entity._retention_expires = time_module.monotonic() - 1.0
+        entity._handle_coordinator_update()
+
+    assert entity._optimistic_retained is False
+    assert entity._optimistic_state is None
+    assert entity.is_on is False  # reverted to the reported state
+    assert "expired without device confirmation" in caplog.text
+
+
+# ── Tolerated-stale coordinator refresh (#362 review round) ──────────
+
+
+@pytest.mark.asyncio
+async def test_switch_write_ok_tolerated_stale_refresh_retains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """last_update_success LIES during the coordinator's 3-strike tolerance
+    window (old data object served unchanged, flag still True): the envelope
+    must detect the unchanged data identity and retain the optimistic state
+    instead of publishing the stale data as if it were fresh."""
+    events: list[str] = []
+    entity, coordinator, inverter = _make_entity(events)
+    entity._cache_value = False
+    inverter.enable_test = AsyncMock(side_effect=lambda: events.append("write") or True)
+    # Tolerance-window shape: refresh completes, flag stays True, data
+    # object identity unchanged.
+    coordinator.async_refresh = AsyncMock(
+        side_effect=lambda: events.append("coordinator-refresh")
+    )
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", True
+    )
+
+    assert coordinator.last_update_success is True
+    assert events == [
+        "optimistic-set",
+        "write",
+        "inverter-refresh",
+        "sleep",
+        "coordinator-refresh",
+    ]
+    _assert_retained(entity, value=True)
+
+
+@pytest.mark.asyncio
+async def test_real_tolerance_window_refresh_retains(
+    hass,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression against the REAL coordinator tolerance window (not a
+    mocked last_update_success): the first UpdateFailed within the 3-strike
+    tolerance returns the OLD self.data unchanged and keeps
+    last_update_success True — the post-write refresh must still report
+    failure so the optimistic state is retained."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EG4 - Envelope Tolerance Test",
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+            CONF_DST_SYNC: False,
+            CONF_LIBRARY_DEBUG: False,
+            CONF_LOCAL_TRANSPORTS: [
+                {
+                    "serial": SERIAL,
+                    "host": "192.168.1.100",
+                    "port": 502,
+                    "transport_type": "modbus_tcp",
+                    "inverter_family": "EG4_HYBRID",
+                    "model": "FlexBOSS21",
+                },
+            ],
+        },
+        options={},
+        entry_id="envelope_tolerance_test",
+    )
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    coordinator.data = {
+        "devices": {SERIAL: {"type": "inverter", "model": "FlexBOSS21"}},
+        "parameters": {SERIAL: {}},
+    }
+    inverter = SimpleNamespace(
+        refresh=AsyncMock(),
+        enable_test=AsyncMock(return_value=True),
+        transport=None,  # inspected by coordinator shutdown at teardown
+    )
+    coordinator._inverter_cache = {SERIAL: inverter}
+    monkeypatch.setattr(
+        coordinator,
+        "_route_update_by_connection_type",
+        AsyncMock(side_effect=UpdateFailed("transient transport error")),
+    )
+
+    events: list[str] = []
+    entity = EnvelopeTestSwitch(coordinator, events)
+    entity.async_write_ha_state = MagicMock()
+    monkeypatch.setattr(base_entity_module.asyncio, "sleep", AsyncMock())
+
+    await entity._execute_switch_action(
+        "test action", "enable_test", "disable_test", True
+    )
+
+    # The tolerance window served the OLD data and kept the flag True...
+    assert coordinator.last_update_success is True
+    assert coordinator._consecutive_update_failures == 1
+    # ...and the envelope still detected the stale refresh and retained.
+    assert entity._optimistic_state is True
+    assert entity._optimistic_retained is True
+
+
+# ── LOCAL named-parameter path (#362 review round) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_named_parameter_success_clears_after_fresh_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LOCAL write ok + fresh coordinator refresh: publish fresh data (the
+    optimistic state clears after the refresh), and the acknowledged value
+    is seeded in place so concurrent cycles converge immediately."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_named_parameter_action("test action", "FUNC_TEST", True)
+
+    assert events == [
+        "optimistic-set",
+        "write",
+        "sleep",
+        "coordinator-refresh",
+        "clear",
+    ]
+    assert entity._optimistic_state is None
+    assert entity._optimistic_retained is False
+    assert coordinator.data["parameters"][SERIAL]["FUNC_TEST"] is True
+
+
+@pytest.mark.asyncio
+async def test_named_parameter_write_ok_stale_refresh_retains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The #362 revert on the highest-traffic path: LOCAL write ok + failed
+    or tolerated-stale refresh must retain the optimistic state (a full
+    rebuild replaces the parameters dict wholesale, wiping the in-place
+    seed) instead of unconditionally clearing onto stale data."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    entity._cache_value = False
+    # Tolerated-stale refresh: identity unchanged, flag still True.
+    coordinator.async_refresh = AsyncMock(
+        side_effect=lambda: events.append("coordinator-refresh")
+    )
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_named_parameter_action("test action", "FUNC_TEST", True)
+
+    assert events == ["optimistic-set", "write", "sleep", "coordinator-refresh"]
+    _assert_retained(entity, value=True)
+    assert entity._pre_write_state is False
+    # The in-place seed still happened (write acknowledged).
+    assert coordinator.data["parameters"][SERIAL]["FUNC_TEST"] is True
+
+
+@pytest.mark.asyncio
+async def test_named_parameter_write_ok_refresh_raises_retains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising post-write refresh after an acknowledged LOCAL write is not
+    a write failure: no raise, optimistic state retained."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    coordinator.async_refresh = AsyncMock(side_effect=RuntimeError("refresh died"))
+    _patch_sleep(monkeypatch, events)
+
+    await entity._execute_named_parameter_action("test action", "FUNC_TEST", False)
+
+    assert events == ["optimistic-set", "write", "sleep"]
+    _assert_retained(entity, value=False)
+
+
+@pytest.mark.asyncio
+async def test_named_parameter_write_failure_clears_and_raises() -> None:
+    """A failed LOCAL write raises, clears optimistic state once, and never
+    arms retention (default clear_optimistic_on_error=True)."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    coordinator.write_named_parameter = AsyncMock(
+        side_effect=HomeAssistantError("Modbus timeout")
+    )
+
+    with pytest.raises(HomeAssistantError, match="Modbus timeout"):
+        await entity._execute_named_parameter_action("test action", "FUNC_TEST", True)
+
+    assert events == ["optimistic-set", "clear"]
+    assert entity._optimistic_state is None
+    assert entity._optimistic_retained is False
+
+
+@pytest.mark.asyncio
+async def test_named_parameter_write_failure_keeps_optimistic_for_cloud_retry() -> None:
+    """#301 byte-for-byte: with clear_optimistic_on_error=False (a cloud
+    retry follows), the local write failure re-raises WITHOUT clearing the
+    optimistic state — no stale pre-write publish between the local failure
+    and the cloud attempt."""
+    events: list[str] = []
+    entity, coordinator, _inverter = _make_entity(events)
+    coordinator.write_named_parameter = AsyncMock(
+        side_effect=HomeAssistantError("Modbus timeout")
+    )
+
+    with pytest.raises(HomeAssistantError, match="Modbus timeout"):
+        await entity._execute_named_parameter_action(
+            "test action", "FUNC_TEST", True, clear_optimistic_on_error=False
+        )
+
+    assert events == ["optimistic-set"]  # no clear published
+    assert entity._optimistic_state is True

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -3537,7 +3537,8 @@ class TestLinkDownParameterRefreshGate:
     async def test_async_refresh_device_parameters_refreshes_down_link(
         self, hass, local_config_entry
     ):
-        """The single-serial public refresh path delegates the same way."""
+        """The single-serial public refresh path delegates the same way and
+        reports success (#362)."""
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
         down = self._fake_inverter(link_down=True)
@@ -3545,9 +3546,29 @@ class TestLinkDownParameterRefreshGate:
         coordinator.data = {"devices": {"DOWN1": {"type": "inverter"}}}
         coordinator.async_request_refresh = AsyncMock()
 
-        await coordinator.async_refresh_device_parameters("DOWN1")
+        result = await coordinator.async_refresh_device_parameters("DOWN1")
 
+        assert result is True
         down.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+
+    async def test_async_refresh_device_parameters_reports_failure(
+        self, hass, local_config_entry
+    ):
+        """#362 golden: a failed refresh returns False (logged, not raised)
+        so write paths can distinguish write-ok+refresh-fail from full
+        success instead of silently reverting optimistic state."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        broken = self._fake_inverter(link_down=False)
+        broken.refresh = AsyncMock(side_effect=ConnectionError("refresh died"))
+        coordinator._inverter_cache = {"INV1": broken}
+        coordinator.data = {"devices": {"INV1": {"type": "inverter"}}}
+        coordinator.async_request_refresh = AsyncMock()
+
+        result = await coordinator.async_refresh_device_parameters("INV1")
+
+        assert result is False
+        coordinator.async_request_refresh.assert_not_awaited()
 
     async def test_note_parameters_written_merges_and_notifies(
         self, hass, local_config_entry

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -54,8 +54,16 @@ def _mock_coordinator(
     coordinator.plant_id = "plant_123"
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.async_request_refresh = AsyncMock()
-    coordinator.async_refresh = AsyncMock()
-    coordinator.async_refresh_device_parameters = AsyncMock()
+
+    # A genuinely-successful full refresh produces a NEW data object each
+    # cycle (only the coordinator's 3-strike tolerance window returns the
+    # old object unchanged, #362) — mirror that so post-write refreshes
+    # count as fresh. Tests exercising stale/tolerated refreshes override.
+    def _fresh_refresh() -> None:
+        coordinator.data = dict(coordinator.data)
+
+    coordinator.async_refresh = AsyncMock(side_effect=_fresh_refresh)
+    coordinator.async_refresh_device_parameters = AsyncMock(return_value=True)
     coordinator.write_named_parameter = AsyncMock()
     # Real dict (not an auto-Mock) so QuickChargeDurationNumber / the Quick
     # Charge switch read a true per-serial duration preference.
@@ -892,6 +900,78 @@ class TestQuickChargeSwitchOptimisticRetention:
             await switch.async_turn_on()
         assert switch._pending_state is None
         assert switch.is_on is False
+
+
+class TestQuickChargeCacheStatePeek:
+    """#362 review round: the retention peek must read genuine device data.
+
+    Quick charge's ``is_on`` consults the #296 ``_pending_state`` hold after
+    the optimistic state — without masking it, the peek (a) echoes the held
+    command back (false convergence: the #362 retention would clear on the
+    next tick regardless of device truth) and (b) can MUTATE
+    ``_pending_state`` as a side effect of the read.
+    """
+
+    def test_cache_state_masks_pending_hold_without_side_effects(self):
+        """The peek masks _pending_state and never consumes the hold — even
+        in the exact shape (expired TTL + fresh unconfirming read) where a
+        normal is_on read WOULD consume it."""
+        coordinator = _mock_coordinator()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        switch._pending_state = True
+        switch._pending_since = (
+            time.monotonic() - switch_module.QUICK_CHARGE_OPTIMISTIC_TTL - 1.0
+        )
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": False,
+            "fetched_at": time.monotonic(),  # fresh, unconfirming, expired
+        }
+
+        # Genuine device truth, not the pending echo...
+        assert switch._cache_state() is False
+        # ...and the hold was NOT consumed by the peek.
+        assert switch._pending_state is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_with_pending_hold_converges_on_truth(self):
+        """Write ok + stale refresh arms #362 retention WITH the #296 pending
+        hold armed: stale ticks keep both; retention ends only on genuine
+        fresh device data (not the pending echo), and the tick never mutates
+        the pending hold through the peek."""
+        coordinator = _mock_coordinator()
+        # Tolerated-stale refresh: identity unchanged, flag still True.
+        coordinator.async_refresh = AsyncMock()
+        switch = EG4QuickChargeSwitch(coordinator, "1234567890")
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        assert switch._optimistic_retained is True
+        assert switch._optimistic_state is True
+        assert switch._pending_state is True
+
+        # Stale pre-write status tick: the peek reads the genuine (stale)
+        # value, so retention survives and the pending hold is untouched.
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": False,
+            "fetched_at": switch._pending_since - 10.0,
+        }
+        switch._handle_coordinator_update()
+
+        assert switch._optimistic_retained is True
+        assert switch._pending_state is True
+        assert switch.is_on is True
+
+        # Fresh confirming status: genuine device truth ends the retention.
+        coordinator.data["devices"]["1234567890"]["quick_charge_status"] = {
+            "hasUnclosedQuickChargeTask": True,
+            "fetched_at": switch._pending_since + 10.0,
+        }
+        switch._handle_coordinator_update()
+
+        assert switch._optimistic_retained is False
+        assert switch._optimistic_state is None
+        assert switch.is_on is True
 
 
 # ── BatteryBackupSwitch ──────────────────────────────────────────────

--- a/tests/test_time_entities.py
+++ b/tests/test_time_entities.py
@@ -1127,7 +1127,7 @@ class TestParameterRefreshScope:
             },
         )
 
-        async def _refresh_device(refresh_serial: str) -> None:
+        async def _refresh_device(refresh_serial: str) -> bool:
             assert refresh_serial == serial
             coordinator.data["parameters"][serial] = {
                 "HOLD_AC_CHARGE_START_HOUR": "20",
@@ -1136,6 +1136,7 @@ class TestParameterRefreshScope:
                 "HOLD_AC_CHARGE_END_MINUTE": "45",
             }
             await coordinator.async_request_refresh()
+            return True
 
         coordinator.async_refresh_device_parameters = AsyncMock(
             side_effect=_refresh_device
@@ -1178,12 +1179,13 @@ class TestParameterRefreshScope:
             "HOLD_AC_CHARGE_START_MINUTE": "0",
         }
 
-        async def _refresh_device(refresh_serial: str) -> None:
+        async def _refresh_device(refresh_serial: str) -> bool:
             coordinator.data["parameters"][refresh_serial] = {
                 "HOLD_AC_CHARGE_START_HOUR": "20",
                 "HOLD_AC_CHARGE_START_MINUTE": "30",
             }
             await coordinator.async_request_refresh()
+            return True
 
         coordinator.async_refresh_device_parameters = AsyncMock(
             side_effect=_refresh_device
@@ -1340,10 +1342,11 @@ class TestWriteFailureConvergence:
             has_local=True,
             parameters={str(spec.base_register): _pack(8, 0)},
         )
-        # The real coordinator method swallows its own exceptions (coordinator_mixins.py),
-        # so this raise cannot occur in production — this test pins time.py's DEFENSIVE
-        # except-branch only; the production-reachable retain-optimistic path is the
-        # explicit link-down branch (covered by the link-down tests).
+        # The real coordinator method catches its own exceptions and reports
+        # failure by returning False (#362, coordinator_mixins.py), so this
+        # raise cannot occur in production — this test pins time.py's
+        # DEFENSIVE except-branch only; the production-reachable paths are the
+        # False return (test below) and the explicit link-down branch.
         coordinator.async_refresh_device_parameters = AsyncMock(
             side_effect=Exception("refresh died")
         )
@@ -1356,6 +1359,32 @@ class TestWriteFailureConvergence:
 
         coordinator.write_register.assert_awaited_once()
         assert entity._optimistic_value == time(7, 15)
+        assert entity.native_value == time(7, 15)
+        assert entity.available is True
+
+    @pytest.mark.asyncio
+    async def test_write_success_refresh_reports_failure_retains_optimistic(self):
+        """#362 golden path: the coordinator refresh helper reports failure
+        by RETURNING False (it logs and swallows its own exceptions), so the
+        schedule entity's retain-optimistic branch must fire on that signal —
+        before #362 the helper swallowed the error and returned None-as-
+        success, silently reverting the entity to the stale pre-write time.
+        """
+        coordinator = _mock_coordinator(
+            has_local=True,
+            parameters={"HOLD_AC_CHARGE_START_HOUR_1": _pack(8, 0)},
+        )
+        coordinator.async_refresh_device_parameters = AsyncMock(return_value=False)
+
+        entity = _entity(coordinator, window=1, is_end=False)
+        _prep(entity)
+
+        # Write succeeds; the reported refresh failure is not raised.
+        await entity.async_set_value(time(7, 15))
+
+        coordinator.write_register.assert_awaited_once()
+        assert entity._optimistic_value == time(7, 15)
+        assert entity._optimistic_retained is True
         assert entity.native_value == time(7, 15)
         assert entity.available is True
 


### PR DESCRIPTION
## Problem

From the post-3.5.0-beta.1 dual bug scan (codex P2.3 + P3, accepted as one design item in #362):

1. `ParameterManagementMixin.async_refresh_device_parameters` caught every refresh exception and returned normally, so callers could not distinguish "write+refresh ok" from "write ok, refresh failed". Schedule time writes (`time.py`) and pure-CLOUD function switches (`base_entity.py`, not cache-seeded by design) then cleared their optimistic state and published the **stale pre-write value** until the next poll corrected it — the service reported success while the entity visibly reverted. The schedule entities' retain-optimistic branch existed but was production-unreachable because the swallow made every refresh look successful.
2. `_optimistic_write_envelope` put the acknowledged write AND the post-write refresh inside one exception boundary, so a transient refresh error (e.g. `inverter.refresh()` network hiccup) after a **successful** cloud write raised "Failed to enable X" and cleared optimistic state even though the hardware accepted the command.

## Design

Refresh helpers report success/failure instead of swallowing; on write-ok + refresh-fail, the optimistic state is **retained** (bounded by a TTL) and logged — a successful write is never converted into a user-facing write failure and the entity never publishes the stale pre-write value the device already superseded.

- **`coordinator_mixins.py`** — `async_refresh_device_parameters` returns `bool` (True = refresh completed; False = failed, logged, never raised). Callers that ignore the return keep their existing behavior.
- **`base_entity.py`** — ALL `EG4BaseSwitch` write surfaces share one contract: `_execute_switch_action` and `_execute_cloud_function_action` (via `_optimistic_write_envelope`) **and the LOCAL named-parameter path `_execute_named_parameter_action`** (the dispatcher behind `_execute_local_with_fallback` — BatteryBackup/OffGrid/all WorkingMode switches) settle through a common `_settle_acknowledged_write` helper with **separate write and refresh exception boundaries**:
  - write fails → clear optimistic state, raise (unchanged; the HYBRID fallback's `clear_optimistic_on_error=False` retention between local failure and cloud retry is preserved byte-for-byte, #301).
  - write ok + refresh ok → publish fresh data after the refresh (unchanged, no bounce). For full coordinator refreshes, "ok" requires **both** `last_update_success` **and a new data object identity** — the flag alone lies during the coordinator's 3-strike tolerance window, which serves the OLD data object unchanged.
  - write ok + refresh fails (reported `False`, raised, or tolerated-stale) → retain optimistic state, log at WARNING, return success.
  - Retention clearing mirrors the schedule time entities' pinned semantics via `EG4BaseSwitch._handle_coordinator_update`: clears when the cache decodes to the written value or anything no longer equal to the pre-write value; a tick still carrying the stale pre-write value keeps it. **Bounded**: `RETAINED_OPTIMISTIC_TTL` (300 s, `QUICK_CHARGE_OPTIMISTIC_TTL` precedent) is the firmware-NAK escape (#251/#331 precedent) — unconverged retention expires with a WARNING and reverts to the reported state.
  - `_cache_state()` peek decodes `is_on` with optimistic state masked (synchronous, side-effect-free contract); `EG4QuickChargeSwitch` overrides it to also mask its #296 `_pending_state` hold, so the peek reads genuine status data and never consumes the hold as a read side effect.
  - The #310 seed ordering (seed acknowledged value before refresh, only on write success) is preserved. The named-parameter path's in-place dict update is deliberately NOT unified with `note_parameters_written` (that channel notifies all listeners; its absence on local success is pinned by `test_local_success_path_not_seeded`) — retention is what guards the revert when a full rebuild wipes the in-place seed.
- **`time.py`** — `_async_refresh_parameters` propagates the coordinator helper's success flag, making the schedule entities' retained-optimistic branch fire on the production-reachable signal (returned `False`) instead of only on the defensive raise path. The schedule entities' own pre-existing retention (unbounded, fresh-data-cleared) is intentionally unchanged in this PR.

`number.py` / `select.py` do **not** flow through these helpers (they use `async_write_with_cloud_fallback` + their own inline optimistic handling and ignore the refresh helper's return), so their behavior is unchanged by this PR — follow-up issue to align time/select/number retention semantics.

## Test plan

Golden ordering/error tests were written **first** in both rounds (13 failed pre-fix in round 1, 11 more added in the review round; 2103 → 2126 collected):

- `tests/test_base_entity_envelope.py` — write fail → raise + clear once + never seed; write ok + refresh ok → ordering + fresh publish; write ok + reported/raised refresh failure retains (both envelope surfaces); raising `inverter.refresh()` is NOT a write failure; retention clears on convergence / other fresh value, survives stale ticks, **expires after the TTL with a WARNING**; **tolerated-stale refresh retains (unit + regression against a REAL `EG4DataUpdateCoordinator` in its 3-strike tolerance window — `last_update_success` stays True, old data object served, retention still armed)**; **LOCAL named-parameter goldens** (fresh-refresh clear, stale-refresh retain, raising-refresh retain, write-fail clear+raise, `clear_optimistic_on_error=False` #301 pinning); `_cache_state` peek semantics.
- `tests/test_switch_entities.py` — **QuickCharge peek**: `_cache_state` masks the `_pending_state` hold without consuming it (even in the expired-TTL + fresh-unconfirming shape where a normal read WOULD consume it); combined refresh-failure + armed pending hold converges only on genuine fresh device data. Existing #296 retention and #301/#310 fallback/seeding tests unchanged and passing.
- `tests/test_time_entities.py` — golden test for the returned-`False` production path arming schedule retention; existing #283 retention/convergence tests unchanged.
- `tests/test_coordinator_local.py` — `async_refresh_device_parameters` returns `True` on success / `False` on failure (logged, not raised; no debounced refresh after failure).

Gates: `ruff check`/`format` clean, `mypy --strict` (tests/mypy.ini) clean, full suite **2123 passed, 3 skipped**.

## Review round (Claude code-reviewer + Codex + Gemini, adjudicated)

- **P1 (Codex, confirmed)**: `_execute_named_parameter_action` was never patched in round 1 — the LOCAL/register write path still cleared optimistic state unconditionally (the exact #362 revert on the highest-traffic path). Now under the same retention semantics via the shared `_settle_acknowledged_write` helper. DRY unification of the in-place seed with `note_parameters_written` was evaluated and deliberately not done (pinned behavior + listener-notify semantic difference).
- **P1 (all three)**: retention bounded by `RETAINED_OPTIMISTIC_TTL` (300 s) with a WARNING on expiry — the firmware-silently-NAKed-write escape. Pre-fix behavior self-corrected loudly; unbounded retention would have wedged silently.
- **P1 (code-reviewer)**: `last_update_success` lies during the 3-strike tolerance window — `_refresh_coordinator_data` now also requires a new data object identity; regression test exercises the real tolerance window, not a mocked flag.
- **P2 (all three)**: `EG4QuickChargeSwitch._cache_state` override — the peek no longer echoes the #296 pending hold (false convergence) nor mutates it as a read side effect.
- **P3**: refresh-returned-False and refresh-raised now both log WARNING.

Fixes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)