### PR TITLE
feat: AC Couple switch entity (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **AC Couple Start/End SOC number entities** ([#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352), requested by @mjstrand): the SOC window governing the AC-coupled source on the inverter's smart port — enabled when battery SOC drops below *Start*, disabled above *End* — scriptable for safe grid/smart-port source transfers. Cloud-only (no local Modbus register): created on Cloud and Hybrid connections for all supported inverters, refreshed from the cloud on a 5-minute cadence (which also picks up portal-side edits), unavailable on devices that do not carry the parameters. A factory-disabled End threshold (`255`, "never stop") shows as unknown with a `disabled_sentinel: true` attribute. Requires pylxpweb ≥ 0.9.39b2.
+- **AC Couple switch** ([#471](https://github.com/joyfulhouse/eg4_web_monitor/issues/471), follow-up to #352 suggested by @mjstrand and @ivanfmartinez): enables/disables the inverter's AC couple function (`FUNC_AC_COUPLING_FUNCTION`) outright — de-energizing the AC-coupled source on the smart port at any battery level, without driving the Start/End SOC window. Same cloud-only architecture as the SOC pair (state from the 5-minute cloud read, writes cloud-routed in every mode, unavailable on devices that lack the function param). Requires pylxpweb ≥ 0.9.39b3.
 
 ## [3.5.1-beta.1] - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -233,15 +233,18 @@ automation:
           entity_id: switch.18kpv_1234567890_battery_backup
 ```
 
-### AC Couple Start/End SOC (cloud connection required)
+### AC Couple controls (cloud connection required)
 
-Inverters expose **AC Couple Start SOC** and **AC Couple End SOC** number
-entities: the AC-coupled source on the smart port is enabled when battery SOC
-drops below *Start* and disabled above *End*. Scripting these lets you
-de-energize the smart port on demand — e.g. to safely transfer a grid-tied
-inverter between the grid and the smart port (#352). The parameters are not
-family-specific: they are used live on off-grid 12000XP systems and on-grid
-hybrid LXP systems alike.
+Inverters expose an **AC Couple** switch plus **AC Couple Start SOC** and
+**AC Couple End SOC** number entities. The switch toggles the AC couple
+function itself (`FUNC_AC_COUPLING_FUNCTION`) — off means the AC-coupled
+source on the smart port is de-energized at any battery level (#471). The
+SOC window governs the function while it is enabled: the source is enabled
+when battery SOC drops below *Start* and disabled above *End* (#352).
+Scripting these lets you de-energize the smart port on demand — e.g. to
+safely transfer a grid-tied inverter between the grid and the smart port.
+The parameters are not family-specific: they are used live on off-grid
+12000XP systems and on-grid hybrid LXP systems alike.
 
 Notes:
 
@@ -256,10 +259,25 @@ Notes:
   attribute in that state; 255 cannot be written from the 0-100 slider —
   set any 0-100 value to take control, or restore 255 from the EG4 portal.
 
+For an on-demand transfer, toggling the switch is the simplest lever:
+
 ```yaml
 script:
   drop_smart_port_power:
     alias: "De-energize smart port before transfer"
+    sequence:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.12000xp_1234567890_ac_couple
+```
+
+Alternatively, drive the SOC window (the source stays governed by battery
+level instead of being switched off outright):
+
+```yaml
+script:
+  drop_smart_port_power_via_soc:
+    alias: "De-energize smart port via SOC window"
     sequence:
       - service: number.set_value
         target:

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -690,24 +690,54 @@ class EG4DataUpdateCoordinator(
         params.update(values)
         self.async_update_listeners()
 
-    def note_ac_couple_soc_written(self, serial: str, key: str, value: int) -> None:
-        """Merge an acknowledged AC couple SOC write into the dedicated store.
+    def note_ac_couple_soc_written(
+        self, serial: str, key: str, value: int | bool
+    ) -> None:
+        """Merge an acknowledged AC couple write into the dedicated store.
 
-        The AC Couple SOC window lives in the ``ac_couple_soc`` device-data
-        store, NOT the parameter cache (GH #352 — no local register, so a
-        HYBRID parameter refresh would wipe cache-seeded values). The written
-        value IS device truth (the cloud write was acknowledged); merging it
-        keeps the UI converged until the next throttled getter read confirms.
+        The AC Couple SOC window and enable state live in the
+        ``ac_couple_soc`` device-data store, NOT the parameter cache (GH #352
+        — no local register, so a HYBRID parameter refresh would wipe
+        cache-seeded values). The written value IS device truth (the cloud
+        write was acknowledged); merging it keeps the UI converged until the
+        next throttled getter read confirms.
 
         Sibling-preserving by design: the store dict is copied and only
         ``key`` is replaced, so writing Start never blanks a known End value
         (and vice versa) — PR #380 review P1.
 
+        Persistent write-seed registry (PR #471 review): the acknowledged
+        write is ALSO recorded in ``_ac_couple_soc_seeds`` — a per-serial dict
+        that lives OUTSIDE ``self.data`` and therefore survives the wholesale
+        ``self.data`` replacement at the end of a refresh cycle. Seeding only
+        ``self.data`` is not enough: a refresh cycle already in flight
+        snapshots the store (throttled carry-forward) BEFORE this write lands,
+        then publishes that stale snapshot on completion — reverting the UI
+        until the next 5-minute cloud read. Every carry-forward path re-applies
+        the registry (:meth:`_overlay_ac_couple_seeds`), and a cloud read
+        initiated AFTER the write clears it (:meth:`_fetch_ac_couple_soc`).
+
+        Each field carries its OWN timestamp (PR #471 round-2 review): a later
+        write to one key must NOT renew an older key's seed, or an in-flight
+        read fetching a legitimate external portal change to that older key
+        would be clobbered by the stale seed. Seeds are keyed
+        ``{serial: {store_key: {"value": ..., "at": monotonic}}}`` and each
+        field's seed is applied/cleared independently.
+
         Args:
             serial: Inverter serial number.
-            key: Store key — ``"start_soc"`` or ``"end_soc"``.
-            value: Acknowledged whole-percent value.
+            key: Store key — ``"start_soc"``, ``"end_soc"`` or ``"enabled"``.
+            value: Acknowledged whole-percent value, or the acknowledged
+                FUNC_AC_COUPLING_FUNCTION state for ``"enabled"`` (GH #471).
         """
+        now = time.monotonic()
+        if not hasattr(self, "_ac_couple_soc_seeds"):
+            self._ac_couple_soc_seeds = {}
+        self._ac_couple_soc_seeds.setdefault(serial, {})[key] = {
+            "value": value,
+            "at": now,
+        }
+
         if not self.data:
             return
         device = self.data.get("devices", {}).get(serial)
@@ -715,7 +745,7 @@ class EG4DataUpdateCoordinator(
             return
         store = dict(device.get("ac_couple_soc") or {})
         store[key] = value
-        store["fetched_at"] = time.monotonic()
+        store["fetched_at"] = now
         device["ac_couple_soc"] = store
         self.async_update_listeners()
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -536,6 +536,11 @@ if TYPE_CHECKING:
         _last_dst_sync: datetime | None
         _dst_sync_interval: timedelta
         _last_status_fetch: dict[str, float]
+        # AC couple write-seed registry (GH #471): {serial: {store_key:
+        # {"value": int|bool, "at": monotonic}}} — survives self.data
+        # replacement so a mid-cycle write is not reverted; per-field
+        # timestamps keep each key's seed lifecycle independent (round-2).
+        _ac_couple_soc_seeds: dict[str, dict[str, dict[str, Any]]]
         _daily_api_offset: int
         _daily_api_ymd: tuple[int, int, int]
         _modbus_transport: ModbusTransport | ModbusSerialTransport | None
@@ -1120,7 +1125,39 @@ class DeviceProcessingMixin(_MixinBase):
         if self.data and serial in self.data.get("devices", {}):
             prev = self.data["devices"][serial].get("ac_couple_soc")
             if prev is not None:
-                target["ac_couple_soc"] = prev
+                target["ac_couple_soc"] = self._overlay_ac_couple_seeds(serial, prev)
+
+    def _overlay_ac_couple_seeds(
+        self, serial: str, store: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Re-apply acknowledged-write seeds on top of a store dict.
+
+        Closes the mid-cycle race (PR #471 review): a refresh cycle snapshots
+        the store early (throttled carry-forward), so a write acknowledged
+        while that cycle is in flight lands its ``note_ac_couple_soc_written``
+        seed in the CURRENT ``self.data`` — which the cycle's stale snapshot
+        then replaces on publish, silently reverting the UI until the next
+        5-minute cloud read. The seed registry survives cycles; every carried
+        store re-applies it here, and ``_fetch_ac_couple_soc`` clears it once
+        a cloud read initiated after the write confirms. Identity is
+        preserved when no seed is pending (the carried-dict staleness
+        provenance and the existing identity assertions rely on that).
+
+        A carry-forward cycle never initiated a cloud read, so every pending
+        per-field seed still wins here (no timestamp comparison — that lives
+        in the fetch path, which is the only place a fresh read can supersede
+        a seed).
+        """
+        seeds = getattr(self, "_ac_couple_soc_seeds", {}).get(serial)
+        if not seeds:
+            return store
+        merged = dict(store)
+        latest = store.get("fetched_at") or 0.0
+        for field, seed in seeds.items():
+            merged[field] = seed["value"]
+            latest = max(latest, seed["at"])
+        merged["fetched_at"] = latest
+        return merged
 
     async def _fetch_ac_couple_soc(
         self, inverter: "BaseInverter", target: dict[str, Any]
@@ -1139,6 +1176,11 @@ class DeviceProcessingMixin(_MixinBase):
         failures. Values are whole percent ints, ``None`` when the device
         does not carry the param (models without AC couple support), and
         the END value 255 is the factory disabled/"never stop" sentinel.
+
+        The store also carries ``enabled`` — the FUNC_AC_COUPLING_FUNCTION
+        state backing the AC Couple switch (GH #471), same cloud-only
+        rationale and same getter read. ``None`` when the param is absent
+        or the installed pylxpweb getter predates it (< 0.9.39b3).
         """
         client = self.client
         if client is None:
@@ -1169,19 +1211,26 @@ class DeviceProcessingMixin(_MixinBase):
             # carry-forward here, not escape to the per-device handler and
             # blank the whole inverter for the cycle (the #378 round-2 bug
             # class).
-            limits: dict[str, int | None] = await asyncio.wait_for(
+            limits: dict[str, int | bool | None] = await asyncio.wait_for(
                 getter(serial), timeout=AC_COUPLE_SOC_FETCH_TIMEOUT
             )
             start_soc = limits.get("start_soc")
             end_soc = limits.get("end_soc")
-            if start_soc is None and end_soc is None:
-                prev = (
-                    self.data["devices"][serial].get("ac_couple_soc")
-                    if self.data and serial in self.data.get("devices", {})
-                    else None
-                )
-                if prev is not None and (
-                    prev.get("start_soc") is not None or prev.get("end_soc") is not None
+            enabled = limits.get("enabled")
+            if not isinstance(enabled, bool):
+                # Absent key (pylxpweb < 0.9.39b3 getter) or unparseable —
+                # never let a fake truthy/falsy value reach the switch.
+                enabled = None
+            prev = (
+                self.data["devices"][serial].get("ac_couple_soc")
+                if self.data and serial in self.data.get("devices", {})
+                else None
+            ) or {}
+            if start_soc is None and end_soc is None and enabled is None:
+                if (
+                    prev.get("start_soc") is not None
+                    or prev.get("end_soc") is not None
+                    or prev.get("enabled") is not None
                 ):
                     # An all-None read is indistinguishable from a total cloud
                     # range-read failure (pylxpweb's range gather swallows
@@ -1192,18 +1241,62 @@ class DeviceProcessingMixin(_MixinBase):
                     # permanently vanished would pin the last-known values
                     # forever — accepted (the capability is static in
                     # practice); revisit if a real report shows otherwise.
-                    target["ac_couple_soc"] = prev
+                    target["ac_couple_soc"] = self._overlay_ac_couple_seeds(
+                        serial, prev
+                    )
                     return
-            target["ac_couple_soc"] = {
+            else:
+                # Per-field carry-forward (PR #471 review, found independently
+                # by two reviewers): a None FIELD on an otherwise-successful
+                # read is likewise indistinguishable from a PARTIAL range-read
+                # failure — the params' true registers are unpinned, so
+                # same-range locality cannot be assumed and one range can fail
+                # while another succeeds. A known value is never overwritten
+                # with None; genuinely-lacking devices never had one to keep
+                # (same static-capability trade as the all-None branch).
+                if start_soc is None:
+                    start_soc = prev.get("start_soc")
+                if end_soc is None:
+                    end_soc = prev.get("end_soc")
+                if enabled is None:
+                    prev_enabled = prev.get("enabled")
+                    if isinstance(prev_enabled, bool):
+                        enabled = prev_enabled
+            store = {
                 "start_soc": start_soc,
                 "end_soc": end_soc,
+                "enabled": enabled,
                 "fetched_at": now,
             }
+            # Acknowledged-write seeds, evaluated PER FIELD (round-2 review):
+            # a field whose seed landed while this read was in flight (stamp
+            # newer than the read's start) is newer device truth than the
+            # read — apply it and keep the seed; a field whose read started
+            # after its write supersedes that seed — drop just that field, so
+            # a later write to a DIFFERENT key never renews this one and
+            # clobbers a legitimate external change the read picked up.
+            #
+            # This timestamp-gated apply-or-clear is DELIBERATELY separate from
+            # _overlay_ac_couple_seeds (used by the carry-forward paths), which
+            # applies every pending seed unconditionally: only this path has a
+            # fresh read to compare a seed against and thus to supersede it. Do
+            # NOT merge the two into one helper (PR #471 review LOW).
+            serial_seeds = getattr(self, "_ac_couple_soc_seeds", {}).get(serial)
+            if serial_seeds:
+                for field in list(serial_seeds):
+                    if serial_seeds[field]["at"] > now:
+                        store[field] = serial_seeds[field]["value"]
+                    else:
+                        del serial_seeds[field]
+                if not serial_seeds:
+                    self._ac_couple_soc_seeds.pop(serial, None)
+            target["ac_couple_soc"] = store
             _LOGGER.debug(
-                "AC couple SOC limits for %s: start=%s end=%s",
+                "AC couple SOC limits for %s: start=%s end=%s enabled=%s",
                 serial,
-                start_soc,
-                end_soc,
+                store["start_soc"],
+                store["end_soc"],
+                store["enabled"],
             )
         except Exception as e:
             _LOGGER.debug("Could not fetch AC couple SOC limits for %s: %s", serial, e)

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -1221,6 +1221,11 @@ class DeviceProcessingMixin(_MixinBase):
                 # Absent key (pylxpweb < 0.9.39b3 getter) or unparseable —
                 # never let a fake truthy/falsy value reach the switch.
                 enabled = None
+            # What this read actually OBSERVED per field, BEFORE carry-forward
+            # substitutes prior values — the seed-clear step below needs to
+            # distinguish "read saw a concrete value" from "read failed/absent
+            # for this field" (post-#473 review).
+            observed = {"start_soc": start_soc, "end_soc": end_soc, "enabled": enabled}
             prev = (
                 self.data["devices"][serial].get("ac_couple_soc")
                 if self.data and serial in self.data.get("devices", {})
@@ -1268,15 +1273,21 @@ class DeviceProcessingMixin(_MixinBase):
                 "enabled": enabled,
                 "fetched_at": now,
             }
-            # Acknowledged-write seeds, evaluated PER FIELD (round-2 review):
-            # a field whose seed landed while this read was in flight (stamp
-            # newer than the read's start) is newer device truth than the
-            # read — apply it and keep the seed; a field whose read started
-            # after its write supersedes that seed — drop just that field, so
-            # a later write to a DIFFERENT key never renews this one and
-            # clobbers a legitimate external change the read picked up.
+            # Acknowledged-write seeds, evaluated PER FIELD. A field's seed is
+            # SUPERSEDED (dropped) only when this read OBSERVED a concrete value
+            # for it (``observed[field] is not None``) AFTER the write — that
+            # value is newer device truth (the write itself, or a later
+            # external change). It is RETAINED and applied when either the seed
+            # post-dates the read's start (a write that raced this in-flight
+            # read) OR the read did not observe the field at all (a partial
+            # range-read failure returned None): a read that never saw the
+            # field cannot confirm or supersede the write, so clearing on
+            # read-start-time alone would revert a just-written value that a
+            # race-reverted ``self.data`` carried back in (post-#473 review).
+            # Per-field timestamps also stop a later write to a DIFFERENT key
+            # from renewing this one and clobbering an external change.
             #
-            # This timestamp-gated apply-or-clear is DELIBERATELY separate from
+            # This apply-or-clear is DELIBERATELY separate from
             # _overlay_ac_couple_seeds (used by the carry-forward paths), which
             # applies every pending seed unconditionally: only this path has a
             # fresh read to compare a seed against and thus to supersede it. Do
@@ -1284,10 +1295,14 @@ class DeviceProcessingMixin(_MixinBase):
             serial_seeds = getattr(self, "_ac_couple_soc_seeds", {}).get(serial)
             if serial_seeds:
                 for field in list(serial_seeds):
-                    if serial_seeds[field]["at"] > now:
-                        store[field] = serial_seeds[field]["value"]
-                    else:
+                    superseded = (
+                        serial_seeds[field]["at"] <= now
+                        and observed.get(field) is not None
+                    )
+                    if superseded:
                         del serial_seeds[field]
+                    else:
+                        store[field] = serial_seeds[field]["value"]
                 if not serial_seeds:
                     self._ac_couple_soc_seeds.pop(serial, None)
             target["ac_couple_soc"] = store

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.39b2", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.39b3", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.5.1-beta.1"
 }

--- a/custom_components/eg4_web_monitor/strings.json
+++ b/custom_components/eg4_web_monitor/strings.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Share Battery"
+      },
+      "ac_couple": {
+        "name": "AC Couple"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -224,6 +224,16 @@ async def async_setup_entry(
                         serial,
                     )
 
+                # AC Couple switch (GH #471): CLOUD-ONLY function param
+                # (FUNC_AC_COUPLING_FUNCTION) with no pinned local register —
+                # same gate as the AC Couple Start/End SOC numbers (GH #352,
+                # number.py): only where a cloud client can read and write
+                # it, NOT family-gated. Devices that truly lack the param
+                # read None from the cloud getter and the switch goes
+                # unavailable instead.
+                if coordinator.has_http_api():
+                    entities.append(EG4ACCoupleSwitch(coordinator, serial))
+
                 # Add battery backup switch (EPS) based on feature detection
                 eps_supported = _supports_eps_battery_backup(device_data)
                 _LOGGER.debug(
@@ -556,6 +566,120 @@ class EG4QuickChargeSwitch(EG4BaseSwitch):
         self._pending_state = turn_on
         self._pending_since = time.monotonic()
         self.async_write_ha_state()
+
+
+class EG4ACCoupleSwitch(EG4BaseSwitch):
+    """AC Couple function switch (GH #471, cloud client required).
+
+    Toggles the inverter-level ``FUNC_AC_COUPLING_FUNCTION`` — enabling or
+    disabling the AC-coupled source on the smart port outright, regardless
+    of the Start/End SOC window (GH #352's number pair; portal wire name
+    confirmed by two independent reporters in that issue). Distinct from the
+    GridBOSS per-port ``FUNC_AC_COUPLE_EN_{n}`` functions.
+
+    CLOUD-ONLY like the SOC pair: the portal writes the function param and
+    no local register is pinned, so writes route through the cloud client in
+    every mode and state reads from the coordinator's dedicated
+    ``ac_couple_soc`` store (throttled 5-minute getter + carry-forward +
+    post-write seeding), never the parameter cache — a HYBRID parameter
+    refresh rebuilds the cache from local registers alone and would wipe any
+    cloud-seeded value (PR #380 review P1). Holding reg 179 bit 11 is the
+    documented CANDIDATE local register (ivanfmartinez, #471 — Luxpower doc
+    + cross-integration use); a LOCAL path is a follow-up once the bit is
+    pinned by a live raw↔named lockstep toggle (pylxpweb reg-179 note).
+
+    The base class's full-refresh write envelope is deliberately NOT used:
+    the store IS the state source and the acknowledged write seeds it
+    directly (``note_ac_couple_soc_written``), so a full coordinator refresh
+    would burn API calls without re-reading the throttled store.
+    """
+
+    def __init__(
+        self,
+        coordinator: EG4DataUpdateCoordinator,
+        serial: str,
+    ) -> None:
+        """Initialize the AC couple switch."""
+        super().__init__(
+            coordinator=coordinator,
+            serial=serial,
+            entity_key="ac_couple",
+            name="AC Couple",
+            icon="mdi:solar-power-variant",
+            translation_key="ac_couple",
+        )
+
+    @property
+    def _stored_enabled(self) -> bool | None:
+        """FUNC_AC_COUPLING_FUNCTION state from the dedicated store."""
+        store = self._device_data.get("ac_couple_soc") or {}
+        value = store.get("enabled")
+        return value if isinstance(value, bool) else None
+
+    @property
+    def available(self) -> bool:
+        """Available only while the store holds a state (or mid-write).
+
+        Absent state — first cloud fetch pending, a pre-0.9.39b3 pylxpweb
+        getter, or a device whose family genuinely lacks the function param
+        — must show unavailable, never a fake OFF.
+        """
+        if not super().available:
+            return False
+        if self._optimistic_state is not None:
+            return True
+        return self._stored_enabled is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the AC couple function state."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        return self._stored_enabled
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the AC couple function."""
+        await self._async_set_ac_couple(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the AC couple function."""
+        await self._async_set_ac_couple(False)
+
+    async def _async_set_ac_couple(self, enabled: bool) -> None:
+        """Write FUNC_AC_COUPLING_FUNCTION through the cloud client."""
+        client = self.coordinator.require_client()
+        method = getattr(client.api.control, "set_inverter_ac_couple_enabled", None)
+        if method is None:
+            raise HomeAssistantError(
+                "Failed to set AC couple: pylxpweb is missing "
+                "set_inverter_ac_couple_enabled (requires >= 0.9.39b3)"
+            )
+        action = "enable" if enabled else "disable"
+        _LOGGER.info("Setting AC couple to %sd for %s", action, self._serial)
+        self._optimistic_state = enabled
+        self.async_write_ha_state()
+        try:
+            result = await method(self._serial, enabled)
+            if not result.success:
+                raise HomeAssistantError(
+                    f"Failed to {action} AC couple for {self._serial}"
+                )
+        except HomeAssistantError:
+            self._optimistic_state = None
+            self.async_write_ha_state()
+            raise
+        except Exception as e:
+            self._optimistic_state = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Failed to {action} AC couple for {self._serial}: {e}"
+            ) from e
+        # Seed the dedicated store (sibling-preserving) with the acknowledged
+        # state; the next throttled getter read confirms. Clear the
+        # optimistic state first — the seed fires listeners, which publish
+        # the store value.
+        self._optimistic_state = None
+        self.coordinator.note_ac_couple_soc_written(self._serial, "enabled", enabled)
 
 
 class EG4BatteryBackupSwitch(EG4BaseSwitch):

--- a/custom_components/eg4_web_monitor/translations/de.json
+++ b/custom_components/eg4_web_monitor/translations/de.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Batterie teilen"
+      },
+      "ac_couple": {
+        "name": "AC-Kopplung"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/en.json
+++ b/custom_components/eg4_web_monitor/translations/en.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Share Battery"
+      },
+      "ac_couple": {
+        "name": "AC Couple"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/es.json
+++ b/custom_components/eg4_web_monitor/translations/es.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Compartir batería"
+      },
+      "ac_couple": {
+        "name": "Acoplamiento AC"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/fr.json
+++ b/custom_components/eg4_web_monitor/translations/fr.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Partage de batterie"
+      },
+      "ac_couple": {
+        "name": "Couplage AC"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/it.json
+++ b/custom_components/eg4_web_monitor/translations/it.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Condivisione batteria"
+      },
+      "ac_couple": {
+        "name": "Accoppiamento AC"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/ja.json
+++ b/custom_components/eg4_web_monitor/translations/ja.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "バッテリー共有"
+      },
+      "ac_couple": {
+        "name": "ACカップリング"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/ko.json
+++ b/custom_components/eg4_web_monitor/translations/ko.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "배터리 공유"
+      },
+      "ac_couple": {
+        "name": "AC 커플링"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/nl.json
+++ b/custom_components/eg4_web_monitor/translations/nl.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Batterij delen"
+      },
+      "ac_couple": {
+        "name": "AC-koppeling"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/pl.json
+++ b/custom_components/eg4_web_monitor/translations/pl.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Współdzielenie baterii"
+      },
+      "ac_couple": {
+        "name": "Sprzężenie AC"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/pt.json
+++ b/custom_components/eg4_web_monitor/translations/pt.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Compartilhar bateria"
+      },
+      "ac_couple": {
+        "name": "Acoplamento AC"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/ru.json
+++ b/custom_components/eg4_web_monitor/translations/ru.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "Совместная батарея"
+      },
+      "ac_couple": {
+        "name": "AC-сопряжение"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/zh-Hans.json
+++ b/custom_components/eg4_web_monitor/translations/zh-Hans.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "电池共享"
+      },
+      "ac_couple": {
+        "name": "交流耦合"
       }
     },
     "number": {

--- a/custom_components/eg4_web_monitor/translations/zh-Hant.json
+++ b/custom_components/eg4_web_monitor/translations/zh-Hant.json
@@ -719,6 +719,9 @@
       },
       "share_battery": {
         "name": "電池共享"
+      },
+      "ac_couple": {
+        "name": "交流耦合"
       }
     },
     "number": {

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.39b2  # keep in sync with manifest.json
+pylxpweb>=0.9.39b3  # keep in sync with manifest.json
 
 # Code quality
 ruff>=0.8.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7552,9 +7552,17 @@ class TestACCoupleSOCStore:
         assert target["ac_couple_soc"]["start_soc"] is None
         assert target["ac_couple_soc"]["end_soc"] is None
 
-    async def test_partial_none_read_replaces_store(self, hass, mock_config_entry):
-        """A read with at least one value is fresh device truth and replaces
-        the store wholesale (including a param going absent)."""
+    async def test_partial_none_read_carries_forward_missing_sibling(
+        self, hass, mock_config_entry
+    ):
+        """Per-field carry-forward (PR #471 review, was
+        test_partial_none_read_replaces_store): a present field is fresh device
+        truth, but a None sibling on the same read is indistinguishable from a
+        PARTIAL range-read failure — the SOC params' true registers are
+        unpinned, so same-range locality cannot be assumed. The known sibling
+        is carried forward, NOT wiped to None (the earlier
+        replace-wholesale contract could blank a known value on a transient
+        partial blip)."""
         coordinator = self._coordinator(
             hass, mock_config_entry, limits={"start_soc": 100, "end_soc": None}
         )
@@ -7565,8 +7573,185 @@ class TestACCoupleSOCStore:
         target: dict[str, Any] = {}
         await coordinator._fetch_ac_couple_soc(inverter, target)
 
-        assert target["ac_couple_soc"]["start_soc"] == 100
-        assert target["ac_couple_soc"]["end_soc"] is None
+        assert target["ac_couple_soc"]["start_soc"] == 100  # fresh value wins
+        assert target["ac_couple_soc"]["end_soc"] == 95  # sibling carried, not wiped
+
+    async def test_enabled_only_read_preserves_soc_siblings(
+        self, hass, mock_config_entry
+    ):
+        """Regression (PR #471 review, both directions): an enabled-only read
+        (SOC ranges dropped by a partial failure) must not wipe known
+        start/end SOC — the #352 number entities keep working."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": None, "end_soc": None, "enabled": True},
+        )
+        inverter = self._inverter()
+        prev = {"start_soc": 85, "end_soc": 95, "enabled": False, "fetched_at": 1.0}
+        coordinator.data = {"devices": {self.SERIAL: {"ac_couple_soc": prev}}}
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        store = target["ac_couple_soc"]
+        assert store["start_soc"] == 85  # SOC siblings preserved
+        assert store["end_soc"] == 95
+        assert store["enabled"] is True  # fresh switch state wins
+
+    async def test_soc_only_read_preserves_enabled_sibling(
+        self, hass, mock_config_entry
+    ):
+        """Regression (PR #471 review): a SOC-only read (FUNC range dropped, or
+        a pre-0.9.39b3 getter with no enabled key) must not wipe a known switch
+        state to None — the AC Couple switch stays available."""
+        coordinator = self._coordinator(
+            hass, mock_config_entry, limits={"start_soc": 90, "end_soc": 95}
+        )
+        inverter = self._inverter()
+        prev = {"start_soc": 85, "end_soc": 95, "enabled": True, "fetched_at": 1.0}
+        coordinator.data = {"devices": {self.SERIAL: {"ac_couple_soc": prev}}}
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        store = target["ac_couple_soc"]
+        assert store["start_soc"] == 90  # fresh value wins
+        assert store["enabled"] is True  # switch state preserved, not wiped
+
+    async def test_inflight_write_seed_survives_stale_read(
+        self, hass, mock_config_entry
+    ):
+        """The mid-cycle race (PR #471 review, HIGH ×2): a write acknowledged
+        while a fetch is in flight (its seed stamp NEWER than the read's start)
+        wins over the read's pre-write cloud state — the switch does not revert.
+        """
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 85, "end_soc": 95, "enabled": False},  # stale
+        )
+        inverter = self._inverter()
+        # A write landed during the read: seed stamped in the future relative
+        # to this fetch's start (now = time.monotonic() captured on entry).
+        coordinator._ac_couple_soc_seeds = {
+            self.SERIAL: {"enabled": {"value": True, "at": time.monotonic() + 1000}}
+        }
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        assert target["ac_couple_soc"]["enabled"] is True  # seed won, no revert
+        # Seed retained (the read was older) for the next cycle.
+        assert "enabled" in coordinator._ac_couple_soc_seeds[self.SERIAL]
+
+    async def test_post_write_read_clears_seed(self, hass, mock_config_entry):
+        """A cloud read INITIATED AFTER the write (seed stamp older than the
+        read's start) is authoritative and clears the seed — normal
+        convergence once the portal reflects the write."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 85, "end_soc": 95, "enabled": True},  # confirmed
+        )
+        inverter = self._inverter()
+        coordinator._ac_couple_soc_seeds = {
+            self.SERIAL: {"enabled": {"value": True, "at": time.monotonic() - 1000}}
+        }
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        assert target["ac_couple_soc"]["enabled"] is True
+        # Whole serial entry dropped once its last field seed cleared.
+        assert self.SERIAL not in coordinator._ac_couple_soc_seeds
+
+    async def test_per_field_seed_timestamps_independent(self, hass, mock_config_entry):
+        """PR #471 round-2 (Gemini HIGH): each seeded field carries its OWN
+        timestamp. A newer write to one key must NOT renew an older key's
+        seed and clobber a legitimate external portal change to that older key
+        that an in-flight read picked up."""
+        # In-flight read returns an EXTERNAL start_soc change (50) and the
+        # pre-write enabled (False, stale).
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 50, "end_soc": 95, "enabled": False},
+        )
+        inverter = self._inverter()
+        # start_soc written EARLIER (before this read started); enabled written
+        # LATER (after this read started, still in flight).
+        coordinator._ac_couple_soc_seeds = {
+            self.SERIAL: {
+                "start_soc": {"value": 20, "at": time.monotonic() - 10},
+                "enabled": {"value": True, "at": time.monotonic() + 1000},
+            }
+        }
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        store = target["ac_couple_soc"]
+        # start_soc seed OLDER than this read -> dropped -> external 50 wins.
+        assert store["start_soc"] == 50
+        assert "start_soc" not in coordinator._ac_couple_soc_seeds[self.SERIAL]
+        # enabled seed NEWER than this read -> applied and retained.
+        assert store["enabled"] is True
+        assert "enabled" in coordinator._ac_couple_soc_seeds[self.SERIAL]
+
+    async def test_carry_forward_reapplies_write_seed(self, hass, mock_config_entry):
+        """A throttled/failed cycle carries the store forward WITH the seed
+        overlaid — the registry outlives the self.data snapshot the in-flight
+        cycle would otherwise publish, so the acknowledged write persists until
+        a post-write read confirms it."""
+        coordinator = self._coordinator(hass, mock_config_entry)
+        prev = {"start_soc": 85, "end_soc": 95, "enabled": False, "fetched_at": 1.0}
+        coordinator.data = {"devices": {self.SERIAL: {"ac_couple_soc": prev}}}
+        coordinator._ac_couple_soc_seeds = {
+            self.SERIAL: {"enabled": {"value": True, "at": time.monotonic()}}
+        }
+
+        target: dict[str, Any] = {}
+        coordinator._carry_forward_ac_couple_soc(self.SERIAL, target)
+
+        assert target["ac_couple_soc"]["enabled"] is True  # seed overlaid
+        assert target["ac_couple_soc"]["start_soc"] == 85  # siblings intact
+
+    async def test_note_written_populates_seed_registry(self, hass, mock_config_entry):
+        """The real seed method records the write in the persistent registry
+        (outside self.data) so it survives a cycle's data replacement."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.data = {"devices": {self.SERIAL: {"type": "inverter"}}}
+
+        before = time.monotonic()
+        coordinator.note_ac_couple_soc_written(self.SERIAL, "enabled", True)
+
+        entry = coordinator._ac_couple_soc_seeds[self.SERIAL]["enabled"]
+        assert entry["value"] is True
+        # Stamp is a real monotonic reading captured during the call (both
+        # reads use the same clock — compare against a value taken before the
+        # call, never a second live reading, so a leaked time-mock elsewhere
+        # in the suite cannot turn this into a MagicMock comparison).
+        assert isinstance(entry["at"], float)
+        assert entry["at"] >= before
+
+    async def test_note_written_independent_field_timestamps(
+        self, hass, mock_config_entry
+    ):
+        """Round-2: a second write to a DIFFERENT key leaves the first key's
+        seed timestamp untouched (no shared per-serial stamp to renew)."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.data = {"devices": {self.SERIAL: {"type": "inverter"}}}
+
+        coordinator.note_ac_couple_soc_written(self.SERIAL, "start_soc", 20)
+        first_at = coordinator._ac_couple_soc_seeds[self.SERIAL]["start_soc"]["at"]
+        coordinator.note_ac_couple_soc_written(self.SERIAL, "enabled", True)
+
+        seeds = coordinator._ac_couple_soc_seeds[self.SERIAL]
+        assert seeds["start_soc"]["at"] == first_at  # untouched by the enabled write
+        assert seeds["enabled"]["at"] >= first_at
 
     async def test_fetch_skipped_without_client(self, hass, mock_config_entry):
         """Pure LOCAL (no cloud client): no fetch, no store, no crash."""
@@ -7733,6 +7918,115 @@ class TestACCoupleSOCStore:
             entity = ACCoupleStartSOCNumber(coordinator, self.SERIAL)
         assert entity.native_value == 85
         assert entity.available is True
+
+    # ── FUNC_AC_COUPLING_FUNCTION enable state (GH #471) ──────────────
+
+    async def test_fetch_stores_enabled(self, hass, mock_config_entry):
+        """The getter's enabled bool rides the same fetch into the store."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 85, "end_soc": 95, "enabled": True},
+        )
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(self._inverter(), target)
+
+        assert target["ac_couple_soc"]["enabled"] is True
+
+    async def test_enabled_absent_from_getter_stores_none(
+        self, hass, mock_config_entry
+    ):
+        """A pre-0.9.39b3 getter result (no enabled key) stores None — the
+        switch goes unavailable while the SOC numbers keep working."""
+        coordinator = self._coordinator(
+            hass, mock_config_entry, limits={"start_soc": 85, "end_soc": 95}
+        )
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(self._inverter(), target)
+
+        assert target["ac_couple_soc"]["start_soc"] == 85
+        assert target["ac_couple_soc"]["enabled"] is None
+
+    async def test_enabled_non_bool_normalized_to_none(self, hass, mock_config_entry):
+        """Defensive: a non-bool leaking through the getter must never reach
+        the switch as a fake truthy/falsy state."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 85, "end_soc": 95, "enabled": "true"},
+        )
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(self._inverter(), target)
+
+        assert target["ac_couple_soc"]["enabled"] is None
+
+    async def test_enabled_only_read_counts_as_values(self, hass, mock_config_entry):
+        """A device carrying only the function param (SOC window absent) is
+        a real read, not the all-None failure shape — it must be stored."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": None, "end_soc": None, "enabled": False},
+        )
+        inverter = self._inverter()
+        prev = {"start_soc": None, "end_soc": None, "enabled": True, "fetched_at": 1.0}
+        coordinator.data = {"devices": {self.SERIAL: {"ac_couple_soc": prev}}}
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        assert target["ac_couple_soc"]["enabled"] is False  # fresh, not prev
+
+    async def test_all_none_read_does_not_wipe_known_enabled(
+        self, hass, mock_config_entry
+    ):
+        """The all-None carry-forward guard covers enabled too: a known
+        switch state must not be wiped by a total range-read failure."""
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": None, "end_soc": None, "enabled": None},
+        )
+        inverter = self._inverter()
+        prev = {"start_soc": None, "end_soc": None, "enabled": True, "fetched_at": 1.0}
+        coordinator.data = {"devices": {self.SERIAL: {"ac_couple_soc": prev}}}
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        assert target["ac_couple_soc"] is prev
+
+    async def test_note_written_enabled_preserves_soc_siblings(
+        self, hass, mock_config_entry
+    ):
+        """Seeding the switch state must not blank known SOC values (the
+        #380 P1 sibling-preservation contract extended to the bool key)."""
+        mock_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.data = {
+            "devices": {
+                self.SERIAL: {
+                    "type": "inverter",
+                    "ac_couple_soc": {
+                        "start_soc": 85,
+                        "end_soc": 95,
+                        "enabled": False,
+                        "fetched_at": 1.0,
+                    },
+                }
+            }
+        }
+
+        coordinator.note_ac_couple_soc_written(self.SERIAL, "enabled", True)
+
+        store = coordinator.data["devices"][self.SERIAL]["ac_couple_soc"]
+        assert store["enabled"] is True
+        assert store["start_soc"] == 85
+        assert store["end_soc"] == 95
+        assert store["fetched_at"] > 1.0
 
 
 class TestFirmwarePollCarryForward:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7666,6 +7666,40 @@ class TestACCoupleSOCStore:
         # Whole serial entry dropped once its last field seed cleared.
         assert self.SERIAL not in coordinator._ac_couple_soc_seeds
 
+    async def test_seed_survives_read_that_missed_the_field(
+        self, hass, mock_config_entry
+    ):
+        """Post-#473 review: a post-write read that did NOT observe the seeded
+        field (its range failed -> None) must NOT clear the seed — it confirmed
+        nothing. Combined with per-field carry-forward pulling a race-reverted
+        pre-write value from self.data, clearing here would revert a just-
+        written switch state for a cycle. The seed is retained and applied."""
+        # The FUNC range failed (enabled=None) while the SOC range succeeded;
+        # self.data was reverted to the pre-write enabled=False by a stale
+        # in-flight cycle, so per-field carry-forward would otherwise pull
+        # False back.
+        coordinator = self._coordinator(
+            hass,
+            mock_config_entry,
+            limits={"start_soc": 85, "end_soc": 95, "enabled": None},
+        )
+        inverter = self._inverter()
+        coordinator.data = {
+            "devices": {
+                self.SERIAL: {"ac_couple_soc": {"enabled": False, "fetched_at": 1.0}}
+            }
+        }
+        coordinator._ac_couple_soc_seeds = {
+            self.SERIAL: {"enabled": {"value": True, "at": time.monotonic() - 1000}}
+        }
+
+        target: dict[str, Any] = {}
+        await coordinator._fetch_ac_couple_soc(inverter, target)
+
+        # Seed wins over the race-reverted carry-forward; write not lost.
+        assert target["ac_couple_soc"]["enabled"] is True
+        assert "enabled" in coordinator._ac_couple_soc_seeds[self.SERIAL]
+
     async def test_per_field_seed_timestamps_independent(self, hass, mock_config_entry):
         """PR #471 round-2 (Gemini HIGH): each seeded field carries its OWN
         timestamp. A newer write to one key must NOT renew an older key's

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -22,6 +22,7 @@ from custom_components.eg4_web_monitor.utils import is_family_control_supported
 from custom_components.eg4_web_monitor.switch import (
     _supports_eps_battery_backup,
     async_setup_entry,
+    EG4ACCoupleSwitch,
     EG4QuickChargeSwitch,
     EG4BatteryBackupSwitch,
     EG4OffGridModeSwitch,
@@ -977,6 +978,308 @@ class TestQuickChargeCacheStatePeek:
 # ── BatteryBackupSwitch ──────────────────────────────────────────────
 
 
+class TestACCoupleSwitch:
+    """AC Couple function switch — cloud client required, family-neutral.
+
+    Toggles FUNC_AC_COUPLING_FUNCTION (GH #471): cloud-only like the #352
+    SOC number pair, state from the coordinator's dedicated ``ac_couple_soc``
+    store (``enabled`` key), writes cloud-routed in every mode. A device
+    that truly lacks the param (or a pre-0.9.39b3 pylxpweb getter) stores
+    ``enabled=None`` and the switch goes unavailable — never a fake OFF.
+    """
+
+    SERIAL = "1234567890"
+
+    @staticmethod
+    def _coordinator(*, store=None, **kwargs):
+        coordinator = _mock_coordinator(**kwargs)
+        if store is not None:
+            coordinator.data["devices"]["1234567890"]["ac_couple_soc"] = store
+
+        def _require_client():
+            if coordinator.client is None:
+                raise HomeAssistantError(
+                    "No local transport or cloud API available for parameter write."
+                )
+            return coordinator.client
+
+        coordinator.require_client = MagicMock(side_effect=_require_client)
+        return coordinator
+
+    def _cloud_write_mock(self, coordinator, *, success=True):
+        mock = AsyncMock(return_value=MagicMock(success=success))
+        coordinator.client.api.control.set_inverter_ac_couple_enabled = mock
+        return mock
+
+    # ── Entity creation gating (cloud client only — no family gate) ───
+
+    @pytest.mark.asyncio
+    async def test_created_with_cloud_client(self, hass):
+        coordinator = self._coordinator(has_http=True)
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+
+        entities = []
+        await async_setup_entry(hass, entry, lambda e, **kw: entities.extend(e))
+
+        assert any(isinstance(e, EG4ACCoupleSwitch) for e in entities)
+
+    @pytest.mark.asyncio
+    async def test_created_for_hybrid(self, hass):
+        """HYBRID has a cloud client — the switch is created (cloud-routed)."""
+        coordinator = self._coordinator(has_http=True, has_local=True)
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+
+        entities = []
+        await async_setup_entry(hass, entry, lambda e, **kw: entities.extend(e))
+
+        assert any(isinstance(e, EG4ACCoupleSwitch) for e in entities)
+
+    @pytest.mark.asyncio
+    async def test_not_created_in_pure_local(self, hass):
+        """Pure LOCAL has no cloud client — the function param can never be
+        read or written, so the switch is not created."""
+        coordinator = self._coordinator(has_http=False, has_local=True, local_only=True)
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+
+        entities = []
+        await async_setup_entry(hass, entry, lambda e, **kw: entities.extend(e))
+
+        assert not any(isinstance(e, EG4ACCoupleSwitch) for e in entities)
+
+    # ── Reads (dedicated coordinator store) ───────────────────────────
+
+    def test_reads_enabled_true(self):
+        coordinator = self._coordinator(
+            store={"start_soc": 85, "end_soc": 95, "enabled": True}
+        )
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is True
+        assert switch.available is True
+
+    def test_reads_enabled_false(self):
+        """A real False is a valid state — distinct from absent/unknown."""
+        coordinator = self._coordinator(store={"enabled": False})
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is False
+        assert switch.available is True
+
+    def test_missing_store_reads_unavailable(self):
+        """No store yet (first cloud fetch pending) -> unavailable, never a
+        fake OFF."""
+        coordinator = self._coordinator()
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is None
+        assert switch.available is False
+
+    def test_none_enabled_reads_unavailable(self):
+        """The SOC pair present but enabled=None (device lacks the function
+        param, or the installed pylxpweb getter predates it) -> the SOC
+        numbers work while the switch stays unavailable."""
+        coordinator = self._coordinator(
+            store={"start_soc": 85, "end_soc": 95, "enabled": None}
+        )
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is None
+        assert switch.available is False
+
+    def test_corrupt_store_value_reads_unavailable(self):
+        """Defensive: a non-bool store value must not crash or lie."""
+        coordinator = self._coordinator(store={"enabled": "garbage"})
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is None
+        assert switch.available is False
+
+    def test_survives_parameter_cache_wipe(self):
+        """The #352 P1-A regression shape: hard-replacing the parameter
+        cache (what a HYBRID local parameter refresh does) must not affect
+        this switch — it never reads the parameter cache."""
+        coordinator = self._coordinator(store={"enabled": True})
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        assert switch.is_on is True
+        coordinator.data["parameters"][self.SERIAL] = {"HOLD_AC_CHARGE_POWER_CMD": 50}
+        assert switch.is_on is True
+        assert switch.available is True
+
+    # ── Writes (cloud-routed in every mode, store-seeded) ─────────────
+
+    @pytest.mark.asyncio
+    async def test_turn_on_cloud_write_seeds_store(self):
+        coordinator = self._coordinator(store={"enabled": False})
+        write = self._cloud_write_mock(coordinator)
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        write.assert_awaited_once_with(self.SERIAL, True)
+        coordinator.note_ac_couple_soc_written.assert_called_once_with(
+            self.SERIAL, "enabled", True
+        )
+        # The parameter cache is NOT the storage — no cache seeding, and no
+        # full-refresh write envelope (the store seed converges the UI).
+        coordinator.note_parameters_written.assert_not_called()
+        coordinator.async_refresh.assert_not_awaited()
+        assert switch._optimistic_state is None
+
+    @pytest.mark.asyncio
+    async def test_turn_off_cloud_write_seeds_store(self):
+        coordinator = self._coordinator(store={"enabled": True})
+        write = self._cloud_write_mock(coordinator)
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        await switch.async_turn_off()
+
+        write.assert_awaited_once_with(self.SERIAL, False)
+        coordinator.note_ac_couple_soc_written.assert_called_once_with(
+            self.SERIAL, "enabled", False
+        )
+
+    @pytest.mark.asyncio
+    async def test_hybrid_write_routes_via_cloud(self):
+        """HYBRID (attached local transport): the write STILL goes through
+        the cloud client — no pinned local register exists (the #352
+        precedent)."""
+        coordinator = self._coordinator(
+            store={"enabled": False}, has_http=True, has_local=True
+        )
+        write = self._cloud_write_mock(coordinator)
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        write.assert_awaited_once_with(self.SERIAL, True)
+        coordinator.client.api.control.control_function.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_preserves_soc_siblings_in_store(self):
+        """Sibling preservation through the REAL coordinator seed method:
+        toggling the switch must not blank known Start/End SOC values."""
+        from custom_components.eg4_web_monitor.coordinator import (
+            EG4DataUpdateCoordinator,
+        )
+
+        coordinator = self._coordinator(
+            store={"start_soc": 85, "end_soc": 95, "enabled": False}
+        )
+        self._cloud_write_mock(coordinator)
+        coordinator.async_update_listeners = MagicMock()
+        coordinator.note_ac_couple_soc_written = MagicMock(
+            side_effect=lambda serial, key, value: (
+                EG4DataUpdateCoordinator.note_ac_couple_soc_written(
+                    coordinator, serial, key, value
+                )
+            )
+        )
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        store = coordinator.data["devices"][self.SERIAL]["ac_couple_soc"]
+        assert store["enabled"] is True
+        assert store["start_soc"] == 85  # siblings untouched
+        assert store["end_soc"] == 95
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_on_populates_seed_registry(self):
+        """PR #471 round-2 review (MEDIUM): prove the switch actually wires
+        into the coordinator's persistent write-seed registry — the race fix.
+
+        The other tests here use a bare MagicMock coordinator, on which
+        ``hasattr(coordinator, "_ac_couple_soc_seeds")`` is always True, so the
+        real seed method's lazy-init never fires and the registry silently
+        stays a MagicMock (no-op). Bind the REAL seed method AND give it a real
+        dict so ``async_turn_on`` -> ``note_ac_couple_soc_written`` is proven
+        end-to-end: a future wiring regression (wrong key/args) would fail here.
+        """
+        from custom_components.eg4_web_monitor.coordinator import (
+            EG4DataUpdateCoordinator,
+        )
+
+        coordinator = self._coordinator(store={"enabled": False})
+        self._cloud_write_mock(coordinator)
+        coordinator.async_update_listeners = MagicMock()
+        coordinator._ac_couple_soc_seeds = {}  # real dict, not the auto-mock
+        coordinator.note_ac_couple_soc_written = MagicMock(
+            side_effect=lambda serial, key, value: (
+                EG4DataUpdateCoordinator.note_ac_couple_soc_written(
+                    coordinator, serial, key, value
+                )
+            )
+        )
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        await switch.async_turn_on()
+
+        seed = coordinator._ac_couple_soc_seeds[self.SERIAL]["enabled"]
+        assert seed["value"] is True  # per-field entry recorded from the switch
+        assert isinstance(seed["at"], float)
+
+    @pytest.mark.asyncio
+    async def test_cloud_write_failure_raises_and_reverts(self):
+        coordinator = self._coordinator(store={"enabled": False})
+        self._cloud_write_mock(coordinator, success=False)
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        with pytest.raises(HomeAssistantError, match="Failed to enable"):
+            await switch.async_turn_on()
+
+        coordinator.note_ac_couple_soc_written.assert_not_called()
+        assert switch._optimistic_state is None
+        assert switch.is_on is False  # store state unchanged
+
+    @pytest.mark.asyncio
+    async def test_cloud_exception_wrapped_and_reverts(self):
+        """A transport-level exception surfaces as HomeAssistantError and
+        the optimistic state is reverted."""
+        coordinator = self._coordinator(store={"enabled": False})
+        coordinator.client.api.control.set_inverter_ac_couple_enabled = AsyncMock(
+            side_effect=OSError("cloud down")
+        )
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        with pytest.raises(HomeAssistantError, match="cloud down"):
+            await switch.async_turn_on()
+
+        assert switch._optimistic_state is None
+        assert switch.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_old_pylxpweb_missing_method_raises(self):
+        """pylxpweb < 0.9.39b3 lacks set_inverter_ac_couple_enabled — the
+        write raises a version-explicit error instead of AttributeError."""
+        coordinator = self._coordinator(store={"enabled": False})
+        # spec'd control object WITHOUT the new method
+        coordinator.client.api.control = MagicMock(spec=[])
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        with pytest.raises(HomeAssistantError, match="0.9.39b3"):
+            await switch.async_turn_on()
+        assert switch._optimistic_state is None
+
+    @pytest.mark.asyncio
+    async def test_write_without_client_raises(self):
+        """No cloud client (defensive: setup gates creation on one) -> the
+        write raises instead of silently doing nothing."""
+        coordinator = self._coordinator(store={"enabled": False})
+        coordinator.client = None
+        switch = EG4ACCoupleSwitch(coordinator, self.SERIAL)
+        _prep(switch)
+
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+
+
 class TestBatteryBackupSwitch:
     """Test BatteryBackup (EPS) switch entity."""
 
@@ -1836,9 +2139,11 @@ class TestOffgridBatteryBackupGating:
         # Exact set: portal-backed AC Charge + PV Charge Priority stay, as
         # do EPS / Off Grid Mode / Charge Last / Share Battery (fail-open,
         # no rejection evidence for them; Share Battery is gated like
-        # Charge Last — all control-capable families, #288).
+        # Charge Last — all control-capable families, #288). AC Couple
+        # (GH #471) is cloud-gated, family-neutral — present here too.
         assert self._switch_keys(entities) == {
             "quick_charge",
+            "ac_couple",
             "battery_backup",
             "off_grid_mode",
             "charge_last",
@@ -1884,6 +2189,7 @@ class TestOffgridBatteryBackupGating:
 
         assert self._switch_keys(entities) == {
             "quick_charge",
+            "ac_couple",
             "battery_backup",
             "off_grid_mode",
             "charge_last",


### PR DESCRIPTION
## Summary
A per-inverter **AC Couple** switch that toggles the portal's `FUNC_AC_COUPLING_FUNCTION` — de-energizing the AC-coupled smart-port source at any battery level. Follow-up to the #352 AC Couple Start/End SOC window, suggested by @mjstrand ("drop the ac couple power at any battery level") and @ivanfmartinez, who confirmed the param on his on-grid hybrid LXP.

Cleaner than driving the SOC window for a grid↔smart-port transfer script: one independent on/off, scriptable via `switch.turn_off`/`turn_on`.

## What it does
- New **AC Couple** switch, created wherever a cloud client is present (not family-gated — the #352 evidence spans off-grid and grid-tied hardware). State from the coordinator's dedicated `ac_couple_soc` store (5-minute throttled cloud getter + carry-forward + post-write seeding); writes cloud-routed in every mode. **Unavailable — never a fake OFF —** while the store lacks a bool (device without the param, or pre-0.9.39b3 pylxpweb).
- 13 locales + README worked example (switch, plus the SOC-window alternative).

## Race + carry-forward hardening (also fixes the shipped #352 numbers)
The tri-vendor review of this PR surfaced two issues in the shared `ac_couple_soc` store that the #352 number entities already ship with; fixed at the store level so both benefit:
- **Mid-cycle write race**: a persistent per-serial, per-field write-seed registry that lives *outside* `self.data`, so a write acknowledged while a refresh cycle is in flight is not reverted when that cycle publishes a pre-write store snapshot. Each field's seed carries its own timestamp and is applied/cleared independently — a later write to one key never renews another key's seed and clobbers a legitimate external portal change an in-flight read picked up.
- **Partial-range read wiping siblings**: a `None` field on an otherwise-successful read is indistinguishable from a partial range-read failure (the SOC params' true registers are unpinned, so same-range locality can't be assumed), so a known value is carried forward per-field instead of wiped.

## Root cause / design
No inverter-level AC couple enable existed. Mirrors the #352 cloud-only architecture exactly (dedicated store, not the parameter cache — a HYBRID local refresh rebuilds the cache from local registers and would wipe cloud-seeded values). Local register path (reg 179 bit 11 candidate) deferred to #472 pending a live pin.

## Test plan
- New: entity creation gate (cloud present, not family-gated; absent in pure-local); read/availability (absent/None/corrupt → unavailable; parameter-cache wipe survived); cloud-routed writes in every mode with store seeding; failure/exception revert; missing-method (pre-0.9.39b3) explicit error. Store: per-field carry-forward both directions; the mid-cycle race (seed survives stale in-flight read; post-write read clears; independent per-field timestamps); switch→registry wiring through a real seed method.
- **2224 tests pass**; `ruff` + `mypy --strict` clean. The reviewer-flagged intermittent unit test was hardened (fragile monotonic comparison removed) and ran clean across 7 full combined-file runs.

## Risk-accepted
- **No staleness ceiling** on the carried-forward store: a device whose params permanently vanish would pin last-known values. This is the explicit #380 design decision, unchanged, and applies equally to the shipped #352 numbers — a cloud outage in HYBRID (healthy local coordinator) shows the last-known value rather than going unavailable. Consistent across all three AC-couple entities.
- **Asymmetric bool guard** (LOW): per-field carry-forward guards `enabled` with `isinstance(bool)` but not the numeric SOC fields; the read side (`number.py`) already excludes bools from numeric fields and nothing writes a bool to those keys.

## Review
Tri-vendor adversarial review (Claude + Codex GPT-5.6-sol xhigh + Gemini 3.1 Pro), 2 rounds. Every confirmed BLOCKER/HIGH/MEDIUM fixed or risk-accepted above; LOWs addressed or noted.

## ⚠️ Merge ordering
Requires **pylxpweb >= 0.9.39b3** (manifest + `tests/requirements-test.txt`). Publish [joyfulhouse/pylxpweb#237](https://github.com/joyfulhouse/pylxpweb/pull/237) to PyPI **before** merging this — until 0.9.39b3 is on PyPI, this branch's CI dependency resolution will fail.

Refs #471, #472, #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)