### PR TITLE
chore(release): 3.5.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1-beta.2] - 2026-07-17
+
+Cloud AC couple controls (a switch plus the Start/End SOC window) and a
+portal event-log sensor, on top of the 3.5.1-beta.1 firmware-update fixes.
+Requires
+[pylxpweb 0.9.39b3](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.39b3)
+(installed automatically).
+
 ### Added
 
 - **AC Couple Start/End SOC number entities** ([#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352), requested by @mjstrand): the SOC window governing the AC-coupled source on the inverter's smart port — enabled when battery SOC drops below *Start*, disabled above *End* — scriptable for safe grid/smart-port source transfers. Cloud-only (no local Modbus register): created on Cloud and Hybrid connections for all supported inverters, refreshed from the cloud on a 5-minute cadence (which also picks up portal-side edits), unavailable on devices that do not carry the parameters. A factory-disabled End threshold (`255`, "never stop") shows as unknown with a `disabled_sentinel: true` attribute. Requires pylxpweb ≥ 0.9.39b2.
 - **AC Couple switch** ([#471](https://github.com/joyfulhouse/eg4_web_monitor/issues/471), follow-up to #352 suggested by @mjstrand and @ivanfmartinez): enables/disables the inverter's AC couple function (`FUNC_AC_COUPLING_FUNCTION`) outright — de-energizing the AC-coupled source on the smart port at any battery level, without driving the Start/End SOC window. Same cloud-only architecture as the SOC pair (state from the 5-minute cloud read, writes cloud-routed in every mode, unavailable on devices that lack the function param). Requires pylxpweb ≥ 0.9.39b3.
+- **Cloud event-log "Last Event" sensor and `fetch_events` service** ([#327](https://github.com/joyfulhouse/eg4_web_monitor/issues/327), requested by @mjstrand): surfaces the portal's own event log — alerts and status messages (e.g. a tripped battery breaker) that never appear in the register data — as a `Last Event` sensor per station, plus a `fetch_events` service that returns recent events for automations (each carries a `record_id` for dedupe). Cloud connections only.
+
+### Fixed
+
+- **Control state no longer briefly reverts after a successful write whose refresh fails** ([#362](https://github.com/joyfulhouse/eg4_web_monitor/issues/362)): a swallowed post-write refresh failure let schedule-time entities and pure-cloud function switches clear their optimistic state and publish the stale pre-write value until the next poll — the service reported success while the entity visibly flipped back. The acknowledged write's optimistic state is now retained until genuinely fresh device data arrives (bounded, with a firmware-NAK escape).
 
 ## [3.5.1-beta.1] - 2026-07-15
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
   "requirements": ["pylxpweb>=0.9.39b3", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.1"
+  "version": "3.5.1-beta.2"
 }


### PR DESCRIPTION
Release **3.5.1-beta.2** — version bump + CHANGELOG finalization for the work merged since [v3.5.1-beta.1](https://github.com/joyfulhouse/eg4_web_monitor/releases/tag/v3.5.1-beta.1). No code changes; all features/fixes are already on `main`.

### In this release
- **AC Couple switch** (#471) + **AC Couple Start/End SOC numbers** (#352) — cloud control of the smart-port AC-coupled source.
- **Cloud event-log Last Event sensor + `fetch_events` service** (#327) — surfaces portal alerts (e.g. tripped breaker) not in the register data. *(CHANGELOG backfilled — this merged after beta.1 without an entry.)*
- **#362** optimistic-state-revert fix — a swallowed post-write refresh failure no longer flips schedule/cloud-switch entities back to the stale value. *(CHANGELOG backfilled.)*

### Requires
**pylxpweb ≥ 0.9.39b3** (published to PyPI, installed automatically).

After merge: tag `v3.5.1-beta.2` + GitHub pre-release (attaches the HACS zip via `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)