### PR TITLE
ci: pin ruff to 0.15.5 in the Bronze tier check (#482)

### DIFF
--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -197,7 +197,10 @@ jobs:
       - name: Install ruff
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # Pinned: an unpinned install floated to ruff 0.16.0, whose expanded
+          # default rule set fails repo-wide (#482). Keep in sync with the
+          # prek.toml ruff-pre-commit rev and tests/requirements-test.txt.
+          pip install "ruff==0.15.5"
 
       - name: Run ruff linter
         run: |

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -17,7 +17,7 @@ voluptuous>=0.15.0
 pylxpweb>=0.9.39b3  # keep in sync with manifest.json
 
 # Code quality
-ruff>=0.8.0
+ruff==0.15.5  # pinned (#482); keep in sync with prek.toml and quality-validation.yml
 pylint>=3.3.0
 
 # Security scanning


### PR DESCRIPTION
Fixes #482.

The **Bronze - Code Quality (Ruff)** tier job installed unpinned ruff (`pip install ruff`); a fresh runner now resolves **0.16.0**, whose expanded default rule set fails repo-wide on files no PR touched (241 errors locally reproduced with `uvx ruff@0.16.0 check .`). The job was green until 2026-07-17 and first failed on the unrelated `fix/476` branch on 2026-07-21 — with the tier checks required on `main`, every PR became unmergeable.

## Fix

- Pin the workflow to `ruff==0.15.5` — the exact version the `prek.toml` ruff-pre-commit hook already runs on every commit, verified clean at the repo root for both `ruff check .` and `ruff format --check .`.
- Pin `tests/requirements-test.txt` to the same version (was `ruff>=0.8.0`) so fresh dev/CI installs can't drift, with cross-references in both files.

Adopting 0.16.0 and triaging its new findings (BLE001, SIM102, DTZ005, UP037, I001, …) is deliberately left as a separate chore — several are behavioral rules that need real review, not blanket suppression (per project policy of never disabling linter rules).

This PR's own CI run doubles as the proof: Bronze Ruff should go green with the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)