### PR TITLE
chore(release): 3.5.1-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1-beta.4] - 2026-07-27
+
 ### Added
 
 - **Grid Always On switch for the smart load port** ([#484](https://github.com/joyfulhouse/eg4_web_monitor/issues/484), requested by @brendonlobo123): the portal's *Maintenance → Remote Set → Smart Load Port → Smart Load* tab carries a **Grid Always On** enable/disable that keeps the smart load port energized from the grid instead of dropping it when the Smart Load SOC window closes. It is now exposed as a switch. **Disabled by default** — it only matters once the smart load port is configured, so enable it from the entity settings if you use that port. Not restricted by inverter model or family: the function comes back in the cloud parameter read on every device checked (18kPV, FlexBOSS21, GridBOSS) and the reporter's screenshot shows it live on a 12000XP, so it is offered wherever it can be read.

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.39b4", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.3"
+  "requirements": ["pylxpweb>=0.9.39b5", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.5.1-beta.4"
 }


### PR DESCRIPTION
Version bump and changelog section only — no code changes. Requires **pylxpweb 0.9.39b5** (published to PyPI).

Bundles five merged PRs (#491, #492, #493, #494, #496) covering four issues.

## What users get

**#484 — Grid Always On switch** for the inverter's Smart Load Port, cloud-routed and disabled by default. The read side is verified against live hardware; **the write path is not**, and #484 stays open pending the reporter's confirmation. Reports *unavailable* rather than a misleading "Off" when the state is genuinely unknown.

**#490 — Internal Temperature no longer shows a false 0 °C / 32 °F** on cloud connections. The EG4 cloud genuinely sends `tinner: 0` for some units, so the sensor now reads unknown rather than a wrong constant. Deliberately **not** a family rule: the defect splits *within* device type code 54 — a 12000XP reports the constant 0 while a 6000XP reports live values — so gating by family would have hidden a reading that demonstrably works.

**#379 — controls no longer snap back** when a post-write refresh fails. Select, number, switch and schedule-time entities now retain an acknowledged value, bounded at five minutes, after which a divergence surfaces with one warning naming the action and serial rather than reverting silently.

**#485 — switch toggles no longer wait out a doomed Modbus timeout** when the local link is already known down, matching what number/select/time controls already did. Also stops a routine incomplete parameter read from logging two warnings.

Plus two latent bugs found while reviewing #490, both in the startup cleanup: an unidentified inverter could permanently lose its Battery Discharge Power sensor, and that cleanup could reach into per-battery and battery-bank entities because it matched any ID merely *ending* with the key.

## Why the pylxpweb pin moves to 0.9.39b5

Two of its fixes are load-bearing here, not incidental:

- **#243** restores client-first routing on the green-mode helpers, which this integration passes as its HYBRID **cloud fallback** (`switch.py:840`). Without it that fallback would retry the local write that just failed.
- **#245** makes every register-mapping branch return an isolated copy. This integration reads `REGISTER_TO_PARAM_KEYS` directly (`switch.py:154`), so a shared mutable table could be corrupted process-wide by any caller.

b5 also carries the battery RS485 short-read guard (#252) and the `get_event_list` response-shape correction (#236).

## Testing

`ruff` (CI-pinned 0.15.5) clean, `mypy` strict clean, **2335 passed, 3 skipped**, all 13 locales complete.

Every constituent PR passed the full tier suite before merging, and each went through adversarial review by gpt-5.6-sol and Claude Opus — which is where the #490 family-gate premise was disproved, the #485 double-warning and unbounded retention were caught, and the #484 fake-OFF was found.