### PR TITLE
chore: require pylxpweb>=0.9.39b6

### DIFF
--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.39b5", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb>=0.9.39b6", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.5.1-beta.4"
 }

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.39b4  # keep in sync with manifest.json
+pylxpweb>=0.9.39b6  # keep in sync with manifest.json
 
 # Code quality
 ruff==0.15.5  # pinned (#482); keep in sync with prek.toml and quality-validation.yml

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -3424,23 +3424,25 @@ class TestCanonicalAbsentPredicateInRRMerge:
         assert key_degraded in merged, "present-but-degraded battery was dropped"
         assert local_battery_key(serial, "BATEMPTY00001", 1) not in merged
 
-    async def test_degraded_row_dropped_on_older_pylxpweb(self, hass):
+    async def test_degraded_row_dropped_on_older_pylxpweb(self, hass, monkeypatch):
         """Without is_absent() the pre-#506 voltage/SOC behaviour is preserved.
 
-        This pins the pin-gated rollout: CI runs against a pylxpweb that has no
-        is_absent(), so this is the path CI actually exercises today.
+        The installed pylxpweb (>=0.9.39b6) ships is_absent(), so the
+        older-pylxpweb condition is simulated by deleting the attribute —
+        the fallback path must keep dropping voltage-0/SOC-0 rows exactly as
+        that pylxpweb's own bank code would.
         """
         serial = "DONGLE506OLD"
         coordinator = EG4DataUpdateCoordinator(
             hass, self._make_config_entry(hass, serial)
         )
 
+        monkeypatch.delattr(BatteryData, "is_absent", raising=True)
+
         degraded = BatteryData(
             battery_index=0, serial_number="BATDEGRADED1", voltage=0.0, soc=0
         )
-        assert not hasattr(degraded, "is_absent"), (
-            "pylxpweb now ships is_absent(); this test's premise needs revisiting"
-        )
+        assert not hasattr(degraded, "is_absent")
 
         merged = coordinator._merge_round_robin_batteries(serial, [degraded])
 


### PR DESCRIPTION
Moves both pylxpweb pins (manifest.json and tests/requirements-test.txt — previously drifted at b5/b4) to **>=0.9.39b6**, now live on PyPI.

This is the sequencing PR that lets #503 and #504 go green: their deliberate contract reds (reg-179 bit-11 and smart-load method pins) resolve once CI installs b6. Merging this first, then those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)