### PR TITLE
test: refuse live cloud requests so the suite cannot burn wall clock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,12 @@ from pylxpweb.transports.data import (
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
-class _CloudRequestInTest(RuntimeError):
-    """Raised when a test reaches pylxpweb's real cloud request path."""
+class CloudRequestInTest(RuntimeError):
+    """Raised when a test reaches pylxpweb's real cloud request path.
+
+    Exported (not name-mangled) so a test can assert on the type rather than
+    matching the message text.
+    """
 
 
 @pytest.fixture(autouse=True)
@@ -39,6 +43,14 @@ def refuse_real_cloud_requests():
     removes the cost, because the backoff sleeps happen whether or not a socket
     ever connects.
 
+    Both seams are closed, because ``_request`` alone is NOT complete: the
+    plant-region lookup and the data export read the session directly
+    (``endpoints/plants.py`` and ``endpoints/export.py`` call
+    ``session.post``/``session.get`` after ``client._get_session()``), so they
+    would bypass a ``_request``-only guard. ``_get_session`` is the accessor
+    every network user shares, which makes the pair airtight; ``_request`` is
+    still patched so the common path fails with a message naming the cause.
+
     Tests that exercise cloud behaviour replace ``coordinator.client`` (or
     patch ``coordinator.LuxpowerClient``) outright and so never reach this.
     Nothing in the suite drives real HTTP, so no test needs the live path; one
@@ -46,13 +58,16 @@ def refuse_real_cloud_requests():
     """
 
     async def _refuse(self: LuxpowerClient, *args: Any, **kwargs: Any) -> Any:
-        raise _CloudRequestInTest(
+        raise CloudRequestInTest(
             "A test reached the real EG4 cloud request path. Mock the "
             "coordinator's client (or the endpoint you are exercising) "
             "instead of letting it attempt a live request."
         )
 
-    with patch.object(LuxpowerClient, "_request", _refuse):
+    with (
+        patch.object(LuxpowerClient, "_request", _refuse),
+        patch.object(LuxpowerClient, "_get_session", _refuse),
+    ):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@
 
 import threading
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, create_autospec
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
+from pylxpweb.client import LuxpowerClient
 from pylxpweb.devices import HybridInverter, MIDDevice
 from pylxpweb.transports import ModbusTransport
 from pylxpweb.transports.data import (
@@ -15,6 +16,44 @@ from pylxpweb.transports.data import (
 )
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+class _CloudRequestInTest(RuntimeError):
+    """Raised when a test reaches pylxpweb's real cloud request path."""
+
+
+@pytest.fixture(autouse=True)
+def refuse_real_cloud_requests():
+    """Fail cloud requests instantly instead of retrying against the network.
+
+    The coordinator constructs a REAL ``LuxpowerClient`` for http/hybrid
+    entries (websession injection), so any test that drives a code path
+    reaching a cloud fetch lands in pylxpweb's request layer. There the
+    injected aiohttp session belongs to a different event loop than the test's,
+    every attempt fails, and pylxpweb retries with exponential backoff
+    (1+2+4+8+16s) until the caller's ``wait_for`` cancels it. That is pure
+    wall-clock: one test spent 55s at ~1% CPU, and on a runner whose egress to
+    the portal blackholes the same paths can exhaust the job timeout.
+
+    Failing at the request boundary — rather than blocking sockets — is what
+    removes the cost, because the backoff sleeps happen whether or not a socket
+    ever connects.
+
+    Tests that exercise cloud behaviour replace ``coordinator.client`` (or
+    patch ``coordinator.LuxpowerClient``) outright and so never reach this.
+    Nothing in the suite drives real HTTP, so no test needs the live path; one
+    that genuinely did could stop this fixture with its own patch.
+    """
+
+    async def _refuse(self: LuxpowerClient, *args: Any, **kwargs: Any) -> Any:
+        raise _CloudRequestInTest(
+            "A test reached the real EG4 cloud request path. Mock the "
+            "coordinator's client (or the endpoint you are exercising) "
+            "instead of letting it attempt a live request."
+        )
+
+    with patch.object(LuxpowerClient, "_request", _refuse):
+        yield
 
 
 def wire_coordinator_write_helpers(coordinator: MagicMock) -> None:

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -1,0 +1,33 @@
+"""The unit suite must never attempt a live EG4 cloud request.
+
+The coordinator builds a REAL ``LuxpowerClient`` for http/hybrid entries, so a
+test that drives any cloud-touching path reaches pylxpweb's request layer. The
+injected aiohttp session belongs to a different event loop than the test's,
+every attempt fails, and pylxpweb retries with exponential backoff — spending
+wall clock (1+2+4+8+16s) until the caller's ``wait_for`` cancels it. One test
+cost 55s at ~1% CPU, the full suite 25 minutes, and a release CI run wedged
+past its job timeout twice.
+
+``refuse_real_cloud_requests`` in conftest closes that off at the request
+boundary, which is what removes the cost: the backoff sleeps happen whether or
+not a socket ever connects, so blocking sockets alone would not have helped.
+
+This tripwire keeps the guard in place. It was verified to FAIL with the
+fixture made non-autouse. A wall-clock assertion was deliberately NOT added
+alongside it: an unreachable host resolves fast enough on a developer machine
+that the timing never trips, so such a test would pass whether or not the guard
+existed and would only look like protection.
+"""
+
+import pytest
+from pylxpweb.client import LuxpowerClient
+
+
+async def test_real_request_path_is_refused():
+    """The autouse guard is installed and fails instead of reaching out."""
+    client = LuxpowerClient("user", "password", base_url="https://example.invalid")
+
+    with pytest.raises(Exception) as excinfo:
+        await client._request("POST", "/WManage/api/inverter/getInverterRuntime")
+
+    assert "real EG4 cloud request path" in str(excinfo.value)

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -12,22 +12,36 @@ past its job timeout twice.
 boundary, which is what removes the cost: the backoff sleeps happen whether or
 not a socket ever connects, so blocking sockets alone would not have helped.
 
-This tripwire keeps the guard in place. It was verified to FAIL with the
-fixture made non-autouse. A wall-clock assertion was deliberately NOT added
-alongside it: an unreachable host resolves fast enough on a developer machine
-that the timing never trips, so such a test would pass whether or not the guard
-existed and would only look like protection.
+These tests keep both seams closed. They were verified to FAIL with the fixture
+made non-autouse. A wall-clock assertion was deliberately NOT added alongside
+them: an unreachable host resolves fast enough on a developer machine that the
+timing never trips, so such a test would pass whether or not the guard existed
+and would only look like protection.
 """
 
 import pytest
 from pylxpweb.client import LuxpowerClient
 
+from .conftest import CloudRequestInTest
 
-async def test_real_request_path_is_refused():
-    """The autouse guard is installed and fails instead of reaching out."""
-    client = LuxpowerClient("user", "password", base_url="https://example.invalid")
 
-    with pytest.raises(Exception) as excinfo:
-        await client._request("POST", "/WManage/api/inverter/getInverterRuntime")
+def _client() -> LuxpowerClient:
+    return LuxpowerClient("user", "password", base_url="https://example.invalid")
 
-    assert "real EG4 cloud request path" in str(excinfo.value)
+
+async def test_request_path_is_refused():
+    """The common seam: everything routed through ``_request``."""
+    with pytest.raises(CloudRequestInTest):
+        await _client()._request("POST", "/WManage/api/inverter/getInverterRuntime")
+
+
+async def test_session_accessor_is_refused():
+    """The second seam, and the reason ``_request`` alone is not enough.
+
+    ``endpoints/plants.py`` and ``endpoints/export.py`` take the session from
+    ``client._get_session()`` and call ``session.post``/``session.get``
+    directly, bypassing ``_request`` entirely. Guarding only ``_request`` would
+    leave those free to reach the network.
+    """
+    with pytest.raises(CloudRequestInTest):
+        await _client()._get_session()


### PR DESCRIPTION
## The problem, precisely

The unit suite was spending most of its wall clock waiting on nothing. `tests/test_fault_warning_sensors.py::TestFaultWarningHybridOverlay::test_transport_runtime_overlays_codes` took **55.53s at ~1% CPU**; the full suite took **25 minutes**. This wedged the v3.5.1-beta.5 release CI past its job timeout twice.

**It was not network I/O.** Stack-dumping mid-wait (`--timeout=12 --timeout-method=thread`) shows the actual mechanism:

```
API request error #1: Task <TCPConnector._resolve_host_with_throttle()> got Future
attached to a different loop, next backoff delay: 1.00 seconds
... error #2 ... 2.00 seconds   ... #3 ... 4.00   ... #4 ... 8.00   ... #5 ... 16.00
```

The chain:

1. `EG4DataUpdateCoordinator.__init__` builds a **real** `LuxpowerClient` for `http`/`hybrid` entries — that's the Platinum websession-injection requirement, working as designed.
2. Any test driving a cloud-touching path therefore reaches pylxpweb's request layer.
3. The injected aiohttp session belongs to a **different event loop** than the test's, so every attempt fails immediately.
4. pylxpweb retries with exponential backoff — `asyncio.sleep(1, 2, 4, 8, 16…)` — until the caller's `wait_for(…_CLOUD_TIMEOUT)` cancels it. Each guarded fetch burns its full timeout.

#502's per-string daily + lifetime tiers made this acute by adding more guarded fetches, but the mechanism predates them: the AC Couple store fetch already cost ~9s in this same test.

## Why blocking sockets would not have fixed it

The obvious guard — refusing real sockets — does not help here, because **nothing reaches the network at all**. The failure is the cross-loop future, and the sleeps are `asyncio.sleep`. Socket blocking would change the exception and leave every backoff sleep in place.

Refusing at the **request boundary** is what removes the cost, and it also subsumes the socket case: a runner whose egress to the portal blackholes can no longer hang either, because the request never starts.

## The change

One autouse fixture in `tests/conftest.py` making `LuxpowerClient._request` fail instantly, plus a tripwire test.

This is safe because of how the suite already works: tests that exercise cloud behaviour replace `coordinator.client` outright or patch `coordinator.LuxpowerClient`, so they never reach the real path — and **nothing in the suite drives real HTTP** (no `aioresponses` anywhere). All 2515 tests pass with the guard in place, so nothing depended on the live path.

## Results

| | before | after |
|---|---|---|
| `test_transport_runtime_overlays_codes` | 55.53s | **0.16s** |
| full suite (CI invocation) | 1521.93s (25:21) | **110.46s (1:50)** |
| tests | 2514 passed | **2515 passed**, 3 skipped |

CPU utilisation over the full run went from ~1-7% to 18%, which is the tell that the waiting is gone.

## On the tripwire

`tests/test_no_live_cloud_requests.py` pins the guard. I verified it genuinely fails by making the fixture non-autouse and re-running — it fails.

I deliberately did **not** pair it with a wall-clock assertion. An unreachable host resolves fast enough on a developer machine that a timing bound never trips, so such a test would pass whether or not the guard existed and would only look like protection.

## Production note, not addressed here

In production the session is valid and this path does not arise, so this is a test-environment fix only and touches no shipped code. It is worth knowing separately that a genuinely unreachable portal will still cost each throttled fetch its full timeout per poll cycle — bounded and carried-forward by design, but a real cost if someone's egress is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
