### PR TITLE
test: make the no-live-cloud guarantee real, not aspirational

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,15 @@ def refuse_real_cloud_requests(request: pytest.FixtureRequest):
     guarantee real rather than aspirational. Opt out with
     ``@pytest.mark.allow_real_cloud_request_path`` when reaching the path is
     the point of the test.
+
+    Scope, measured rather than assumed. A violation is reported for a passing
+    test, a failing test (both the failure and the violation surface), and each
+    parametrized case independently. A SKIPPED test never runs its body, so
+    there is nothing to catch. An XFAILED test is the one hole: pytest absorbs
+    the teardown error, so a violating xfail would pass unreported. The suite
+    currently contains no xfail tests, and a violation still costs no wall
+    clock because the refusal is immediate — but the guarantee is "no test
+    reaches the network unreported EXCEPT under xfail", not something broader.
     """
     attempts: list[str] = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,16 +145,18 @@ def refuse_real_cloud_requests(request: pytest.FixtureRequest):
     * An XFAILED test is the one hole: pytest absorbs the teardown error, so a
       violating xfail passes unreported. The suite has no xfail tests today,
       and a violation costs no wall clock because the refusal is immediate.
-    * An attempt made after this fixture's teardown — during a later fixture's
-      finalizer — is still recorded by the session-scoped patch, but lands in
-      the NEXT test's bucket. Attribution can therefore be off by one test;
-      detection is not lost.
+    * An attempt made after this fixture's teardown — during a finalizer that
+      runs later, or during session setup before any test — is still recorded
+      by the session-scoped patch and surfaces against the NEXT test.
+      Attribution is off by one test; detection is not lost. This is why the
+      buffer is drained ONLY at teardown: clearing it on entry as well would
+      discard exactly those late attempts instead of deferring them, turning
+      an attribution quirk into a silent miss.
     * ``get_closest_marker`` honours class- and module-level marks, so a
       module-wide ``pytestmark`` would opt an entire file out. That is the
       normal pytest inheritance rule, not a special case here, but it means
       the marker should be applied per-test.
     """
-    del _cloud_attempts[:]
     yield
     attempts = list(_cloud_attempts)
     del _cloud_attempts[:]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ _cloud_attempts: list[str] = []
 # The production signature, captured before patching, so a test can prove the
 # stand-in still mirrors it rather than merely being non-permissive.
 PRODUCTION_REQUEST_SIGNATURE = inspect.signature(LuxpowerClient._request)
+PRODUCTION_GET_SESSION_SIGNATURE = inspect.signature(LuxpowerClient._get_session)
 
 
 async def _refuse_request(
@@ -84,17 +85,19 @@ async def _refuse_session(self: LuxpowerClient) -> NoReturn:
     raise CloudRequestInTest(_REFUSAL_MESSAGE)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _patch_cloud_request_paths():
-    """Hold the refusal patches for the WHOLE session.
+_cloud_patchers: list[Any] = []
 
-    Deliberately session-scoped rather than per-test. Pytest sets the
-    plugin's own autouse fixtures up before this module's, which means they
-    tear down AFTER a function-scoped guard has already been restored — so a
-    cloud call made during another fixture's teardown, during module/session
-    setup, or by a task drained while ``hass`` shuts down would reach the real
-    method and retry against the network. Holding the patch for the session
-    leaves no window in which the real methods are reachable.
+
+def _start_cloud_refusal() -> None:
+    """Patch both cloud seams for the entire pytest process.
+
+    Applied from ``pytest_configure`` — before collection and before any
+    fixture of any scope — and lifted in ``pytest_unconfigure``. Neither a
+    per-test nor a session-scoped FIXTURE is sufficient: a fixture starts
+    after collection and after the session fixtures pytest sets up ahead of
+    it, and is restored before those same fixtures finish tearing down. Import
+    or collection-time calls, and equal-scope setup/finalizers, would slip
+    through those windows and retry against the network unrecorded.
 
     The coordinator constructs a REAL ``LuxpowerClient`` for http/hybrid
     entries (websession injection), so any code path reaching a cloud fetch
@@ -117,11 +120,33 @@ def _patch_cloud_request_paths():
     every network user shares, which makes the pair airtight; ``_request`` is
     still patched so the common path fails with a message naming the cause.
     """
-    with (
-        patch.object(LuxpowerClient, "_request", _refuse_request),
-        patch.object(LuxpowerClient, "_get_session", _refuse_session),
+    for attribute, replacement in (
+        ("_request", _refuse_request),
+        ("_get_session", _refuse_session),
     ):
-        yield
+        patcher = patch.object(LuxpowerClient, attribute, replacement)
+        patcher.start()
+        _cloud_patchers.append(patcher)
+
+
+def _stop_cloud_refusal() -> None:
+    """Lift the patches and report anything nobody else consumed.
+
+    The per-test fixture drains the buffer at each teardown, but attempts made
+    after the LAST test's teardown — a session finalizer, or interpreter
+    shutdown work — have no test to be attributed to. Reporting them here
+    means they are loud rather than lost.
+    """
+    while _cloud_patchers:
+        _cloud_patchers.pop().stop()
+
+    if _cloud_attempts:
+        unattributed = sorted(set(_cloud_attempts))
+        del _cloud_attempts[:]
+        raise CloudRequestInTest(
+            f"cloud request(s) attempted outside any test: {unattributed}. "
+            f"{_REFUSAL_MESSAGE}"
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -141,17 +166,23 @@ def refuse_real_cloud_requests(request: pytest.FixtureRequest):
 
     * Reported for a passing test, a failing test (the failure and the
       violation both surface), and each parametrized case independently.
-    * A SKIPPED test never runs its body, so there is nothing to catch.
-    * An XFAILED test is the one hole: pytest absorbs the teardown error, so a
-      violating xfail passes unreported. The suite has no xfail tests today,
-      and a violation costs no wall clock because the refusal is immediate.
+    * A test skipped by ``@pytest.mark.skip`` never runs its body, so there is
+      nothing to catch. A RUNTIME ``pytest.skip()`` is different: the body ran,
+      so a prior violation is reported as SKIPPED plus ERROR.
+    * Plain non-strict ``xfail`` is the hole: pytest absorbs the teardown error
+      and the run still exits 0. ``xfail(raises=...)`` with a mismatch, and
+      dynamic ``pytest.xfail()``, can still surface it. The suite has no xfail
+      tests today, and a violation costs no wall clock because the refusal is
+      immediate.
     * An attempt made after this fixture's teardown — during a finalizer that
-      runs later, or during session setup before any test — is still recorded
-      by the session-scoped patch and surfaces against the NEXT test.
-      Attribution is off by one test; detection is not lost. This is why the
-      buffer is drained ONLY at teardown: clearing it on entry as well would
-      discard exactly those late attempts instead of deferring them, turning
-      an attribution quirk into a silent miss.
+      runs later — is still recorded, because the patches are held by
+      ``pytest_configure``/``pytest_unconfigure`` rather than by any fixture,
+      and surfaces against the NEXT test. Attribution is off by one test;
+      detection is not lost. This is why the buffer is drained ONLY at
+      teardown: clearing it on entry as well would discard exactly those late
+      attempts instead of deferring them, turning an attribution quirk into a
+      silent miss. Anything left over after the final test is reported by
+      ``_stop_cloud_refusal``.
     * ``get_closest_marker`` honours class- and module-level marks, so a
       module-wide ``pytestmark`` would opt an entire file out. That is the
       normal pytest inheritance rule, not a special case here, but it means
@@ -166,6 +197,11 @@ def refuse_real_cloud_requests(request: pytest.FixtureRequest):
         raise CloudRequestInTest(
             f"{len(attempts)} cloud request(s) attempted: {unique}. {_REFUSAL_MESSAGE}"
         )
+
+
+def pytest_unconfigure(config):
+    """Lift the cloud-refusal patches at the very end of the run."""
+    _stop_cloud_refusal()
 
 
 def wire_coordinator_write_helpers(coordinator: MagicMock) -> None:
@@ -349,6 +385,7 @@ def pytest_configure(config):
         "request path; the refusal is still raised, but reaching it is not "
         "treated as a failure.",
     )
+    _start_cloud_refusal()
 
     # Store original threading.enumerate
     original_enumerate = threading.enumerate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for EG4 Web Monitor integration tests."""
 
+import inspect
 import threading
 from types import SimpleNamespace
 from typing import Any, NoReturn
@@ -43,24 +44,66 @@ def stub_cloud_client() -> SimpleNamespace:
     The optional getters are deliberately absent, so the production code's own
     "installed pylxpweb predates this getter" branches no-op rather than the
     call exploding on a thinner double.
+
+    ``base_url`` is present because the coordinator reads it outside any fetch
+    (``get_station_device_info`` builds the plant's configuration URL from it),
+    so a double without it would fail there for a reason unrelated to the test.
     """
     return SimpleNamespace(
-        analytics=SimpleNamespace(), api=SimpleNamespace(control=SimpleNamespace())
+        analytics=SimpleNamespace(),
+        api=SimpleNamespace(control=SimpleNamespace()),
+        base_url="https://monitor.eg4electronics.com",
     )
 
 
-@pytest.fixture(autouse=True)
-def refuse_real_cloud_requests(request: pytest.FixtureRequest):
-    """Refuse cloud requests, and FAIL the test that made one.
+_cloud_attempts: list[str] = []
+
+# The production signature, captured before patching, so a test can prove the
+# stand-in still mirrors it rather than merely being non-permissive.
+PRODUCTION_REQUEST_SIGNATURE = inspect.signature(LuxpowerClient._request)
+
+
+async def _refuse_request(
+    self: LuxpowerClient,
+    method: str,
+    endpoint: str,
+    *,
+    data: dict[str, Any] | None = None,
+    cache_key: str | None = None,
+    cache_endpoint: str | None = None,
+    _retry_count: int = 0,
+) -> NoReturn:
+    """Stand-in for ``LuxpowerClient._request`` — records, then refuses."""
+    _cloud_attempts.append(f"{method} {endpoint}")
+    raise CloudRequestInTest(_REFUSAL_MESSAGE)
+
+
+async def _refuse_session(self: LuxpowerClient) -> NoReturn:
+    """Stand-in for ``LuxpowerClient._get_session`` — records, then refuses."""
+    _cloud_attempts.append("_get_session")
+    raise CloudRequestInTest(_REFUSAL_MESSAGE)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _patch_cloud_request_paths():
+    """Hold the refusal patches for the WHOLE session.
+
+    Deliberately session-scoped rather than per-test. Pytest sets the
+    plugin's own autouse fixtures up before this module's, which means they
+    tear down AFTER a function-scoped guard has already been restored — so a
+    cloud call made during another fixture's teardown, during module/session
+    setup, or by a task drained while ``hass`` shuts down would reach the real
+    method and retry against the network. Holding the patch for the session
+    leaves no window in which the real methods are reachable.
 
     The coordinator constructs a REAL ``LuxpowerClient`` for http/hybrid
-    entries (websession injection), so any test that drives a code path
-    reaching a cloud fetch lands in pylxpweb's request layer. There the
-    injected aiohttp session belongs to a different event loop than the test's,
-    every attempt fails, and pylxpweb retries with exponential backoff
-    (1+2+4+8+16s) until the caller's ``wait_for`` cancels it. That is pure
-    wall-clock: one test spent 55s at ~1% CPU, and on a runner whose egress to
-    the portal blackholes the same paths can exhaust the job timeout.
+    entries (websession injection), so any code path reaching a cloud fetch
+    lands in pylxpweb's request layer. There the injected aiohttp session
+    belongs to a different event loop than the test's, every attempt fails, and
+    pylxpweb retries with exponential backoff (1+2+4+8+16s) until the caller's
+    ``wait_for`` cancels it. That is pure wall clock: one test spent 55s at ~1%
+    CPU, and on a runner whose egress to the portal blackholes the same paths
+    can exhaust the job timeout.
 
     Failing at the request boundary — rather than blocking sockets — is what
     removes the cost, because the backoff sleeps happen whether or not a socket
@@ -73,49 +116,48 @@ def refuse_real_cloud_requests(request: pytest.FixtureRequest):
     would bypass a ``_request``-only guard. ``_get_session`` is the accessor
     every network user shares, which makes the pair airtight; ``_request`` is
     still patched so the common path fails with a message naming the cause.
-
-    Refusing is NOT enough on its own. Every cloud fetch call site wraps its
-    work in a broad ``except Exception`` and carries values forward, so a
-    refusal is swallowed into "optional data missing" and the offending test
-    still passes — silently attempting a live request on every run. So the
-    attempts are recorded and reported at teardown, which is what makes the
-    guarantee real rather than aspirational. Opt out with
-    ``@pytest.mark.allow_real_cloud_request_path`` when reaching the path is
-    the point of the test.
-
-    Scope, measured rather than assumed. A violation is reported for a passing
-    test, a failing test (both the failure and the violation surface), and each
-    parametrized case independently. A SKIPPED test never runs its body, so
-    there is nothing to catch. An XFAILED test is the one hole: pytest absorbs
-    the teardown error, so a violating xfail would pass unreported. The suite
-    currently contains no xfail tests, and a violation still costs no wall
-    clock because the refusal is immediate — but the guarantee is "no test
-    reaches the network unreported EXCEPT under xfail", not something broader.
     """
-    attempts: list[str] = []
-
-    async def _refuse_request(
-        self: LuxpowerClient,
-        method: str,
-        endpoint: str,
-        *,
-        data: dict[str, Any] | None = None,
-        cache_key: str | None = None,
-        cache_endpoint: str | None = None,
-        _retry_count: int = 0,
-    ) -> NoReturn:
-        attempts.append(f"{method} {endpoint}")
-        raise CloudRequestInTest(_REFUSAL_MESSAGE)
-
-    async def _refuse_session(self: LuxpowerClient) -> NoReturn:
-        attempts.append("_get_session")
-        raise CloudRequestInTest(_REFUSAL_MESSAGE)
-
     with (
         patch.object(LuxpowerClient, "_request", _refuse_request),
         patch.object(LuxpowerClient, "_get_session", _refuse_session),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def refuse_real_cloud_requests(request: pytest.FixtureRequest):
+    """FAIL the test that attempted a cloud request.
+
+    Refusing is NOT enough on its own. Every cloud fetch call site wraps its
+    work in a broad ``except Exception`` and carries values forward, so a
+    refusal is swallowed into "optional data missing" and the offending test
+    still passes — silently attempting a live request on every run. Recording
+    the attempts and reporting them here is what makes the guarantee real
+    rather than aspirational. Opt out with
+    ``@pytest.mark.allow_real_cloud_request_path`` when reaching the path is
+    the point of the test.
+
+    Scope, measured rather than assumed:
+
+    * Reported for a passing test, a failing test (the failure and the
+      violation both surface), and each parametrized case independently.
+    * A SKIPPED test never runs its body, so there is nothing to catch.
+    * An XFAILED test is the one hole: pytest absorbs the teardown error, so a
+      violating xfail passes unreported. The suite has no xfail tests today,
+      and a violation costs no wall clock because the refusal is immediate.
+    * An attempt made after this fixture's teardown — during a later fixture's
+      finalizer — is still recorded by the session-scoped patch, but lands in
+      the NEXT test's bucket. Attribution can therefore be off by one test;
+      detection is not lost.
+    * ``get_closest_marker`` honours class- and module-level marks, so a
+      module-wide ``pytestmark`` would opt an entire file out. That is the
+      normal pytest inheritance rule, not a special case here, but it means
+      the marker should be applied per-test.
+    """
+    del _cloud_attempts[:]
+    yield
+    attempts = list(_cloud_attempts)
+    del _cloud_attempts[:]
 
     if attempts and request.node.get_closest_marker(_ALLOW_CLOUD_MARKER) is None:
         unique = sorted(set(attempts))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 """Fixtures for EG4 Web Monitor integration tests."""
 
 import threading
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, NoReturn
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
@@ -26,9 +27,31 @@ class CloudRequestInTest(RuntimeError):
     """
 
 
+_ALLOW_CLOUD_MARKER = "allow_real_cloud_request_path"
+
+_REFUSAL_MESSAGE = (
+    "A test reached the real EG4 cloud request path. Give the coordinator a "
+    "stub client (see stub_cloud_client) instead of letting it attempt a live "
+    f"request, or mark the test with @pytest.mark.{_ALLOW_CLOUD_MARKER} if "
+    "reaching the path is the point."
+)
+
+
+def stub_cloud_client() -> SimpleNamespace:
+    """A client double with the surface the coordinator's fetches touch.
+
+    The optional getters are deliberately absent, so the production code's own
+    "installed pylxpweb predates this getter" branches no-op rather than the
+    call exploding on a thinner double.
+    """
+    return SimpleNamespace(
+        analytics=SimpleNamespace(), api=SimpleNamespace(control=SimpleNamespace())
+    )
+
+
 @pytest.fixture(autouse=True)
-def refuse_real_cloud_requests():
-    """Fail cloud requests instantly instead of retrying against the network.
+def refuse_real_cloud_requests(request: pytest.FixtureRequest):
+    """Refuse cloud requests, and FAIL the test that made one.
 
     The coordinator constructs a REAL ``LuxpowerClient`` for http/hybrid
     entries (websession injection), so any test that drives a code path
@@ -51,24 +74,45 @@ def refuse_real_cloud_requests():
     every network user shares, which makes the pair airtight; ``_request`` is
     still patched so the common path fails with a message naming the cause.
 
-    Tests that exercise cloud behaviour replace ``coordinator.client`` (or
-    patch ``coordinator.LuxpowerClient``) outright and so never reach this.
-    Nothing in the suite drives real HTTP, so no test needs the live path; one
-    that genuinely did could stop this fixture with its own patch.
+    Refusing is NOT enough on its own. Every cloud fetch call site wraps its
+    work in a broad ``except Exception`` and carries values forward, so a
+    refusal is swallowed into "optional data missing" and the offending test
+    still passes — silently attempting a live request on every run. So the
+    attempts are recorded and reported at teardown, which is what makes the
+    guarantee real rather than aspirational. Opt out with
+    ``@pytest.mark.allow_real_cloud_request_path`` when reaching the path is
+    the point of the test.
     """
+    attempts: list[str] = []
 
-    async def _refuse(self: LuxpowerClient, *args: Any, **kwargs: Any) -> Any:
-        raise CloudRequestInTest(
-            "A test reached the real EG4 cloud request path. Mock the "
-            "coordinator's client (or the endpoint you are exercising) "
-            "instead of letting it attempt a live request."
-        )
+    async def _refuse_request(
+        self: LuxpowerClient,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> NoReturn:
+        attempts.append(f"{method} {endpoint}")
+        raise CloudRequestInTest(_REFUSAL_MESSAGE)
+
+    async def _refuse_session(self: LuxpowerClient) -> NoReturn:
+        attempts.append("_get_session")
+        raise CloudRequestInTest(_REFUSAL_MESSAGE)
 
     with (
-        patch.object(LuxpowerClient, "_request", _refuse),
-        patch.object(LuxpowerClient, "_get_session", _refuse),
+        patch.object(LuxpowerClient, "_request", _refuse_request),
+        patch.object(LuxpowerClient, "_get_session", _refuse_session),
     ):
         yield
+
+    if attempts and request.node.get_closest_marker(_ALLOW_CLOUD_MARKER) is None:
+        unique = sorted(set(attempts))
+        raise CloudRequestInTest(
+            f"{len(attempts)} cloud request(s) attempted: {unique}. {_REFUSAL_MESSAGE}"
+        )
 
 
 def wire_coordinator_write_helpers(coordinator: MagicMock) -> None:
@@ -239,13 +283,20 @@ def create_mock_station(
 
 
 def pytest_configure(config):
-    """Configure pytest to allow asyncio shutdown threads.
+    """Register markers and allow asyncio shutdown threads.
 
     pytest-homeassistant-custom-component verifies no unexpected threads remain after tests.
     The asyncio event loop may create a daemon thread named '_run_safe_shutdown_loop'
     during shutdown which is expected and harmless. This configuration patches threading.enumerate
     to filter out this thread during cleanup verification.
     """
+    config.addinivalue_line(
+        "markers",
+        f"{_ALLOW_CLOUD_MARKER}: test intends to reach pylxpweb's cloud "
+        "request path; the refusal is still raised, but reaching it is not "
+        "treated as a failure.",
+    )
+
     # Store original threading.enumerate
     original_enumerate = threading.enumerate
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -82,7 +82,12 @@ from pylxpweb.transports.data import (
     MidboxRuntimeData,
 )
 
-from tests.conftest import make_real_inverter, make_real_mid, make_transport_spec
+from tests.conftest import (
+    stub_cloud_client,
+    make_real_inverter,
+    make_real_mid,
+    make_transport_spec,
+)
 
 
 @pytest.fixture
@@ -5534,6 +5539,7 @@ class TestHybridTransportExclusiveSensors:
         """bt_temperature from transport_runtime overlays into hybrid sensors."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # REAL inverter so the FULL base property surface mapped by
         # _process_inverter_object is exercised against the genuine class shape,
@@ -5575,6 +5581,7 @@ class TestHybridTransportExclusiveSensors:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             grid_l1_voltage=120.1,
@@ -5600,6 +5607,7 @@ class TestHybridTransportExclusiveSensors:
         """Without _transport_runtime, overlay is skipped entirely."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # REAL inverter with NO runtime/transport injected: the real class
         # defaults _transport_runtime and _transport to None, so the overlay
@@ -5620,6 +5628,7 @@ class TestHybridTransportExclusiveSensors:
         """None values in transport_runtime do not overwrite existing sensors."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # REAL inverter with a sparse runtime: only inverter_rms_current_r is
         # set, and NO pv/grid/battery power, so the real consumption_power
@@ -5654,6 +5663,7 @@ class TestHybridTransportExclusiveSensors:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             grid_l1_voltage=0.0,  # firmware-dead reg 193
@@ -5686,6 +5696,7 @@ class TestHybridTransportExclusiveSensors:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             grid_l1_voltage=121.3,
@@ -7087,6 +7098,7 @@ class TestPV456DataPath:
 
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = _SpecInverter(runtime)
         result = await coordinator._process_inverter_object(inverter)

--- a/tests/test_fault_warning_sensors.py
+++ b/tests/test_fault_warning_sensors.py
@@ -52,7 +52,12 @@ from custom_components.eg4_web_monitor.sensor import (
 )
 from pylxpweb.transports.data import InverterRuntimeData, MidboxRuntimeData
 
-from tests.conftest import make_real_inverter, make_real_mid, make_transport_spec
+from tests.conftest import (
+    stub_cloud_client,
+    make_real_inverter,
+    make_real_mid,
+    make_transport_spec,
+)
 
 CODE_KEYS = ("fault_code", "warning_code")
 
@@ -185,6 +190,7 @@ class TestFaultWarningHybridOverlay:
         """HYBRID: codes from the attached transport overlay into sensors."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             fault_code=0x0000_0010,
@@ -206,6 +212,7 @@ class TestFaultWarningHybridOverlay:
         """HYBRID: 0 (no fault/warning) is a real state and overlays too."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(fault_code=0, warning_code=0)
         inverter = make_real_inverter("1111111111", "FlexBOSS21", runtime=runtime)

--- a/tests/test_issue_261_hybrid_sensor_flicker.py
+++ b/tests/test_issue_261_hybrid_sensor_flicker.py
@@ -49,7 +49,7 @@ from pylxpweb.transports.data import (
     InverterRuntimeData,
 )
 
-from tests.conftest import make_real_inverter, make_transport_spec
+from tests.conftest import stub_cloud_client, make_real_inverter, make_transport_spec
 
 
 @pytest.fixture
@@ -109,6 +109,7 @@ class TestBatteryBankReg96Fallback:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = await _make_hybrid_inverter()
         # Combined read with reg 96 = 0: aggregate soc valid, count None, no
@@ -131,6 +132,7 @@ class TestBatteryBankReg96Fallback:
         """A trustworthy transport count keeps the live local bank (unchanged)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = await _make_hybrid_inverter()
         inverter._transport_battery = BatteryBankData(
@@ -153,6 +155,7 @@ class TestBatteryBankReg96Fallback:
         """#169 preserved: a genuine secondary reports 0 on BOTH sources → skip."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = await _make_hybrid_inverter()
         inverter._transport_battery = BatteryBankData(
@@ -182,6 +185,7 @@ class TestFaultCodeStickyOnLinkDown:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "LXP-LB-US 10K")
         inverter.refresh = AsyncMock()
@@ -209,6 +213,7 @@ class TestFaultCodeStickyOnLinkDown:
         """Link down with no prior poll → codes simply absent (no crash)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "LXP-LB-US 10K")
         inverter.refresh = AsyncMock()
@@ -228,6 +233,7 @@ class TestFaultCodeStickyOnLinkDown:
         """Link up: the live overlay value is used, not a stale prior value."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(fault_code=0x0000_0020, warning_code=0)
         inverter = make_real_inverter("1111111111", "LXP-LB-US 10K", runtime=runtime)
@@ -254,6 +260,7 @@ class TestFaultCodeStickyOnLinkDown:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "LXP-LB-US 10K")
         inverter.refresh = AsyncMock()

--- a/tests/test_issue_490_internal_temperature.py
+++ b/tests/test_issue_490_internal_temperature.py
@@ -61,6 +61,7 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
 from custom_components.eg4_web_monitor.sensor import _should_create_sensor
 
 from .conftest import make_real_inverter
+from tests.conftest import stub_cloud_client
 
 _OFFGRID = {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
 
@@ -239,6 +240,7 @@ class TestEndToEndWiring:
         """
         cloud_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, cloud_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "12000XP")
         inverter.refresh = AsyncMock()
@@ -273,6 +275,7 @@ class TestEndToEndWiring:
         """
         cloud_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, cloud_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("2222222222", "6000XP")
         inverter.refresh = AsyncMock()
@@ -302,6 +305,7 @@ class TestEndToEndWiring:
         """
         cloud_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, cloud_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(internal_temperature=0)
         inverter = make_real_inverter("3333333333", "12000XP", runtime=runtime)

--- a/tests/test_issue_490_internal_temperature.py
+++ b/tests/test_issue_490_internal_temperature.py
@@ -60,8 +60,7 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
 )
 from custom_components.eg4_web_monitor.sensor import _should_create_sensor
 
-from .conftest import make_real_inverter
-from tests.conftest import stub_cloud_client
+from .conftest import make_real_inverter, stub_cloud_client
 
 _OFFGRID = {"inverter_family": INVERTER_FAMILY_EG4_OFFGRID}
 

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -29,12 +29,14 @@ def _client() -> LuxpowerClient:
     return LuxpowerClient("user", "password", base_url="https://example.invalid")
 
 
+@pytest.mark.allow_real_cloud_request_path
 async def test_request_path_is_refused():
     """The common seam: everything routed through ``_request``."""
-    with pytest.raises(CloudRequestInTest):
+    with pytest.raises(CloudRequestInTest, match="real EG4 cloud request path"):
         await _client()._request("POST", "/WManage/api/inverter/getInverterRuntime")
 
 
+@pytest.mark.allow_real_cloud_request_path
 async def test_session_accessor_is_refused():
     """The second seam, and the reason ``_request`` alone is not enough.
 
@@ -43,5 +45,23 @@ async def test_session_accessor_is_refused():
     directly, bypassing ``_request`` entirely. Guarding only ``_request`` would
     leave those free to reach the network.
     """
-    with pytest.raises(CloudRequestInTest):
+    with pytest.raises(CloudRequestInTest, match="real EG4 cloud request path"):
         await _client()._get_session()
+
+
+@pytest.mark.allow_real_cloud_request_path
+async def test_refusal_keeps_request_signature():
+    """The stand-in must reject calls the real ``_request`` would reject.
+
+    ``create_autospec(LuxpowerClient)`` derives its spec from the patched
+    attribute, so a permissive ``*args, **kwargs`` stand-in would silently
+    accept argument shapes the production signature forbids and weaken every
+    autospec-based test.
+    """
+    with pytest.raises(TypeError):
+        await _client()._request()
+
+    with pytest.raises(TypeError):
+        await _client()._request(
+            "POST", "/WManage/api/inverter/getInverterRuntime", nonexistent=1
+        )

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -31,11 +31,26 @@ from typing import Any
 import pytest
 from pylxpweb.client import LuxpowerClient
 
-from .conftest import PRODUCTION_REQUEST_SIGNATURE, CloudRequestInTest
+from .conftest import (
+    PRODUCTION_GET_SESSION_SIGNATURE,
+    PRODUCTION_REQUEST_SIGNATURE,
+    CloudRequestInTest,
+)
 
 
 def _client() -> LuxpowerClient:
     return LuxpowerClient("user", "password", base_url="https://example.invalid")
+
+
+def _binding_shape(sig: inspect.Signature) -> list[tuple[str, Any, Any]]:
+    """Name, kind and default — what argument binding actually uses.
+
+    Annotations are excluded on purpose: pylxpweb uses postponed evaluation, so
+    its annotations are strings while the stand-ins' are objects. Comparing
+    those would fail on a cosmetic difference and say nothing about which calls
+    bind.
+    """
+    return [(p.name, p.kind, p.default) for p in sig.parameters.values()]
 
 
 @pytest.mark.allow_real_cloud_request_path
@@ -75,19 +90,36 @@ def test_refusal_matches_production_request_signature():
     broad production ``except`` would swallow it.
     """
 
-    def _binding_shape(sig: inspect.Signature) -> list[tuple[str, Any, Any]]:
-        """Name, kind and default — what argument binding actually uses.
-
-        Annotations are excluded on purpose: pylxpweb uses postponed
-        evaluation, so its annotations are strings while the stand-in's are
-        objects. Comparing those would fail on a cosmetic difference and say
-        nothing about which calls bind.
-        """
-        return [(p.name, p.kind, p.default) for p in sig.parameters.values()]
-
     assert _binding_shape(inspect.signature(LuxpowerClient._request)) == _binding_shape(
         PRODUCTION_REQUEST_SIGNATURE
     ), (
         "the refusal stand-in no longer mirrors LuxpowerClient._request; "
         "update it to the current production signature"
     )
+
+
+@pytest.mark.allow_real_cloud_request_path
+def test_refusal_matches_production_get_session_shape():
+    """The second seam needs the same drift check as the first.
+
+    ``_get_session`` had no signature or coroutine check at all, so a
+    stand-in that drifted from production — or stopped being a coroutine —
+    would go unnoticed while every autospec-derived double inherited the
+    wrong shape.
+    """
+    assert _binding_shape(inspect.signature(LuxpowerClient._get_session)) == (
+        _binding_shape(PRODUCTION_GET_SESSION_SIGNATURE)
+    )
+
+
+@pytest.mark.allow_real_cloud_request_path
+def test_refusals_are_still_coroutine_functions():
+    """Parameter shape alone would miss an async/sync flip.
+
+    ``create_autospec`` decides between ``AsyncMock`` and ``MagicMock`` from
+    this property, so a stand-in that stopped being a coroutine function would
+    silently change what every autospec-based double returns, without altering
+    a single parameter.
+    """
+    assert inspect.iscoroutinefunction(LuxpowerClient._request)
+    assert inspect.iscoroutinefunction(LuxpowerClient._get_session)

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -1,4 +1,12 @@
-"""The unit suite must never attempt a live EG4 cloud request.
+"""No test may attempt a live EG4 cloud request — and now it is enforced.
+
+Before enforcement this file's opening claim was aspirational: 33 tests
+attempted a request on every run and were merely refused, which the call sites'
+broad ``except Exception`` swallowed. ``refuse_real_cloud_requests`` now records
+attempts and raises at teardown, so the sentence above is a checked property
+rather than an intention. Its exact scope, including the xfail hole, is
+documented on that fixture.
+
 
 The coordinator builds a REAL ``LuxpowerClient`` for http/hybrid entries, so a
 test that drives any cloud-touching path reaches pylxpweb's request layer. The

--- a/tests/test_no_live_cloud_requests.py
+++ b/tests/test_no_live_cloud_requests.py
@@ -7,30 +7,31 @@ attempts and raises at teardown, so the sentence above is a checked property
 rather than an intention. Its exact scope, including the xfail hole, is
 documented on that fixture.
 
+Why it mattered: the coordinator builds a REAL ``LuxpowerClient`` for
+http/hybrid entries, so a test driving any cloud-touching path reaches
+pylxpweb's request layer. The injected aiohttp session belongs to a different
+event loop than the test's, every attempt fails, and pylxpweb retries with
+exponential backoff — spending wall clock (1+2+4+8+16s) until the caller's
+``wait_for`` cancels it. One test cost 55s at ~1% CPU, the full suite 25
+minutes, and a release CI run wedged past its job timeout twice. Closing this
+at the request boundary is what removes the cost: the backoff sleeps happen
+whether or not a socket ever connects, so blocking sockets would not have
+helped.
 
-The coordinator builds a REAL ``LuxpowerClient`` for http/hybrid entries, so a
-test that drives any cloud-touching path reaches pylxpweb's request layer. The
-injected aiohttp session belongs to a different event loop than the test's,
-every attempt fails, and pylxpweb retries with exponential backoff — spending
-wall clock (1+2+4+8+16s) until the caller's ``wait_for`` cancels it. One test
-cost 55s at ~1% CPU, the full suite 25 minutes, and a release CI run wedged
-past its job timeout twice.
-
-``refuse_real_cloud_requests`` in conftest closes that off at the request
-boundary, which is what removes the cost: the backoff sleeps happen whether or
-not a socket ever connects, so blocking sockets alone would not have helped.
-
-These tests keep both seams closed. They were verified to FAIL with the fixture
-made non-autouse. A wall-clock assertion was deliberately NOT added alongside
-them: an unreachable host resolves fast enough on a developer machine that the
-timing never trips, so such a test would pass whether or not the guard existed
-and would only look like protection.
+These tests keep both seams closed and were verified to FAIL with the patches
+lifted. A wall-clock assertion was deliberately NOT added alongside them: an
+unreachable host resolves fast enough on a developer machine that the timing
+never trips, so such a test would pass whether or not the guard existed and
+would only look like protection.
 """
+
+import inspect
+from typing import Any
 
 import pytest
 from pylxpweb.client import LuxpowerClient
 
-from .conftest import CloudRequestInTest
+from .conftest import PRODUCTION_REQUEST_SIGNATURE, CloudRequestInTest
 
 
 def _client() -> LuxpowerClient:
@@ -58,18 +59,35 @@ async def test_session_accessor_is_refused():
 
 
 @pytest.mark.allow_real_cloud_request_path
-async def test_refusal_keeps_request_signature():
-    """The stand-in must reject calls the real ``_request`` would reject.
+def test_refusal_matches_production_request_signature():
+    """The stand-in must mirror the real ``_request`` signature exactly.
 
-    ``create_autospec(LuxpowerClient)`` derives its spec from the patched
-    attribute, so a permissive ``*args, **kwargs`` stand-in would silently
-    accept argument shapes the production signature forbids and weaken every
-    autospec-based test.
+    ``create_autospec(LuxpowerClient)`` derives its spec from whatever is
+    patched onto the class, so a stand-in whose signature drifts from
+    production silently changes what every autospec-based test accepts.
+
+    Comparing against the signature captured BEFORE patching is what makes
+    this a real check: asserting only that some call raises ``TypeError``
+    would still pass for a stand-in missing a keyword-only parameter. And
+    drift is not hypothetical in one direction — the pylxpweb pin is
+    unbounded, so an added parameter that production starts passing would
+    make argument binding raise before the attempt is ever recorded, and the
+    broad production ``except`` would swallow it.
     """
-    with pytest.raises(TypeError):
-        await _client()._request()
 
-    with pytest.raises(TypeError):
-        await _client()._request(
-            "POST", "/WManage/api/inverter/getInverterRuntime", nonexistent=1
-        )
+    def _binding_shape(sig: inspect.Signature) -> list[tuple[str, Any, Any]]:
+        """Name, kind and default — what argument binding actually uses.
+
+        Annotations are excluded on purpose: pylxpweb uses postponed
+        evaluation, so its annotations are strings while the stand-in's are
+        objects. Comparing those would fail on a cosmetic difference and say
+        nothing about which calls bind.
+        """
+        return [(p.name, p.kind, p.default) for p in sig.parameters.values()]
+
+    assert _binding_shape(inspect.signature(LuxpowerClient._request)) == _binding_shape(
+        PRODUCTION_REQUEST_SIGNATURE
+    ), (
+        "the refusal stand-in no longer mirrors LuxpowerClient._request; "
+        "update it to the current production signature"
+    )

--- a/tests/test_offgrid_registers.py
+++ b/tests/test_offgrid_registers.py
@@ -66,6 +66,7 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
 from custom_components.eg4_web_monitor.sensor import _should_create_sensor
 
 from .conftest import make_real_inverter, make_transport_spec
+from tests.conftest import stub_cloud_client
 
 
 @pytest.fixture
@@ -329,6 +330,7 @@ class TestCloudHybridPath:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "12000XP")
         inverter.refresh = AsyncMock()
@@ -362,6 +364,7 @@ class TestCloudHybridPath:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "12000XP")
         inverter.refresh = AsyncMock()
@@ -393,6 +396,7 @@ class TestCloudHybridPath:
         real HYBRID session it populates from cloud-supplemental runtime."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             output_power=1324.0,
@@ -425,6 +429,7 @@ class TestCloudHybridPath:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # Pure cloud: NO transport and NO transport runtime — cloud-side
         # property values are patched onto the real class so the property
@@ -512,6 +517,7 @@ class TestOffgridCloudOutputPowerGate:
         mirror publishes NO output_power key (entity stays absent)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1111111111", "12000XP")
         inverter.refresh = AsyncMock()
@@ -538,6 +544,7 @@ class TestOffgridCloudOutputPowerGate:
         the gate must still drop the untrusted cloud value (codex r2 HIGH)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("3333333333", "12000XP")
         inverter.refresh = AsyncMock()
@@ -564,6 +571,7 @@ class TestOffgridCloudOutputPowerGate:
         value (live-verified 2365 W on FlexBOSS21)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("2222222222", "FlexBOSS21")
         inverter.refresh = AsyncMock()
@@ -590,6 +598,7 @@ class TestOffgridCloudOutputPowerGate:
         output_power from reg 170 — the local register always wins."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(output_power=1324.0)
         inverter = make_real_inverter("1111111111", "12000XP", runtime=runtime)
@@ -828,6 +837,7 @@ class TestSmartLoadSensors:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # Reporter's capture: EV charging on the GEN-port smart load.
         runtime = InverterRuntimeData(
@@ -1004,6 +1014,7 @@ class TestOffgridLinkDownLoadFallback:
         """No transport runtime + offgrid family → split sum (365+2999+0)."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("4233740012", "6000XP")
         inverter.refresh = AsyncMock()
@@ -1031,6 +1042,7 @@ class TestOffgridLinkDownLoadFallback:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         inverter = make_real_inverter("1234567890", "FlexBOSS21")
         inverter.refresh = AsyncMock()
@@ -1051,6 +1063,7 @@ class TestOffgridLinkDownLoadFallback:
         """Healthy hybrid: the local energy balance wins over the cloud split."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(
             pv_total_power=1000,

--- a/tests/test_offgrid_registers.py
+++ b/tests/test_offgrid_registers.py
@@ -65,8 +65,7 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
 )
 from custom_components.eg4_web_monitor.sensor import _should_create_sensor
 
-from .conftest import make_real_inverter, make_transport_spec
-from tests.conftest import stub_cloud_client
+from .conftest import make_real_inverter, make_transport_spec, stub_cloud_client
 
 
 @pytest.fixture

--- a/tests/test_operating_state.py
+++ b/tests/test_operating_state.py
@@ -47,7 +47,7 @@ from custom_components.eg4_web_monitor.coordinator_mappings import (
 from custom_components.eg4_web_monitor.sensor import EG4InverterSensor
 from pylxpweb.transports.data import InverterRuntimeData
 
-from tests.conftest import make_real_inverter, make_transport_spec
+from tests.conftest import stub_cloud_client, make_real_inverter, make_transport_spec
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -259,6 +259,7 @@ class TestOperatingStateCloudHybrid:
         """_process_inverter_object decodes status_code -> operating_state."""
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         runtime = InverterRuntimeData(device_status=0x40, pv_total_power=1500)
         inverter = make_real_inverter("1111111111", "FlexBOSS21", runtime=runtime)
@@ -285,6 +286,7 @@ class TestOperatingStateCloudHybrid:
         """
         mock_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        coordinator.client = stub_cloud_client()
 
         # No runtime/energy -> inverter.has_data is False -> early return.
         inverter = make_real_inverter("2222222222", "FlexBOSS21")


### PR DESCRIPTION
Follow-up to #510, from the union of four external review legs. #510 removed the wall clock; this makes its stated guarantee true.

## The finding

#510's guard refused cloud requests but did **not fail the test that made one**. Every cloud fetch call site wraps its work in a broad `except Exception` and carries values forward, so the refusal was swallowed into "optional data missing" and the offending test still passed.

So the module docstring's claim — that the suite never attempts a live cloud request — was **factually false**: 33 tests attempted one on every run, they just got refused quietly. The tripwire proved the patch was *installed*, not that it was *respected*.

This is a pre-existing condition rather than a regression from #502: those same tests were already failing their login after ~31s of backoff, so none was ever receiving cloud data. #502 made them fast, not vacuous.

## What changed

**Enforcement.** Attempts are recorded and raised at teardown, with `@pytest.mark.allow_real_cloud_request_path` as the supported opt-out (used by the tripwires, since reaching the path is their point). That marker also answers the "no escape hatch" finding.

**The 33 offenders, fixed.** Enforcement is self-verifying — switching it on named every one. Each builds a coordinator from a cloud entry and then drives `_process_inverter_object`; they now get `stub_cloud_client()`, a double carrying the `api.control` surface the fetches touch, with the optional getters deliberately absent so production's own "installed pylxpweb predates this getter" branches no-op rather than exploding on a thinner double.

| file | offenders |
|---|---|
| `test_offgrid_registers.py` | 12 |
| `test_coordinator.py` | 7 |
| `test_issue_261_hybrid_sensor_flicker.py` | 7 |
| `test_issue_490_internal_temperature.py` | 3 |
| `test_fault_warning_sensors.py` | 2 |
| `test_operating_state.py` | 2 |

**Signature fidelity.** The refusals now take `_request`'s exact production signature. A permissive `*args, **kwargs` stand-in meant `create_autospec(LuxpowerClient)` derived a spec that accepted argument shapes the real method rejects, silently weakening every autospec-based test. A new tripwire pins this.

**Plus** `NoReturn` annotations and `pytest.raises(..., match=...)` in the tripwires.

## One bug worth flagging

My marker registration initially went into a **second** `pytest_configure`, which Python silently shadowed with the existing one further down the file — so it never ran, while everything still appeared green. Ruff's F811 caught it. It is merged into the existing hook, and `--markers` now genuinely lists the marker.

## Results

`ruff` clean · `mypy --strict` clean (40 files) · **2517 passed, 3 skipped, 0 errors, 101.65s** · target test 0.14s

#510's timings hold: the suite stays at ~1:42 against 25:21 before, and no test can now attempt a live request without failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #511 — delivers item 1 (test-side enforcement); item 2 (shipped-side unreachable-portal cost) remains open.
