### PR TITLE
feat: diagnostics platform + hardened bug-report form (require debug logs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,12 +8,32 @@ body:
       value: |
         Thanks for reporting! Please fill out all fields so we can investigate quickly.
 
+        ⚠️ **Debug logs and a diagnostics download are required.** Almost every bug in this
+        integration comes down to what the EG4 cloud or your inverter actually returned, and
+        neither is visible in a screenshot or a default (warnings-only) log. Reports without
+        them usually stall on a round-trip asking for exactly this, so we now collect it up
+        front. It takes about two minutes:
+
+        **Debug logs**
+        1. Go to **Settings → Devices & Services → EG4 Web Monitor**
+        2. Click **⋮ (three dots) → Enable debug logging**
+        3. Reproduce the problem (or wait ~2 minutes for a few update cycles)
+        4. Click **⋮ → Disable debug logging** — Home Assistant downloads the log file automatically
+        5. Attach that file below (drag & drop), or paste the relevant portion
+
+        **Diagnostics download** (credentials, hosts and the plant name are redacted;
+        serial numbers are replaced with aliases)
+        1. Same page: **⋮ (three dots) → Download diagnostics**
+        2. Attach the JSON file to this issue (drag & drop into any text field)
+        3. On versions **before v3.5.1-beta.6** the menu item does not exist yet — just
+           write "not available on my version" in the diagnostics field below
+
   - type: input
     id: integration_version
     attributes:
       label: Integration Version
       description: "Found in Settings > Devices & Services > EG4 Web Monitor"
-      placeholder: "v3.2.0"
+      placeholder: "v3.5.1-beta.5"
     validations:
       required: true
 
@@ -22,7 +42,7 @@ body:
     attributes:
       label: Home Assistant Version
       description: "Found in Settings > About"
-      placeholder: "2025.3.1"
+      placeholder: "2026.7.1"
     validations:
       required: true
 
@@ -75,15 +95,58 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: affected_entities
+    attributes:
+      label: Affected Entity ID(s)
+      description: |
+        The exact entity ID(s), from Settings > Devices & Services > Entities
+        (e.g. `sensor.eg4_12000xp_1234567890_state_of_charge`). Entity IDs tell us
+        exactly which data path is involved — a friendly name or screenshot often doesn't.
+      placeholder: "sensor.battery_bank_1234567890_battery_bank_capacity_percent"
+    validations:
+      required: false
+
   - type: textarea
     id: logs
     attributes:
-      label: Home Assistant Logs
+      label: Debug Logs (required)
       description: |
-        Relevant logs from Settings > System > Logs (filter by "eg4").
-      render: shell
+        DEBUG-level logs captured while reproducing the issue — see the instructions at the
+        top of this form (Settings → Devices & Services → EG4 Web Monitor → ⋮ → Enable debug
+        logging, reproduce, Disable debug logging, attach the downloaded file).
+        Default warnings-only logs are not enough: the DEBUG level is where the actual
+        cloud/Modbus payloads appear.
+        ⚠️ Debug logs contain your device serial numbers and plant id as-is (unlike the
+        diagnostics download, they are not redacted) — mask them before attaching if that
+        matters to you.
     validations:
-      required: false
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics Download (required)
+      description: |
+        Attach the diagnostics JSON (Settings → Devices & Services → EG4 Web Monitor →
+        ⋮ → Download diagnostics). Credentials, hosts and the plant name are redacted
+        and serial numbers are aliased automatically. Drag & drop the file here.
+        If your version predates v3.5.1-beta.6, write "not available on my version";
+        if the problem happens during initial setup (before a config entry exists),
+        write "N/A — issue occurs during onboarding".
+      placeholder: Drag & drop the diagnostics JSON file here.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I attached DEBUG-level logs captured while the problem was occurring (not just the default warnings log)
+          required: true
+        - label: I attached the diagnostics download (or explained above why it is not possible)
+          required: true
 
   - type: textarea
     id: screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Diagnostics download**: *Settings → Devices & Services → EG4 Web Monitor → ⋮ → Download diagnostics* now produces a JSON dump of the config entry and the coordinator's current data — what the cloud or your local transport actually returned — so a bug report can carry the evidence without a capture round-trip. Credentials, hosts, the plant name and station identity/location fields are redacted outright, and a non-default portal URL is treated as private topology and redacted too; device, dongle and battery serial numbers are replaced with aliases (`SN_1`, `SN_2`, …) everywhere they appear — as dict keys, as values, lowercased inside derived strings, and embedded inside longer strings such as unique IDs — and the plant id becomes `PLANT_1`, so the dump stays correlatable without exposing identifying values. The download also works on an entry whose setup failed (a config-only snapshot), which is exactly when a reporter needs it. The bug-report form now asks for this file (and for debug logs) up front; note that **debug logs, unlike the diagnostics download, contain serials and the plant id as-is** — the form says so.
+
+### Fixed
+
+- **Smart Load switch moved to the Configuration section** (from #499's follow-up question): the switch shipped in 3.5.1-beta.5 without an entity category, so Home Assistant filed it under *Controls* while Grid Always On and the five Smart Load threshold numbers from the same portal panel all sit under *Configuration*. It now declares the configuration category and the panel's seven entities appear together. The #499 reporter also **hardware-confirmed the write path** (a toggle in Home Assistant reflects in the portal), so the switch's unverified-write caveat is retired.
+
 ## [3.5.1-beta.5] - 2026-08-02
 
 ### Added

--- a/custom_components/eg4_web_monitor/diagnostics.py
+++ b/custom_components/eg4_web_monitor/diagnostics.py
@@ -1,0 +1,264 @@
+"""Diagnostics support for the EG4 Web Monitor integration.
+
+Settings -> Devices & Services -> EG4 Web Monitor -> Download diagnostics.
+
+The download exists so a bug report can show exactly what the cloud or the
+local transport returned, without a round-trip asking the reporter to capture
+it by hand. Credentials, hosts, the plant name/title and station location
+fields are redacted outright; device, dongle and battery serial numbers are
+replaced with aliases (``SN_1``, ``SN_2``, ...) everywhere they appear — as
+dict keys, as values, and embedded inside longer strings such as unique IDs —
+and the plant id likewise becomes ``PLANT_1``, so the structure stays
+correlatable across the whole dump without exposing identifying values.
+Aliases are deterministic for a given inventory but may renumber if devices
+are added or removed between downloads.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_DONGLE_HOST,
+    CONF_MODBUS_HOST,
+    CONF_PLANT_ID,
+    CONF_PLANT_NAME,
+)
+from .coordinator import EG4DataUpdateCoordinator
+
+TO_REDACT = {
+    "username",
+    "password",
+    CONF_PLANT_NAME,
+    CONF_MODBUS_HOST,
+    CONF_DONGLE_HOST,
+    # Station/location fields (HA treats location and personal data as
+    # sensitive diagnostics content); nested occurrences are covered because
+    # async_redact_data walks the whole tree.
+    "name",
+    "address",
+    "phone",
+    "latitude",
+    "longitude",
+    "lat",
+    "lng",
+    "country",
+    "city",
+}
+
+# The default portal URLs are public knowledge and useful evidence; anything
+# else (a proxy, an internal hostname) is the reporter's private topology.
+_PUBLIC_BASE_URLS = {
+    "https://monitor.eg4electronics.com",
+    "https://us.luxpowertek.com",
+    "https://eu.luxpowertek.com",
+}
+
+# Config-entry keys whose values are device serials and must join the alias
+# map before the entry data is dumped.
+_SERIAL_ENTRY_KEYS = ("inverter_serial", "dongle_serial")
+
+# A shorter string is more likely to be a coincidental substring than a
+# serial; real EG4/dongle/battery serials are 10+ characters.
+_MIN_SERIAL_LEN = 4
+
+
+def _walk_serials(obj: Any, serials: set[str]) -> None:
+    """Recursively collect serial-shaped values from the data tree.
+
+    Two sources beyond the top-level device keys: any dict stored under a
+    ``batteries`` key is keyed by battery serial (serial-first identity,
+    #252), and any value whose key mentions ``serial`` or is ``battery_sn``
+    is a serial regardless of where it sits (e.g. the
+    ``battery_serial_number`` sensor value).
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(key, str):
+                lowered = key.lower()
+                if lowered == "batteries" and isinstance(value, dict):
+                    serials.update(str(k) for k in value)
+                if ("serial" in lowered or lowered == "battery_sn") and isinstance(
+                    value, str
+                ):
+                    serials.add(value)
+            _walk_serials(value, serials)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            _walk_serials(item, serials)
+
+
+def _collect_serials(
+    coordinator: EG4DataUpdateCoordinator | None, entry: ConfigEntry
+) -> list[str]:
+    """Collect every device serial the dump could contain, deterministically.
+
+    Device dict keys are the authoritative inventory; the recursive walk adds
+    battery serials (both as ``batteries`` dict keys and as serial-valued
+    fields anywhere in the tree); entry data can add local device serials
+    that predate a successful poll. Sorted so aliasing is deterministic for
+    a given inventory.
+    """
+    serials: set[str] = set()
+    if coordinator is not None:
+        data = coordinator.data or {}
+        serials.update(str(key) for key in data.get("devices", {}))
+        _walk_serials(data, serials)
+
+    entry_data = entry.data
+    for key in _SERIAL_ENTRY_KEYS:
+        value = entry_data.get(key)
+        if value:
+            serials.add(str(value))
+    for transport in entry_data.get("local_transports", []) or []:
+        if isinstance(transport, dict):
+            for key in _SERIAL_ENTRY_KEYS:
+                value = transport.get(key)
+                if value:
+                    serials.add(str(value))
+
+    # A too-short "serial" (or an empty one) would corrupt the dump through
+    # coincidental substring hits; drop them rather than alias them.
+    serials = {s for s in serials if len(s) >= _MIN_SERIAL_LEN}
+
+    # Longest first, so a serial that happens to contain another as a
+    # substring is replaced before its fragment can be.
+    return sorted(serials, key=lambda s: (-len(s), s))
+
+
+def _build_alias_pattern(aliases: dict[str, str]) -> re.Pattern[str] | None:
+    """Compile one case-insensitive pattern over all serials, longest first.
+
+    A purely numeric serial (or the plant id) gets digit-boundary guards so
+    it only matches where it is not part of a longer number — otherwise an
+    energy reading that happens to contain the plant id as a substring would
+    be corrupted by the replacement.
+    """
+    if not aliases:
+        return None
+    parts = []
+    for serial in aliases:
+        escaped = re.escape(serial)
+        if serial.isdigit():
+            escaped = rf"(?<!\d){escaped}(?!\d)"
+        parts.append(escaped)
+    return re.compile("|".join(parts), re.IGNORECASE)
+
+
+def _alias_serials(
+    obj: Any, aliases: dict[str, str], pattern: re.Pattern[str] | None
+) -> Any:
+    """Recursively replace serials in keys, values and embedded strings.
+
+    Matching is case-insensitive (letter-bearing dongle/battery serials can
+    appear lowercased in derived strings such as entity IDs); the longest
+    serial wins where one embeds another because the pattern lists serials
+    longest first.
+    """
+    if pattern is None:
+        return obj
+    if isinstance(obj, dict):
+        return {
+            _alias_serials(key, aliases, pattern): _alias_serials(
+                value, aliases, pattern
+            )
+            for key, value in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        return [_alias_serials(item, aliases, pattern) for item in obj]
+    if isinstance(obj, str):
+        return pattern.sub(lambda m: aliases[m.group(0).upper()], obj)
+    # An int-typed serial or plant id (the cloud returns plantId as a
+    # number) would otherwise sail past the string replacement.
+    if isinstance(obj, int) and not isinstance(obj, bool) and str(obj) in aliases:
+        return aliases[str(obj)]
+    return obj
+
+
+def _jsonable(obj: Any) -> Any:
+    """Reduce arbitrary values to JSON-serializable primitives.
+
+    Unknown objects become a bounded ``<TypeName>`` placeholder rather than
+    ``repr()`` — a repr can embed credentials, hosts or tokens (e.g. an
+    aiohttp exception carrying the connection target), and nothing
+    downstream could redact free-form repr text reliably.
+    """
+    if isinstance(obj, dict):
+        return {str(key): _jsonable(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return [_jsonable(item) for item in obj]
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    return f"<{type(obj).__name__}>"
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry.
+
+    Works on a failed-setup or unloaded entry too: ``runtime_data`` is only
+    assigned after the first successful refresh, and a reporter whose setup
+    fails is exactly the reporter who needs to attach evidence — so the dump
+    degrades to a config-only snapshot instead of raising.
+    """
+    coordinator_candidate = getattr(entry, "runtime_data", None)
+    coordinator: EG4DataUpdateCoordinator | None = (
+        coordinator_candidate
+        if isinstance(coordinator_candidate, EG4DataUpdateCoordinator)
+        else None
+    )
+
+    serials = _collect_serials(coordinator, entry)
+    aliases = {
+        serial.upper(): f"SN_{index}" for index, serial in enumerate(serials, start=1)
+    }
+    plant_id = entry.data.get(CONF_PLANT_ID)
+    if plant_id:
+        aliases[str(plant_id).upper()] = "PLANT_1"
+    pattern = _build_alias_pattern(aliases)
+
+    def _clean(obj: Any) -> Any:
+        return _alias_serials(
+            async_redact_data(_jsonable(obj), TO_REDACT), aliases, pattern
+        )
+
+    try:
+        pylxpweb_version = version("pylxpweb")
+    except PackageNotFoundError:
+        pylxpweb_version = "unknown"
+
+    base_url = entry.data.get("base_url")
+    entry_data = dict(entry.data)
+    if base_url and base_url.rstrip("/") not in _PUBLIC_BASE_URLS:
+        entry_data["base_url"] = "**REDACTED**"
+
+    result: dict[str, Any] = {
+        "entry": {
+            "data": _clean(entry_data),
+            "options": _clean(dict(entry.options)),
+        },
+        "versions": {
+            "pylxpweb": pylxpweb_version,
+        },
+    }
+
+    if coordinator is None:
+        result["coordinator"] = None
+        return result
+
+    result["coordinator"] = {
+        "connection_type": coordinator.connection_type,
+        "last_update_success": coordinator.last_update_success,
+        "update_interval": str(coordinator.update_interval),
+        "device_count": len((coordinator.data or {}).get("devices", {})),
+        "serial_aliases": sorted(aliases.values()),
+        "data": _clean(coordinator.data or {}),
+    }
+    return result

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -975,13 +975,18 @@ class EG4SmartLoadSwitch(EG4CloudStoreSwitch):
     Distinct from the GridBOSS/MID per-port ``FUNC_SMART_LOAD_EN_{n}``
     functions, which address different hardware.
 
-    The WRITE path is unverified on hardware (the read side is verified on an
-    18kPV, a FlexBOSS21 and a GridBOSS by a 2026-08-01 cloud probe); #499 stays
-    open pending the reporter's confirmation. Disabled by default for that
-    reason and because it only matters once the smart load port is configured.
+    The WRITE path is hardware-confirmed: the #499 reporter toggled the switch
+    in Home Assistant and watched the portal reflect it (2026-08-02, 12000XP).
+    Disabled by default because it only matters once the smart load port is
+    configured.
+
+    CONFIG category to sit beside Grid Always On and the five threshold
+    numbers from the same portal panel — shipping without a category filed it
+    under Controls while every sibling was under Configuration (#499 report).
     """
 
     _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.CONFIG
 
     _store_key = "smart_load"
     _cloud_method = "set_inverter_smart_load_enabled"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,184 @@
+"""Tests for the diagnostics platform (issue-reporting hardening).
+
+The download exists so a bug report can show what the cloud or local
+transport returned without a capture round-trip. These tests pin the
+promises the bug-report template makes about it: credentials, hosts,
+plant/station identity and location fields are redacted; device, dongle
+and battery serial numbers are aliased consistently everywhere they
+appear — as dict keys, as values (string OR int), lowercased inside
+derived strings, and embedded inside longer strings such as unique IDs —
+and the dump degrades to a config-only snapshot on a failed-setup entry
+instead of raising.
+"""
+
+import json
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.eg4_web_monitor.const import DOMAIN
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
+from custom_components.eg4_web_monitor.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+SERIAL = "1234567890"
+DONGLE_SERIAL = "BA12345678"
+PLANT_ID = "12345"
+
+
+@pytest.fixture
+def entry(hass):
+    """Config entry with credentials, a host and local serials to protect."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EG4 Web Monitor - 123 Private Street",
+        data={
+            "username": "real_user",
+            "password": "real_pass",
+            "base_url": "https://monitor.eg4electronics.com",
+            "plant_id": PLANT_ID,
+            "plant_name": "My Home Address",
+            "connection_type": "http",
+            "modbus_host": "10.0.0.42",
+            "inverter_serial": SERIAL,
+            "dongle_serial": DONGLE_SERIAL,
+        },
+        options={"sensor_update_interval": 20},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _make_coordinator(hass, entry):
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    coordinator.client = None  # never used by diagnostics
+    coordinator.data = {
+        "devices": {
+            SERIAL: {
+                "sensors": {
+                    "soc": 40,
+                    "battery_serial_number": "BATSN001",
+                    # The plant id embedded in a longer number must NOT be
+                    # replaced (digit-boundary guard).
+                    "energy_reading": 3123456,
+                },
+                "unique_id": f"{SERIAL}_state_of_charge",
+                # Letter-bearing serials appear lowercased in derived strings.
+                "entity_id": f"sensor.eg4_{DONGLE_SERIAL.lower()}_soc",
+                "batteries": {
+                    "BATSN002": {"sensors": {"battery_sn": "BATSN002", "soc": 41}}
+                },
+            }
+        },
+        "station": {
+            "plant_id": int(PLANT_ID),  # int-typed, as the cloud returns it
+            "name": "123 Private Street",
+            "address": "123 Private Street, Springfield",
+            "timezone": "GMT -8",
+        },
+    }
+    return coordinator
+
+
+async def _diagnostics(hass, entry):
+    coordinator = _make_coordinator(hass, entry)
+    entry.runtime_data = coordinator
+    return await async_get_config_entry_diagnostics(hass, entry)
+
+
+async def test_secrets_redacted_and_serials_aliased(hass, entry):
+    """Credentials/hosts/plant identity redacted; no real serial anywhere."""
+    result = await _diagnostics(hass, entry)
+    dump = json.dumps(result)
+
+    for secret in (
+        "real_user",
+        "real_pass",
+        "My Home Address",
+        "10.0.0.42",
+        "Private Street",  # entry title is omitted, station name/address redacted
+    ):
+        assert secret not in dump
+    # Device, dongle AND battery serials — battery serials appear both as
+    # `batteries` dict keys and as serial-valued sensor fields; the dongle
+    # serial also appears lowercased inside an entity ID.
+    for serial in (
+        SERIAL,
+        DONGLE_SERIAL,
+        DONGLE_SERIAL.lower(),
+        "BATSN001",
+        "BATSN002",
+    ):
+        assert serial not in dump
+    assert "**REDACTED**" in dump
+
+
+async def test_alias_is_consistent_across_keys_and_embedded_strings(hass, entry):
+    """The same serial gets the same alias as a dict key and inside a string."""
+    result = await _diagnostics(hass, entry)
+
+    devices = result["coordinator"]["data"]["devices"]
+    (alias_key,) = devices.keys()
+    assert alias_key.startswith("SN_")
+    # The unique_id used the serial as a prefix; the alias must replace it
+    # there too, with the identical alias.
+    assert devices[alias_key]["unique_id"] == f"{alias_key}_state_of_charge"
+    # Entry data's inverter_serial gets an alias from the same map.
+    assert result["entry"]["data"]["inverter_serial"].startswith("SN_")
+
+
+async def test_plant_id_aliased_including_int_but_not_embedded_digits(hass, entry):
+    """PLANT_1 replaces the plant id as str and int; longer numbers survive."""
+    result = await _diagnostics(hass, entry)
+
+    station = result["coordinator"]["data"]["station"]
+    assert station["plant_id"] == "PLANT_1"  # was int-typed
+    assert result["entry"]["data"]["plant_id"] == "PLANT_1"
+    # 3123456 contains "12345" but is a different number — must be untouched.
+    devices = result["coordinator"]["data"]["devices"]
+    (alias_key,) = devices.keys()
+    assert devices[alias_key]["sensors"]["energy_reading"] == 3123456
+    # Useful non-identifying station fields survive.
+    assert station["timezone"] == "GMT -8"
+
+
+async def test_failed_setup_entry_returns_config_only_snapshot(hass, entry):
+    """No runtime_data (setup failed / unloaded) -> config-only dump, no raise."""
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["coordinator"] is None
+    dump = json.dumps(result)
+    for secret in ("real_user", "real_pass", SERIAL, DONGLE_SERIAL):
+        assert secret not in dump
+    # Entry serials still alias without a coordinator inventory.
+    assert result["entry"]["data"]["inverter_serial"].startswith("SN_")
+
+
+async def test_structure_and_versions(hass, entry):
+    """The dump is JSON-serializable and carries the essentials."""
+    result = await _diagnostics(hass, entry)
+
+    json.dumps(result)  # must not raise
+    assert result["coordinator"]["connection_type"] == "http"
+    assert result["coordinator"]["device_count"] == 1
+    assert result["versions"]["pylxpweb"] not in ("", None)
+    assert result["entry"]["options"] == {"sensor_update_interval": 20}
+
+
+async def test_unknown_objects_become_type_placeholders(hass, entry):
+    """repr() is never emitted — a repr can embed hosts or credentials."""
+
+    class _Secretive:
+        def __repr__(self) -> str:  # pragma: no cover - the point is it never runs
+            return "ClientConnectorError(host='10.0.0.42', password='real_pass')"
+
+    coordinator = _make_coordinator(hass, entry)
+    coordinator.data["devices"][SERIAL]["transport"] = _Secretive()
+    entry.runtime_data = coordinator
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    dump = json.dumps(result)
+    assert "10.0.0.42" not in dump
+    assert "real_pass" not in dump
+    assert "<_Secretive>" in dump

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
 
 from custom_components.eg4_web_monitor.const import (
     INVERTER_FAMILY_EG4_OFFGRID,
@@ -1867,6 +1868,15 @@ class TestSmartLoadSwitch:
 
         switch = next(e for e in entities if isinstance(e, EG4SmartLoadSwitch))
         assert switch.entity_registry_enabled_default is False
+
+    def test_config_entity_category(self):
+        """CONFIG, to sit beside Grid Always On and the five threshold
+        numbers from the same portal panel — shipping without a category
+        filed it under Controls while every sibling was under Configuration
+        (#499 follow-up report)."""
+        coordinator = self._coordinator(store={"enabled": True})
+        switch = EG4SmartLoadSwitch(coordinator, self.SERIAL)
+        assert switch.entity_category is EntityCategory.CONFIG
 
     # ── Reads (dedicated coordinator store) ───────────────────────────
 


### PR DESCRIPTION
Triage keeps stalling on a round-trip asking reporters for evidence: #514 arrived with an empty logs section, #478 closed without ever getting the data, and the #478 thread even asked for a diagnostics download **the integration did not have**. This PR makes the evidence arrive with the report.

## 1. A real diagnostics platform

*Settings → Devices & Services → EG4 Web Monitor → ⋮ → Download diagnostics* now produces a JSON dump of the config entry and the coordinator's current data — what the cloud or local transport actually returned.

**Redaction, adversarially reviewed** (codex gpt-5.6-sol high + Gemini 3.1 Pro; convergent findings, all fixed in-round):
- Credentials, hosts, plant name, and station identity/location fields redacted; **entry title omitted** entirely (it embeds the plant name); a **non-default `base_url`** is treated as private topology and redacted
- Device, dongle and **battery** serials aliased `SN_n` — case-insensitively (letter-bearing serials appear lowercased in derived entity IDs), across dict keys, values, and embedded substrings; battery serials collected both as `batteries` dict keys (serial-first identity, #252) and as serial-valued fields anywhere in the tree
- Plant id aliased `PLANT_1`, **including int-typed occurrences**, with digit-boundary guards so an energy reading that merely contains the digits is not corrupted
- Unknown objects become `<TypeName>` placeholders, never `repr()` — a repr can embed credentials or hosts (aiohttp exceptions carry the connection target)
- **Works on a failed-setup entry** (config-only snapshot instead of HTTP 500) — the reporter whose setup fails is exactly the reporter who needs to attach evidence
- `entry.options` goes through the same redact+alias pipeline

Review findings deliberately *not* code-fixed here, documented instead: debug logs (the other required attachment) contain serials/plant-id as-is — the form warns about this; redacting identifiers at the logging call sites is a possible follow-up.

## 2. Hardened bug-report form

- **DEBUG logs required**, with the exact UI capture steps inline (enable debug logging → reproduce → disable → the log downloads automatically)
- **Diagnostics download required**, with honest escapes: versions predating this feature, and onboarding/config-flow failures where no entry exists yet
- `render: shell` removed from the logs field — GitHub issue forms don't accept file attachments in rendered textareas
- New entity-ID field, confirmation checkboxes

## 3. Smart Load switch → Configuration category (#499 follow-up)

The #499 reporter asked why the switch sat under *Controls* while Grid Always On and the five threshold numbers from the same portal panel sit under *Configuration* — shipping without a category was the inconsistency. Also retires the unverified-write caveat: the same reporter hardware-confirmed the write path (HA toggle reflects in the portal).

## Gate

ruff + format clean · mypy --strict clean (41 files) · **2526 passed, 3 skipped, 1:44** · 7 new tests (6 diagnostics incl. failed-setup, int-plant-id, digit-boundary, lowercase-serial, repr-placeholder; 1 entity-category)

🤖 Generated with [Claude Code](https://claude.com/claude-code)