### PR TITLE
fix: shared connectivity breaker for cloud side-fetches; family-table contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An unreachable EG4 portal no longer costs tens of dead seconds every poll cycle** ([#511](https://github.com/joyfulhouse/eg4_web_monitor/issues/511)): every supplemental cloud fetch (quick-charge status, per-string PV energy, the event log, the AC Couple / Smart Load parameter stores, voltage limits) bounds its call with a timeout — which caps each call, but on a portal that is genuinely unreachable (blocked egress, DNS blackhole) every one of them still burned its full timeout every cycle, serially, forever. They now share one connectivity breaker: after three consecutive connectivity-class failures the supplemental fetches are skipped instantly for five minutes, then retried. Only connectivity-class failures count — an HTTP-level answer from the portal (even an error) proves it is reachable and closes the breaker. Entity behavior is unchanged: skipped fetches take the exact same carry-forward path a timed-out fetch always took, just without the wait, and the main runtime polling is not affected. A single warning log line announces the pause.
+
 - **Smart Load switch moved to the Configuration section** (from #499's follow-up question): the switch shipped in 3.5.1-beta.5 without an entity category, so Home Assistant filed it under *Controls* while Grid Always On and the five Smart Load threshold numbers from the same portal panel all sit under *Configuration*. It now declares the configuration category and the panel's seven entities appear together. The #499 reporter also **hardware-confirmed the write path** (a toggle in Home Assistant reflects in the portal), so the switch's unverified-write caveat is retired.
 
 ## [3.5.1-beta.5] - 2026-08-02

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -12,15 +12,17 @@ final coordinator class inheriting all mixins together.
 import asyncio
 import logging
 import time
-from collections.abc import Callable, Collection
+from collections.abc import Awaitable, Callable, Collection, Coroutine
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import dt as dt_util
+from pylxpweb.exceptions import LuxpowerConnectionError
 
 if TYPE_CHECKING:
     from homeassistant.helpers.storage import Store
@@ -128,6 +130,90 @@ CLOUD_PARAM_STORE_RETRY_FLOOR = 120.0
 # earlier review threads refer to.
 AC_COUPLE_SOC_FETCH_INTERVAL = CLOUD_PARAM_STORE_FETCH_INTERVAL
 AC_COUPLE_SOC_FETCH_TIMEOUT = CLOUD_PARAM_STORE_FETCH_TIMEOUT
+
+# ── Shared connectivity breaker for supplemental cloud side-fetches (#511) ──
+# Every guarded side-fetch (quick-charge status, per-string PV energy, event
+# log, cloud param stores, voltage limits) bounds its cloud call with its own
+# timeout. That caps each call, but on a portal that is genuinely UNREACHABLE
+# (blocked egress, DNS blackhole) every one of them still burns its full
+# timeout every poll cycle, serially — tens of dead seconds per cycle, forever.
+# The breaker shares one connectivity verdict across all of them: after
+# _SIDEFETCH_BREAKER_THRESHOLD consecutive connectivity-class failures the
+# side-fetches are skipped instantly for _SIDEFETCH_BREAKER_COOLDOWN seconds,
+# then attempts resume (an implicit half-open probe: one success closes the
+# breaker, one connectivity failure re-opens it for another cooldown).
+#
+# Only connectivity-class failures count — a timeout on the outer wait_for, an
+# aiohttp transport error, or pylxpweb's own connection error. An HTTP-level
+# API error (auth, bad request, device offline) proves the portal IS reachable
+# and resets the streak, exactly like a success.
+#
+# Two normal-return shapes carry connectivity evidence INSIDE the result and
+# must not blindly reset the streak: a ``gather(return_exceptions=True)``
+# result whose members are all connectivity-class exceptions (a failure), and
+# a store getter's empty dict, which pylxpweb returns after swallowing its
+# internal per-range errors (ambiguous — neither proof of reachability nor a
+# counted failure). Call sites pass a ``classify`` callback for these.
+_SIDEFETCH_BREAKER_THRESHOLD = 3
+_SIDEFETCH_BREAKER_COOLDOWN = 300.0
+
+# The connectivity-class exceptions the breaker counts, shared with call-site
+# ``classify`` callbacks that inspect gathered results.
+SIDEFETCH_CONNECTIVITY_ERRORS = (
+    TimeoutError,
+    aiohttp.ClientError,
+    LuxpowerConnectionError,
+)
+
+
+def _classify_gathered_responses(responses: Any) -> bool | None:
+    """Breaker verdict for a ``gather(return_exceptions=True)`` result.
+
+    True (reachability proven) if ANY member is a real payload or a
+    non-connectivity exception (an HTTP-level answer); False (a counted
+    connectivity failure) when every member is a connectivity-class
+    exception; None when there is no evidence either way — an empty list,
+    or members that are all cancellations (a ``CancelledError`` says the
+    CALLER stopped waiting, nothing about the portal; the call site
+    re-raises it, and it must not reset a streak on the way through).
+    """
+    if not isinstance(responses, list):
+        return None
+    members = [
+        item for item in responses if not isinstance(item, asyncio.CancelledError)
+    ]
+    if not members:
+        return None
+    if all(isinstance(item, SIDEFETCH_CONNECTIVITY_ERRORS) for item in members):
+        return False
+    return True
+
+
+def _classify_store_limits(limits: Any) -> bool | None:
+    """Breaker verdict for a cloud param-store getter result.
+
+    The getters swallow their internal per-range errors and — verified
+    against pylxpweb's control endpoints — return a NON-EMPTY schema dict
+    with every value ``None`` after a total failure, so truthiness of the
+    dict proves nothing. Reachability is proven only by at least one
+    non-``None`` value (``False`` and ``0`` are real portal answers);
+    anything else is neutral.
+    """
+    if isinstance(limits, dict) and any(value is not None for value in limits.values()):
+        return True
+    return None
+
+
+class _CloudSidefetchSkipped(Exception):
+    """Raised in place of a side-fetch's cloud call while the breaker is open.
+
+    Deliberately an ordinary Exception: every side-fetch call site already
+    wraps its cloud call in a broad ``except Exception`` whose handler does
+    the right degraded thing (carry forward previous values, stamp the retry
+    floor). Raising into that handler reuses each site's existing failure
+    semantics unchanged — the skip just costs microseconds instead of the
+    site's full timeout.
+    """
 
 
 @dataclass(frozen=True)
@@ -867,6 +953,143 @@ class DeviceProcessingMixin(_MixinBase):
     Provides static methods for property mapping.
     """
 
+    # Shared connectivity breaker state (#511). Class-level defaults so the
+    # mixin needs no __init__; the first failure writes instance attributes.
+    _sidefetch_consecutive_failures: int = 0
+    # None = closed. A monotonic deadline, never 0.0 (the d66cc92 fresh-boot
+    # class: monotonic is host uptime, so early-uptime comparisons against a
+    # 0.0 default misclassify).
+    _sidefetch_open_until: float | None = None
+    # True between a cooldown expiring and the first probe's verdict: a
+    # single connectivity failure in that state re-opens immediately (a real
+    # half-open, not another three-strike round).
+    _sidefetch_half_open: bool = False
+
+    def _sidefetch_note_reachable(self) -> None:
+        """The portal answered: close the breaker fully.
+
+        Also clears an open deadline: with concurrent device processing, a
+        sibling call can open (or re-open) the breaker while THIS call was
+        already in flight — its success is fresher evidence than the
+        sibling's failure, and leaving the deadline in place would skip
+        every fetch for the whole cooldown despite proven reachability
+        (delta-review P2).
+        """
+        self._sidefetch_consecutive_failures = 0
+        self._sidefetch_half_open = False
+        self._sidefetch_open_until = None
+
+    def _sidefetch_note_connectivity_failure(self) -> None:
+        """Count one connectivity-class failure; open on threshold or probe."""
+        if self._sidefetch_half_open:
+            # The half-open probe failed — one strike re-opens.
+            self._sidefetch_half_open = False
+            self._sidefetch_consecutive_failures = 0
+            self._sidefetch_open_until = time.monotonic() + _SIDEFETCH_BREAKER_COOLDOWN
+            _LOGGER.warning(
+                "Cloud portal still unreachable after cooldown; pausing "
+                "supplemental cloud fetches for another %.0fs",
+                _SIDEFETCH_BREAKER_COOLDOWN,
+            )
+            return
+        self._sidefetch_consecutive_failures += 1
+        if self._sidefetch_consecutive_failures >= _SIDEFETCH_BREAKER_THRESHOLD:
+            self._sidefetch_consecutive_failures = 0
+            self._sidefetch_open_until = time.monotonic() + _SIDEFETCH_BREAKER_COOLDOWN
+            _LOGGER.warning(
+                "Cloud portal unreachable (%d consecutive side-fetch "
+                "connectivity failures); pausing supplemental cloud fetches "
+                "for %.0fs. Runtime polling and previously fetched values "
+                "are unaffected",
+                _SIDEFETCH_BREAKER_THRESHOLD,
+                _SIDEFETCH_BREAKER_COOLDOWN,
+            )
+
+    @staticmethod
+    def _discard_skipped_awaitable(call: "Awaitable[Any]") -> None:
+        """Dispose of a never-to-be-awaited call without asyncio complaints.
+
+        A bare coroutine is closed (never awaited — no RuntimeWarning). A
+        gather() Future has ALREADY scheduled its children, so it is
+        cancelled — and because a ``return_exceptions=True`` gathering future
+        finishes WITH the CancelledError as its exception rather than in the
+        CANCELLED state, the exception must also be retrieved via a done
+        callback or the event loop logs "exception was never retrieved".
+        """
+        if isinstance(call, Coroutine):
+            call.close()
+        elif isinstance(call, asyncio.Future):
+            call.cancel()
+
+            def _retrieve(fut: "asyncio.Future[Any]") -> None:
+                if not fut.cancelled():
+                    fut.exception()
+
+            call.add_done_callback(_retrieve)
+
+    async def _breakered_cloud_call(
+        self,
+        call: "Awaitable[Any]",
+        *,
+        timeout: float,
+        classify: "Callable[[Any], bool | None] | None" = None,
+    ) -> Any:
+        """Run one supplemental cloud call through the shared breaker (#511).
+
+        Drop-in for the side-fetches' ``asyncio.wait_for(call, timeout=...)``:
+        same await, same timeout, same exception propagation — plus the shared
+        connectivity bookkeeping. While the breaker is open the awaitable is
+        discarded unrun and ``_CloudSidefetchSkipped`` is raised instead,
+        which each call site's existing broad ``except Exception`` handler
+        turns into its normal degraded behavior (carry-forward + retry stamp)
+        without burning the timeout.
+
+        Only connectivity-class failures advance the breaker: the outer
+        ``TimeoutError``, aiohttp transport errors, and pylxpweb's
+        ``LuxpowerConnectionError``. A raised non-connectivity exception is an
+        HTTP-level answer — reachability proven — and closes the breaker.
+
+        A NORMAL return usually proves reachability too, but two shapes carry
+        connectivity evidence inside the result: a
+        ``gather(return_exceptions=True)`` list whose members are all
+        connectivity-class exceptions, and a store getter's empty dict (the
+        getter swallows its internal per-range errors). Sites with such
+        shapes pass ``classify``: return True for reachability proven, False
+        for a connectivity failure to count, None for no evidence either way.
+        """
+        now = time.monotonic()
+        open_until = self._sidefetch_open_until
+        if open_until is not None:
+            if now < open_until:
+                self._discard_skipped_awaitable(call)
+                raise _CloudSidefetchSkipped(
+                    f"cloud side-fetch skipped, breaker open for another "
+                    f"{open_until - now:.0f}s (portal unreachable)"
+                )
+            # Cooldown expired: this call is the half-open probe. Concurrent
+            # sites in the same cycle may each probe once before the first
+            # verdict lands — bounded by the device count, accepted.
+            self._sidefetch_open_until = None
+            self._sidefetch_half_open = True
+        try:
+            result = await asyncio.wait_for(call, timeout=timeout)
+        except SIDEFETCH_CONNECTIVITY_ERRORS:
+            self._sidefetch_note_connectivity_failure()
+            raise
+        except Exception:
+            # Reachability proven (an HTTP-level answer arrived); the failure
+            # itself is the call site's to handle.
+            self._sidefetch_note_reachable()
+            raise
+        else:
+            verdict = classify(result) if classify is not None else True
+            if verdict is True:
+                self._sidefetch_note_reachable()
+            elif verdict is False:
+                self._sidefetch_note_connectivity_failure()
+            # None: ambiguous result — no evidence in either direction.
+            return result
+
     def _get_device_grid_type(self, serial: str) -> str | None:
         """Look up user-selected grid type for a device from config entry.
 
@@ -978,7 +1201,7 @@ class DeviceProcessingMixin(_MixinBase):
             # escalated backoff sleep (up to ~60s) would otherwise hold a
             # coordinator slot for the whole storm. A timeout is a failed
             # read — the caller's carry-forward path handles it.
-            status = await asyncio.wait_for(
+            status = await self._breakered_cloud_call(
                 client.api.control.get_quick_charge_status(inverter.serial_number),
                 timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
             )
@@ -1364,7 +1587,7 @@ class DeviceProcessingMixin(_MixinBase):
             else:
                 try:
                     local_now = dt_util.now(_resolve_chart_day_timezone(self))
-                    response = await asyncio.wait_for(
+                    response = await self._breakered_cloud_call(
                         fetch_daily(serial, local_now.year, local_now.month),
                         timeout=PV_STRING_ENERGY_CLOUD_TIMEOUT,
                     )
@@ -1416,7 +1639,7 @@ class DeviceProcessingMixin(_MixinBase):
 
             if due_lifetime_strings:
                 try:
-                    responses = await asyncio.wait_for(
+                    responses = await self._breakered_cloud_call(
                         asyncio.gather(
                             *(
                                 fetch_lifetime(serial, f"ePv{string_number}Day")
@@ -1425,6 +1648,11 @@ class DeviceProcessingMixin(_MixinBase):
                             return_exceptions=True,
                         ),
                         timeout=PV_STRING_ENERGY_CLOUD_TIMEOUT,
+                        # gather(return_exceptions=True) hides connectivity
+                        # failures inside a NORMAL return — inspect it, or a
+                        # fast-failing outage would reset the breaker streak
+                        # every cycle and it would never open (review P1).
+                        classify=_classify_gathered_responses,
                     )
                 except Exception as e:
                     _LOGGER.debug(
@@ -1561,7 +1789,7 @@ class DeviceProcessingMixin(_MixinBase):
             return
 
         try:
-            response = await asyncio.wait_for(
+            response = await self._breakered_cloud_call(
                 fetch(serial, rows=1), timeout=EVENT_LOG_CLOUD_TIMEOUT
             )
             rows = response.get("rows") or []
@@ -1629,7 +1857,7 @@ class DeviceProcessingMixin(_MixinBase):
                 # the cloud getStatusInfo is the authoritative live state
                 # (#296). Bounded like the throttled fetch — a backoff-stalled
                 # cloud call must not hang the caller; timeout -> unknown.
-                status = await asyncio.wait_for(
+                status = await self._breakered_cloud_call(
                     client.api.control.get_quick_charge_status(serial),
                     timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
                 )
@@ -1799,8 +2027,14 @@ class DeviceProcessingMixin(_MixinBase):
             # carry-forward here, not escape to the per-device handler and
             # blank the whole inverter for the cycle (the #378 round-2 bug
             # class).
-            limits: dict[str, float | bool | None] = await asyncio.wait_for(
-                getter(serial), timeout=CLOUD_PARAM_STORE_FETCH_TIMEOUT
+            limits: dict[str, float | bool | None] = await self._breakered_cloud_call(
+                getter(serial),
+                timeout=CLOUD_PARAM_STORE_FETCH_TIMEOUT,
+                # The getter swallows its internal per-range errors and
+                # returns an all-None schema dict — truthy, so truthiness
+                # proves nothing (delta-review P1). Only a non-None value
+                # is reachability evidence.
+                classify=_classify_store_limits,
             )
             values: dict[str, Any] = {}
             for field in spec.fields:

--- a/tests/test_register_contract_harness.py
+++ b/tests/test_register_contract_harness.py
@@ -531,6 +531,38 @@ def _local_fidelity_offenders(
     return offenders, stale
 
 
+def test_family_register_tables_have_not_diverged() -> None:
+    """Every family's register->param table must equal the base table (#505).
+
+    ``switch.py``'s ``_local_params_can_carry`` (and the LOCAL register
+    gates built on it) probe pylxpweb's BASE ``REGISTER_TO_PARAM_KEYS``,
+    not the family-resolved ``get_register_to_param_mapping(family)``.
+    That is sound ONLY while every family resolves to the same table —
+    true today because #476 unified the reg-110 layout lineage-wide, and
+    pinned in pylxpweb by its own contract test. If a family table ever
+    diverges again (the #476 history shows it can), the base-table probe
+    would answer wrongly for that family and a switch could be created or
+    suppressed against the wrong layout.
+
+    This assertion is the eg4-side half of that pin: a divergence fails
+    HERE, loudly, with the instruction that ``_local_params_can_carry``
+    must become family-aware before the divergence ships.
+
+    Enumerating ``InverterFamily`` (plus ``None``) means a newly added
+    family is covered automatically rather than silently exempted.
+    """
+    base = get_register_to_param_mapping()
+    for family in [None, *(member.value for member in InverterFamily)]:
+        resolved = get_register_to_param_mapping(family)
+        assert resolved == base, (
+            f"Register table for family {family!r} diverged from the base "
+            "table. switch.py's _local_params_can_carry probes the BASE "
+            "table only — make it (and the LOCAL register gates that use "
+            "it) family-aware before shipping this divergence, or a "
+            "capability probe will answer wrongly for this family."
+        )
+
+
 def test_local_runtime_mapping_follows_canonical_registers() -> None:
     """Every runtime register's ha_sensor_key is fed by its canonical field."""
     offenders, stale = _local_fidelity_offenders(

--- a/tests/test_sidefetch_breaker.py
+++ b/tests/test_sidefetch_breaker.py
@@ -1,0 +1,317 @@
+"""Shared connectivity breaker for supplemental cloud side-fetches (#511).
+
+Each side-fetch bounds its cloud call with a timeout, but on a genuinely
+unreachable portal every one of them still burned its full timeout every
+poll cycle, serially. The breaker shares one connectivity verdict: after
+three consecutive connectivity-class failures the side-fetches skip
+instantly for a cooldown, then a half-open probe decides. Only
+connectivity-class failures count — an HTTP-level API answer proves the
+portal is reachable and closes the breaker like a success does.
+"""
+
+import asyncio
+import itertools
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+from pylxpweb.exceptions import LuxpowerAPIError, LuxpowerConnectionError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.eg4_web_monitor import coordinator_mixins
+from custom_components.eg4_web_monitor.const import DOMAIN
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
+from custom_components.eg4_web_monitor.coordinator_mixins import (
+    _SIDEFETCH_BREAKER_THRESHOLD,
+    _CloudSidefetchSkipped,
+)
+
+
+@pytest.fixture
+async def coordinator(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "u",
+            "password": "p",
+            "connection_type": "http",
+            "plant_id": "1",
+        },
+    )
+    entry.add_to_hass(hass)
+    coord = EG4DataUpdateCoordinator(hass, entry)
+    coord.client = None
+    return coord
+
+
+async def _ok():
+    return "payload"
+
+
+async def _timeout():
+    raise TimeoutError
+
+
+async def _aiohttp_error():
+    raise aiohttp.ClientError("transport down")
+
+
+async def _pylxpweb_conn_error():
+    raise LuxpowerConnectionError("no route to portal")
+
+
+async def _api_error():
+    raise LuxpowerAPIError("API error (HTTP 400): bad request")
+
+
+async def _trip(coordinator, failing=_timeout):
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD):
+        with pytest.raises(Exception):
+            await coordinator._breakered_cloud_call(failing(), timeout=5)
+
+
+@pytest.mark.parametrize("failing", [_timeout, _aiohttp_error, _pylxpweb_conn_error])
+async def test_breaker_opens_after_threshold_connectivity_failures(
+    coordinator, failing
+):
+    """Each connectivity error class trips it; the next call skips instantly."""
+    await _trip(coordinator, failing)
+
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_ok(), timeout=5)
+
+
+async def test_success_resets_the_streak(coordinator):
+    """N-1 failures then a success -> streak gone; N-1 more do not open it."""
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD - 1):
+        with pytest.raises(TimeoutError):
+            await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD - 1):
+        with pytest.raises(TimeoutError):
+            await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+
+    # Still closed: this call runs (and succeeds) rather than skipping.
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_api_error_counts_as_reachability(coordinator):
+    """An HTTP-level answer proves the portal is up: resets, never opens."""
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD * 2):
+        with pytest.raises(LuxpowerAPIError):
+            await coordinator._breakered_cloud_call(_api_error(), timeout=5)
+
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_cooldown_expiry_half_opens_and_success_closes(coordinator):
+    """After the cooldown the next call really runs; success closes fully."""
+    await _trip(coordinator)
+    opened_at = coordinator._sidefetch_open_until
+    assert opened_at is not None
+
+    with patch.object(coordinator_mixins.time, "monotonic", return_value=opened_at + 1):
+        assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+    assert coordinator._sidefetch_open_until is None
+
+    # Fully closed: a single new failure does not skip the following call.
+    with pytest.raises(TimeoutError):
+        await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_half_open_single_failure_reopens_immediately(coordinator):
+    """ONE connectivity failure at half-open re-opens for a full cooldown.
+
+    A real half-open: the post-cooldown probe gets one strike, not another
+    three-strike round — otherwise every cooldown expiry would burn up to
+    three full fetch timeouts before pausing again (review P2).
+    """
+    await _trip(coordinator)
+    opened_at = coordinator._sidefetch_open_until
+    with patch.object(coordinator_mixins.time, "monotonic", return_value=opened_at + 1):
+        with pytest.raises(TimeoutError):
+            await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+        assert coordinator._sidefetch_open_until is not None
+        # And the very next call skips instantly.
+        with pytest.raises(_CloudSidefetchSkipped):
+            await coordinator._breakered_cloud_call(_ok(), timeout=5)
+
+
+async def test_gathered_all_connectivity_failures_count(coordinator):
+    """gather(return_exceptions=True) hiding connectivity errors still trips.
+
+    Review P1: a fast-failing outage returns the exceptions INSIDE a normal
+    gather result, which used to reset the streak — the breaker could never
+    open. With the classify hook, three all-connectivity gather results open
+    it.
+    """
+    from custom_components.eg4_web_monitor.coordinator_mixins import (
+        _classify_gathered_responses,
+    )
+
+    async def _gathered():
+        return [LuxpowerConnectionError("down"), TimeoutError()]
+
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD):
+        await coordinator._breakered_cloud_call(
+            _gathered(), timeout=5, classify=_classify_gathered_responses
+        )
+
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_ok(), timeout=5)
+
+
+async def test_gathered_mixed_result_proves_reachability(coordinator):
+    """One real payload (or HTTP-level error) in the gather resets the streak."""
+    from custom_components.eg4_web_monitor.coordinator_mixins import (
+        _classify_gathered_responses,
+    )
+
+    async def _mixed():
+        return [LuxpowerConnectionError("down"), {"real": "payload"}]
+
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD * 2):
+        await coordinator._breakered_cloud_call(
+            _mixed(), timeout=5, classify=_classify_gathered_responses
+        )
+
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_all_none_store_result_is_neutral(coordinator):
+    """A failed store getter's all-None SCHEMA dict must not reset the streak.
+
+    Delta-review P1: pylxpweb's getters swallow internal per-range errors
+    and return a NON-EMPTY dict with every value None — truthy, so a
+    truthiness classify wrongly counted it as reachability. Only a non-None
+    value proves the portal answered.
+    """
+    from custom_components.eg4_web_monitor.coordinator_mixins import (
+        _classify_store_limits,
+    )
+
+    async def _failed_getter():
+        # The real shape: schema keys present, every value None.
+        return {"start_soc": None, "end_soc": None, "enabled": None}
+
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD - 1):
+        with pytest.raises(TimeoutError):
+            await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    # The neutral result must NOT reset the streak...
+    await coordinator._breakered_cloud_call(
+        _failed_getter(), timeout=5, classify=_classify_store_limits
+    )
+    # ...so one more connectivity failure opens the breaker.
+    with pytest.raises(TimeoutError):
+        await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_ok(), timeout=5)
+
+
+async def test_store_result_with_false_value_proves_reachability(coordinator):
+    """False and 0 are real portal answers — they close the breaker."""
+    from custom_components.eg4_web_monitor.coordinator_mixins import (
+        _classify_store_limits,
+    )
+
+    async def _real_answer():
+        return {"start_soc": None, "enabled": False}
+
+    for _ in range(_SIDEFETCH_BREAKER_THRESHOLD - 1):
+        with pytest.raises(TimeoutError):
+            await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    await coordinator._breakered_cloud_call(
+        _real_answer(), timeout=5, classify=_classify_store_limits
+    )
+    # Streak reset: the next failure is #1, not #3 — no skip follows.
+    with pytest.raises(TimeoutError):
+        await coordinator._breakered_cloud_call(_timeout(), timeout=5)
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_concurrent_success_closes_an_open_breaker(coordinator):
+    """A success completing AFTER a sibling opened the breaker closes it.
+
+    Delta-review P2: with concurrent device processing, call A can open the
+    breaker while already-admitted call B is in flight; B's success is
+    fresher evidence and must clear the deadline, not just the streak.
+    """
+    await _trip(coordinator)  # A: breaker now open
+    assert coordinator._sidefetch_open_until is not None
+
+    # B (admitted before the open) completes successfully.
+    coordinator._sidefetch_note_reachable()
+
+    assert coordinator._sidefetch_open_until is None
+    assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_gathered_cancellations_are_neutral(coordinator):
+    """CancelledError members carry no portal evidence in either direction.
+
+    Delta-review P2: the caller stopping to wait says nothing about the
+    portal; a cancellation-bearing gather must neither reset a streak nor
+    count as a failure — the call site re-raises it afterwards.
+    """
+    from custom_components.eg4_web_monitor.coordinator_mixins import (
+        _classify_gathered_responses,
+    )
+
+    assert _classify_gathered_responses([asyncio.CancelledError()]) is None
+    assert (
+        _classify_gathered_responses(
+            [LuxpowerConnectionError("down"), asyncio.CancelledError()]
+        )
+        is False
+    )
+    assert (
+        _classify_gathered_responses([{"payload": 1}, asyncio.CancelledError()]) is True
+    )
+
+
+async def test_skip_closes_coroutine_without_warning(coordinator):
+    """The unawaited coroutine is closed — no 'never awaited' warning."""
+    await _trip(coordinator)
+
+    called = False
+
+    async def _would_run():
+        nonlocal called
+        called = True
+
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_would_run(), timeout=5)
+    assert called is False
+
+
+async def test_skip_cancels_gather_future(coordinator):
+    """A gather() future (children already scheduled) is cancelled on skip."""
+    await _trip(coordinator)
+
+    started = False
+
+    async def _child():
+        nonlocal started
+        started = True
+        await asyncio.sleep(10)
+
+    fut = asyncio.gather(_child(), return_exceptions=True)
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(fut, timeout=5)
+    # Awaiting the cancelled gather drives the cancellation to completion
+    # deterministically (a single sleep(0) beat is not always enough). With
+    # return_exceptions=True a _GatheringFuture finishes WITH the
+    # CancelledError rather than transitioning to the CANCELLED state, so
+    # done() + the raise is the correct assertion, not cancelled().
+    with pytest.raises(asyncio.CancelledError):
+        await fut
+    assert fut.done()
+
+
+async def test_fresh_boot_none_sentinel(coordinator):
+    """A closed breaker at tiny monotonic values must not skip (d66cc92)."""
+    with patch.object(
+        coordinator_mixins.time, "monotonic", side_effect=itertools.count(1.0).__next__
+    ):
+        assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"


### PR DESCRIPTION
Closes the last two code-actionable open issues.

Fixes #511
Fixes #505

## #511 item 2 — the unreachable-portal cost

Every supplemental cloud fetch (quick-charge status ×2, per-string PV daily, PV lifetime, event log, the AC Couple / Smart Load param stores) bounds its call with a timeout. That caps each call — but on a portal that is genuinely unreachable, every one of them still burned its full 10–30s timeout **every poll cycle, serially, forever**.

They now share one connectivity breaker (`DeviceProcessingMixin._breakered_cloud_call`, a drop-in for the sites' `asyncio.wait_for`):
- **3 consecutive connectivity-class failures** (`TimeoutError`, `aiohttp.ClientError`, `LuxpowerConnectionError`) → side-fetches pause for **300s** (one warning log line)
- **True half-open** after the cooldown: one probe strike re-opens; reachability closes fully
- Skips raise an ordinary exception into each site's **existing** broad-except handler — entity behavior is byte-identical to a timed-out fetch (same carry-forward, same retry stamps), minus the wait
- An HTTP-level answer from the portal — even an error — proves reachability and closes the breaker; main runtime polling is untouched

## The review gate earned its keep — twice

Round 1 (codex gpt-5.6-sol high + Gemini 3.1 Pro) refuted the initial design with a reproduced P1: `gather(return_exceptions=True)` results and the store getters hide connectivity failures inside **normal returns**, resetting the streak — on a fast-failing outage the breaker would never open. Plus: skipped gather futures log "exception was never retrieved", and the half-open needed three strikes instead of one.

Round 2 (codex delta pass on the fix round) then refuted the fix: my `{}`-based store classify was empirically wrong — pylxpweb's getters return **truthy all-None schema dicts** on total failure (verified at the control-endpoint sources), so truthiness proves nothing; a concurrent success failed to clear a sibling's freshly-set deadline; and gathered `CancelledError` members were mis-classified as portal evidence.

All fixed via `classify` verdicts (True = reachable / False = counted failure / None = neutral), a done-callback retrieving the cancelled future's exception, a dedicated half-open flag, and deadline-clearing on reachability. Each finding is pinned by a dedicated test.

## #505 — family-table contract

`switch.py`'s `_local_params_can_carry` probes pylxpweb's **base** register table, sound exactly while every family resolves to the same table (#476 unified the layout lineage-wide). A new contract test enumerates `InverterFamily` (+ `None`) and fails loudly with instructions if any family's table ever diverges again — the eg4-side half of pylxpweb's own pin, per the fix shape the issue proposed.

## Gate

ruff + format clean · mypy --strict clean (41 files) · **2543 passed, 3 skipped, 1:42** · 17 new tests (16 breaker incl. every review finding; 1 contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)