### PR TITLE
Fix side-fetch breaker state and call-site coverage

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -81,6 +81,13 @@ _LOGGER = logging.getLogger(__name__)
 # isolation is a pylxpweb architectural item deliberately not attempted here.
 QUICK_CHARGE_CLOUD_STATUS_TIMEOUT = 10.0
 
+# Firmware status and battery-backup are supplemental cloud reads just like
+# quick-charge status. Bound them independently so neither can monopolize a
+# coordinator slot while the shared client is backing off.
+FIRMWARE_UPDATE_CLOUD_TIMEOUT = 10.0
+BATTERY_BACKUP_CLOUD_TIMEOUT = 10.0
+BATTERY_BACKUP_FETCH_INTERVAL = 30.0
+
 # Portal event-log poll throttle (#327).  Events are pushed to the cloud
 # out-of-band by the device (some never surface in registers), so the Last
 # Event sensor polls /WManage/api/analyze/event/list — but events are rare,
@@ -1005,6 +1012,13 @@ class DeviceProcessingMixin(_MixinBase):
                 _SIDEFETCH_BREAKER_COOLDOWN,
             )
 
+    def _sidefetch_note_inconclusive(self) -> None:
+        """Return an inconclusive half-open probe to a bounded open state."""
+        if not self._sidefetch_half_open:
+            return
+        self._sidefetch_half_open = False
+        self._sidefetch_open_until = time.monotonic() + _SIDEFETCH_BREAKER_COOLDOWN
+
     @staticmethod
     def _discard_skipped_awaitable(call: "Awaitable[Any]") -> None:
         """Dispose of a never-to-be-awaited call without asyncio complaints.
@@ -1029,7 +1043,7 @@ class DeviceProcessingMixin(_MixinBase):
 
     async def _breakered_cloud_call(
         self,
-        call: "Awaitable[Any]",
+        call: "Awaitable[Any] | Callable[[], Awaitable[Any]]",
         *,
         timeout: float,
         classify: "Callable[[Any], bool | None] | None" = None,
@@ -1056,12 +1070,16 @@ class DeviceProcessingMixin(_MixinBase):
         getter swallows its internal per-range errors). Sites with such
         shapes pass ``classify``: return True for reachability proven, False
         for a connectivity failure to count, None for no evidence either way.
+        A zero-argument factory may be supplied instead of an already-created
+        awaitable when constructing the operation itself schedules work (for
+        example ``asyncio.gather``); the factory runs only after admission.
         """
         now = time.monotonic()
         open_until = self._sidefetch_open_until
         if open_until is not None:
             if now < open_until:
-                self._discard_skipped_awaitable(call)
+                if not callable(call):
+                    self._discard_skipped_awaitable(call)
                 raise _CloudSidefetchSkipped(
                     f"cloud side-fetch skipped, breaker open for another "
                     f"{open_until - now:.0f}s (portal unreachable)"
@@ -1072,7 +1090,13 @@ class DeviceProcessingMixin(_MixinBase):
             self._sidefetch_open_until = None
             self._sidefetch_half_open = True
         try:
-            result = await asyncio.wait_for(call, timeout=timeout)
+            awaitable = call() if callable(call) else call
+            result = await asyncio.wait_for(awaitable, timeout=timeout)
+        except asyncio.CancelledError:
+            # Cancellation says nothing about portal connectivity. A cancelled
+            # half-open probe still needs a bounded state before propagating.
+            self._sidefetch_note_inconclusive()
+            raise
         except SIDEFETCH_CONNECTIVITY_ERRORS:
             self._sidefetch_note_connectivity_failure()
             raise
@@ -1087,7 +1111,12 @@ class DeviceProcessingMixin(_MixinBase):
                 self._sidefetch_note_reachable()
             elif verdict is False:
                 self._sidefetch_note_connectivity_failure()
-            # None: ambiguous result — no evidence in either direction.
+            elif self._sidefetch_half_open:
+                # The probe completed but supplied no connectivity evidence.
+                # It cannot close the breaker, and leaving half_open=True with
+                # no deadline would admit every later side-fetch indefinitely.
+                # Return to OPEN for one cooldown without counting a failure.
+                self._sidefetch_note_inconclusive()
             return result
 
     def _get_device_grid_type(self, serial: str) -> str | None:
@@ -1211,16 +1240,27 @@ class DeviceProcessingMixin(_MixinBase):
         elif hasattr(inverter, "get_quick_charge_detail"):
             # Prefer the full detail (remaining time + task metadata);
             # version-guard for older pylxpweb exposing only the boolean.
-            status = await inverter.get_quick_charge_detail()
+            if getattr(inverter, "transport", None) is None:
+                status = await self._breakered_cloud_call(
+                    lambda: inverter.get_quick_charge_detail(),
+                    timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
+                )
+            else:
+                status = await inverter.get_quick_charge_detail()
             # Raw holding reg 234 (minutes); None on cloud. Lets the duration
             # number mirror the live register on LOCAL/HYBRID instead of a
             # stored preference. getattr guards older pylxpweb without it.
             quick_charge_minute = getattr(status, "quickChargeMinute", None)
         elif hasattr(inverter, "get_quick_charge_status"):
+            if getattr(inverter, "transport", None) is None:
+                active = await self._breakered_cloud_call(
+                    lambda: inverter.get_quick_charge_status(),
+                    timeout=QUICK_CHARGE_CLOUD_STATUS_TIMEOUT,
+                )
+            else:
+                active = await inverter.get_quick_charge_status()
             return {
-                "hasUnclosedQuickChargeTask": (
-                    await inverter.get_quick_charge_status()
-                ),
+                "hasUnclosedQuickChargeTask": active,
                 "fetched_at": time.monotonic(),
             }
         else:
@@ -1269,7 +1309,8 @@ class DeviceProcessingMixin(_MixinBase):
         now = time.monotonic()
         serial = inverter.serial_number
         qc_key = f"qc_{serial}"
-        if now - self._last_status_fetch.get(qc_key, 0.0) >= interval:
+        last_fetch = self._last_status_fetch.get(qc_key)
+        if last_fetch is None or now - last_fetch >= interval:
             try:
                 status_dict = await self._read_quick_charge_status(inverter, target)
                 if status_dict is not None:
@@ -1640,7 +1681,7 @@ class DeviceProcessingMixin(_MixinBase):
             if due_lifetime_strings:
                 try:
                     responses = await self._breakered_cloud_call(
-                        asyncio.gather(
+                        lambda: asyncio.gather(
                             *(
                                 fetch_lifetime(serial, f"ePv{string_number}Day")
                                 for string_number in due_lifetime_strings
@@ -2165,9 +2206,15 @@ class DeviceProcessingMixin(_MixinBase):
         if not hasattr(device, "check_firmware_updates"):
             return None
         try:
-            await device.check_firmware_updates()
+            await self._breakered_cloud_call(
+                lambda: device.check_firmware_updates(),
+                timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+            )
             if hasattr(device, "get_firmware_update_progress"):
-                await device.get_firmware_update_progress()
+                await self._breakered_cloud_call(
+                    lambda: device.get_firmware_update_progress(),
+                    timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+                )
         except Exception as e:
             _LOGGER.debug(
                 "Could not refresh firmware updates for %s (using last cached state): %s",
@@ -2176,6 +2223,51 @@ class DeviceProcessingMixin(_MixinBase):
             )
         # Extract from the device's cached state regardless of refresh outcome.
         return self._extract_firmware_update_info(device)
+
+    async def _fetch_battery_backup_status(
+        self,
+        inverter: "BaseInverter",
+        processed: dict[str, Any],
+        *,
+        now: float,
+    ) -> None:
+        """Fetch cloud battery-backup state with timeout, breaker, and carry-forward."""
+        if inverter.transport is not None:
+            return
+        fetch = getattr(inverter, "get_battery_backup_status", None)
+        if not callable(fetch):
+            return
+        if not hasattr(self, "_last_status_fetch"):
+            self._last_status_fetch = {}
+
+        serial = inverter.serial_number
+        key = f"bb_{serial}"
+        last_fetch = self._last_status_fetch.get(key)
+        if last_fetch is not None and now - last_fetch < BATTERY_BACKUP_FETCH_INTERVAL:
+            if self.data and serial in self.data.get("devices", {}):
+                previous = self.data["devices"][serial].get("battery_backup_status")
+                if previous is not None:
+                    processed["battery_backup_status"] = previous
+            return
+
+        try:
+            enabled = await self._breakered_cloud_call(
+                lambda: fetch(), timeout=BATTERY_BACKUP_CLOUD_TIMEOUT
+            )
+        except Exception as exc:
+            self._last_status_fetch[key] = now
+            if self.data and serial in self.data.get("devices", {}):
+                previous = self.data["devices"][serial].get("battery_backup_status")
+                if previous is not None:
+                    processed["battery_backup_status"] = previous
+            _LOGGER.debug(
+                "Could not fetch battery backup status for %s: %s", serial, exc
+            )
+            return
+
+        processed["battery_backup_status"] = {"enabled": enabled}
+        self._last_status_fetch[key] = now
+        _LOGGER.debug("Battery backup status for %s: %s", serial, enabled)
 
     async def _process_inverter_object(
         self, inverter: "BaseInverter"
@@ -2634,9 +2726,8 @@ class DeviceProcessingMixin(_MixinBase):
                 if key in processed["sensors"]:
                     processed["sensors"][key] = None
 
-        # Fetch quick charge and battery backup status with 30s throttle
-        # These are cloud API calls that should not run every update cycle
-        _STATUS_FETCH_INTERVAL = 30  # seconds
+        # Fetch quick charge and battery backup status with independent throttles.
+        # These are cloud API calls that should not run every update cycle.
         if not hasattr(self, "_last_status_fetch"):
             self._last_status_fetch: dict[str, float] = {}
         now = time.monotonic()
@@ -2658,41 +2749,9 @@ class DeviceProcessingMixin(_MixinBase):
         # 5-minute throttle and getter.
         await self._fetch_smart_load(inverter, processed)
 
-        # Battery backup (EPS) status
-        # Skip cloud API call when local transport is attached — the parameter
-        # data from local Modbus already provides FUNC_EPS_EN which the switch
-        # entity uses as a fallback. The cloud remoteRead endpoint frequently
-        # returns apiBlocked anyway since the dongle relay is often busy.
-        has_local_transport = inverter.transport is not None
-        if not has_local_transport:
-            bb_key = f"bb_{serial}"
-            last_bb = self._last_status_fetch.get(bb_key, 0.0)
-            if now - last_bb >= _STATUS_FETCH_INTERVAL:
-                try:
-                    if hasattr(inverter, "get_battery_backup_status"):
-                        battery_backup_enabled = (
-                            await inverter.get_battery_backup_status()
-                        )
-                        processed["battery_backup_status"] = {
-                            "enabled": battery_backup_enabled,
-                        }
-                        self._last_status_fetch[bb_key] = now
-                        _LOGGER.debug(
-                            "Battery backup status for %s: %s",
-                            serial,
-                            battery_backup_enabled,
-                        )
-                except Exception as e:
-                    self._last_status_fetch[bb_key] = now
-                    _LOGGER.debug(
-                        "Could not fetch battery backup status for %s: %s",
-                        serial,
-                        e,
-                    )
-            elif self.data and serial in self.data.get("devices", {}):
-                prev = self.data["devices"][serial].get("battery_backup_status")
-                if prev is not None:
-                    processed["battery_backup_status"] = prev
+        # Battery backup (EPS) status. Local transport already supplies
+        # FUNC_EPS_EN, so only cloud-only devices use this supplemental path.
+        await self._fetch_battery_backup_status(inverter, processed, now=now)
 
         # Add last_polled timestamps so users can see when data was last fetched
         # (not just when it last changed)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7260,6 +7260,22 @@ class TestCloudPVStringEnergy:
         assert target["sensors"]["pv2_yield_lifetime"] == 4.0
         assert target["sensors"]["pv3_yield_lifetime"] == 0.0
 
+    async def test_open_breaker_does_not_start_lifetime_children(
+        self, hass, mock_config_entry
+    ):
+        """The gather and its three requests are created only after admission."""
+        analytics = SimpleNamespace(get_energy_total_breakdown=AsyncMock())
+        coordinator = self._coordinator(hass, mock_config_entry, analytics)
+        coordinator._sidefetch_open_until = time.monotonic() + 300.0
+        target: dict[str, Any] = {
+            "features": {"pv_string_count": 3},
+            "sensors": {},
+        }
+
+        await coordinator._fetch_pv_string_energy(self.SERIAL, target)
+
+        analytics.get_energy_total_breakdown.assert_not_called()
+
     async def test_lifetime_omitted_year_carries_previous_value(
         self, hass, mock_config_entry
     ):

--- a/tests/test_sidefetch_breaker.py
+++ b/tests/test_sidefetch_breaker.py
@@ -11,7 +11,8 @@ portal is reachable and closes the breaker like a success does.
 
 import asyncio
 import itertools
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -315,3 +316,145 @@ async def test_fresh_boot_none_sentinel(coordinator):
         coordinator_mixins.time, "monotonic", side_effect=itertools.count(1.0).__next__
     ):
         assert await coordinator._breakered_cloud_call(_ok(), timeout=5) == "payload"
+
+
+async def test_neutral_half_open_probe_returns_to_open_state(coordinator):
+    """An inconclusive probe must not leave an unbounded half-open state."""
+    await _trip(coordinator)
+    opened_at = coordinator._sidefetch_open_until
+    assert opened_at is not None
+
+    async def _neutral():
+        return {"start_soc": None, "enabled": None}
+
+    with patch.object(coordinator_mixins.time, "monotonic", return_value=opened_at + 1):
+        await coordinator._breakered_cloud_call(
+            _neutral(), timeout=5, classify=lambda _result: None
+        )
+
+    assert coordinator._sidefetch_half_open is False
+    assert coordinator._sidefetch_open_until is not None
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_ok(), timeout=5)
+
+
+async def test_cancelled_half_open_probe_returns_to_open_state(coordinator):
+    """Caller cancellation is inconclusive and cannot strand half-open state."""
+    await _trip(coordinator)
+    opened_at = coordinator._sidefetch_open_until
+    assert opened_at is not None
+
+    async def _cancelled():
+        raise asyncio.CancelledError
+
+    with patch.object(coordinator_mixins.time, "monotonic", return_value=opened_at + 1):
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator._breakered_cloud_call(_cancelled(), timeout=5)
+
+    assert coordinator._sidefetch_half_open is False
+    assert coordinator._sidefetch_open_until is not None
+
+
+async def test_lazy_call_factory_runs_only_after_breaker_admission(coordinator):
+    """A factory avoids scheduling gather children before the open check."""
+    created = 0
+
+    def _factory():
+        nonlocal created
+        created += 1
+        return _ok()
+
+    assert await coordinator._breakered_cloud_call(_factory, timeout=5) == "payload"
+    assert created == 1
+
+    await _trip(coordinator)
+    with pytest.raises(_CloudSidefetchSkipped):
+        await coordinator._breakered_cloud_call(_factory, timeout=5)
+    assert created == 1
+
+
+async def test_firmware_calls_are_bounded_by_shared_breaker(coordinator):
+    """An open breaker starts neither firmware endpoint."""
+    await _trip(coordinator)
+    device = MagicMock()
+    device.serial_number = "1234567890"
+    device.check_firmware_updates = AsyncMock()
+    device.get_firmware_update_progress = AsyncMock()
+    device.firmware_update_available = False
+
+    assert await coordinator._poll_firmware_update_info(device) is None
+    device.check_firmware_updates.assert_not_awaited()
+    device.get_firmware_update_progress.assert_not_awaited()
+
+
+async def test_cloud_quick_charge_detail_is_bounded_by_shared_breaker(coordinator):
+    """Cloud-only quick-charge helpers cannot bypass an open breaker."""
+    await _trip(coordinator)
+    inverter = MagicMock()
+    inverter.serial_number = "1234567890"
+    inverter.transport = None
+    inverter.get_quick_charge_detail = AsyncMock(
+        return_value=SimpleNamespace(
+            hasUnclosedQuickChargeTask=False,
+            remainTimeBeforeQuickChargeStop=0,
+            unclosedQuickChargeTaskId=None,
+            unclosedQuickChargeTaskStatus=None,
+            quickChargeMinute=0,
+        )
+    )
+    coordinator.client = None
+
+    await coordinator._fetch_quick_charge_status(inverter, {})
+
+    inverter.get_quick_charge_detail.assert_not_awaited()
+
+
+async def test_battery_backup_call_is_bounded_by_shared_breaker(coordinator):
+    """An open breaker starts no battery-backup request."""
+    await _trip(coordinator)
+    inverter = MagicMock()
+    inverter.serial_number = "1234567890"
+    inverter.transport = None
+    inverter.get_battery_backup_status = AsyncMock(return_value=True)
+    processed: dict = {}
+
+    await coordinator._fetch_battery_backup_status(inverter, processed, now=1.0)
+
+    inverter.get_battery_backup_status.assert_not_awaited()
+    assert "battery_backup_status" not in processed
+
+
+async def test_battery_backup_first_fetch_runs_at_low_host_uptime(coordinator):
+    """A missing stamp is due even when monotonic uptime is below 30 seconds."""
+    inverter = MagicMock()
+    inverter.serial_number = "1234567890"
+    inverter.transport = None
+    inverter.get_battery_backup_status = AsyncMock(return_value=True)
+    processed: dict = {}
+
+    await coordinator._fetch_battery_backup_status(inverter, processed, now=1.0)
+
+    inverter.get_battery_backup_status.assert_awaited_once()
+    assert processed["battery_backup_status"] == {"enabled": True}
+
+
+async def test_quick_charge_first_fetch_runs_at_low_host_uptime(coordinator):
+    """Quick-charge has the same explicit never-fetched sentinel contract."""
+    inverter = MagicMock()
+    inverter.serial_number = "1234567890"
+    inverter.transport = None
+    inverter.get_quick_charge_detail = AsyncMock(
+        return_value=SimpleNamespace(
+            hasUnclosedQuickChargeTask=False,
+            remainTimeBeforeQuickChargeStop=0,
+            unclosedQuickChargeTaskId=None,
+            unclosedQuickChargeTaskStatus=None,
+            quickChargeMinute=0,
+        )
+    )
+    coordinator.client = None
+
+    with patch.object(coordinator_mixins.time, "monotonic", return_value=1.0):
+        await coordinator._fetch_quick_charge_status(inverter, {})
+
+    inverter.get_quick_charge_detail.assert_awaited_once()


### PR DESCRIPTION
## Summary

- resolve neutral and cancelled half-open probes into a bounded breaker state
- admit lazy awaitable factories so an open breaker never schedules PV lifetime children
- route firmware, cloud quick-charge, and battery-backup supplemental calls through the shared breaker and explicit outer timeouts
- preserve cached firmware/battery-backup state on skips and failures
- use explicit never-fetched sentinels for quick-charge and battery-backup on freshly booted hosts

## Root cause

The merged #511 breaker left `half_open=True` after an inconclusive normal return and after caller cancellation. Two supplemental call sites bypassed the breaker entirely, cloud-only quick-charge helpers could also bypass it, and the PV lifetime `gather()` scheduled children before the breaker checked its deadline. Battery-backup had no outer timeout and used `0.0` as a monotonic never-fetched sentinel.

## Validation

- deterministic regressions failed in all five original paths before implementation
- `2552 passed, 3 skipped`
- 405 focused coordinator/breaker tests passed
- Ruff check passed
- Ruff format check passed (`116 files already formatted`)
- strict mypy passed across 41 source files
- pre-commit hooks passed

Tracks `eg4-scg1` and resolves two startup-sentinel items from `eg4-06er`.
