### PR TITLE
fix: wire number optimistic retention updates

### DIFF
--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -202,10 +202,8 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             )
 
     async def async_added_to_hass(self) -> None:
-        """When entity is added to hass."""
-        self.async_on_remove(
-            self.coordinator.async_add_listener(self.async_write_ha_state)
-        )
+        """Register the retention-aware coordinator callback."""
+        await super().async_added_to_hass()
 
     # ── Regime effectiveness (SOC vs Voltage) ──────────────────────────────
 

--- a/tests/test_optimistic_retention.py
+++ b/tests/test_optimistic_retention.py
@@ -411,6 +411,29 @@ class TestNumberRetainsAcknowledgedWrite:
         return entity
 
     @pytest.mark.asyncio
+    async def test_production_listener_runs_retention_convergence_and_ttl(self, caplog):
+        """The registered coordinator callback must be the retention handler."""
+        coordinator = _coordinator(
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_all_ok=False
+        )
+        entity = self._entity(coordinator)
+        await entity.async_added_to_hass()
+
+        callback = coordinator.async_add_listener.call_args.args[0]
+        assert callback == entity._handle_coordinator_update
+
+        await entity.async_set_native_value(95)
+        assert entity._optimistic_retained is True
+        _expire(entity)
+
+        with caplog.at_level("WARNING"):
+            callback()
+
+        assert entity._optimistic_retained is False
+        assert entity.native_value == 80
+        assert "expired without device confirmation" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_retains_on_failed_refresh(self):
         """Write ack'd + refresh failed → the written value stays published."""
         coordinator = _coordinator(


### PR DESCRIPTION
## Summary

- route number entities through the shared optimistic-retention coordinator handler
- preserve acknowledged writes until device convergence or the retention TTL expires
- cover the real production listener path with a regression test

## Root cause

`EG4BaseNumberEntity.async_added_to_hass()` registered `async_write_ha_state` directly. That bypassed `EG4OptimisticEntity._handle_coordinator_update()`, so the convergence and TTL logic already implemented for optimistic writes never ran from actual coordinator updates.

## Verification

- `pytest -q`: 2544 passed, 3 skipped
- focused optimistic/number tests: 280 passed
- `ruff check .`
- `ruff format --check .`
- `mypy --strict custom_components/eg4_web_monitor`
- pre-commit hooks

Tracks `eg4-1784213053000-189-c167c51a` / #379.
