### PR TITLE
fix: unwind failed entry setup

### DIFF
--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -593,9 +593,62 @@ def _async_cleanup_stale_smart_port_entities(
     return pending_serials
 
 
+async def _async_cleanup_failed_entry_setup(
+    hass: HomeAssistant,
+    entry: EG4ConfigEntry,
+    coordinator: EG4DataUpdateCoordinator,
+) -> None:
+    """Roll back resources acquired by an entry that did not finish setup."""
+    if coordinator._platform_setup_started:
+        try:
+            await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        except Exception:
+            _LOGGER.warning(
+                "Error rolling back partially set up platforms for %s",
+                entry.title,
+                exc_info=True,
+            )
+
+    try:
+        await coordinator.async_shutdown()
+    except Exception:
+        _LOGGER.warning(
+            "Error shutting down coordinator after failed setup for %s",
+            entry.title,
+            exc_info=True,
+        )
+
+    if coordinator.client is not None:
+        try:
+            await coordinator.client.close()
+        except Exception:
+            _LOGGER.warning(
+                "Error closing HTTP client after failed setup for %s",
+                entry.title,
+                exc_info=True,
+            )
+
+    entry.runtime_data = None  # type: ignore[assignment]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
+    """Set up an entry and unwind every acquired resource on failure."""
+    try:
+        return await _async_setup_entry(hass, entry)
+    except (Exception, asyncio.CancelledError):
+        coordinator = entry.runtime_data
+        if coordinator is not None:
+            await _async_cleanup_failed_entry_setup(hass, entry, coordinator)
+        raise
+
+
+async def _async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
     """Set up EG4 Web Monitor from a config entry."""
     _LOGGER.debug("Setting up EG4 Web Monitor entry: %s", entry.entry_id)
+
+    # A failed constructor must not accidentally clean up stale runtime data
+    # retained by a test harness or an interrupted previous setup attempt.
+    entry.runtime_data = None  # type: ignore[assignment]
 
     # Configure library debug logging based on user preference (options, data fallback)
     library_debug = entry.options.get(
@@ -648,13 +701,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
 
     # Initialize the coordinator
     coordinator = EG4DataUpdateCoordinator(hass, entry)
+    coordinator._platform_setup_started = False
+    entry.runtime_data = coordinator
     await coordinator._async_load_pv_string_lifetime_state()
 
     # Perform initial data fetch
     await coordinator.async_config_entry_first_refresh()
-
-    # Store coordinator in runtime_data
-    entry.runtime_data = coordinator
 
     # One-time migration: remove stale local-format battery entities
     # Old local keys used numeric-only battery indices (e.g., "0", "1")
@@ -829,6 +881,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
     # Forward entry setup to platforms (creates devices and entities)
     # Sensor platform first to create parent devices before other platforms
     # reference them via via_device.
+    coordinator._platform_setup_started = True
     try:
         await hass.config_entries.async_forward_entry_setups(entry, SENSOR_PLATFORM)
         await hass.config_entries.async_forward_entry_setups(entry, OTHER_PLATFORMS)

--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -599,7 +599,9 @@ async def _async_cleanup_failed_entry_setup(
     coordinator: EG4DataUpdateCoordinator,
 ) -> None:
     """Roll back resources acquired by an entry that did not finish setup."""
-    if coordinator._platform_setup_started:
+    try:
+        if not coordinator._platform_setup_started:
+            return
         try:
             await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
         except Exception:
@@ -608,27 +610,29 @@ async def _async_cleanup_failed_entry_setup(
                 entry.title,
                 exc_info=True,
             )
-
-    try:
-        await coordinator.async_shutdown()
-    except Exception:
-        _LOGGER.warning(
-            "Error shutting down coordinator after failed setup for %s",
-            entry.title,
-            exc_info=True,
-        )
-
-    if coordinator.client is not None:
+    finally:
         try:
-            await coordinator.client.close()
-        except Exception:
-            _LOGGER.warning(
-                "Error closing HTTP client after failed setup for %s",
-                entry.title,
-                exc_info=True,
-            )
-
-    entry.runtime_data = None  # type: ignore[assignment]
+            try:
+                await coordinator.async_shutdown()
+            except Exception:
+                _LOGGER.warning(
+                    "Error shutting down coordinator after failed setup for %s",
+                    entry.title,
+                    exc_info=True,
+                )
+        finally:
+            try:
+                if coordinator.client is not None:
+                    try:
+                        await coordinator.client.close()
+                    except Exception:
+                        _LOGGER.warning(
+                            "Error closing HTTP client after failed setup for %s",
+                            entry.title,
+                            exc_info=True,
+                        )
+            finally:
+                entry.runtime_data = None  # type: ignore[assignment]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -317,6 +317,10 @@ class EG4DataUpdateCoordinator(
         # Background task tracking for proper cleanup
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._shutdown_listener_fired: bool = False
+        # Entry setup sets this immediately before forwarding the first
+        # platform.  Failed setup uses it to avoid unloading platforms that
+        # were never started while still rolling back partial forwarding.
+        self._platform_setup_started: bool = False
 
         # Track availability state for Silver tier logging requirement
         self._last_available_state: bool = True

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -1861,7 +1861,10 @@ class LocalTransportMixin(_MixinBase):
             # Schedule an immediate follow-up refresh to load real register data.
             # This runs AFTER async_config_entry_first_refresh() completes and
             # entity platforms finish setup.
-            self.hass.async_create_task(self.async_request_refresh())
+            task = self.hass.async_create_task(self.async_request_refresh())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._remove_task_from_set)
+            task.add_done_callback(self._log_task_exception)
             return self._build_static_local_data()
 
         # Phase 2+: Normal register read path

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for EG4 Data Update Coordinator with pylxpweb 0.3.5 device objects API."""
 
+import asyncio
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -1851,6 +1852,32 @@ class TestStaticLocalData:
         assert sensors["firmware_version"] == "ARM-1.0"
         assert sensors["connection_transport"] == "Modbus"
         assert sensors["transport_host"] == "192.168.1.100"
+
+    async def test_static_follow_up_refresh_is_tracked_and_cancelled(
+        self, hass, local_config_entry
+    ):
+        """The zero-read phase must not leave an unload-racing refresh task."""
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        refresh_started = asyncio.Event()
+        keep_refresh_running = asyncio.Event()
+
+        async def blocked_refresh() -> None:
+            refresh_started.set()
+            await keep_refresh_running.wait()
+
+        coordinator.async_request_refresh = blocked_refresh
+
+        await coordinator._async_update_local_data()
+        await refresh_started.wait()
+
+        assert len(coordinator._background_tasks) == 1
+        refresh_task = next(iter(coordinator._background_tasks))
+        assert not refresh_task.done()
+
+        await coordinator.async_shutdown()
+
+        assert refresh_task.cancelled()
+        assert coordinator._background_tasks == set()
 
     async def test_static_data_has_all_inverter_sensor_keys(
         self, hass, local_config_entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
 """Tests for __init__.py (setup and teardown) in EG4 Web Monitor integration."""
 
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -323,6 +325,122 @@ class TestAsyncSetupEntry:
             assert "switch" in all_platforms
             assert "button" in all_platforms
             assert "select" in all_platforms
+
+    @patch("custom_components.eg4_web_monitor.EG4DataUpdateCoordinator")
+    async def test_first_refresh_failure_unwinds_coordinator_and_client(
+        self, mock_coordinator_class, hass: HomeAssistant, mock_config_entry
+    ):
+        """A failed initial refresh must not strand setup-owned resources."""
+        mock_config_entry.add_to_hass(hass)
+        mock_config_entry.runtime_data = None
+        coordinator = MagicMock()
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=RuntimeError("initial refresh failed")
+        )
+        coordinator.async_shutdown = AsyncMock()
+        coordinator.client = MagicMock()
+        coordinator.client.close = AsyncMock()
+        mock_coordinator_class.return_value = coordinator
+
+        with (
+            patch.object(
+                hass.config_entries, "async_forward_entry_setups", new=AsyncMock()
+            ) as forward,
+            patch.object(
+                hass.config_entries, "async_unload_platforms", new=AsyncMock()
+            ) as unload,
+            pytest.raises(RuntimeError, match="initial refresh failed"),
+        ):
+            await async_setup_entry(hass, mock_config_entry)
+
+        coordinator.async_shutdown.assert_awaited_once_with()
+        coordinator.client.close.assert_awaited_once_with()
+        forward.assert_not_awaited()
+        unload.assert_not_awaited()
+        assert mock_config_entry.runtime_data is None
+
+    @patch("custom_components.eg4_web_monitor.EG4DataUpdateCoordinator")
+    async def test_partial_platform_failure_rolls_back_before_shutdown(
+        self, mock_coordinator_class, hass: HomeAssistant, mock_config_entry
+    ):
+        """Partially forwarded platforms are unloaded before resource shutdown."""
+        mock_config_entry.add_to_hass(hass)
+        mock_config_entry.runtime_data = None
+        coordinator = MagicMock()
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock()
+        coordinator.async_shutdown = AsyncMock()
+        coordinator.client = MagicMock()
+        coordinator.client.close = AsyncMock()
+        mock_coordinator_class.return_value = coordinator
+        calls: list[str] = []
+
+        async def forward_platforms(*_args):
+            calls.append("forward")
+            if len(calls) == 2:
+                raise RuntimeError("platform setup failed")
+
+        async def unload_platforms(*_args):
+            calls.append("unload")
+            return True
+
+        coordinator.async_shutdown.side_effect = lambda: calls.append("shutdown")
+        coordinator.client.close.side_effect = lambda: calls.append("close")
+
+        with (
+            patch.object(
+                hass.config_entries,
+                "async_forward_entry_setups",
+                side_effect=forward_platforms,
+            ),
+            patch.object(
+                hass.config_entries,
+                "async_unload_platforms",
+                side_effect=unload_platforms,
+            ) as unload,
+            pytest.raises(RuntimeError, match="platform setup failed"),
+        ):
+            await async_setup_entry(hass, mock_config_entry)
+
+        unload.assert_awaited_once()
+        assert calls == ["forward", "forward", "unload", "shutdown", "close"]
+        assert mock_config_entry.runtime_data is None
+
+    @patch("custom_components.eg4_web_monitor.EG4DataUpdateCoordinator")
+    async def test_cancelled_platform_setup_also_unwinds(
+        self, mock_coordinator_class, hass: HomeAssistant, mock_config_entry
+    ):
+        """Cancellation follows the same rollback contract as other failures."""
+        mock_config_entry.add_to_hass(hass)
+        mock_config_entry.runtime_data = None
+        coordinator = MagicMock()
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock()
+        coordinator.async_shutdown = AsyncMock()
+        coordinator.client = MagicMock()
+        coordinator.client.close = AsyncMock()
+        mock_coordinator_class.return_value = coordinator
+
+        with (
+            patch.object(
+                hass.config_entries,
+                "async_forward_entry_setups",
+                new=AsyncMock(side_effect=asyncio.CancelledError),
+            ),
+            patch.object(
+                hass.config_entries,
+                "async_unload_platforms",
+                new=AsyncMock(return_value=True),
+            ) as unload,
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await async_setup_entry(hass, mock_config_entry)
+
+        unload.assert_awaited_once()
+        coordinator.async_shutdown.assert_awaited_once_with()
+        coordinator.client.close.assert_awaited_once_with()
+        assert mock_config_entry.runtime_data is None
 
 
 class TestSmartPortCleanupOnReboot:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -442,6 +442,30 @@ class TestAsyncSetupEntry:
         coordinator.client.close.assert_awaited_once_with()
         assert mock_config_entry.runtime_data is None
 
+    @patch("custom_components.eg4_web_monitor.EG4DataUpdateCoordinator")
+    async def test_cleanup_cancellation_still_closes_client_and_clears_runtime(
+        self, mock_coordinator_class, hass: HomeAssistant, mock_config_entry
+    ):
+        """A second cancellation cannot strand later rollback steps."""
+        mock_config_entry.add_to_hass(hass)
+        mock_config_entry.runtime_data = None
+        coordinator = MagicMock()
+        coordinator._platform_setup_started = False
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=RuntimeError("initial refresh failed")
+        )
+        coordinator.async_shutdown = AsyncMock(side_effect=asyncio.CancelledError)
+        coordinator.client = MagicMock()
+        coordinator.client.close = AsyncMock()
+        mock_coordinator_class.return_value = coordinator
+
+        with pytest.raises(asyncio.CancelledError):
+            await async_setup_entry(hass, mock_config_entry)
+
+        coordinator.client.close.assert_awaited_once_with()
+        assert mock_config_entry.runtime_data is None
+
 
 class TestSmartPortCleanupOnReboot:
     """Regression tests for #217: smart-port registry cleanup across restarts.


### PR DESCRIPTION
## Summary

- roll back partially forwarded platforms when config-entry setup fails
- shut down the coordinator and close its HTTP client after refresh, setup, or cancellation failures
- clear failed runtime data so later retries cannot reuse a dead coordinator
- track the zero-read LOCAL follow-up refresh as coordinator-owned background work

## Root cause

The coordinator acquired a Home Assistant stop listener, transports, background state, and (for cloud modes) a client before the first refresh. `runtime_data` was assigned only after that refresh, and setup had no general failure owner. An initial-refresh error or partial platform-forward failure therefore skipped the normal unload path. Separately, the LOCAL static phase created an untracked refresh task that could outlive setup and race transport shutdown.

## Verification

- setup/coordinator regression suite: 590 passed
- full test suite: 2547 passed, 3 skipped
- `ruff check .`
- `ruff format --check .`
- configured strict mypy: 41 source files clean
- pre-commit hooks

Tracks `eg4-06er.1` (audit INT-05 / INT-07).
