### PR TITLE
fix: expose inverter battery temperature

### DIFF
--- a/custom_components/eg4_web_monitor/const/sensors/inverter.py
+++ b/custom_components/eg4_web_monitor/const/sensors/inverter.py
@@ -86,6 +86,18 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "icon": "mdi:battery",
     },
+    # Inverter-reported battery temperature (input register 67 / cloud tBat).
+    # pylxpweb normalizes the firmware's exact 0x7F "no reading" sentinel to
+    # None before coordinator mapping, so the entity is unknown rather than
+    # presenting a dangerous-looking 127 °C value on battery-less secondaries.
+    "battery_temperature": {
+        "name": "Battery Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "icon": "mdi:thermometer",
+        "entity_category": "diagnostic",
+    },
     "hybrid_power": {
         "name": "Hybrid Power",
         "unit": UnitOfPower.WATT,

--- a/tests/test_battery_temperature_sensor.py
+++ b/tests/test_battery_temperature_sensor.py
@@ -1,0 +1,89 @@
+"""Regression coverage for the inverter battery-temperature entity (I67)."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import EntityCategory, UnitOfTemperature
+from pylxpweb.transports.data import InverterRuntimeData
+
+from custom_components.eg4_web_monitor.const import SENSOR_TYPES
+from custom_components.eg4_web_monitor.coordinator_mappings import (
+    _build_runtime_sensor_mapping,
+)
+from custom_components.eg4_web_monitor.sensor import (
+    EG4InverterSensor,
+    _create_inverter_sensors,
+)
+
+
+def _coordinator(value: float | None) -> MagicMock:
+    """Return a minimal healthy coordinator publishing I67's normalized value."""
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_device_info.return_value = None
+    coordinator.has_http_api.return_value = False
+    coordinator.has_configured_local_transport.return_value = False
+    coordinator.data = {
+        "devices": {
+            "INV001": {
+                "type": "inverter",
+                "model": "FlexBOSS21",
+                "features": {"inverter_family": "EG4_HYBRID"},
+                "sensors": {"battery_temperature": value},
+                "batteries": {},
+            }
+        }
+    }
+    return coordinator
+
+
+def test_i67_has_temperature_diagnostic_metadata() -> None:
+    """The already-mapped I67 key must have a real HA sensor description."""
+    config = SENSOR_TYPES["battery_temperature"]
+
+    assert config == {
+        "name": "Battery Temperature",
+        "unit": UnitOfTemperature.CELSIUS,
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "icon": "mdi:thermometer",
+        "entity_category": "diagnostic",
+    }
+
+
+def test_i67_creates_an_inverter_entity_and_preserves_signed_value() -> None:
+    """A valid signed I67 reading reaches an inverter-scoped HA entity."""
+    coordinator = _coordinator(-12.0)
+
+    inverter_entities, battery_entities = _create_inverter_sensors(
+        coordinator,
+        "INV001",
+        coordinator.data["devices"]["INV001"],
+    )
+
+    assert battery_entities == []
+    assert len(inverter_entities) == 1
+    entity = inverter_entities[0]
+    assert isinstance(entity, EG4InverterSensor)
+    assert entity.unique_id == "INV001_battery_temperature"
+    assert entity.native_value == -12.0
+    assert entity.device_class == SensorDeviceClass.TEMPERATURE
+    assert entity.state_class == SensorStateClass.MEASUREMENT
+    assert entity.native_unit_of_measurement == UnitOfTemperature.CELSIUS
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
+    assert entity.available is True
+
+
+def test_i67_no_reading_sentinel_remains_unknown() -> None:
+    """pylxpweb's 0x7f normalization must surface as unknown, never 127 °C."""
+    runtime = InverterRuntimeData(battery_temperature=127.0)
+    assert runtime.battery_temperature is None
+    assert _build_runtime_sensor_mapping(runtime)["battery_temperature"] is None
+
+    coordinator = _coordinator(None)
+    inverter_entities, _ = _create_inverter_sensors(
+        coordinator,
+        "INV001",
+        coordinator.data["devices"]["INV001"],
+    )
+    assert inverter_entities[0].native_value is None


### PR DESCRIPTION
## Summary

- add the missing Home Assistant sensor description for inverter battery temperature
- keep I67 read-only and diagnostic, with Celsius/measurement metadata
- pin the full dependency-to-entity contract, including signed readings and the `0x7f` no-reading sentinel

## Root cause and provenance

`pylxpweb` already maps input register 67 / cloud `tBat` to `InverterRuntimeData.battery_temperature`, normalizes the exact firmware sentinel `0x7f` to `None`, and the integration already copies that field into coordinator data. The key was absent from `SENSOR_TYPES`, so entity creation silently discarded it even though documentation referred to the entity.

This PR does not copy an ant0nkr mapping and adds no writable control; it exposes an existing canonical, independently documented read-only value.

## Verification

- focused mapping/entity suite: 67 passed
- full test suite: 2546 passed, 3 skipped
- `ruff check .`
- `ruff format --check .`
- configured strict mypy: 41 source files clean
- pre-commit hooks

Tracks `eg4-uwa0.1` / audit MAP-01.
