### PR TITLE
Fix mixed Modbus transport poll starvation

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -458,9 +458,12 @@ class EG4DataUpdateCoordinator(
             else DEFAULT_DONGLE_UPDATE_INTERVAL,
         )
 
-        # Per-transport last-poll timestamps (monotonic)
-        self._last_modbus_poll: float = 0.0
-        self._last_dongle_poll: float = 0.0
+        # Per-transport last-poll timestamps (monotonic).  ``None`` means the
+        # transport gate has never fired; a numeric zero is not a safe sentinel
+        # because monotonic time is host uptime and may still be below the poll
+        # interval immediately after boot.
+        self._last_modbus_poll: float | None = None
+        self._last_dongle_poll: float | None = None
 
         # Store HTTP polling interval for client cache alignment
         self._http_polling_interval: int = http_interval_seconds
@@ -855,27 +858,41 @@ class EG4DataUpdateCoordinator(
         ttl = timedelta(seconds=interval)
         inverter.set_cache_ttls(runtime=ttl, energy=ttl, battery=ttl)
 
+    @staticmethod
+    def _poll_gate_key(transport_type: str) -> str:
+        """Return the interval-gate key for a concrete transport type.
+
+        Modbus TCP and serial intentionally share one configured interval and
+        timestamp.  Callers that pre-compute due transports must therefore ask
+        the gate once for the normalized key and apply that decision to both
+        concrete types in the same coordinator tick.
+        """
+        if transport_type in ("modbus_tcp", "modbus_serial"):
+            return "modbus"
+        return transport_type
+
     def _should_poll_transport(self, transport_type: str) -> bool:
         """Check whether enough time has elapsed to poll this transport type.
 
-        Uses monotonic timestamps. Returns True on first call (timestamp==0.0).
+        Uses monotonic timestamps. Returns True on the first call (timestamp is
+        ``None``), including immediately after a fresh host boot.
         Updates the timestamp when returning True.
         """
+        gate_key = self._poll_gate_key(transport_type)
         interval_map: dict[str, tuple[str, str]] = {
-            "modbus_tcp": ("_last_modbus_poll", "_modbus_interval"),
-            "modbus_serial": ("_last_modbus_poll", "_modbus_interval"),
+            "modbus": ("_last_modbus_poll", "_modbus_interval"),
             "wifi_dongle": ("_last_dongle_poll", "_dongle_interval"),
         }
-        attrs = interval_map.get(transport_type)
+        attrs = interval_map.get(gate_key)
         if attrs is None:
             return True  # Unknown type: always poll
 
         ts_attr, interval_attr = attrs
         now = time.monotonic()
-        last_poll: float = getattr(self, ts_attr)
+        last_poll: float | None = getattr(self, ts_attr)
         interval: int = getattr(self, interval_attr)
 
-        if now - last_poll < interval:
+        if last_poll is not None and now - last_poll < interval:
             return False
 
         setattr(self, ts_attr, now)

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -142,12 +142,19 @@ class HTTPUpdateMixin(_MixinBase):
         """
         if not self._local_transport_configs:
             return True  # No local transports -> always refresh (HTTP-only fallback)
-        unique_types = {
-            c.get("transport_type", "modbus_tcp") for c in self._local_transport_configs
+        gate_representatives: dict[str, str] = {}
+        for config in self._local_transport_configs:
+            transport_type = config.get("transport_type", "modbus_tcp")
+            gate_representatives.setdefault(
+                self._poll_gate_key(transport_type), transport_type
+            )
+        # Eagerly evaluate ALL independent gates so every monotonic timestamp
+        # is stamped even when an earlier one is True. TCP and serial share the
+        # normalized Modbus gate and therefore consume one decision per tick.
+        results = {
+            gate: self._should_poll_transport(transport_type)
+            for gate, transport_type in gate_representatives.items()
         }
-        # Eagerly evaluate ALL types so every transport's monotonic timestamp
-        # is stamped even when an earlier one is True.
-        results = {tt: self._should_poll_transport(tt) for tt in unique_types}
         # MID device is on the dongle — gate its refresh by dongle interval.
         # If no dongle transport exists, fall back to any-transport-ready.
         if "wifi_dongle" in results:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -1886,18 +1886,22 @@ class LocalTransportMixin(_MixinBase):
 
         # Partition configs: only poll transports whose interval has elapsed.
         # Skipped devices retain cached data from the pre-population above.
-        # Pre-compute which transport types should poll this tick so that the
-        # interval gate fires once per type, not once per device.  Without this,
-        # the first device of a type stamps the timestamp and all subsequent
-        # devices of the same type get skipped.
-        transport_types_seen: set[str] = set()
-        pollable_types: set[str] = set()
+        # Pre-compute which interval gates should poll this tick so each gate
+        # fires once, not once per device or concrete transport type.  TCP and
+        # serial both normalize to the shared Modbus gate; its one decision is
+        # applied to both, preventing stable-order starvation (eg4-mkxg).
+        poll_gates_seen: set[str] = set()
+        pollable_gates: set[str] = set()
         for config in self._local_transport_configs:
             tt = config.get("transport_type", "modbus_tcp")
-            if tt not in transport_types_seen:
-                transport_types_seen.add(tt)
+            gate_key = self._poll_gate_key(tt)
+            if gate_key not in poll_gates_seen:
+                poll_gates_seen.add(gate_key)
+                # Pass the first concrete representative for compatibility
+                # with instrumentation that observes transport names; the
+                # gate method normalizes it internally to ``gate_key``.
                 if self._should_poll_transport(tt):
-                    pollable_types.add(tt)
+                    pollable_gates.add(gate_key)
 
         # Pre-compute parameter refresh decision once for the entire poll cycle
         # so every device sees the same answer.  Stored as instance attr because
@@ -1930,7 +1934,7 @@ class LocalTransportMixin(_MixinBase):
         for config in self._local_transport_configs:
             transport_type = config.get("transport_type", "modbus_tcp")
             serial = config.get("serial", "")
-            if transport_type in pollable_types:
+            if self._poll_gate_key(transport_type) in pollable_gates:
                 configs_to_poll.append(config)
             else:
                 if serial:

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -747,8 +747,8 @@ if TYPE_CHECKING:
         _dongle_model: str
         _modbus_interval: int
         _dongle_interval: int
-        _last_modbus_poll: float
-        _last_dongle_poll: float
+        _last_modbus_poll: float | None
+        _last_dongle_poll: float | None
         _shutdown_listener_remove: Callable[[], None] | None
         _shutdown_listener_fired: bool
         _debounced_refresh: Any
@@ -760,6 +760,7 @@ if TYPE_CHECKING:
         def get_inverter_object(self, serial: str) -> BaseInverter | None: ...
         async def async_request_refresh(self) -> None: ...
         def _rebuild_inverter_cache(self) -> None: ...
+        def _poll_gate_key(self, transport_type: str) -> str: ...
 
         # ── DeviceProcessingMixin methods ──
         def _get_device_grid_type(self, serial: str) -> str | None: ...

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3913,15 +3913,29 @@ class TestPerTransportIntervals:
         coordinator = EG4DataUpdateCoordinator(hass, dongle_only_local_config_entry)
         assert coordinator.update_interval == timedelta(seconds=30)
 
+    @pytest.mark.parametrize(
+        ("transport_type", "timestamp_attr"),
+        [
+            ("modbus_tcp", "_last_modbus_poll"),
+            ("modbus_serial", "_last_modbus_poll"),
+            ("wifi_dongle", "_last_dongle_poll"),
+        ],
+    )
     def test_should_poll_transport_first_call_always_true(
-        self, hass, mixed_local_config_entry
+        self, hass, mixed_local_config_entry, transport_type, timestamp_attr
     ):
-        """First call to _should_poll_transport always returns True (timestamp==0.0)."""
+        """First poll is due even when monotonic uptime is below the interval."""
         mixed_local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, mixed_local_config_entry)
-        assert coordinator._last_modbus_poll == 0.0
-        assert coordinator._should_poll_transport("modbus_tcp") is True
-        assert coordinator._last_modbus_poll > 0.0
+        assert getattr(coordinator, timestamp_attr) is None
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.time.monotonic",
+            return_value=1.0,
+        ):
+            assert coordinator._should_poll_transport(transport_type) is True
+
+        assert getattr(coordinator, timestamp_attr) == 1.0
 
     def test_should_poll_transport_within_interval_false(
         self, hass, mixed_local_config_entry
@@ -4006,6 +4020,109 @@ class TestPerTransportIntervals:
         assert "BBBB222222" in all_serials, (
             "Second modbus_tcp device was skipped (transport interval bug)"
         )
+
+    @pytest.mark.asyncio
+    async def test_mixed_modbus_types_share_due_decision_across_ticks(self, hass):
+        """TCP and serial poll together without false fresh cached data.
+
+        Regression for eg4-mkxg: both Modbus types use the same configured
+        interval and timestamp, but the local partition used to ask that shared
+        gate once per concrete type.  Stable TCP-first ordering stamped the
+        clock before serial was checked, so serial was skipped on every due
+        tick and its cached/static device remained present as if healthy.
+
+        This covers a fresh host (monotonic uptime below the 5s interval), an
+        in-window cached tick, and the next due tick.  A skipped tick must keep
+        the prior successful ``last_polled`` value rather than fabricate one.
+        """
+        tcp_serial = "TCP1111111"
+        serial_serial = "SER2222222"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EG4 - Mixed Modbus TCP and Serial",
+            data={
+                CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+                CONF_LOCAL_TRANSPORTS: [
+                    {
+                        "serial": tcp_serial,
+                        "host": "192.168.1.100",
+                        "port": 502,
+                        "transport_type": "modbus_tcp",
+                        "inverter_family": "EG4_HYBRID",
+                        "model": "FlexBOSS21",
+                    },
+                    {
+                        "serial": serial_serial,
+                        "serial_port": "/dev/ttyUSB0",
+                        "transport_type": "modbus_serial",
+                        "inverter_family": "EG4_HYBRID",
+                        "model": "18kPV",
+                    },
+                ],
+            },
+            options={},
+        )
+        entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator._local_static_phase_done = True
+        coordinator._local_parameters_loaded = True
+        coordinator._last_parameter_refresh = dt_util.utcnow()
+        coordinator.data = {
+            "devices": {
+                tcp_serial: {
+                    "type": "inverter",
+                    "sensors": {"last_polled": "cached-tcp"},
+                },
+                serial_serial: {
+                    "type": "inverter",
+                    "sensors": {"last_polled": "cached-serial"},
+                },
+            },
+            "parameters": {tcp_serial: {}, serial_serial: {}},
+        }
+
+        current_tick = 0.0
+        polls_by_tick: dict[float, set[str]] = {}
+        states_by_tick: dict[float, dict[str, Any]] = {}
+
+        async def tracking_group(configs, processed, availability):
+            polled = polls_by_tick.setdefault(current_tick, set())
+            for config in configs:
+                serial = config["serial"]
+                polled.add(serial)
+                availability[serial] = True
+                device = dict(processed["devices"][serial])
+                sensors = dict(device["sensors"])
+                sensors["last_polled"] = current_tick
+                device["sensors"] = sensors
+                processed["devices"][serial] = device
+
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.coordinator.time.monotonic"
+            ) as monotonic,
+            patch.object(
+                coordinator,
+                "_process_local_transport_group",
+                side_effect=tracking_group,
+            ),
+        ):
+            for current_tick in (1.0, 3.0, 6.0):
+                monotonic.return_value = current_tick
+                result = await coordinator._async_update_local_data()
+                coordinator.data = result
+                states_by_tick[current_tick] = {
+                    serial: result["devices"][serial]["sensors"]["last_polled"]
+                    for serial in (tcp_serial, serial_serial)
+                }
+
+        both = {tcp_serial, serial_serial}
+        assert polls_by_tick == {1.0: both, 6.0: both}
+        assert states_by_tick == {
+            1.0: {tcp_serial: 1.0, serial_serial: 1.0},
+            3.0: {tcp_serial: 1.0, serial_serial: 1.0},
+            6.0: {tcp_serial: 6.0, serial_serial: 6.0},
+        }
 
     @pytest.mark.asyncio
     async def test_local_data_skipped_devices_use_cache(


### PR DESCRIPTION
## Summary

- make Modbus TCP and Modbus serial consume one shared due/not-due decision per coordinator tick
- replace `0.0` with `None` as the never-polled sentinel so a fresh host with low monotonic uptime still performs its first poll
- normalize gate keys consistently in local polling and HTTP/MID refresh decisions
- preserve cached device state on genuinely skipped ticks without falsely starving one concrete Modbus transport forever

## RCA

TCP and serial intentionally share one configured Modbus interval and timestamp, but polling previously called the shared gate once per concrete transport type. With stable TCP-first order, TCP stamped the timestamp and serial immediately saw the same gate as not due. Serial could therefore be skipped on every due cycle while stale cached data continued to look healthy. Separately, `0.0` was not a valid never-polled sentinel when host monotonic uptime was still below the interval.

## Verification

- deterministic regression covers first boot, cached in-window tick, and the next due tick with both TCP and serial
- focused regression: 5 passed
- relevant coordinator suite: 494 passed
- full suite: 2546 passed, 3 skipped
- Ruff check/format, mypy (41 files), pre-commit, and diff check: passed

## Tracking

- bead: `eg4-mkxg` (closed after acceptance)
