### PR TITLE
Mark local processing failures and aggregates stale

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -111,6 +111,24 @@ _NO_SERIAL_EXPOSE_POLLS = 3
 # stale-TCP-slot window — typically 1-5 minutes — recovers promptly.
 ATTACH_RETRY_INTERVAL_SECONDS = 60.0
 
+_LOCAL_TRANSPORT_LINK_DOWN_ERROR = "Local transport link down"
+_LOCAL_DATA_PROCESSING_ERROR = "Local data processing failed"
+
+
+def _stale_parallel_member_error(
+    devices: dict[str, Any], member_serials: list[str]
+) -> str:
+    """Describe why a parallel aggregate cannot be considered fresh."""
+    serials = sorted(member_serials)
+    if all(
+        devices.get(serial, {}).get("error") == _LOCAL_TRANSPORT_LINK_DOWN_ERROR
+        for serial in serials
+    ):
+        reason = _LOCAL_TRANSPORT_LINK_DOWN_ERROR
+    else:
+        reason = "Stale local data"
+    return f"{reason} for member(s): {', '.join(serials)}"
+
 
 class LocalTransportMixin(_MixinBase):
     """Mixin handling local transport operations for the coordinator."""
@@ -1579,6 +1597,14 @@ class LocalTransportMixin(_MixinBase):
                 e,
             )
             device_availability[serial] = False
+            # The new result was pre-populated with the prior cycle so a
+            # skipped transport can carry data forward.  An attempted poll
+            # that reaches an unexpected integration/mapping failure is not a
+            # skip: those retained measurements are now stale and must stop
+            # passing the entity availability contract.  A successful later
+            # poll replaces this dictionary and naturally clears the marker.
+            if (device_data := processed.get("devices", {}).get(serial)) is not None:
+                device_data["error"] = _LOCAL_DATA_PROCESSING_ERROR
 
     async def _deferred_local_parameter_load(self) -> None:
         """Background task: load parameters and detect features for local devices.
@@ -2158,13 +2184,14 @@ class LocalTransportMixin(_MixinBase):
 
             first_serial = master_serial
 
-            # Members whose device data is error-marked (link-down — see
-            # _sync_transport_link_state, which runs before this method).
+            # Members whose device data is error-marked (link-down from
+            # _sync_transport_link_state, or an integration-side processing
+            # failure retained from _process_single_local_device).
             # Their carried-forward sensors are STALE: an aggregate mixing
             # stale and fresh members is wrong in both directions, so the
             # group is error-marked below — honest unavailability beats a
-            # quietly wrong total (eg4-57g review).
-            link_down_members = sorted(
+            # quietly wrong total (eg4-57g review; eg4-06er.2).
+            stale_members = sorted(
                 member_serial
                 for member_serial, member_data in group_devices
                 if "error" in member_data
@@ -2328,11 +2355,11 @@ class LocalTransportMixin(_MixinBase):
                     continue
                 has_mid_device = True
                 # The GridBOSS CTs are authoritative contributors to the
-                # group's grid/consumption values — a link-down (error-
-                # marked) GridBOSS taints the aggregate the same way a
-                # link-down inverter member does.
-                if "error" in device_data and serial not in link_down_members:
-                    link_down_members.append(serial)
+                # group's grid/consumption values — any stale/error-marked
+                # GridBOSS taints the aggregate the same way an inverter
+                # member does.
+                if "error" in device_data and serial not in stale_members:
+                    stale_members.append(serial)
                 gb_sensors = device_data.get("sensors", {})
 
                 # Apply the canonical GridBOSS workflow to the parallel group.
@@ -2372,7 +2399,7 @@ class LocalTransportMixin(_MixinBase):
 
             group_device_id = f"parallel_group_{group_name.lower()}"
 
-            if link_down_members:
+            if stale_members:
                 # Don't claim a fresh poll for an aggregate built from stale
                 # members — carry the previous stamp forward (if any) so it
                 # reflects the last genuinely fresh aggregate.
@@ -2399,13 +2426,12 @@ class LocalTransportMixin(_MixinBase):
                 "member_serials": [serial for serial, _ in group_devices],
                 "sensors": group_sensors,
             }
-            if link_down_members:
+            if stale_members:
                 # Error key -> all PG sensor entities go unavailable
                 # (base_entity availability contract), exactly like the
-                # link-down members themselves.
-                pg_device_data["error"] = (
-                    f"Local transport link down for member(s): "
-                    f"{', '.join(sorted(link_down_members))}"
+                # stale members themselves.
+                pg_device_data["error"] = _stale_parallel_member_error(
+                    processed["devices"], stale_members
                 )
             processed["devices"][group_device_id] = pg_device_data
 
@@ -2793,7 +2819,7 @@ class LocalTransportMixin(_MixinBase):
                 if processed is not None:
                     device_data = processed.get("devices", {}).get(serial)
                     if device_data is not None:
-                        device_data["error"] = "Local transport link down"
+                        device_data["error"] = _LOCAL_TRANSPORT_LINK_DOWN_ERROR
                 if serial in self._link_down_notified:
                     continue
                 self._link_down_notified.add(serial)
@@ -2833,9 +2859,11 @@ class LocalTransportMixin(_MixinBase):
         stale aggregate while the coordinator wrapper suppresses the first
         UpdateFailed cycles.  Apply the same rule the partial path uses: a
         group is tainted when any of its members — or the GridBOSS CT
-        contributor — is error-marked (link-down).  A transient full outage
-        with no link-down marks leaves the groups alone, matching the
-        member entities (which also stay available on cached values then).
+        contributor — is error-marked, whether from a declared link outage
+        or an unexpected processing failure.  A transient typed transport
+        failure below the link-down threshold has no mark and leaves the
+        groups alone, matching the member entities (which also keep serving
+        cached values during that bounded retry window).
         The carried ``parallel_group_last_polled`` stamp is left untouched
         (no fresh-poll claim is ever made on this path).
 
@@ -2870,9 +2898,8 @@ class LocalTransportMixin(_MixinBase):
             # GridBOSS CTs contribute to every group (partial-path parity).
             stale.update(gridboss_down)
             if stale:
-                device_data["error"] = (
-                    f"Local transport link down for member(s): "
-                    f"{', '.join(sorted(stale))}"
+                device_data["error"] = _stale_parallel_member_error(
+                    devices, list(stale)
                 )
 
     async def _attach_serial_transports_to_station(

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -4055,6 +4055,8 @@ class TestLocalLinkDownFlow:
             spec=[
                 "transport",
                 "transport_link_down",
+                "transport_energy",
+                "transport_battery",
                 "transport_runtime",
                 "refresh",
                 "serial_number",
@@ -4063,6 +4065,8 @@ class TestLocalLinkDownFlow:
         inverter.serial_number = "CE11111111"
         inverter.transport = transport
         inverter.transport_link_down = True
+        inverter.transport_energy = None
+        inverter.transport_battery = None
         inverter.transport_runtime = None  # cleared at the down transition
         inverter.refresh = AsyncMock()
         coordinator._inverter_cache["CE11111111"] = inverter
@@ -4286,6 +4290,159 @@ class TestParallelGroupLinkDownMarking:
         assert "parallel_group_last_polled" not in pg_data["sensors"]
 
 
+class TestLocalProcessingFailureStaleness:
+    """A post-read integration error must not leave cached data looking fresh."""
+
+    async def test_mapping_failure_marks_member_and_parallel_group_stale(self, hass):
+        """One broken mapper taints its device and every dependent aggregate."""
+        from datetime import UTC, datetime
+
+        from custom_components.eg4_web_monitor.base_entity import EG4BaseSensor
+
+        broken_serial = "BROKEN0001"
+        healthy_serial = "HEALTHY001"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EG4 - Mapping Failure",
+            data={
+                CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+                CONF_DST_SYNC: False,
+                CONF_LIBRARY_DEBUG: False,
+                CONF_LOCAL_TRANSPORTS: [
+                    {
+                        "serial": broken_serial,
+                        "host": "192.168.1.70",
+                        "port": 502,
+                        "transport_type": "modbus_tcp",
+                        "inverter_family": "EG4_HYBRID",
+                        "model": "FlexBOSS21",
+                    },
+                    {
+                        "serial": healthy_serial,
+                        "host": "192.168.1.71",
+                        "port": 502,
+                        "transport_type": "modbus_tcp",
+                        "inverter_family": "EG4_HYBRID",
+                        "model": "FlexBOSS21",
+                    },
+                ],
+            },
+            entry_id="mapping_failure_staleness",
+        )
+        entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+        coordinator._local_static_phase_done = True
+        coordinator._local_parameters_loaded = True
+        coordinator._last_parameter_refresh = dt_util.utcnow()
+
+        runtimes: dict[str, InverterRuntimeData] = {}
+        for serial, role, pv_power in (
+            (broken_serial, 1, 1000),
+            (healthy_serial, 2, 2000),
+        ):
+            runtime = InverterRuntimeData(
+                pv_total_power=pv_power,
+                battery_soc=50,
+                battery_voltage=53,
+                rectifier_power=0,
+                parallel_number=1,
+                parallel_master_slave=role,
+                parallel_phase=0,
+            )
+            runtimes[serial] = runtime
+            inverter = make_real_inverter(serial, "FlexBOSS21", runtime=runtime)
+            inverter.refresh = AsyncMock()
+            inverter.detect_features = AsyncMock()
+            inverter._transport = make_transport_spec(is_connected=True)
+            inverter._transport_energy = None
+            inverter._transport_battery = None
+            coordinator._inverter_cache[serial] = inverter
+            coordinator._firmware_cache[serial] = "TEST-FW"
+
+        old_stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+        coordinator.data = {
+            "devices": {
+                broken_serial: {
+                    "type": "inverter",
+                    "serial": broken_serial,
+                    "parallel_number": 1,
+                    "parallel_master_slave": 1,
+                    "sensors": {"pv_total_power": 1000},
+                },
+                healthy_serial: {
+                    "type": "inverter",
+                    "serial": healthy_serial,
+                    "parallel_number": 1,
+                    "parallel_master_slave": 2,
+                    "sensors": {"pv_total_power": 1500},
+                },
+                "parallel_group_a": {
+                    "type": "parallel_group",
+                    "member_serials": [broken_serial, healthy_serial],
+                    "sensors": {
+                        "pv_total_power": 2500,
+                        "parallel_group_last_polled": old_stamp,
+                    },
+                },
+            },
+            "parameters": {},
+        }
+
+        def fail_one_mapping(runtime: InverterRuntimeData) -> dict[str, Any]:
+            if runtime is runtimes[broken_serial]:
+                raise ValueError("deterministic mapping failure")
+            return _build_runtime_sensor_mapping(runtime)
+
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_local._build_runtime_sensor_mapping",
+                side_effect=fail_one_mapping,
+            ),
+        ):
+            result = await coordinator._async_update_local_data()
+
+        assert result["devices"][broken_serial]["error"] == (
+            "Local data processing failed"
+        )
+        assert "error" not in result["devices"][healthy_serial]
+        group = result["devices"]["parallel_group_a"]
+        assert group["error"] == f"Stale local data for member(s): {broken_serial}"
+        assert group["sensors"]["parallel_group_last_polled"] == old_stamp
+
+        coordinator.data = result
+        broken_sensor = EG4BaseSensor(
+            coordinator, broken_serial, "pv_total_power", device_type="inverter"
+        )
+        group_sensor = EG4BaseSensor(
+            coordinator,
+            "parallel_group_a",
+            "pv_total_power",
+            device_type="parallel_group",
+        )
+        assert broken_sensor.available is False
+        assert group_sensor.available is False
+
+        # A later successful mapping replaces both retained dictionaries, so
+        # unavailability converges without a reload or manual cleanup.
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+        ):
+            recovered = await coordinator._async_update_local_data()
+
+        assert "error" not in recovered["devices"][broken_serial]
+        recovered_group = recovered["devices"]["parallel_group_a"]
+        assert "error" not in recovered_group
+        assert recovered_group["sensors"]["parallel_group_last_polled"] != old_stamp
+        assert recovered_group["sensors"]["pv_total_power"] == 3000
+
+
 class TestFullOutageParallelGroupMarking:
     """eg4-57g review r2 HIGH: on a FULL outage, UpdateFailed raises before
     _process_local_parallel_groups() runs — the carried-forward PG entry
@@ -4303,6 +4460,8 @@ class TestFullOutageParallelGroupMarking:
             spec=[
                 "transport",
                 "transport_link_down",
+                "transport_energy",
+                "transport_battery",
                 "transport_runtime",
                 "refresh",
                 "serial_number",
@@ -4311,6 +4470,8 @@ class TestFullOutageParallelGroupMarking:
         inverter.serial_number = serial
         inverter.transport = transport
         inverter.transport_link_down = True
+        inverter.transport_energy = None
+        inverter.transport_battery = None
         inverter.transport_runtime = None  # cleared at the down transition
         inverter.refresh = AsyncMock()
         return inverter


### PR DESCRIPTION
## Summary

- mark carried device measurements unavailable after an unexpected LOCAL integration/mapping failure instead of presenting the prior cycle as fresh
- taint dependent parallel-group aggregates when any inverter or GridBOSS contributor is error-marked
- retain the aggregate's last genuinely fresh poll timestamp during the failure and clear all markers naturally on the next successful map
- preserve the existing bounded semantics for typed transient transport failures below the link-down threshold

## RCA

LOCAL updates pre-populate each result with prior device dictionaries so interval-skipped transports retain their state. When an attempted device update later raised an unexpected integration-side exception, only a side `device_availability` map was set false. The retained device dictionary had no error marker, so sensor availability stayed true. With a healthy sibling, parallel-group processing then summed the stale member with fresh data and stamped the aggregate as freshly polled.

The fix marks only the retained dictionary from the attempted, unexpected-processing path. The aggregate error wording still distinguishes a pure declared transport-link outage from general stale local data.

## Verification

- RED regression reproduced a successful transport read followed by one deterministic mapping exception beside a healthy parallel sibling
- regression verifies member and aggregate unavailability, retained aggregate timestamp, and automatic recovery
- related coordinator suite: 512 passed
- full suite: 2544 passed, 3 skipped
- Ruff check/format, strict configured mypy (41 files), pre-commit, and diff check: passed

## Tracking

- bead: `eg4-06er.2`
