### PR TITLE
fix: serialize schedule and battery-mode logical writes

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -318,6 +318,15 @@ class EG4DataUpdateCoordinator(
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._shutdown_listener_fired: bool = False
 
+        # Multi-call controls must be serialized as one logical transaction.
+        # The low-level transport lock protects each individual request, but it
+        # cannot stop another service call from interleaving between (for
+        # example) a schedule's hour/minute writes or the battery regime's
+        # charge/discharge writes.  Coordinator ownership shares the lock across
+        # separate entity instances while the control key keeps unrelated
+        # controls on the same inverter independent.
+        self._control_transaction_locks: dict[tuple[str, str], asyncio.Lock] = {}
+
         # Track availability state for Silver tier logging requirement
         self._last_available_state: bool = True
 
@@ -1159,6 +1168,20 @@ class EG4DataUpdateCoordinator(
 
     # ── Battery control regime (SOC vs Voltage, register 179 bits 9/10) ──────
 
+    def control_transaction_lock(self, serial: str, control: str) -> asyncio.Lock:
+        """Return the lock for one device's logical multi-call control.
+
+        Locks live for the coordinator lifetime.  Both key components come from
+        the configured device/control tables, so this dictionary is bounded by
+        the number of entities rather than by user-provided values.
+        """
+        key = (serial, control)
+        lock = self._control_transaction_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._control_transaction_locks[key] = lock
+        return lock
+
     def get_configured_control_modes(self) -> tuple[str, str]:
         """Return the configured ``(charge_mode, discharge_mode)`` for entity gating.
 
@@ -1204,6 +1227,15 @@ class EG4DataUpdateCoordinator(
         Raises:
             HomeAssistantError: If no write path is available or a write fails.
         """
+        async with self.control_transaction_lock(serial, "battery_control_mode"):
+            await self._async_write_battery_control_mode(
+                serial, charge_mode, discharge_mode
+            )
+
+    async def _async_write_battery_control_mode(
+        self, serial: str, charge_mode: str, discharge_mode: str
+    ) -> None:
+        """Execute a battery regime write with its logical lock already held."""
         charge_voltage = charge_mode == CONTROL_MODE_VOLTAGE
         discharge_voltage = discharge_mode == CONTROL_MODE_VOLTAGE
 
@@ -1215,6 +1247,15 @@ class EG4DataUpdateCoordinator(
                 await self.write_named_parameter(
                     PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage, serial=serial
                 )
+            except asyncio.CancelledError as err:
+                # Cancellation of the in-flight request is ambiguous: it may
+                # have landed before the response coroutine was interrupted.
+                # Re-read while holding the logical lock, then preserve the
+                # caller's cancellation.
+                await self._converge_partial_battery_mode_write(
+                    serial, charge_voltage, err
+                )
+                raise
             except HomeAssistantError:
                 # Charge bit landed but the discharge bit did not — register
                 # 179 holds a MIXED regime (cloud-path parity with
@@ -1248,6 +1289,11 @@ class EG4DataUpdateCoordinator(
                 discharge_result = await client.api.control.control_function(
                     serial, PARAM_FUNC_BAT_DISCHARGE_CONTROL, discharge_voltage
                 )
+            except asyncio.CancelledError as err:
+                await self._converge_partial_battery_mode_write(
+                    serial, charge_voltage, err
+                )
+                raise
             except Exception as err:
                 await self._raise_partial_battery_mode_write(
                     serial, charge_voltage, err
@@ -1286,6 +1332,22 @@ class EG4DataUpdateCoordinator(
         untouched (the device still holds its previous value) — so the cache
         converges on what actually landed while the error still surfaces.
         """
+        await self._converge_partial_battery_mode_write(serial, charge_voltage, err)
+        raise HomeAssistantError(
+            f"Failed to set battery control mode for {serial}: the regime may "
+            "be partially applied (charge and discharge bits are written "
+            "separately) — device state was re-read"
+        ) from err
+
+    async def _converge_partial_battery_mode_write(
+        self, serial: str, charge_voltage: bool, err: BaseException | None
+    ) -> None:
+        """Best-effort convergence after the charge bit was acknowledged.
+
+        Returning instead of translating the error lets cancellation callers
+        preserve ``CancelledError`` after the cache is made honest. The
+        logical-control lock remains held until this cleanup finishes.
+        """
         _LOGGER.warning(
             "Battery control mode write for %s partially applied (discharge "
             "bit failed%s); re-reading device parameters to reflect the "
@@ -1306,11 +1368,6 @@ class EG4DataUpdateCoordinator(
                     "write failed for %s",
                     serial,
                 )
-        raise HomeAssistantError(
-            f"Failed to set battery control mode for {serial}: the regime may "
-            "be partially applied (charge and discharge bits are written "
-            "separately) — device state was re-read"
-        ) from err
 
     def _get_device_object(self, serial: str) -> BaseInverter | Any | None:
         """Get device object (inverter or MID device) by serial number.

--- a/custom_components/eg4_web_monitor/time.py
+++ b/custom_components/eg4_web_monitor/time.py
@@ -34,6 +34,7 @@ hour/minute values (or Peak Shaving's LSP params).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import time
 from typing import TYPE_CHECKING, Any
@@ -333,6 +334,13 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         data arrives or the retention TTL expires (#379,
         :class:`EG4OptimisticEntity`).
         """
+        async with self.coordinator.control_transaction_lock(
+            self.serial, f"schedule:{self._register}"
+        ):
+            await self._async_set_value_locked(value)
+
+    async def _async_set_value_locked(self, value: time) -> None:
+        """Execute a schedule write with its logical control lock held."""
         boundary_value = time(hour=value.hour, minute=value.minute)
         packed = pack_time(boundary_value.hour, boundary_value.minute)
         _LOGGER.info(
@@ -446,6 +454,10 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
                 result = await client.api.control.write_parameter(
                     self.serial, param, str(field)
                 )
+            except asyncio.CancelledError as err:
+                if wrote_any:
+                    await self._async_converge_partial_write(param, err)
+                raise
             except Exception as err:
                 if wrote_any:
                     await self._async_raise_partial_write(param, err)
@@ -476,6 +488,23 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         (LOCAL) cannot read the just-written register anyway; cloud param
         poll or link recovery converges the entity later.
         """
+        await self._async_converge_partial_write(failed_param, err)
+        raise HomeAssistantError(
+            f"Failed to set {failed_param} for {self.serial}: the schedule "
+            "time may be partially applied (hour and minute are written "
+            "separately) — device state was re-read"
+        ) from err
+
+    async def _async_converge_partial_write(
+        self, failed_param: str, err: BaseException | None
+    ) -> None:
+        """Best-effort re-read after an acknowledged first field write.
+
+        Returning instead of translating the error lets cancellation callers
+        preserve ``CancelledError`` after convergence. The logical-control
+        lock remains held during cleanup so a later writer cannot race the
+        re-read.
+        """
         _LOGGER.warning(
             "Cloud schedule write for %s partially applied (%s failed%s); "
             "re-reading device parameters to reflect the actual state",
@@ -485,11 +514,6 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         )
         if not self.coordinator.is_transport_link_down(self.serial):
             await self._async_refresh_parameters()
-        raise HomeAssistantError(
-            f"Failed to set {failed_param} for {self.serial}: the schedule "
-            "time may be partially applied (hour and minute are written "
-            "separately) — device state was re-read"
-        ) from err
 
     async def _async_refresh_parameters(self) -> bool:
         """Re-read parameters so all schedule entities converge on the write.

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -8,6 +8,7 @@ Covers methods not already tested in test_coordinator.py:
 - _log_transport_error
 """
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -3571,6 +3572,178 @@ class TestBatteryControlModeMethods:
         calls = coordinator.client.api.control.control_function.call_args_list
         assert calls[0][0] == ("INV001", "FUNC_BAT_CHARGE_CONTROL", False)
         assert calls[1][0] == ("INV001", "FUNC_BAT_DISCHARGE_CONTROL", True)
+
+    async def test_concurrent_battery_control_mode_writes_do_not_interleave(
+        self, hass, local_config_entry
+    ):
+        """Charge/discharge bit pairs are serialized as one logical write."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        first_charge_started = asyncio.Event()
+        release_first_charge = asyncio.Event()
+        second_discharge_written = asyncio.Event()
+        hardware = {"charge": False, "discharge": False}
+        calls: list[tuple[str, bool]] = []
+
+        async def _write_named_parameter(
+            param: str, value: bool, *, serial: str
+        ) -> bool:
+            assert serial == "INV001"
+            calls.append((param, value))
+            if param == "FUNC_BAT_CHARGE_CONTROL":
+                hardware["charge"] = value
+                if value:
+                    first_charge_started.set()
+                    await release_first_charge.wait()
+            else:
+                hardware["discharge"] = value
+                if value:
+                    second_discharge_written.set()
+            return True
+
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=_write_named_parameter
+        )
+
+        first_task = asyncio.create_task(
+            coordinator.async_write_battery_control_mode("INV001", "voltage", "soc")
+        )
+        await first_charge_started.wait()
+        second_task = asyncio.create_task(
+            coordinator.async_write_battery_control_mode("INV001", "soc", "voltage")
+        )
+        await asyncio.sleep(0)
+
+        assert not second_discharge_written.is_set()
+        assert not second_task.done()
+        release_first_charge.set()
+
+        await asyncio.gather(first_task, second_task)
+
+        assert hardware == {"charge": False, "discharge": True}
+        assert calls == [
+            ("FUNC_BAT_CHARGE_CONTROL", True),
+            ("FUNC_BAT_DISCHARGE_CONTROL", False),
+            ("FUNC_BAT_CHARGE_CONTROL", False),
+            ("FUNC_BAT_DISCHARGE_CONTROL", True),
+        ]
+
+    async def test_control_transaction_locks_are_scoped_by_device_and_control(
+        self, hass, local_config_entry
+    ):
+        """Only writes to the same logical resource contend."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+
+        battery = coordinator.control_transaction_lock("INV001", "battery_control_mode")
+
+        assert battery is coordinator.control_transaction_lock(
+            "INV001", "battery_control_mode"
+        )
+        assert battery is not coordinator.control_transaction_lock(
+            "INV002", "battery_control_mode"
+        )
+        assert battery is not coordinator.control_transaction_lock(
+            "INV001", "schedule:68"
+        )
+
+    async def test_cancelled_partial_local_battery_write_refreshes_before_unlock(
+        self, hass, local_config_entry
+    ):
+        """Cancellation re-reads because the in-flight discharge is ambiguous."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=True)
+        coordinator.note_parameters_written = MagicMock()
+
+        async def _refresh_under_lock(serial: str) -> None:
+            assert serial == "INV001"
+            assert coordinator.control_transaction_lock(
+                serial, "battery_control_mode"
+            ).locked()
+
+        coordinator._refresh_device_parameters = AsyncMock(
+            side_effect=_refresh_under_lock
+        )
+        discharge_started = asyncio.Event()
+        hold_discharge = asyncio.Event()
+
+        async def _write_named_parameter(
+            param: str, _value: bool, *, serial: str
+        ) -> bool:
+            assert serial == "INV001"
+            if param == "FUNC_BAT_DISCHARGE_CONTROL":
+                discharge_started.set()
+                await hold_discharge.wait()
+            return True
+
+        coordinator.write_named_parameter = AsyncMock(
+            side_effect=_write_named_parameter
+        )
+
+        task = asyncio.create_task(
+            coordinator.async_write_battery_control_mode("INV001", "voltage", "soc")
+        )
+        await discharge_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        coordinator._refresh_device_parameters.assert_awaited_once_with("INV001")
+        coordinator.note_parameters_written.assert_not_called()
+        assert not coordinator.control_transaction_lock(
+            "INV001", "battery_control_mode"
+        ).locked()
+
+    async def test_cancelled_partial_cloud_battery_write_refreshes_before_unlock(
+        self, hass, local_config_entry
+    ):
+        """Cloud cancellation after the charge ACK re-reads the mixed regime."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.has_local_transport = MagicMock(return_value=False)
+
+        async def _refresh_under_lock(serial: str) -> None:
+            assert serial == "INV001"
+            assert coordinator.control_transaction_lock(
+                serial, "battery_control_mode"
+            ).locked()
+
+        coordinator._refresh_device_parameters = AsyncMock(
+            side_effect=_refresh_under_lock
+        )
+        discharge_started = asyncio.Event()
+        hold_discharge = asyncio.Event()
+        success = MagicMock(success=True)
+
+        async def _control_function(
+            _serial: str, param: str, _value: bool
+        ) -> MagicMock:
+            if param == "FUNC_BAT_DISCHARGE_CONTROL":
+                discharge_started.set()
+                await hold_discharge.wait()
+            return success
+
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.control_function = AsyncMock(
+            side_effect=_control_function
+        )
+
+        task = asyncio.create_task(
+            coordinator.async_write_battery_control_mode("INV001", "voltage", "soc")
+        )
+        await discharge_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        coordinator._refresh_device_parameters.assert_awaited_once_with("INV001")
+        assert not coordinator.control_transaction_lock(
+            "INV001", "battery_control_mode"
+        ).locked()
 
     async def test_async_write_battery_control_mode_hybrid_fallback(
         self, hass, local_config_entry

--- a/tests/test_time_entities.py
+++ b/tests/test_time_entities.py
@@ -25,6 +25,7 @@ the live cloud register probes in pylxpweb docs/inverters/. Every schedule time
 entity is registry-disabled by default (opt-in advanced feature).
 """
 
+import asyncio
 from datetime import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -953,6 +954,134 @@ class TestWritePaths:
         coordinator.async_refresh_device_parameters.assert_awaited_once_with(
             "1234567890"
         )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_classic_cloud_writes_do_not_interleave(self):
+        """A schedule boundary's hour/minute writes are one logical unit.
+
+        Reproduce audit INT-04 deterministically: the first request pauses after
+        its hour write while a second request attempts the same boundary. With
+        no logical transaction lock the calls land as A-hour, B-hour, B-minute,
+        A-minute and synthesize 20:15 -- a value requested by neither caller.
+        """
+        serial = "1234567890"
+        coordinator = _mock_coordinator(serial=serial, has_local=False)
+        locks: dict[tuple[str, str], asyncio.Lock] = {}
+        coordinator.control_transaction_lock = MagicMock(
+            side_effect=lambda lock_serial, control: locks.setdefault(
+                (lock_serial, control), asyncio.Lock()
+            )
+        )
+        first_hour_started = asyncio.Event()
+        release_first_hour = asyncio.Event()
+        second_minute_written = asyncio.Event()
+        hardware = {"hour": 0, "minute": 0}
+        calls: list[tuple[str, str]] = []
+        success = MagicMock()
+        success.success = True
+
+        async def _write_parameter(
+            write_serial: str, param: str, value: str
+        ) -> MagicMock:
+            assert write_serial == serial
+            calls.append((param, value))
+            if param.endswith("_HOUR"):
+                hardware["hour"] = int(value)
+                if value == "8":
+                    first_hour_started.set()
+                    await release_first_hour.wait()
+            else:
+                hardware["minute"] = int(value)
+                if value == "45":
+                    second_minute_written.set()
+            return success
+
+        coordinator.client.api.control.write_parameter = AsyncMock(
+            side_effect=_write_parameter
+        )
+        first = _entity(coordinator, serial=serial)
+        second = _entity(coordinator, serial=serial)
+        _prep(first)
+        _prep(second)
+
+        first_task = asyncio.create_task(first.async_set_value(time(8, 15)))
+        await first_hour_started.wait()
+        second_task = asyncio.create_task(second.async_set_value(time(20, 45)))
+        await asyncio.sleep(0)
+
+        assert not second_minute_written.is_set()
+        assert not second_task.done()
+        release_first_hour.set()
+
+        await asyncio.gather(first_task, second_task)
+
+        assert hardware == {"hour": 20, "minute": 45}
+        assert calls == [
+            ("HOLD_AC_CHARGE_START_HOUR", "8"),
+            ("HOLD_AC_CHARGE_START_MINUTE", "15"),
+            ("HOLD_AC_CHARGE_START_HOUR", "20"),
+            ("HOLD_AC_CHARGE_START_MINUTE", "45"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_partial_cloud_write_converges_before_unlock(self):
+        """Cancellation after the hour ACK still re-reads the mixed state."""
+        serial = "1234567890"
+        coordinator = _mock_coordinator(
+            serial=serial,
+            has_local=False,
+            parameters={
+                "HOLD_AC_CHARGE_START_HOUR": "8",
+                "HOLD_AC_CHARGE_START_MINUTE": "0",
+            },
+        )
+        locks: dict[tuple[str, str], asyncio.Lock] = {}
+        coordinator.control_transaction_lock = MagicMock(
+            side_effect=lambda lock_serial, control: locks.setdefault(
+                (lock_serial, control), asyncio.Lock()
+            )
+        )
+        minute_started = asyncio.Event()
+        hold_minute = asyncio.Event()
+        success = MagicMock(success=True)
+
+        async def _write_parameter(
+            _write_serial: str, param: str, _value: str
+        ) -> MagicMock:
+            if param.endswith("_MINUTE"):
+                minute_started.set()
+                await hold_minute.wait()
+            return success
+
+        async def _refresh_mixed(refresh_serial: str) -> bool:
+            assert refresh_serial == serial
+            assert locks[(serial, "schedule:68")].locked()
+            coordinator.data["parameters"][serial] = {
+                "HOLD_AC_CHARGE_START_HOUR": "20",
+                "HOLD_AC_CHARGE_START_MINUTE": "0",
+            }
+            return True
+
+        coordinator.client.api.control.write_parameter = AsyncMock(
+            side_effect=_write_parameter
+        )
+        coordinator.async_refresh_device_parameters = AsyncMock(
+            side_effect=_refresh_mixed
+        )
+        entity = _entity(coordinator, serial=serial)
+        _prep(entity)
+
+        task = asyncio.create_task(entity.async_set_value(time(20, 30)))
+        await minute_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        coordinator.async_refresh_device_parameters.assert_awaited_once_with(serial)
+        assert entity._optimistic_value is None
+        assert entity.native_value == time(20, 0)
+        assert not locks[(serial, "schedule:68")].locked()
 
     @pytest.mark.asyncio
     async def test_cloud_write_failure_raises(self):


### PR DESCRIPTION
## Summary

- add coordinator-owned locks keyed by inverter serial and logical control
- serialize each classic schedule hour/minute pair across separate entity instances
- serialize each battery charge/discharge regime pair across concurrent callers
- keep partial-write convergence inside the logical lock and preserve cancellation semantics

## Root cause

The transport and dependency locks protect individual requests, not a logical operation made of multiple requests. Two successful classic schedule calls could therefore run as A-hour, B-hour, B-minute, A-minute. Requests for 08:15 and 20:45 would leave 20:15, a value requested by neither caller. The charge/discharge bit pair used for battery control mode had the same transaction boundary gap.

An entity-owned lock would not be sufficient because Home Assistant can have separate entity instances and config-flow callers targeting the same inverter/control. The coordinator is the shared owner.

## Lock and cancellation design

- Locks are keyed by `(serial, control)`, so different inverters and different schedule registers do not contend.
- Each operation acquires one logical lock and never nests logical locks, avoiding a new lock-order cycle.
- Schedule locking covers optimistic state, the multi-call write, and confirmation/convergence. Battery locking covers both bit writes, cloud fallback, and partial-write convergence.
- If cancellation arrives after the first field/bit was acknowledged, the known partial state is converged while the lock is still held, then `CancelledError` is re-raised. An interrupted local discharge request is treated as ambiguous and re-read; an ordinary definite local failure retains the existing known-charge-bit seed behavior.
- Locks live only for the coordinator lifetime and the key space is bounded by configured serial/control combinations.

## Regression coverage

- deterministic concurrent classic schedule writes across separate entity instances
- deterministic concurrent battery-mode pair writes
- lock identity/isolation across serials and controls
- schedule cancellation after the hour acknowledgement
- local and cloud battery cancellation after the charge acknowledgement
- assertions that convergence occurs before lock release
- all existing partial-failure convergence tests remain green

## Validation

- `pytest -q tests`: **2549 passed, 3 skipped**
- focused schedule/battery/coordinator suite: **372 passed**
- configured strict mypy: **Success: no issues found in 41 source files**
- configured `prek` hooks: whitespace, EOF, large-file, Ruff, Ruff format, and mypy all passed
- `git diff --check`: passed

Tracking: `eg4-xa9f`; audit findings INT-04 and INT-12.
