### PR TITLE
Protect parameter ACKs from stale polls

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -280,12 +280,16 @@ class EG4DataUpdateCoordinator(
         # cleared on success — without this, a transient boot-time failure
         # parked the device on cloud data until a manual reload (eg4-05l).
         self._failed_attach_serials: set[str] = set()
-        self._last_attach_retry: float = 0.0
+        self._last_attach_retry: float | None = None
         # Per-serial monotonic stamps for DEGRADED cloud refreshes: a hybrid
         # coordinator can tick at the fastest LOCAL interval (5s) — degraded
         # devices' cloud fallback must stay throttled to the cloud-safe HTTP
         # interval regardless (review HIGH on eg4-o5m).
         self._last_degraded_cloud_refresh: dict[str, float] = {}
+        # ``None`` means the cloud parallel-group energy fetch has never run.
+        # Numeric zero is a valid monotonic timestamp and would suppress the
+        # first fetch while process uptime is under the throttle interval.
+        self._last_pg_energy_fetch: float | None = None
         # Serials with an open transport_link_down Repairs issue (eg4-57g):
         # one-shot per down transition, cleared when the link recovers.
         self._link_down_notified: set[str] = set()
@@ -309,6 +313,11 @@ class EG4DataUpdateCoordinator(
         self._param_retry_due: bool = False
         self._param_completed_this_cycle: set[str] = set()
         self._param_attempted_this_cycle: bool = False
+        # Acknowledged parameter writes must survive an older local parameter
+        # poll already in flight. Raw reads capture this generation at start;
+        # newer seeds remain authoritative until a later read observes them.
+        self._parameter_write_generation: int = 0
+        self._parameter_write_seeds: dict[str, dict[str, tuple[Any, int]]] = {}
 
         # DST sync tracking
         self._last_dst_sync: datetime | None = None
@@ -535,6 +544,10 @@ class EG4DataUpdateCoordinator(
 
         try:
             data = await self._route_update_by_connection_type()
+            # A write can be acknowledged after one endpoint's parameter read
+            # completes while another endpoint/group is still awaited. Apply
+            # retained seeds at the final no-await publish boundary too.
+            self._overlay_parameter_write_seeds(data)
             self._consecutive_update_failures = 0
 
             # On startup (no prior cache), suppress 0 values for
@@ -700,14 +713,88 @@ class EG4DataUpdateCoordinator(
         reverting the entity after its optimistic value clears. The written
         value IS device truth (the cloud write was acknowledged), expressed
         in the same local-raw representation the attached-transport cache
-        uses. A later successful parameter read overwrites it with fresh
-        device data.
+        uses. A later successful parameter read that starts after the write
+        overwrites it with fresh device data. Reads already in flight retain
+        this acknowledged value instead of publishing their stale snapshot.
         """
         if not self.data:
             return
+        # Cloud-fed parameter caches get their own authoritative refresh and
+        # must not retain a local-raw seed indefinitely. The generation
+        # envelope is only needed when raw local register reads can race the
+        # acknowledged write.
+        if self.params_are_local_raw(serial):
+            self._parameter_write_generation += 1
+            generation = self._parameter_write_generation
+            seeds = self._parameter_write_seeds.setdefault(serial, {})
+            for key, value in values.items():
+                seeds[key] = (value, generation)
         params = self.data.setdefault("parameters", {}).setdefault(serial, {})
         params.update(values)
         self.async_update_listeners()
+
+    def _reconcile_parameter_read(
+        self,
+        serial: str,
+        values: dict[str, Any],
+        *,
+        read_complete: bool,
+        read_generation: int,
+        observed_keys: Collection[str] | None = None,
+    ) -> dict[str, Any]:
+        """Reconcile a raw read with acknowledged writes around its lifetime.
+
+        A complete read, or a partial read that contains a seeded key, may
+        retire seeds that existed before the read began. A seed written after
+        the read began is overlaid and retained for the next read. Partial
+        reads keep seeds for ranges they did not observe. ``observed_keys``
+        must contain only freshly read keys, never sticky carry-forward keys.
+        """
+        seeds = self._parameter_write_seeds.get(serial)
+        if not seeds:
+            return values
+
+        reconciled = dict(values)
+        remaining: dict[str, tuple[Any, int]] = {}
+        for key, (seed_value, seed_generation) in seeds.items():
+            observed_by_read = read_complete or (
+                observed_keys is not None and key in observed_keys
+            )
+            if seed_generation <= read_generation and observed_by_read:
+                continue
+            reconciled[key] = seed_value
+            remaining[key] = (seed_value, seed_generation)
+
+        if remaining:
+            self._parameter_write_seeds[serial] = remaining
+        else:
+            self._parameter_write_seeds.pop(serial, None)
+        return reconciled
+
+    def _overlay_parameter_write_seeds(self, data: dict[str, Any]) -> None:
+        """Overlay retained parameter ACKs immediately before publishing data."""
+        if not self._parameter_write_seeds:
+            return
+
+        devices = data.get("devices")
+        device_serials = set(devices) if isinstance(devices, dict) else set()
+        parameters = data.get("parameters")
+        if not isinstance(parameters, dict):
+            parameters = {}
+            data["parameters"] = parameters
+
+        for serial, seeds in self._parameter_write_seeds.items():
+            serial_parameters = parameters.get(serial)
+            if serial_parameters is None:
+                # Do not resurrect a device removed from this coordinator.
+                if serial not in device_serials:
+                    continue
+                serial_parameters = {}
+                parameters[serial] = serial_parameters
+            if not isinstance(serial_parameters, dict):
+                continue
+            for key, (value, _generation) in seeds.items():
+                serial_parameters[key] = value
 
     def note_ac_couple_soc_written(
         self, serial: str, key: str, value: float | bool

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -100,8 +100,8 @@ def _maybe_bust_degraded_cloud_cache(
     if client is None:
         return False
     now = _time.monotonic()
-    last = last_refresh.get(serial, 0.0)
-    if now - last < http_interval:
+    last = last_refresh.get(serial)
+    if last is not None and now - last < http_interval:
         return False
     last_refresh[serial] = now
     client.invalidate_cache_for_device(serial)
@@ -177,7 +177,10 @@ class HTTPUpdateMixin(_MixinBase):
             from .coordinator_local import ATTACH_RETRY_INTERVAL_SECONDS
 
             now = _time.monotonic()
-            if now - self._last_attach_retry < ATTACH_RETRY_INTERVAL_SECONDS:
+            if (
+                self._last_attach_retry is not None
+                and now - self._last_attach_retry < ATTACH_RETRY_INTERVAL_SECONDS
+            ):
                 return
             self._last_attach_retry = now
             await self._attach_local_transports_to_station()
@@ -853,8 +856,8 @@ class HTTPUpdateMixin(_MixinBase):
                 # Cloud API — throttle to 60s intervals
                 _PG_ENERGY_INTERVAL = 60  # seconds
                 now_mono = _time.monotonic()
-                last_pg = getattr(self, "_last_pg_energy_fetch", 0.0)
-                if now_mono - last_pg >= _PG_ENERGY_INTERVAL:
+                last_pg = getattr(self, "_last_pg_energy_fetch", None)
+                if last_pg is None or now_mono - last_pg >= _PG_ENERGY_INTERVAL:
                     energy_tasks = []
                     for group in groups:
                         if group.inverters:

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -866,8 +866,16 @@ class LocalTransportMixin(_MixinBase):
             }
 
             if include_params:
+                parameter_read_generation = self._parameter_write_generation
                 param_data, param_read_complete = await self._read_modbus_parameters(
                     transport, device_data, device=inverter
+                )
+                param_data = self._reconcile_parameter_read(
+                    serial,
+                    param_data,
+                    read_complete=param_read_complete,
+                    read_generation=parameter_read_generation,
+                    observed_keys=param_data,
                 )
                 if not param_read_complete:
                     # Sticky carry-forward (#282): keep last-known values for
@@ -1490,11 +1498,19 @@ class LocalTransportMixin(_MixinBase):
                 param_transport = inverter.transport
                 if read_entity_params and param_transport:
                     self._param_attempted_this_cycle = True
+                    parameter_read_generation = self._parameter_write_generation
                     (
                         param_data,
                         param_read_complete,
                     ) = await self._read_modbus_parameters(
                         param_transport, device_data, device=inverter
+                    )
+                    param_data = self._reconcile_parameter_read(
+                        serial,
+                        param_data,
+                        read_complete=param_read_complete,
+                        read_generation=parameter_read_generation,
+                        observed_keys=param_data,
                     )
                     if param_read_complete:
                         self._param_completed_this_cycle.add(serial)
@@ -2599,7 +2615,10 @@ class LocalTransportMixin(_MixinBase):
         if not self._failed_attach_serials or self.station is None:
             return
         now = time.monotonic()
-        if now - self._last_attach_retry < ATTACH_RETRY_INTERVAL_SECONDS:
+        if (
+            self._last_attach_retry is not None
+            and now - self._last_attach_retry < ATTACH_RETRY_INTERVAL_SECONDS
+        ):
             return
         self._last_attach_retry = now
 

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -712,8 +712,9 @@ if TYPE_CHECKING:
         _local_transport_configs: list[dict[str, Any]]
         _local_transports_attached: bool
         _failed_attach_serials: set[str]
-        _last_attach_retry: float
+        _last_attach_retry: float | None
         _last_degraded_cloud_refresh: dict[str, float]
+        _last_pg_energy_fetch: float | None
         _local_parameters_loaded: bool
         _local_static_phase_done: bool
         _data_validation_enabled: bool
@@ -727,6 +728,8 @@ if TYPE_CHECKING:
         _param_completed_this_cycle: set[str]
         _param_attempted_this_cycle: bool
         _parameter_refresh_interval: timedelta
+        _parameter_write_generation: int
+        _parameter_write_seeds: dict[str, dict[str, tuple[Any, int]]]
         _last_dst_sync: datetime | None
         _dst_sync_interval: timedelta
         _last_status_fetch: dict[str, float]
@@ -760,6 +763,15 @@ if TYPE_CHECKING:
         def get_inverter_object(self, serial: str) -> BaseInverter | None: ...
         async def async_request_refresh(self) -> None: ...
         def _rebuild_inverter_cache(self) -> None: ...
+        def _reconcile_parameter_read(
+            self,
+            serial: str,
+            values: dict[str, Any],
+            *,
+            read_complete: bool,
+            read_generation: int,
+            observed_keys: Collection[str] | None = None,
+        ) -> dict[str, Any]: ...
 
         # ── DeviceProcessingMixin methods ──
         def _get_device_grid_type(self, serial: str) -> str | None: ...
@@ -3953,7 +3965,14 @@ class ParameterManagementMixin(_MixinBase):
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
                 return False
 
-            # Use force=True to bypass cache when refreshing parameters after changes
+            # Use force=True to bypass cache when refreshing parameters after changes.
+            # Snapshot the integration's write generation before the read: the
+            # pylxpweb cache generation keeps a raced result stale for its next
+            # fetch, but the returned parameter dict can still be pre-write.
+            current_generation = getattr(self, "_parameter_write_generation", 0)
+            parameter_read_generation = (
+                current_generation if isinstance(current_generation, int) else 0
+            )
             await inverter.refresh(force=True, include_parameters=True)
 
             if hasattr(inverter, "parameters") and inverter.parameters:
@@ -3963,7 +3982,22 @@ class ParameterManagementMixin(_MixinBase):
                 if "parameters" not in self.data:
                     self.data["parameters"] = {}
 
-                self.data["parameters"][serial] = inverter.parameters
+                parameter_values = dict(inverter.parameters)
+                read_complete = (
+                    getattr(inverter, "parameters_complete", True) is not False
+                )
+                write_seeds = getattr(self, "_parameter_write_seeds", None)
+                if isinstance(write_seeds, dict):
+                    parameter_values = self._reconcile_parameter_read(
+                        serial,
+                        parameter_values,
+                        read_complete=read_complete,
+                        read_generation=parameter_read_generation,
+                        # pylxpweb merges its own sticky carry-forward on partial
+                        # reads, so none of those keys can be proven freshly read.
+                        observed_keys=parameter_values if read_complete else (),
+                    )
+                self.data["parameters"][serial] = parameter_values
                 return True
 
             _LOGGER.warning(

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -464,6 +464,44 @@ class TestProcessStationData:
 
     @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
     @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_first_cloud_parallel_energy_fetch_fires_on_young_clock(
+        self, mock_aiohttp, mock_client_cls, hass, http_config_entry
+    ):
+        """No prior PG fetch must be distinct from monotonic timestamp zero."""
+        http_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, http_config_entry)
+        coordinator.station = _mock_station()
+
+        member = MagicMock()
+        member.serial_number = "INV001"
+        group = MagicMock()
+        group.name = "A"
+        group.inverters = [member]
+        group.mid_device = None
+        group._has_local_energy.return_value = False
+        group._fetch_energy_data = AsyncMock()
+        group._energy = None
+        group.today_yielding = 0.0
+        coordinator.station.parallel_groups = [group]
+
+        with (
+            patch.object(
+                coordinator,
+                "_process_parallel_group_object",
+                new=AsyncMock(return_value={"type": "parallel_group", "sensors": {}}),
+            ),
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_http._time.monotonic",
+                return_value=1.0,
+            ),
+        ):
+            await coordinator._process_station_data()
+
+        group._fetch_energy_data.assert_awaited_once_with("INV001")
+        assert coordinator._last_pg_energy_fetch == 1.0
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
     async def test_api_metrics_when_client_exists(
         self, mock_aiohttp, mock_client_cls, hass, http_config_entry
     ):

--- a/tests/test_coordinator_hybrid.py
+++ b/tests/test_coordinator_hybrid.py
@@ -632,6 +632,45 @@ class TestAttachRetryAndDegradedFallback:
         mock_self.station.attach_local_transports.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_first_retry_fires_on_a_young_monotonic_clock(self) -> None:
+        """An absent retry stamp must not suppress work during early uptime."""
+        from custom_components.eg4_web_monitor.coordinator import (
+            EG4DataUpdateCoordinator,
+        )
+
+        attach_result = MagicMock()
+        attach_result.failed_serials = []
+        attach_result.unmatched_serials = []
+
+        mock_self = MagicMock()
+        mock_self.station = MagicMock()
+        mock_self.station.attach_local_transports = AsyncMock(
+            return_value=attach_result
+        )
+        mock_self._failed_attach_serials = {"4524850115"}
+        mock_self._last_attach_retry = None
+        mock_self._local_transport_configs = [
+            {"serial": "4524850115", "transport_type": "wifi_dongle"}
+        ]
+
+        cfg = self._net_cfg("4524850115")
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_local._build_transport_configs",
+                return_value=[cfg],
+            ),
+            patch(
+                "custom_components.eg4_web_monitor.coordinator_local.time.monotonic",
+                return_value=1.0,
+            ),
+            patch("custom_components.eg4_web_monitor.coordinator_local.ir"),
+        ):
+            await EG4DataUpdateCoordinator._maybe_retry_failed_attaches(mock_self)
+
+        mock_self.station.attach_local_transports.assert_awaited_once_with([cfg])
+        assert mock_self._last_attach_retry == 1.0
+
+    @pytest.mark.asyncio
     async def test_retry_noop_without_failures(self) -> None:
         """No failed serials -> no retry work at all."""
         from custom_components.eg4_web_monitor.coordinator import (
@@ -902,6 +941,31 @@ class TestAttachRetryAndDegradedFallback:
         assert mock_self._last_attach_retry > 0.0
 
     @pytest.mark.asyncio
+    async def test_first_full_reattach_fires_on_a_young_monotonic_clock(self) -> None:
+        """The no-attempt sentinel is distinct from monotonic timestamp zero."""
+        from custom_components.eg4_web_monitor.coordinator import (
+            EG4DataUpdateCoordinator,
+        )
+
+        mock_self = MagicMock()
+        mock_self.connection_type = CONNECTION_TYPE_HYBRID
+        mock_self._local_transport_configs = [{"serial": "4524850115"}]
+        mock_self._local_transports_attached = False
+        mock_self._failed_attach_serials = set()
+        mock_self._last_attach_retry = None
+        mock_self._attach_local_transports_to_station = AsyncMock()
+        mock_self._maybe_retry_failed_attaches = AsyncMock()
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_http._time.monotonic",
+            return_value=1.0,
+        ):
+            await EG4DataUpdateCoordinator._ensure_local_transports(mock_self)
+
+        mock_self._attach_local_transports_to_station.assert_awaited_once()
+        assert mock_self._last_attach_retry == 1.0
+
+    @pytest.mark.asyncio
     async def test_ensure_local_transports_full_reattach_backoff(self) -> None:
         """The full re-attach respects the bounded retry interval."""
         import time as time_mod
@@ -1054,6 +1118,27 @@ class TestTransportLinkDown:
             _maybe_bust_degraded_cloud_cache(client, stamps, 60, "1111111111") is False
         )
         client.invalidate_cache_for_device.assert_called_once()
+
+    def test_bust_helper_first_call_fires_on_a_young_monotonic_clock(self) -> None:
+        """Missing stamp is not timestamp zero, even just after process start."""
+        from custom_components.eg4_web_monitor.coordinator_http import (
+            _maybe_bust_degraded_cloud_cache,
+        )
+
+        client = MagicMock()
+        stamps: dict[str, float] = {}
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_http._time.monotonic",
+            return_value=1.0,
+        ):
+            assert (
+                _maybe_bust_degraded_cloud_cache(client, stamps, 60, "1111111111")
+                is True
+            )
+
+        client.invalidate_cache_for_device.assert_called_once_with("1111111111")
+        assert stamps == {"1111111111": 1.0}
 
     def test_bust_helper_no_client(self) -> None:
         """Without a cloud client there is nothing to bust."""

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -8,6 +8,7 @@ Covers methods not already tested in test_coordinator.py:
 - _log_transport_error
 """
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -743,6 +744,154 @@ class TestStickyParameterCarryForward:
         assert result["parameters"]["INV001"] == {"HOLD_CHG_POWER_PERCENT_CMD": 60}
         assert coordinator._last_parameter_refresh is not None
         assert coordinator._param_retry_pending == set()
+
+    async def test_acknowledged_write_during_read_survives_stale_result(
+        self, hass, local_config_entry
+    ):
+        """A poll begun before an ACK cannot publish its pre-write snapshot."""
+        coordinator = self._seed_coordinator(hass, local_config_entry)
+        coordinator.async_update_listeners = MagicMock()
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        async def stale_read(
+            transport: Any,
+            device_data: dict[str, Any] | None = None,
+            device: Any = None,
+        ) -> tuple[dict[str, Any], bool]:
+            read_started.set()
+            await release_read.wait()
+            return {"HOLD_CHG_POWER_PERCENT_CMD": 60}, True
+
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator, "_read_modbus_parameters", side_effect=stale_read
+            ),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+            patch.object(
+                coordinator, "_process_local_parallel_groups", new_callable=AsyncMock
+            ),
+        ):
+            update_task = asyncio.create_task(coordinator._async_update_local_data())
+            await asyncio.wait_for(read_started.wait(), timeout=1)
+            coordinator.note_parameters_written(
+                "INV001", {"HOLD_CHG_POWER_PERCENT_CMD": 90}
+            )
+            release_read.set()
+            result = await update_task
+
+        assert result["parameters"]["INV001"]["HOLD_CHG_POWER_PERCENT_CMD"] == 90
+
+        # A partial read begun after the write cannot retire a seed for a
+        # register range it did not observe.
+        coordinator.data = result
+        coordinator._last_parameter_refresh = None
+        coordinator._last_parameter_attempt = None
+
+        async def unrelated_partial_read(
+            transport: Any,
+            device_data: dict[str, Any] | None = None,
+            device: Any = None,
+        ) -> tuple[dict[str, Any], bool]:
+            return {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 95}, False
+
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator,
+                "_read_modbus_parameters",
+                side_effect=unrelated_partial_read,
+            ),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+            patch.object(
+                coordinator, "_process_local_parallel_groups", new_callable=AsyncMock
+            ),
+        ):
+            partial = await coordinator._async_update_local_data()
+
+        assert partial["parameters"]["INV001"]["HOLD_CHG_POWER_PERCENT_CMD"] == 90
+        assert (
+            "HOLD_CHG_POWER_PERCENT_CMD" in coordinator._parameter_write_seeds["INV001"]
+        )
+
+        # A later complete read that begins after the write is authoritative
+        # and retires the retained write seed.
+        coordinator.data = partial
+        coordinator._last_parameter_refresh = None
+        coordinator._last_parameter_attempt = None
+
+        async def post_write_read(
+            transport: Any,
+            device_data: dict[str, Any] | None = None,
+            device: Any = None,
+        ) -> tuple[dict[str, Any], bool]:
+            return {"HOLD_CHG_POWER_PERCENT_CMD": 75}, True
+
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator, "_read_modbus_parameters", side_effect=post_write_read
+            ),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+            patch.object(
+                coordinator, "_process_local_parallel_groups", new_callable=AsyncMock
+            ),
+        ):
+            converged = await coordinator._async_update_local_data()
+
+        assert converged["parameters"]["INV001"]["HOLD_CHG_POWER_PERCENT_CMD"] == 75
+        assert coordinator._parameter_write_seeds.get("INV001") is None
+
+    async def test_acknowledged_write_after_read_survives_remaining_cycle_work(
+        self, hass, local_config_entry
+    ):
+        """The final publish overlays ACKs received while other groups finish."""
+        coordinator = self._seed_coordinator(hass, local_config_entry)
+        coordinator.async_update_listeners = MagicMock()
+        read_finished = asyncio.Event()
+        release_cycle = asyncio.Event()
+
+        async def stale_read(
+            transport: Any,
+            device_data: dict[str, Any] | None = None,
+            device: Any = None,
+        ) -> tuple[dict[str, Any], bool]:
+            return {"HOLD_CHG_POWER_PERCENT_CMD": 60}, True
+
+        async def finish_parallel_groups(processed: dict[str, Any]) -> None:
+            read_finished.set()
+            await release_cycle.wait()
+
+        with (
+            patch.object(coordinator, "_should_poll_transport", return_value=True),
+            patch.object(
+                coordinator, "_read_modbus_parameters", side_effect=stale_read
+            ),
+            patch.object(
+                coordinator, "_fetch_quick_charge_status", new_callable=AsyncMock
+            ),
+            patch.object(
+                coordinator,
+                "_process_local_parallel_groups",
+                side_effect=finish_parallel_groups,
+            ),
+        ):
+            update_task = asyncio.create_task(coordinator._async_update_data())
+            await asyncio.wait_for(read_finished.wait(), timeout=1)
+            coordinator.note_parameters_written(
+                "INV001", {"HOLD_CHG_POWER_PERCENT_CMD": 90}
+            )
+            release_cycle.set()
+            result = await update_task
+
+        assert result["parameters"]["INV001"]["HOLD_CHG_POWER_PERCENT_CMD"] == 90
 
 
 # Targeted parameter reads per cycle for the seeded FlexBOSS21 (model-fallback
@@ -3775,6 +3924,73 @@ class TestLinkDownParameterRefreshGate:
         assert coordinator.data["parameters"]["UP1"] == {"HOLD_X": 1}
         assert coordinator.data["parameters"]["DOWN1"] == {"HOLD_Y": 2}
 
+    async def test_background_refresh_cannot_revert_mid_read_write(
+        self, hass, local_config_entry
+    ):
+        """The pylxpweb refresh path obeys the same write-generation envelope."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        inverter = self._fake_inverter(
+            link_down=False, parameters={"HOLD_CHG_POWER_PERCENT_CMD": 60}
+        )
+        inverter.parameters_complete = True
+        coordinator._inverter_cache = {"INV1": inverter}
+        coordinator.data = {
+            "devices": {"INV1": {"type": "inverter"}},
+            "parameters": {"INV1": {"HOLD_CHG_POWER_PERCENT_CMD": 60}},
+        }
+        coordinator.async_update_listeners = MagicMock()
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        async def stale_refresh(**_kwargs: Any) -> None:
+            read_started.set()
+            await release_read.wait()
+            inverter.parameters = {"HOLD_CHG_POWER_PERCENT_CMD": 60}
+
+        inverter.refresh = AsyncMock(side_effect=stale_refresh)
+        refresh_task = asyncio.create_task(
+            coordinator._refresh_device_parameters("INV1")
+        )
+        await asyncio.wait_for(read_started.wait(), timeout=1)
+        coordinator.note_parameters_written("INV1", {"HOLD_CHG_POWER_PERCENT_CMD": 90})
+        release_read.set()
+
+        assert await refresh_task is True
+        assert coordinator.data["parameters"]["INV1"] == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 90
+        }
+
+        # pylxpweb's partial snapshot already contains sticky carried keys, so
+        # the integration cannot treat their presence as proof this range was
+        # freshly observed. Keep the ACK seed through that partial result.
+        async def partial_refresh(**_kwargs: Any) -> None:
+            inverter.parameters = {
+                "HOLD_CHG_POWER_PERCENT_CMD": 60,
+                "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 95,
+            }
+            inverter.parameters_complete = False
+
+        inverter.refresh = AsyncMock(side_effect=partial_refresh)
+        assert await coordinator._refresh_device_parameters("INV1") is True
+        assert coordinator.data["parameters"]["INV1"] == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 90,
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 95,
+        }
+        assert "INV1" in coordinator._parameter_write_seeds
+
+        # A complete post-write read finally converges and retires the seed.
+        async def complete_refresh(**_kwargs: Any) -> None:
+            inverter.parameters = {"HOLD_CHG_POWER_PERCENT_CMD": 75}
+            inverter.parameters_complete = True
+
+        inverter.refresh = AsyncMock(side_effect=complete_refresh)
+        assert await coordinator._refresh_device_parameters("INV1") is True
+        assert coordinator.data["parameters"]["INV1"] == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 75
+        }
+        assert coordinator._parameter_write_seeds.get("INV1") is None
+
     async def test_routine_parameter_refresh_logs_at_debug(
         self, hass, local_config_entry, caplog: pytest.LogCaptureFixture
     ):
@@ -3994,6 +4210,22 @@ class TestLinkDownParameterRefreshGate:
         coordinator.note_parameters_written("INV001", {"HOLD_B": 2})
 
         coordinator.async_update_listeners.assert_not_called()
+
+    async def test_cloud_parameters_update_without_retaining_local_raw_seed(
+        self, hass, local_config_entry
+    ):
+        """Cloud-fed caches converge immediately but do not pin a raw seed."""
+        local_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
+        coordinator.data = {"parameters": {"INV001": {"HOLD_A": 1}}}
+        coordinator.async_update_listeners = MagicMock()
+
+        with patch.object(coordinator, "params_are_local_raw", return_value=False):
+            coordinator.note_parameters_written("INV001", {"HOLD_A": 2})
+
+        assert coordinator.data["parameters"]["INV001"] == {"HOLD_A": 2}
+        assert coordinator._parameter_write_seeds == {}
+        coordinator.async_update_listeners.assert_called_once()
 
 
 # ── Transport link-down flow (eg4-57g / #226 attached-but-dead) ──────


### PR DESCRIPTION
## RCA

The audit found two related first-publication failures:

- A numeric 0.0 was used as the never-run value for monotonic throttles. On a process with less uptime than the interval, the first attach retry, degraded cloud cache bust, or cloud parallel-group energy fetch was incorrectly suppressed.
- note_parameters_written updated only the currently published dictionary. A raw parameter read begun before the ACK could later replace that dictionary with its pre-write snapshot. The same stale publication was possible through the direct pylxpweb background refresh path, and after a device read completed while another endpoint or parallel-group task was still awaited.
- pylxpweb already leaves a raced parameter cache unstamped, but its returned dictionary can still be pre-write. On partial reads it also contains sticky carried values, so key presence alone does not prove that a seeded register was freshly observed.

## Fix

- Use None as the explicit never-run sentinel for attach retries and cloud parallel-group energy, and treat an absent per-device degraded-refresh stamp as immediately due.
- Retain acknowledged local-raw parameter values with a monotonic write generation.
- Snapshot that generation at every raw/local and direct pylxpweb parameter read boundary.
- Retire seeds only after a later authoritative observation: any complete post-write read, or a raw partial read that freshly returned that exact key.
- Overlay newer/unobserved ACKs both at the read boundary and at the final no-await coordinator publish boundary.
- Keep cloud-fed parameter caches unpinned; they still receive the immediate cache update but do not retain local-raw seeds indefinitely.
- Preserve compatibility with lightweight coordinator test doubles and older pylxpweb objects.

## Deliberate companion split

This branch is isolated from the other audit fixes. Quick Charge and Battery Backup first-run sentinels are handled in PR #518. Mixed Modbus/dongle poll-gate sentinels are handled in PR #523. The complete audit and cross-implementation RCA are in PR #524.

## Regression coverage

Tests deterministically reproduce:

- an ACK arriving while a complete raw read is blocked in flight;
- an ACK arriving after one device read while remaining cycle work is blocked;
- a raced direct pylxpweb background refresh;
- partial sticky carry-forward that must not falsely retire a seed;
- later complete-read convergence and seed retirement;
- pure-cloud caches avoiding persistent local-raw seeds;
- all three young-uptime first-run throttle failures.

## Verification

- Full suite: 2,551 passed, 3 skipped
- Coordinator HTTP/local/hybrid suite: 250 passed
- Ruff check and format: pass
- Strict mypy: pass
- Pre-commit hooks: pass
- Diff check: pass

Tracking: eg4-06er.3