### PR TITLE
fix: serialize shared physical endpoint operations

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -109,9 +109,14 @@ from .coordinator_mixins import (
     is_transport_link_down as _device_transport_link_down,
 )
 from .const.sensors import SENSOR_TYPES
+from .transport_serialization import (
+    EndpointOperationLock,
+    physical_endpoint_key,
+)
 from .utils import async_write_with_cloud_fallback
 
 _LOGGER = logging.getLogger(__name__)
+_ENDPOINT_OPERATION_LOCKS_DATA = f"{DOMAIN}_endpoint_operation_locks"
 
 PV_STRING_LIFETIME_STORAGE_VERSION = 1
 PV_STRING_LIFETIME_STORAGE_KEY = f"{DOMAIN}_pv_string_lifetime"
@@ -274,6 +279,13 @@ class EG4DataUpdateCoordinator(
             CONF_LOCAL_TRANSPORTS, []
         )
         self._local_transports_attached = False
+        # One lock per physical host:port or serial adapter. pylxpweb's
+        # operation lock is intentionally per transport instance, while this
+        # Home Assistant-scoped registry owns the physical boundary across
+        # logical devices and separate EG4 config-entry coordinators alike.
+        self._endpoint_operation_locks: dict[str, EndpointOperationLock] = (
+            hass.data.setdefault(_ENDPOINT_OPERATION_LOCKS_DATA, {})
+        )
         # Serials whose local-transport attach failed (commonly: the dongle's
         # single TCP slot still held by the previous session right after an
         # HA restart). Retried with a bounded interval each update cycle and
@@ -1011,19 +1023,98 @@ class EG4DataUpdateCoordinator(
         transport = self.get_local_transport(serial)
         if not transport:
             raise HomeAssistantError(no_transport_message)
+        endpoint_lock = self._endpoint_operation_lock_for_transport(transport)
 
-        try:
+        async def _execute_write() -> None:
             if not transport.is_connected:
                 _LOGGER.debug(reconnect_message, *reconnect_args)
                 await transport.connect()
 
             await write(transport)
+
+        try:
+            if endpoint_lock is None:
+                await _execute_write()
+            else:
+                # Keep reconnect + write in one endpoint transaction. The
+                # transport operation re-enters this task-owned lock, matching
+                # pylxpweb's named-parameter RMW nesting contract.
+                async with endpoint_lock:
+                    await _execute_write()
             _LOGGER.debug(success_message, *success_args)
             return True
 
         except Exception as err:
             _LOGGER.error(failure_message, *failure_args, err)
             raise HomeAssistantError(translated_error(err)) from err
+
+    def _endpoint_operation_lock_for_transport(
+        self, transport: Any
+    ) -> EndpointOperationLock | None:
+        """Return and install the lock owned by a transport's endpoint.
+
+        pylxpweb serializes complete operations with ``_op_lock``, but owns
+        that lock per transport instance. Multiple logical devices on one
+        dongle/RS485 adapter therefore cannot see each other's work. Rebinding
+        the existing operation seam preserves concrete transport identity and
+        expands the lock boundary to the physical endpoint.
+        """
+        endpoint_key = physical_endpoint_key(transport)
+        if endpoint_key is None:
+            return None
+        endpoint_locks = getattr(self, "_endpoint_operation_locks", None)
+        if endpoint_locks is None:
+            # A small number of focused tests construct the coordinator with
+            # __new__ to exercise isolated mixin behavior. Keep the private
+            # helper total for those partial objects; normal coordinators use
+            # the Home Assistant-scoped registry initialized in __init__.
+            endpoint_locks = {}
+            self._endpoint_operation_locks = endpoint_locks
+        lock = endpoint_locks.get(endpoint_key)
+        if lock is None:
+            lock = EndpointOperationLock()
+            endpoint_locks[endpoint_key] = lock
+        if getattr(transport, "_op_lock", None) is lock:
+            return lock
+        try:
+            # Real pylxpweb transports initialize this private operation seam
+            # in BaseTransport. object.__setattr__ also supports autospecced
+            # test doubles whose spec omits instance-only attributes.
+            object.__setattr__(transport, "_op_lock", lock)
+        except (AttributeError, TypeError):
+            _LOGGER.warning(
+                "Cannot serialize %s operations on endpoint %s: transport "
+                "does not expose pylxpweb's operation-lock seam",
+                type(transport).__name__,
+                endpoint_key,
+            )
+        return lock
+
+    def _bind_endpoint_operation_lock(self, transport: Any) -> Any:
+        """Bind a transport to its physical endpoint and preserve identity."""
+        self._endpoint_operation_lock_for_transport(transport)
+        return transport
+
+    async def _connect_endpoint_transport(self, transport: Any) -> Any:
+        """Connect a transport without racing another endpoint operation."""
+        endpoint_lock = self._endpoint_operation_lock_for_transport(transport)
+        if transport.is_connected:
+            return transport
+        if endpoint_lock is None:
+            await transport.connect()
+            return transport
+        async with endpoint_lock:
+            # Another waiter may have connected this same transport first.
+            if not transport.is_connected:
+                await transport.connect()
+        return transport
+
+    def _bind_device_endpoint_lock(self, device: Any) -> Any | None:
+        """Bind and return a device transport's physical-endpoint lock."""
+        transport = getattr(device, "transport", None)
+        if transport is None:
+            return None
+        return self._bind_endpoint_operation_lock(transport)
 
     async def write_named_parameter(
         self,

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -230,6 +230,7 @@ class HTTPUpdateMixin(_MixinBase):
             if transport is None:
                 no_transport.append(device)
                 continue
+            transport = self._bind_device_endpoint_lock(device)
             # Group by the PUBLIC host/port (network transports — TCP dongle).
             host = getattr(transport, "host", None)
             port = getattr(transport, "port", None)

--- a/custom_components/eg4_web_monitor/coordinator_local.py
+++ b/custom_components/eg4_web_monitor/coordinator_local.py
@@ -806,12 +806,12 @@ class LocalTransportMixin(_MixinBase):
         )
 
         transport_name = connection_type.capitalize()
+        transport = self._bind_endpoint_operation_lock(transport)
 
         try:
             _LOGGER.debug("Fetching %s data for inverter %s", transport_name, serial)
 
-            if not transport.is_connected:
-                await transport.connect()
+            await self._connect_endpoint_transport(transport)
 
             # Create or reuse BaseInverter via factory
             if serial not in self._inverter_cache:
@@ -833,6 +833,11 @@ class LocalTransportMixin(_MixinBase):
                 self._inverter_cache[serial] = inverter
             else:
                 inverter = self._inverter_cache[serial]
+
+            # Cached legacy inverters retain the raw global transport. Bind it
+            # before any refresh so direct writes/background work cannot
+            # overlap this poll.
+            self._bind_device_endpoint_lock(inverter)
 
             include_params = self._local_parameters_loaded
             await inverter.refresh(include_parameters=include_params)
@@ -1117,8 +1122,8 @@ class LocalTransportMixin(_MixinBase):
                     device_availability[serial] = False
                     return
 
-                if not transport.is_connected:
-                    await transport.connect()
+                transport = self._bind_endpoint_operation_lock(transport)
+                await self._connect_endpoint_transport(transport)
 
                 # Propagate split-phase config for per-leg power fallback
                 grid_type = config.get(CONF_GRID_TYPE)
@@ -1172,9 +1177,9 @@ class LocalTransportMixin(_MixinBase):
             if is_gridboss:
                 mid_device = self._mid_device_cache[serial]
 
-                transport = mid_device.transport
-                if transport and not transport.is_connected:
-                    await transport.connect()
+                transport = self._bind_device_endpoint_lock(mid_device)
+                if transport:
+                    await self._connect_endpoint_transport(transport)
 
                 await mid_device.refresh()
 
@@ -1226,9 +1231,9 @@ class LocalTransportMixin(_MixinBase):
             else:
                 inverter = self._inverter_cache[serial]
 
-                transport = inverter.transport
-                if transport and not transport.is_connected:
-                    await transport.connect()
+                transport = self._bind_device_endpoint_lock(inverter)
+                if transport:
+                    await self._connect_endpoint_transport(transport)
 
                 # Use the per-cycle decision computed in _async_update_local_data
                 # (or fall back to the direct check for the deprecated single-
@@ -1597,6 +1602,7 @@ class LocalTransportMixin(_MixinBase):
             loaded = 0
             for serial, inverter in self._inverter_cache.items():
                 try:
+                    self._bind_device_endpoint_lock(inverter)
                     # force=False: reuse cached runtime/energy/battery from
                     # the poll cycle, only fetch parameters (holding registers)
                     await inverter.refresh(force=False, include_parameters=True)
@@ -2578,6 +2584,7 @@ class LocalTransportMixin(_MixinBase):
                 self._align_inverter_cache_ttls(inverter, tt)
                 if tt == "modbus_tcp":
                     modbus_inverters.append(inverter)
+                self._bind_device_endpoint_lock(inverter)
 
         # Propagate validation to MID devices.  set_max_system_power()
         # cannot be called here because inverter features have not been
@@ -2585,6 +2592,7 @@ class LocalTransportMixin(_MixinBase):
         for mid in self.station.all_mid_devices:
             if mid.transport is not None:
                 mid.validate_data = validation_enabled
+                self._bind_device_endpoint_lock(mid)
         return modbus_inverters
 
     async def _maybe_retry_failed_attaches(self) -> None:
@@ -2924,7 +2932,8 @@ class LocalTransportMixin(_MixinBase):
                     inverter_family=config.inverter_family,
                     **input_block_size_kwargs(self._max_input_block_size),
                 )
-                await transport.connect()
+                transport = self._bind_endpoint_operation_lock(transport)
+                await self._connect_endpoint_transport(transport)
                 device._transport = transport
                 result.matched += 1
 
@@ -2985,6 +2994,7 @@ class LocalTransportMixin(_MixinBase):
         await asyncio.sleep(2)  # Let setup and first static refresh complete
         for inverter in inverters:
             try:
+                self._bind_device_endpoint_lock(inverter)
                 _LOGGER.debug(
                     "Draining Modbus buffer for %s after restart",
                     inverter.serial_number,

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -4160,21 +4160,27 @@ class BackgroundTaskMixin(_MixinBase):
     """Mixin for background task management operations."""
 
     @staticmethod
-    async def _shutdown_transport(transport: Any) -> None:
+    async def _shutdown_transport(transport: Any) -> bool:
         """Terminally close a transport when it exposes an interrupt seam.
 
         Newer pylxpweb dongle transports serialize reusable ``disconnect()``
         behind their transaction lock.  During coordinator shutdown that lock
         may belong to the very hung read we need to interrupt.  Inspect the
         concrete type (rather than a dynamic mock attribute) and prefer its
-        terminal shutdown method; older and reusable transports retain the
-        existing disconnect fallback.
+        terminal shutdown method even while ``is_connected`` is still false
+        during a pending dial. Older transports retain the reusable disconnect
+        fallback only while they report a live connection.
+
+        Return whether a shutdown operation was invoked.
         """
         terminal_shutdown = getattr(type(transport), "async_shutdown", None)
         if callable(terminal_shutdown):
             await terminal_shutdown(transport)
-            return
+            return True
+        if not getattr(transport, "is_connected", False):
+            return False
         await transport.disconnect()
+        return True
 
     async def _cancel_background_tasks(self) -> None:
         """Cancel all background tasks and wait for them to finish."""
@@ -4246,91 +4252,68 @@ class BackgroundTaskMixin(_MixinBase):
         _LOGGER.debug("Coordinator shutdown complete, all background tasks cleaned up")
 
     async def _disconnect_all_transports(self) -> None:
-        """Disconnect all active transports (legacy and cached).
+        """Shut down every unique terminal-capable or active transport.
 
-        Covers three transport sources:
+        Covers four transport sources:
         1. Legacy single-device _modbus_transport / _dongle_transport
         2. Inverters in _inverter_cache (LOCAL/HYBRID mode)
         3. MID devices in _mid_device_cache (LOCAL/HYBRID mode)
+        4. Station-attached devices not represented by either cache
+
+        Terminal-capable transports are visited regardless of ``is_connected``
+        so an in-flight connect is marked terminal before it can install a late
+        socket. Object-identity de-duplication spans every source.
         """
-        # Legacy transports (old single-device config format)
+        transports: list[tuple[str, Any]] = []
+
+        # Legacy transports (old single-device config format).
         for attr in ("_modbus_transport", "_dongle_transport"):
             transport = getattr(self, attr, None)
-            if transport is not None and getattr(transport, "is_connected", False):
-                try:
-                    await self._shutdown_transport(transport)
-                    _LOGGER.debug("Disconnected legacy transport %s", attr)
-                except Exception:
-                    _LOGGER.debug(
-                        "Error disconnecting %s (ignored)", attr, exc_info=True
-                    )
+            if transport is not None:
+                transports.append((f"legacy transport {attr}", transport))
 
-        # Cached inverter transports (LOCAL/HYBRID with local_transports config)
+        # Cached inverter transports (LOCAL/HYBRID with local_transports config).
         for serial, inverter in self._inverter_cache.items():
             transport = inverter.transport
-            if transport is not None and getattr(transport, "is_connected", False):
-                try:
-                    await self._shutdown_transport(transport)
-                    _LOGGER.debug("Disconnected transport for inverter %s", serial)
-                except Exception:
-                    _LOGGER.debug(
-                        "Error disconnecting inverter %s transport (ignored)",
-                        serial,
-                        exc_info=True,
-                    )
+            if transport is not None:
+                transports.append((f"inverter {serial} transport", transport))
 
-        # Cached MID device transports (GridBOSS in LOCAL/HYBRID mode)
+        # Cached MID device transports (GridBOSS in LOCAL/HYBRID mode).
         for serial, mid_device in self._mid_device_cache.items():
             transport = mid_device.transport
-            if transport is not None and getattr(transport, "is_connected", False):
-                try:
-                    await self._shutdown_transport(transport)
-                    _LOGGER.debug("Disconnected transport for MID device %s", serial)
-                except Exception:
-                    _LOGGER.debug(
-                        "Error disconnecting MID %s transport (ignored)",
-                        serial,
-                        exc_info=True,
-                    )
+            if transport is not None:
+                transports.append((f"MID {serial} transport", transport))
 
         # Station-attached transports (HYBRID attach path). Devices attached
         # via Station.attach_local_transports() or the serial attach helper
         # are not guaranteed to appear in the caches above — notably MID
         # devices, since _rebuild_inverter_cache() only caches inverters —
-        # which leaked open serial ports across reloads (#233). De-dup by
-        # object identity so a transport shared with a cache entry closes once.
+        # which leaked open serial ports across reloads (#233).
         station = getattr(self, "station", None)
         if station is not None:
-            seen: set[int] = set()
-            for cache in (self._inverter_cache, self._mid_device_cache):
-                for cached in cache.values():
-                    if cached.transport is not None:
-                        seen.add(id(cached.transport))
             station_devices: list[Any] = list(
                 getattr(station, "all_inverters", None) or []
             )
             station_devices.extend(getattr(station, "all_mid_devices", None) or [])
             for device in station_devices:
                 transport = getattr(device, "transport", None)
-                if (
-                    transport is None
-                    or id(transport) in seen
-                    or not getattr(transport, "is_connected", False)
-                ):
-                    continue
-                seen.add(id(transport))
-                try:
-                    await self._shutdown_transport(transport)
-                    _LOGGER.debug(
-                        "Disconnected station transport for %s",
-                        getattr(device, "serial_number", "?"),
-                    )
-                except Exception:
-                    _LOGGER.debug(
-                        "Error disconnecting station transport for %s (ignored)",
-                        getattr(device, "serial_number", "?"),
-                        exc_info=True,
-                    )
+                if transport is not None:
+                    serial = getattr(device, "serial_number", "?")
+                    transports.append((f"station transport for {serial}", transport))
+
+        seen: set[int] = set()
+        for description, transport in transports:
+            identity = id(transport)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            try:
+                if await self._shutdown_transport(transport):
+                    _LOGGER.debug("Shut down %s", description)
+            except Exception:
+                _LOGGER.debug(
+                    "Error shutting down %s (ignored)", description, exc_info=True
+                )
 
     def _remove_task_from_set(self, task: asyncio.Task[Any]) -> None:
         """Remove completed task from background tasks set."""

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -4159,6 +4159,23 @@ class DSTSyncMixin(_MixinBase):
 class BackgroundTaskMixin(_MixinBase):
     """Mixin for background task management operations."""
 
+    @staticmethod
+    async def _shutdown_transport(transport: Any) -> None:
+        """Terminally close a transport when it exposes an interrupt seam.
+
+        Newer pylxpweb dongle transports serialize reusable ``disconnect()``
+        behind their transaction lock.  During coordinator shutdown that lock
+        may belong to the very hung read we need to interrupt.  Inspect the
+        concrete type (rather than a dynamic mock attribute) and prefer its
+        terminal shutdown method; older and reusable transports retain the
+        existing disconnect fallback.
+        """
+        terminal_shutdown = getattr(type(transport), "async_shutdown", None)
+        if callable(terminal_shutdown):
+            await terminal_shutdown(transport)
+            return
+        await transport.disconnect()
+
     async def _cancel_background_tasks(self) -> None:
         """Cancel all background tasks and wait for them to finish."""
         for task in self._background_tasks:
@@ -4241,7 +4258,7 @@ class BackgroundTaskMixin(_MixinBase):
             transport = getattr(self, attr, None)
             if transport is not None and getattr(transport, "is_connected", False):
                 try:
-                    await transport.disconnect()
+                    await self._shutdown_transport(transport)
                     _LOGGER.debug("Disconnected legacy transport %s", attr)
                 except Exception:
                     _LOGGER.debug(
@@ -4253,7 +4270,7 @@ class BackgroundTaskMixin(_MixinBase):
             transport = inverter.transport
             if transport is not None and getattr(transport, "is_connected", False):
                 try:
-                    await transport.disconnect()
+                    await self._shutdown_transport(transport)
                     _LOGGER.debug("Disconnected transport for inverter %s", serial)
                 except Exception:
                     _LOGGER.debug(
@@ -4267,7 +4284,7 @@ class BackgroundTaskMixin(_MixinBase):
             transport = mid_device.transport
             if transport is not None and getattr(transport, "is_connected", False):
                 try:
-                    await transport.disconnect()
+                    await self._shutdown_transport(transport)
                     _LOGGER.debug("Disconnected transport for MID device %s", serial)
                 except Exception:
                     _LOGGER.debug(
@@ -4303,7 +4320,7 @@ class BackgroundTaskMixin(_MixinBase):
                     continue
                 seen.add(id(transport))
                 try:
-                    await transport.disconnect()
+                    await self._shutdown_transport(transport)
                     _LOGGER.debug(
                         "Disconnected station transport for %s",
                         getattr(device, "serial_number", "?"),

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -711,6 +711,7 @@ if TYPE_CHECKING:
         _http_polling_interval: int
         _local_transport_configs: list[dict[str, Any]]
         _local_transports_attached: bool
+        _endpoint_operation_locks: dict[str, Any]
         _failed_attach_serials: set[str]
         _last_attach_retry: float
         _last_degraded_cloud_refresh: dict[str, float]
@@ -760,6 +761,9 @@ if TYPE_CHECKING:
         def get_inverter_object(self, serial: str) -> BaseInverter | None: ...
         async def async_request_refresh(self) -> None: ...
         def _rebuild_inverter_cache(self) -> None: ...
+        def _bind_endpoint_operation_lock(self, transport: Any) -> Any: ...
+        def _bind_device_endpoint_lock(self, device: Any) -> Any | None: ...
+        async def _connect_endpoint_transport(self, transport: Any) -> Any: ...
 
         # ── DeviceProcessingMixin methods ──
         def _get_device_grid_type(self, serial: str) -> str | None: ...
@@ -1159,6 +1163,8 @@ class DeviceProcessingMixin(_MixinBase):
         transport = getattr(inverter, "transport", None)
         if transport is None:
             return None
+        transport = self._bind_device_endpoint_lock(inverter)
+        assert transport is not None
         if is_transport_link_down(inverter):
             _LOGGER.debug(
                 "Skipping reg 234 read for %s: local transport link is down "
@@ -3953,6 +3959,7 @@ class ParameterManagementMixin(_MixinBase):
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
                 return False
 
+            self._bind_device_endpoint_lock(inverter)
             # Use force=True to bypass cache when refreshing parameters after changes
             await inverter.refresh(force=True, include_parameters=True)
 

--- a/custom_components/eg4_web_monitor/transport_serialization.py
+++ b/custom_components/eg4_web_monitor/transport_serialization.py
@@ -1,0 +1,57 @@
+"""Serialize local transport operations by physical endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+def physical_endpoint_key(transport: Any) -> str | None:
+    """Return the physical connection key for a local transport.
+
+    Network transports share a host/port endpoint. Serial transports expose
+    their tty path as ``port`` without a host. Transports without either
+    public shape cannot be proven to share hardware and remain unchanged.
+    """
+    host = getattr(transport, "host", None)
+    port = getattr(transport, "port", None)
+    if host is not None and port is not None:
+        return f"network:{str(host).strip().casefold()}:{port}"
+    if isinstance(port, str) and port:
+        return f"serial:{port}"
+    return None
+
+
+class EndpointOperationLock:
+    """Task-reentrant lock shared by transports on one physical endpoint.
+
+    pylxpweb transport operations can re-enter their operation lock: a named
+    parameter write holds it across the whole read-modify-write sequence and
+    calls raw read/write methods that acquire it again. A plain asyncio lock
+    would deadlock that valid nesting, so the integration-owned endpoint lock
+    mirrors that task-reentrant contract while expanding its ownership from
+    one transport object to every logical device on the same adapter.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[Any] | None = None
+        self._depth = 0
+
+    async def __aenter__(self) -> EndpointOperationLock:
+        """Acquire the endpoint, or re-enter it from the owning task."""
+        task = asyncio.current_task()
+        if task is not None and self._owner is task:
+            self._depth += 1
+            return self
+        await self._lock.acquire()
+        self._owner = task
+        self._depth = 1
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Release one nesting level and wake the next endpoint operation."""
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -1960,6 +1960,7 @@ class _SingleSlotTransport:
         self.disconnected = asyncio.Event()
         self.shutdown_calls = 0
         self.disconnect_calls = 0
+        self.shutdown_requested = False
         self.split_phase = False
         self._op_lock: Any = None
 
@@ -1983,7 +1984,8 @@ class _SingleSlotTransport:
     async def connect(self) -> None:
         """Represent a lifecycle operation that is outside pylxpweb's op lock."""
         await self.endpoint.run(f"{self.operation_name}_connect")
-        self.is_connected = True
+        if not self.shutdown_requested:
+            self.is_connected = True
 
     async def disconnect(self) -> None:
         """Model a reusable disconnect serialized behind the operation lock."""
@@ -1999,9 +2001,23 @@ class _SingleSlotTransport:
     async def async_shutdown(self) -> None:
         """Model pylxpweb terminal shutdown bypassing a held operation lock."""
         self.shutdown_calls += 1
+        self.shutdown_requested = True
         self.is_connected = False
         self.disconnected.set()
         self.endpoint.release.set()
+
+
+class _ReusableOnlyTransport:
+    """Transport without pylxpweb's optional terminal shutdown seam."""
+
+    def __init__(self, *, is_connected: bool) -> None:
+        self.is_connected = is_connected
+        self.disconnect_calls = 0
+
+    async def disconnect(self) -> None:
+        """Model the protocol's idempotent reusable disconnect."""
+        self.disconnect_calls += 1
+        self.is_connected = False
 
 
 class _SingleSlotInverter:
@@ -2511,6 +2527,82 @@ class TestPhysicalEndpointOperationSerialization:
         assert transport.disconnected.is_set()
         assert transport.shutdown_calls == 1
         assert transport.disconnect_calls == 0
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_terminal_shutdown_marks_cached_inflight_connect_once(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """A cached transport still dialing is terminally closed exactly once."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("cached_connect")
+        transport = _SingleSlotTransport(endpoint, operation_name="cached")
+        transport.is_connected = False
+        inverter = _SingleSlotInverter("INV001", transport)
+        coordinator._inverter_cache = {"INV001": inverter}  # type: ignore[dict-item]
+        # The same object is also station-attached. Shutdown de-duplication must
+        # not skip it merely because the cache saw it while still disconnected.
+        coordinator.station = _mock_station([inverter])  # type: ignore[list-item]
+
+        connect_task = asyncio.create_task(transport.connect())
+        await endpoint.entered["cached_connect"].wait()
+        try:
+            await coordinator._disconnect_all_transports()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(connect_task, return_exceptions=True)
+
+        assert transport.shutdown_requested is True
+        assert transport.shutdown_calls == 1
+        assert transport.disconnect_calls == 0
+        assert transport.is_connected is False
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_terminal_shutdown_marks_uncached_station_inflight_connect(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """An uncached station transport still dialing receives the terminal seam."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("station_connect")
+        transport = _SingleSlotTransport(endpoint, operation_name="station")
+        transport.is_connected = False
+        inverter = _SingleSlotInverter("INV001", transport)
+        coordinator._inverter_cache = {}
+        coordinator.station = _mock_station([inverter])  # type: ignore[list-item]
+
+        connect_task = asyncio.create_task(transport.connect())
+        await endpoint.entered["station_connect"].wait()
+        try:
+            await coordinator._disconnect_all_transports()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(connect_task, return_exceptions=True)
+
+        assert transport.shutdown_requested is True
+        assert transport.shutdown_calls == 1
+        assert transport.disconnect_calls == 0
+        assert transport.is_connected is False
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_shutdown_transport_uses_reusable_disconnect_fallback_only_when_live(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Clients without async_shutdown retain the connected-only fallback."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        connected = _ReusableOnlyTransport(is_connected=True)
+        disconnected = _ReusableOnlyTransport(is_connected=False)
+
+        assert await coordinator._shutdown_transport(connected) is True
+        assert await coordinator._shutdown_transport(disconnected) is False
+
+        assert connected.disconnect_calls == 1
+        assert connected.is_connected is False
+        assert disconnected.disconnect_calls == 0
 
     @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
     @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -27,9 +27,13 @@ from custom_components.eg4_web_monitor.const import (
     CONNECTION_TYPE_HYBRID,
     DEFAULT_DONGLE_UPDATE_INTERVAL,
     DOMAIN,
+    GRID_TYPE_SPLIT_PHASE,
 )
 from custom_components.eg4_web_monitor.coordinator import (
     EG4DataUpdateCoordinator,
+)
+from custom_components.eg4_web_monitor.transport_serialization import (
+    EndpointOperationLock,
 )
 from pylxpweb.exceptions import (
     LuxpowerAPIError,
@@ -1915,6 +1919,102 @@ class _FakeTcpTransport:
         self.port = port
 
 
+class _SingleSlotEndpoint:
+    """Deterministic endpoint that records overlapping physical operations."""
+
+    def __init__(self, *operation_names: str) -> None:
+        self.active = 0
+        self.max_active = 0
+        self.entered = {name: asyncio.Event() for name in operation_names}
+        self.release = asyncio.Event()
+
+    async def run(self, operation_name: str) -> None:
+        """Hold an operation in flight until the test releases the endpoint."""
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        self.entered[operation_name].set()
+        try:
+            await self.release.wait()
+        finally:
+            self.active -= 1
+
+
+class _SingleSlotTransport:
+    """Transport facade backed by a shared fake physical endpoint."""
+
+    transport_type = "modbus_tcp"
+
+    def __init__(
+        self,
+        endpoint: _SingleSlotEndpoint,
+        *,
+        operation_name: str,
+        host: str | None = "192.168.1.50",
+        port: int | str = 502,
+    ) -> None:
+        self.endpoint = endpoint
+        self.operation_name = operation_name
+        self.host = host
+        self.port = port
+        self.is_connected = True
+        self.disconnected = asyncio.Event()
+        self.split_phase = False
+        self._op_lock: Any = None
+
+    async def _run_serialized(self) -> None:
+        """Use the operation-lock seam exposed by real pylxpweb transports."""
+        if self._op_lock is None:
+            await self.endpoint.run(self.operation_name)
+            return
+        async with self._op_lock:
+            await self.endpoint.run(self.operation_name)
+
+    async def read_runtime(self) -> None:
+        """Represent a poll/background read on the physical endpoint."""
+        await self._run_serialized()
+
+    async def write_named_parameters(self, _parameters: dict[str, Any]) -> bool:
+        """Represent a write on the physical endpoint."""
+        await self._run_serialized()
+        return True
+
+    async def connect(self) -> None:
+        """Represent a lifecycle operation that is outside pylxpweb's op lock."""
+        await self.endpoint.run(f"{self.operation_name}_connect")
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        """Interrupt a pending read, matching coordinator shutdown semantics."""
+        self.is_connected = False
+        self.disconnected.set()
+        self.endpoint.release.set()
+
+
+class _SingleSlotInverter:
+    """Minimal inverter that always performs one transport read per refresh."""
+
+    def __init__(self, serial: str, transport: _SingleSlotTransport) -> None:
+        self.serial_number = serial
+        self._transport: Any = transport
+        self.parameters: dict[str, Any] = {"loaded": True}
+        self.transport_runtime = SimpleNamespace(
+            pv_total_power=0,
+            battery_soc=0,
+            rectifier_power=0,
+        )
+        self.transport_energy = None
+        self.transport_battery = None
+
+    @property
+    def transport(self) -> Any:
+        """Return the attached transport like pylxpweb's device objects."""
+        return self._transport
+
+    async def refresh(self, **_kwargs: Any) -> None:
+        """Run one physical transport operation."""
+        await self._transport.read_runtime()
+
+
 def _tracking_refresh(counter: dict[str, int]) -> Any:
     """Build a refresh coroutine that records concurrent-entry depth."""
 
@@ -2045,6 +2145,383 @@ class TestSerialEndpointGrouping:
         inv1.refresh.assert_awaited_once()
         inv2.refresh.assert_awaited_once()
         assert counter["max"] == 2
+
+
+class TestPhysicalEndpointOperationSerialization:
+    """Polls, writes, and background work share one endpoint lock."""
+
+    async def test_endpoint_lock_is_task_reentrant(self) -> None:
+        """Nested pylxpweb RMW operations do not deadlock themselves."""
+        lock = EndpointOperationLock()
+
+        async def nested_operation() -> None:
+            async with lock:
+                async with lock:
+                    return
+
+        await asyncio.wait_for(nested_operation(), timeout=0.1)
+
+    @staticmethod
+    def _install_devices(
+        coordinator: EG4DataUpdateCoordinator,
+        *devices: _SingleSlotInverter,
+    ) -> None:
+        coordinator.station = _mock_station(list(devices))
+        coordinator._local_transports_attached = True
+        coordinator._inverter_cache = {
+            device.serial_number: device for device in devices
+        }  # type: ignore[dict-item]
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_poll_and_write_on_shared_endpoint_do_not_overlap(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """A write waits while another device is polling the same adapter."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("poll", "write")
+        poll_device = _SingleSlotInverter(
+            "INV001", _SingleSlotTransport(endpoint, operation_name="poll")
+        )
+        write_device = _SingleSlotInverter(
+            "INV002", _SingleSlotTransport(endpoint, operation_name="write")
+        )
+        self._install_devices(coordinator, poll_device, write_device)
+
+        poll_task = asyncio.create_task(coordinator._refresh_station_devices())
+        await endpoint.entered["poll"].wait()
+        write_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV002")
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["write"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(poll_task, write_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_serial_adapter_operations_do_not_overlap(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Distinct devices on one tty path share the operation lock."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("poll", "write")
+        poll_transport = _SingleSlotTransport(
+            endpoint,
+            operation_name="poll",
+            host=None,
+            port="/dev/ttyUSB0",
+        )
+        write_transport = _SingleSlotTransport(
+            endpoint,
+            operation_name="write",
+            host=None,
+            port="/dev/ttyUSB0",
+        )
+        coordinator._bind_endpoint_operation_lock(poll_transport)
+        coordinator._bind_endpoint_operation_lock(write_transport)
+
+        poll_task = asyncio.create_task(poll_transport.read_runtime())
+        await endpoint.entered["poll"].wait()
+        write_task = asyncio.create_task(
+            write_transport.write_named_parameters({"FUNC_EPS_EN": True})
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["write"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(poll_task, write_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_background_parameter_load_and_write_do_not_overlap(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Deferred parameter work shares the adapter lock with writes."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        coordinator.async_request_refresh = AsyncMock()
+        endpoint = _SingleSlotEndpoint("background", "write")
+        background_device = _SingleSlotInverter(
+            "INV001", _SingleSlotTransport(endpoint, operation_name="background")
+        )
+        write_device = _SingleSlotInverter(
+            "INV002", _SingleSlotTransport(endpoint, operation_name="write")
+        )
+        self._install_devices(coordinator, background_device, write_device)
+
+        background_task = asyncio.create_task(
+            coordinator._deferred_local_parameter_load()
+        )
+        await endpoint.entered["background"].wait()
+        write_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV002")
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["write"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(background_task, write_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_independent_endpoints_remain_concurrent(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Endpoint locking does not impose a coordinator-wide bottleneck."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("first", "second")
+        first = _SingleSlotInverter(
+            "INV001",
+            _SingleSlotTransport(
+                endpoint,
+                operation_name="first",
+                host="192.168.1.50",
+            ),
+        )
+        second = _SingleSlotInverter(
+            "INV002",
+            _SingleSlotTransport(
+                endpoint,
+                operation_name="second",
+                host="192.168.1.51",
+            ),
+        )
+        self._install_devices(coordinator, first, second)
+
+        first_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV001")
+        )
+        second_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV002")
+        )
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    endpoint.entered["first"].wait(),
+                    endpoint.entered["second"].wait(),
+                ),
+                timeout=1,
+            )
+            assert endpoint.max_active == 2
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_reconnect_and_write_share_one_endpoint_transaction(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Two disconnected devices cannot dial the single-slot endpoint together."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint(
+            "first_connect", "second_connect", "first", "second"
+        )
+        first_transport = _SingleSlotTransport(endpoint, operation_name="first")
+        second_transport = _SingleSlotTransport(endpoint, operation_name="second")
+        first_transport.is_connected = False
+        second_transport.is_connected = False
+        first = _SingleSlotInverter("INV001", first_transport)
+        second = _SingleSlotInverter("INV002", second_transport)
+        self._install_devices(coordinator, first, second)
+
+        first_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV001")
+        )
+        await endpoint.entered["first_connect"].wait()
+        second_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV002")
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["second_connect"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_separate_config_entries_share_physical_endpoint_lock(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Two coordinators cannot bypass the same adapter boundary."""
+        hybrid_config_entry.add_to_hass(hass)
+        second_entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EG4 - Second Hybrid Test",
+            data={
+                **hybrid_config_entry.data,
+                CONF_PLANT_ID: "67890",
+                CONF_LOCAL_TRANSPORTS: [
+                    {
+                        **hybrid_config_entry.data[CONF_LOCAL_TRANSPORTS][0],
+                        "serial": "INV002",
+                    }
+                ],
+            },
+            entry_id="second_hybrid_test_entry",
+        )
+        second_entry.add_to_hass(hass)
+        first_coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        second_coordinator = EG4DataUpdateCoordinator(hass, second_entry)
+        endpoint = _SingleSlotEndpoint("first", "second")
+        first = _SingleSlotInverter(
+            "INV001",
+            _SingleSlotTransport(
+                endpoint,
+                operation_name="first",
+                host="EG4-GATEWAY.local",
+            ),
+        )
+        second = _SingleSlotInverter(
+            "INV002",
+            _SingleSlotTransport(
+                endpoint,
+                operation_name="second",
+                host="eg4-gateway.LOCAL",
+            ),
+        )
+        self._install_devices(first_coordinator, first)
+        self._install_devices(second_coordinator, second)
+
+        first_task = asyncio.create_task(
+            first_coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV001")
+        )
+        await endpoint.entered["first"].wait()
+        second_task = asyncio.create_task(
+            second_coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV002")
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["second"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_legacy_poll_and_write_do_not_overlap(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Deprecated single-transport polling uses the endpoint lock too."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("poll", "write")
+        transport = _SingleSlotTransport(endpoint, operation_name="poll")
+        inverter = _SingleSlotInverter("INV001", transport)
+        coordinator.station = None
+        coordinator._modbus_transport = transport  # type: ignore[assignment]
+        coordinator._inverter_cache = {"INV001": inverter}  # type: ignore[dict-item]
+        coordinator._local_parameters_loaded = True
+        coordinator._firmware_cache["INV001"] = "FAKE"
+        coordinator._read_modbus_parameters = AsyncMock(  # type: ignore[method-assign]
+            return_value=({}, True)
+        )
+        coordinator._build_local_device_data = MagicMock(  # type: ignore[method-assign]
+            return_value={"sensors": {}}
+        )
+
+        poll_task = asyncio.create_task(
+            coordinator._async_update_local_transport_data(
+                transport,
+                "INV001",
+                "18kPV",
+                "modbus",
+            )
+        )
+        await endpoint.entered["poll"].wait()
+        transport.operation_name = "write"
+        write_task = asyncio.create_task(
+            coordinator.write_named_parameter("FUNC_EPS_EN", True, "INV001")
+        )
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert not endpoint.entered["write"].is_set()
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(poll_task, write_task, return_exceptions=True)
+
+        assert endpoint.max_active == 1
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_shutdown_disconnect_bypasses_held_endpoint_lock(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Shutdown can close a socket to interrupt an in-flight read."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("poll")
+        transport = _SingleSlotTransport(endpoint, operation_name="poll")
+        inverter = _SingleSlotInverter("INV001", transport)
+        coordinator.station = None
+        coordinator._inverter_cache = {"INV001": inverter}  # type: ignore[dict-item]
+        coordinator._bind_device_endpoint_lock(inverter)
+
+        poll_task = asyncio.create_task(inverter.refresh())
+        await endpoint.entered["poll"].wait()
+        shutdown_task = asyncio.create_task(coordinator._disconnect_all_transports())
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(transport.disconnected.wait()), timeout=0.1
+            )
+        finally:
+            endpoint.release.set()
+            await asyncio.gather(poll_task, shutdown_task, return_exceptions=True)
+
+        assert transport.disconnected.is_set()
+
+    @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
+    @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
+    async def test_reconfigure_preserves_concrete_transport_behavior(
+        self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
+    ) -> None:
+        """Repeated configuration still updates concrete transport settings."""
+        hybrid_config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, hybrid_config_entry)
+        endpoint = _SingleSlotEndpoint("unused")
+        transport = _SingleSlotTransport(endpoint, operation_name="unused")
+        inverter = _SingleSlotInverter("INV001", transport)
+        coordinator.station = _mock_station([inverter])  # type: ignore[list-item]
+        coordinator._get_device_grid_type = MagicMock(  # type: ignore[method-assign]
+            side_effect=[GRID_TYPE_SPLIT_PHASE, "single_phase"]
+        )
+        coordinator._align_inverter_cache_ttls = MagicMock()  # type: ignore[method-assign]
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_local._LOCAL_REGISTER_TRANSPORTS",
+            (_SingleSlotTransport,),
+        ):
+            coordinator._configure_attached_devices()
+            assert transport.split_phase is True
+            coordinator._configure_attached_devices()
+
+        assert transport.split_phase is False
 
 
 class TestMidboxVoltageCanary:

--- a/tests/test_coordinator_http.py
+++ b/tests/test_coordinator_http.py
@@ -1958,6 +1958,8 @@ class _SingleSlotTransport:
         self.port = port
         self.is_connected = True
         self.disconnected = asyncio.Event()
+        self.shutdown_calls = 0
+        self.disconnect_calls = 0
         self.split_phase = False
         self._op_lock: Any = None
 
@@ -1984,7 +1986,19 @@ class _SingleSlotTransport:
         self.is_connected = True
 
     async def disconnect(self) -> None:
-        """Interrupt a pending read, matching coordinator shutdown semantics."""
+        """Model a reusable disconnect serialized behind the operation lock."""
+        self.disconnect_calls += 1
+        if self._op_lock is not None:
+            async with self._op_lock:
+                self.is_connected = False
+                self.disconnected.set()
+            return
+        self.is_connected = False
+        self.disconnected.set()
+
+    async def async_shutdown(self) -> None:
+        """Model pylxpweb terminal shutdown bypassing a held operation lock."""
+        self.shutdown_calls += 1
         self.is_connected = False
         self.disconnected.set()
         self.endpoint.release.set()
@@ -2470,7 +2484,7 @@ class TestPhysicalEndpointOperationSerialization:
 
     @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
     @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")
-    async def test_shutdown_disconnect_bypasses_held_endpoint_lock(
+    async def test_terminal_shutdown_bypasses_held_endpoint_lock(
         self, mock_aiohttp, mock_client_cls, hass, hybrid_config_entry
     ) -> None:
         """Shutdown can close a socket to interrupt an in-flight read."""
@@ -2495,6 +2509,8 @@ class TestPhysicalEndpointOperationSerialization:
             await asyncio.gather(poll_task, shutdown_task, return_exceptions=True)
 
         assert transport.disconnected.is_set()
+        assert transport.shutdown_calls == 1
+        assert transport.disconnect_calls == 0
 
     @patch("custom_components.eg4_web_monitor.coordinator.LuxpowerClient")
     @patch("custom_components.eg4_web_monitor.coordinator.aiohttp_client")


### PR DESCRIPTION
## Summary

- own one task-reentrant operation lock per physical network endpoint or serial adapter
- share that lock across logical devices and separate EG4 config-entry coordinators in the same Home Assistant instance
- bind HYBRID/LOCAL/legacy polls, direct writes, deferred parameter reads, quick-charge reads, parameter refreshes, and buffer drains to the shared endpoint boundary
- keep independent endpoints concurrent and preserve concrete pylxpweb transport identity

## Root cause

The coordinator already grouped normal polls by endpoint, but that only serialized poll-versus-poll work inside one update coroutine. pylxpweb correctly protects multi-register operations with a task-reentrant `_op_lock`, but each logical device receives a separate transport object and therefore a separate lock.

That left physical single-slot hardware unprotected across object boundaries: a poll for device A could overlap a named/raw write, deferred parameter load, quick-charge register read, parameter refresh, or startup buffer drain for device B. Separate config entries could also construct independent coordinators for the same endpoint and bypass a coordinator-local registry.

## Design

`EndpointOperationLock` mirrors pylxpweb's task-reentrant operation-lock contract. The integration installs one Home Assistant-scoped instance into every pinned pylxpweb transport sharing a normalized `host:port` or serial-port key. Reusing pylxpweb's existing operation seam has three useful properties:

- complete transport operations remain atomic, including nested named-parameter read/modify/write calls
- concrete `ModbusTransport`, `ModbusSerialTransport`, and `DongleTransport` identity is preserved; no proxy changes `isinstance`, attributes, mocks, or shutdown de-duplication
- steady-state work pays only the existing transport lock acquisition; repeated binding is an identity check, and different endpoints still run concurrently

Reconnect plus write is held as one endpoint transaction so two disconnected device objects cannot dial a single-slot endpoint together. Disconnect is deliberately not held behind the operation lock: coordinator shutdown must close the socket immediately to interrupt a hung read before cancelling background tasks.

## Regression coverage

The deterministic fake single-slot endpoint covers:

- poll versus write on one TCP endpoint
- two devices on one serial adapter
- deferred parameter work versus write
- reconnect plus write on disconnected device transports
- separate config-entry coordinators sharing one physical endpoint
- the deprecated single-device transport path
- shutdown interrupting a lock-held read
- task-reentrant nested operations
- concrete transport behavior after repeated configuration
- continued concurrency for independent endpoints

## Verification

- `pytest -q tests` — **2556 passed, 3 skipped**
- endpoint/group focus — **14 passed**
- coordinator/local/write-path focus — **592 passed** before the final added reconnect regression; the full suite above includes it
- `mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — success, 42 source files
- `prek run --all-files` with the project virtualenv on `PATH` — all hooks passed (YAML, EOF, whitespace, large files, Ruff, Ruff format, mypy)
- `git diff --check` — clean

## Companion PR context

- Audit/RCA index: #524 (ARC-01)
- Mixed transport cadence/starvation fix: #523; orthogonal to this physical-operation boundary
- pylxpweb atomic Quick Charge/H233 logical transaction: joyfulhouse/pylxpweb#260; complementary per-device RMW protection, while this PR protects across transport instances sharing hardware

No register mappings, entity behavior, or polling intervals change in this PR.


## Terminal lifecycle reconciliation

A paired integration/dependency review found that the coordinator only selected transports whose `is_connected` flag was already true. A dongle still inside `connect()` deliberately keeps that flag false until the socket and initial-data phase are usable, so entry unload could skip the terminal seam and allow the old transport to finish connecting after reload. The station de-duplication pass also pre-marked cached identities before proving shutdown had run.

The final shutdown pass now:

- collects legacy, inverter-cache, MID-cache, and station-attached transports before dispatch
- de-duplicates object identities across all four sources
- invokes a concrete `async_shutdown()` regardless of the transient connected flag
- retains reusable `disconnect()` only for older transports that report a live connection

Deterministic regressions cover cached and uncached station transports with a connect held in flight, cache/station identity duplication, no resurrection, and clients without the optional terminal method.

Companion dependency PR joyfulhouse/pylxpweb#263 makes the terminal flag authoritative across connect and request retry boundaries.

Reconciliation verification at `d71c680`:

- shutdown/endpoint focus: **24 passed**
- full integration suite: **2556 passed, 3 skipped**
- Ruff and Ruff format: passed
- strict mypy: **42 source files clean**
- all prek hooks: passed
- `git diff --check`: clean