### PR TITLE
Fix multi-entry logging and registry cleanup lifecycle

### DIFF
--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -1,6 +1,7 @@
 """EG4 Web Monitor integration for Home Assistant."""
 
 import asyncio
+from dataclasses import dataclass, field
 import logging
 from typing import Any, TypeAlias
 
@@ -24,6 +25,8 @@ from homeassistant.helpers.storage import Store
 from .const import (
     CONF_CONNECTION_TYPE,
     CONF_HTTP_POLLING_INTERVAL,
+    CONF_LIBRARY_DEBUG,
+    CONF_LOCAL_TRANSPORTS,
     CONF_SENSOR_UPDATE_INTERVAL,
     CONNECTION_TYPE_HTTP,
     DEFAULT_HTTP_POLLING_INTERVAL,
@@ -148,6 +151,182 @@ RECONCILE_HISTORY_SCHEMA = vol.Schema(
 
 # Config entry only - no YAML configuration supported
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+_LIBRARY_LOGGING_DATA_KEY = f"{DOMAIN}_library_logging"
+
+
+@dataclass(slots=True)
+class _LibraryLoggingState:
+    """Home Assistant-scoped ownership of the process-global library logger."""
+
+    original_level: int
+    entry_preferences: dict[str, bool] = field(default_factory=dict)
+
+
+@callback
+def _async_register_library_logging(hass: HomeAssistant, entry: EG4ConfigEntry) -> None:
+    """Register one loaded entry's preference and reconcile the shared logger."""
+    pylxpweb_logger = logging.getLogger("pylxpweb")
+    state = hass.data.get(_LIBRARY_LOGGING_DATA_KEY)
+    if not isinstance(state, _LibraryLoggingState):
+        state = _LibraryLoggingState(original_level=pylxpweb_logger.level)
+        hass.data[_LIBRARY_LOGGING_DATA_KEY] = state
+
+    state.entry_preferences[entry.entry_id] = bool(
+        entry.options.get(
+            CONF_LIBRARY_DEBUG,
+            entry.data.get(CONF_LIBRARY_DEBUG, False),
+        )
+    )
+    debug_enabled = any(state.entry_preferences.values())
+    pylxpweb_logger.setLevel(logging.DEBUG if debug_enabled else logging.WARNING)
+    _LOGGER.debug(
+        "Reconciled pylxpweb logging for %d loaded entries: %s",
+        len(state.entry_preferences),
+        "DEBUG" if debug_enabled else "WARNING",
+    )
+
+
+@callback
+def _async_unregister_library_logging(
+    hass: HomeAssistant, entry: EG4ConfigEntry
+) -> None:
+    """Drop one entry's preference and restore the remaining/baseline level."""
+    state = hass.data.get(_LIBRARY_LOGGING_DATA_KEY)
+    if not isinstance(state, _LibraryLoggingState):
+        return
+
+    state.entry_preferences.pop(entry.entry_id, None)
+    pylxpweb_logger = logging.getLogger("pylxpweb")
+    if state.entry_preferences:
+        debug_enabled = any(state.entry_preferences.values())
+        pylxpweb_logger.setLevel(logging.DEBUG if debug_enabled else logging.WARNING)
+        return
+
+    pylxpweb_logger.setLevel(state.original_level)
+    hass.data.pop(_LIBRARY_LOGGING_DATA_KEY, None)
+
+
+def _domain_device_identifiers(device: dr.DeviceEntry) -> set[str]:
+    """Return this integration's identifiers from one registry device."""
+    return {identifier for domain, identifier in device.identifiers if domain == DOMAIN}
+
+
+@callback
+def _async_remove_registry_ownership(
+    hass: HomeAssistant,
+    entry: EG4ConfigEntry,
+    *,
+    device_ids: set[str] | None = None,
+) -> tuple[int, int]:
+    """Remove this entry's entities/devices without deleting shared identities.
+
+    If ``device_ids`` is provided, only that device subtree is detached (the
+    reconfigure path).  Otherwise all records owned by the entry are removed
+    (the config-entry deletion path).  A device linked to another config entry
+    is retained and only this entry's ownership is removed.
+    """
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    entry_devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    if device_ids is not None:
+        entry_devices = [device for device in entry_devices if device.id in device_ids]
+
+    removed_entities = 0
+    for entity in list(
+        er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    ):
+        if device_ids is not None and entity.device_id not in device_ids:
+            continue
+        entity_registry.async_remove(entity.entity_id)
+        removed_entities += 1
+
+    removed_devices = 0
+    for device in entry_devices:
+        # The registry itself deletes a device when its final config-entry link
+        # is removed.  Keep shared devices by detaching only this entry; remove
+        # exclusively-owned devices explicitly after their entities are gone.
+        other_config_entries = device.config_entries - {entry.entry_id}
+        if other_config_entries:
+            device_registry.async_update_device(
+                device.id, remove_config_entry_id=entry.entry_id
+            )
+            continue
+        device_registry.async_remove_device(device.id)
+        removed_devices += 1
+
+    return removed_entities, removed_devices
+
+
+@callback
+def _async_cleanup_removed_registry_devices(
+    hass: HomeAssistant,
+    entry: EG4ConfigEntry,
+    coordinator: EG4DataUpdateCoordinator,
+) -> None:
+    """Prune serial/plant device trees absent after a successful first refresh.
+
+    Only authoritative root identities are considered: station identifiers and
+    physical devices carrying a serial number.  Battery banks and individual
+    batteries are never inferred absent from the LOCAL static first refresh;
+    they are removed only as descendants of a definitively absent parent.
+    """
+    data = coordinator.data or {}
+    live_root_identifiers = {str(serial) for serial in data.get("devices", {})}
+    live_root_identifiers.update(
+        str(transport["serial"])
+        for transport in entry.data.get(CONF_LOCAL_TRANSPORTS, [])
+        if transport.get("serial")
+    )
+    if coordinator.station is not None:
+        for collection_name in ("all_inverters", "all_mid_devices"):
+            for device in getattr(coordinator.station, collection_name, ()) or ():
+                if serial := getattr(device, "serial_number", None):
+                    live_root_identifiers.add(str(serial))
+    if "station" in data and coordinator.plant_id is not None:
+        live_root_identifiers.add(f"station_{coordinator.plant_id}")
+
+    device_registry = dr.async_get(hass)
+    entry_devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    stale_device_ids: set[str] = set()
+    for device in entry_devices:
+        identifiers = _domain_device_identifiers(device)
+        if not identifiers:
+            continue
+        is_station = any(
+            identifier.startswith("station_") for identifier in identifiers
+        )
+        is_physical_device = device.serial_number is not None
+        if (is_station or is_physical_device) and identifiers.isdisjoint(
+            live_root_identifiers
+        ):
+            stale_device_ids.add(device.id)
+
+    # Remove every descendant of a stale root, but do not inspect battery
+    # membership independently: it is intentionally incomplete at LOCAL setup.
+    while True:
+        descendants = {
+            device.id
+            for device in entry_devices
+            if device.via_device_id in stale_device_ids
+        }
+        expanded = stale_device_ids | descendants
+        if expanded == stale_device_ids:
+            break
+        stale_device_ids = expanded
+
+    if not stale_device_ids:
+        return
+
+    entity_count, device_count = _async_remove_registry_ownership(
+        hass, entry, device_ids=stale_device_ids
+    )
+    _LOGGER.info(
+        "Removed %d stale entities and %d stale devices after reconfigure for %s",
+        entity_count,
+        device_count,
+        entry.entry_id,
+    )
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
@@ -595,20 +774,22 @@ def _async_cleanup_stale_smart_port_entities(
 
 async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
     """Set up EG4 Web Monitor from a config entry."""
+    _async_register_library_logging(hass, entry)
+    try:
+        setup_ok = await _async_setup_entry(hass, entry)
+    except BaseException:
+        # Setup failures and cancellation must not leave a process-global
+        # logger preference owned by an entry that never became loaded.
+        _async_unregister_library_logging(hass, entry)
+        raise
+    if not setup_ok:
+        _async_unregister_library_logging(hass, entry)
+    return setup_ok
+
+
+async def _async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
+    """Set up an entry after its shared logging ownership is registered."""
     _LOGGER.debug("Setting up EG4 Web Monitor entry: %s", entry.entry_id)
-
-    # Configure library debug logging based on user preference (options, data fallback)
-    library_debug = entry.options.get(
-        "library_debug", entry.data.get("library_debug", False)
-    )
-    pylxpweb_logger = logging.getLogger("pylxpweb")
-
-    if library_debug:
-        pylxpweb_logger.setLevel(logging.DEBUG)
-        _LOGGER.info("Enabled DEBUG logging for pylxpweb library")
-    else:
-        # Set to WARNING to suppress INFO logs from library
-        pylxpweb_logger.setLevel(logging.WARNING)
 
     # Force-migrate: add HTTP polling interval for existing entries
     # and bump HTTP-only users below 60s minimum to 90s default
@@ -655,6 +836,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool:
 
     # Store coordinator in runtime_data
     entry.runtime_data = coordinator
+
+    # Reconfigure reloads retain Home Assistant registry records by default.
+    # Remove only physical serial/station trees proven absent by this fresh
+    # first refresh, preserving shared devices and incomplete battery data.
+    _async_cleanup_removed_registry_devices(hass, entry, coordinator)
 
     # One-time migration: remove stale local-format battery entities
     # Old local keys used numeric-only battery indices (e.g., "0", "1")
@@ -872,6 +1058,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> bool
         if coordinator.client is not None:
             await coordinator.client.close()
 
+        _async_unregister_library_logging(hass, entry)
+
     return bool(unload_ok)
 
 
@@ -882,8 +1070,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> None
     It purges all statistics for this integration's entities, allowing
     TOTAL_INCREASING sensors to reset when the integration is re-added.
 
-    Entity Registry entries (names, areas, labels) are NOT deleted,
-    so they will be automatically restored when re-adding the integration.
+    Entity/device registry records owned only by this entry are deleted. Shared
+    devices survive with their remaining config-entry ownership intact.
     """
     _LOGGER.info("Removing EG4 Web Monitor entry: %s", entry.entry_id)
 
@@ -926,6 +1114,13 @@ async def async_remove_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> None
             _LOGGER.warning("Failed to purge entity statistics: %s", e)
     else:
         _LOGGER.debug("No entities found to purge statistics for")
+
+    removed_entities, removed_devices = _async_remove_registry_ownership(hass, entry)
+    _LOGGER.info(
+        "Removed %d entity registry entries and %d exclusively-owned devices",
+        removed_entities,
+        removed_devices,
+    )
 
     await Store(
         hass,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,10 @@
 """Tests for __init__.py (setup and teardown) in EG4 Web Monitor integration."""
 
 import logging
-import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,11 @@
 """Tests for __init__.py (setup and teardown) in EG4 Web Monitor integration."""
 
+import logging
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -25,6 +28,7 @@ from custom_components.eg4_web_monitor.const import (
     CONF_BASE_URL,
     CONF_CONNECTION_TYPE,
     CONF_DST_SYNC,
+    CONF_LIBRARY_DEBUG,
     CONF_PLANT_ID,
     CONF_PLANT_NAME,
     CONF_VERIFY_SSL,
@@ -323,6 +327,411 @@ class TestAsyncSetupEntry:
             assert "switch" in all_platforms
             assert "button" in all_platforms
             assert "select" in all_platforms
+
+
+class TestLibraryLoggingLifecycle:
+    """Regression coverage for process-global pylxpweb logger ownership."""
+
+    @staticmethod
+    def _coordinator() -> MagicMock:
+        """Build a coordinator double that can be set up and unloaded."""
+        coordinator = MagicMock()
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock()
+        coordinator.async_shutdown = AsyncMock()
+        coordinator.client = None
+        coordinator.data = {"devices": {}, "device_info": {}, "parameters": {}}
+        return coordinator
+
+    @staticmethod
+    def _entry(entry_id: str, *, library_debug: bool) -> MockConfigEntry:
+        """Build one independently configurable HTTP entry."""
+        return MockConfigEntry(
+            domain=DOMAIN,
+            title=entry_id,
+            entry_id=entry_id,
+            data={
+                CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP,
+                CONF_USERNAME: entry_id,
+                CONF_PASSWORD: "secret",
+                CONF_PLANT_ID: entry_id,
+            },
+            options={CONF_LIBRARY_DEBUG: library_debug},
+        )
+
+    async def test_preferences_compose_and_successful_unload_reconciles(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Any debug owner wins; unloading restores the remaining preference."""
+        logger = logging.getLogger("pylxpweb")
+        original_level = logger.level
+        logger.setLevel(logging.ERROR)
+        debug_entry = self._entry("debug_entry", library_debug=True)
+        quiet_entry = self._entry("quiet_entry", library_debug=False)
+        debug_entry.add_to_hass(hass)
+        quiet_entry.add_to_hass(hass)
+        debug_coordinator = self._coordinator()
+        quiet_coordinator = self._coordinator()
+
+        try:
+            with (
+                patch(
+                    "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                    side_effect=[debug_coordinator, quiet_coordinator],
+                ),
+                patch.object(
+                    hass.config_entries,
+                    "async_forward_entry_setups",
+                    new=AsyncMock(),
+                ),
+                patch.object(
+                    hass.config_entries,
+                    "async_unload_platforms",
+                    new=AsyncMock(return_value=True),
+                ),
+            ):
+                assert await async_setup_entry(hass, debug_entry)
+                assert logger.level == logging.DEBUG
+
+                # The later quiet entry must not disable the existing owner.
+                assert await async_setup_entry(hass, quiet_entry)
+                assert logger.level == logging.DEBUG
+
+                assert await async_unload_entry(hass, debug_entry)
+                assert logger.level == logging.WARNING
+
+                assert await async_unload_entry(hass, quiet_entry)
+                assert logger.level == logging.ERROR
+        finally:
+            logger.setLevel(original_level)
+
+    async def test_failed_setup_rolls_back_debug_ownership(
+        self, hass: HomeAssistant
+    ) -> None:
+        """An entry that never loads cannot leave process-global DEBUG behind."""
+        logger = logging.getLogger("pylxpweb")
+        original_level = logger.level
+        logger.setLevel(logging.ERROR)
+        entry = self._entry("failed_entry", library_debug=True)
+        entry.add_to_hass(hass)
+        coordinator = self._coordinator()
+        coordinator.async_config_entry_first_refresh.side_effect = RuntimeError("boom")
+
+        try:
+            with patch(
+                "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                return_value=coordinator,
+            ):
+                with pytest.raises(RuntimeError, match="boom"):
+                    await async_setup_entry(hass, entry)
+            assert logger.level == logging.ERROR
+        finally:
+            logger.setLevel(original_level)
+
+    async def test_failed_unload_keeps_loaded_entry_preference(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A platform unload failure leaves the still-loaded owner's level intact."""
+        logger = logging.getLogger("pylxpweb")
+        original_level = logger.level
+        logger.setLevel(logging.ERROR)
+        entry = self._entry("loaded_entry", library_debug=True)
+        entry.add_to_hass(hass)
+        coordinator = self._coordinator()
+
+        try:
+            with (
+                patch(
+                    "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                    return_value=coordinator,
+                ),
+                patch.object(
+                    hass.config_entries,
+                    "async_forward_entry_setups",
+                    new=AsyncMock(),
+                ),
+                patch.object(
+                    hass.config_entries,
+                    "async_unload_platforms",
+                    new=AsyncMock(return_value=False),
+                ),
+            ):
+                assert await async_setup_entry(hass, entry)
+                assert not await async_unload_entry(hass, entry)
+                assert logger.level == logging.DEBUG
+        finally:
+            logger.setLevel(original_level)
+
+
+class TestRegistryLifecycleCleanup:
+    """Regression coverage for removed serial/plant registry ownership."""
+
+    @staticmethod
+    def _seed_device(
+        hass: HomeAssistant,
+        entry: MockConfigEntry,
+        identifier: str,
+        *,
+        serial_number: str | None = None,
+        via_device: tuple[str, str] | None = None,
+    ):
+        """Create one domain device linked to a config entry."""
+        return dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, identifier)},
+            name=identifier,
+            manufacturer="EG4 Electronics",
+            model="Test Device",
+            serial_number=serial_number,
+            via_device=via_device,
+        )
+
+    @staticmethod
+    def _seed_entity(
+        hass: HomeAssistant,
+        entry: MockConfigEntry,
+        device_id: str,
+        unique_id: str,
+    ):
+        """Create one registry entity owned by an entry and device."""
+        return er.async_get(hass).async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=entry,
+            device_id=device_id,
+        )
+
+    @staticmethod
+    def _coordinator(data: dict, *, plant_id: str | None = None) -> MagicMock:
+        """Build a setup-capable coordinator with authoritative first data."""
+        coordinator = MagicMock()
+        coordinator._async_load_pv_string_lifetime_state = AsyncMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock()
+        coordinator.async_shutdown = AsyncMock()
+        coordinator.client = None
+        coordinator.data = data
+        coordinator.plant_id = plant_id
+        coordinator.station = None
+        return coordinator
+
+    async def test_setup_preserves_device_in_authoritative_station_membership(
+        self, hass: HomeAssistant, mock_config_entry
+    ) -> None:
+        """A transient processing omission cannot delete a cloud station member."""
+        mock_config_entry.add_to_hass(hass)
+        live = self._seed_device(
+            hass, mock_config_entry, "CLOUDLIVE", serial_number="CLOUDLIVE"
+        )
+        live_entity = self._seed_entity(
+            hass, mock_config_entry, live.id, "CLOUDLIVE_output_power"
+        )
+        coordinator = self._coordinator(
+            {
+                "station": {"name": "Current"},
+                "devices": {},
+                "device_info": {},
+                "parameters": {},
+            },
+            plant_id="current",
+        )
+        coordinator.station = SimpleNamespace(
+            all_inverters=[SimpleNamespace(serial_number="CLOUDLIVE")],
+            all_mid_devices=[],
+        )
+
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                return_value=coordinator,
+            ),
+            patch.object(
+                hass.config_entries, "async_forward_entry_setups", new=AsyncMock()
+            ),
+        ):
+            assert await async_setup_entry(hass, mock_config_entry)
+
+        assert dr.async_get(hass).async_get_device({(DOMAIN, "CLOUDLIVE")}) is not None
+        assert er.async_get(hass).async_get(live_entity.entity_id) is not None
+
+    async def test_setup_prunes_removed_serial_tree_and_old_station(
+        self, hass: HomeAssistant, mock_config_entry
+    ) -> None:
+        """A successful reconfigure reload removes absent roots and descendants."""
+        mock_config_entry.add_to_hass(hass)
+        device_registry = dr.async_get(hass)
+        entity_registry = er.async_get(hass)
+
+        live = self._seed_device(
+            hass, mock_config_entry, "LIVE123", serial_number="LIVE123"
+        )
+        live_entity = self._seed_entity(
+            hass, mock_config_entry, live.id, "LIVE123_output_power"
+        )
+        stale = self._seed_device(
+            hass, mock_config_entry, "STALE123", serial_number="STALE123"
+        )
+        stale_bank = self._seed_device(
+            hass,
+            mock_config_entry,
+            "STALE123_battery_bank",
+            via_device=(DOMAIN, "STALE123"),
+        )
+        stale_battery = self._seed_device(
+            hass,
+            mock_config_entry,
+            "BAT-STALE",
+            via_device=(DOMAIN, "STALE123_battery_bank"),
+        )
+        stale_entities = [
+            self._seed_entity(
+                hass, mock_config_entry, stale.id, "STALE123_output_power"
+            ),
+            self._seed_entity(
+                hass,
+                mock_config_entry,
+                stale_bank.id,
+                "STALE123_battery_bank_soc",
+            ),
+            self._seed_entity(
+                hass,
+                mock_config_entry,
+                stale_battery.id,
+                "STALE123_BAT-STALE_soc",
+            ),
+        ]
+        old_station = self._seed_device(hass, mock_config_entry, "station_old")
+        old_station_entity = self._seed_entity(
+            hass, mock_config_entry, old_station.id, "station_old_name"
+        )
+        current_station = self._seed_device(hass, mock_config_entry, "station_current")
+        current_station_entity = self._seed_entity(
+            hass, mock_config_entry, current_station.id, "station_current_name"
+        )
+
+        coordinator = self._coordinator(
+            {
+                "station": {"name": "Current"},
+                "devices": {
+                    "LIVE123": {
+                        "type": "inverter",
+                        "model": "Test",
+                        "sensors": {},
+                        "batteries": {},
+                    }
+                },
+                "device_info": {},
+                "parameters": {},
+            },
+            plant_id="current",
+        )
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                return_value=coordinator,
+            ),
+            patch.object(
+                hass.config_entries, "async_forward_entry_setups", new=AsyncMock()
+            ),
+        ):
+            assert await async_setup_entry(hass, mock_config_entry)
+
+        assert device_registry.async_get_device({(DOMAIN, "LIVE123")}) is not None
+        assert entity_registry.async_get(live_entity.entity_id) is not None
+        assert (
+            device_registry.async_get_device({(DOMAIN, "station_current")}) is not None
+        )
+        assert entity_registry.async_get(current_station_entity.entity_id) is not None
+        for identifier in ("STALE123", "STALE123_battery_bank", "BAT-STALE"):
+            assert device_registry.async_get_device({(DOMAIN, identifier)}) is None
+        assert device_registry.async_get_device({(DOMAIN, "station_old")}) is None
+        for entity in (*stale_entities, old_station_entity):
+            assert entity_registry.async_get(entity.entity_id) is None
+
+    async def test_setup_detaches_but_preserves_shared_stale_device(
+        self, hass: HomeAssistant, mock_config_entry
+    ) -> None:
+        """Cleanup removes only this entry's ownership from a shared identity."""
+        mock_config_entry.add_to_hass(hass)
+        other_entry = MockConfigEntry(
+            domain=DOMAIN, entry_id="other_entry", data={CONF_PLANT_ID: "other"}
+        )
+        other_entry.add_to_hass(hass)
+        shared = self._seed_device(
+            hass, mock_config_entry, "SHARED123", serial_number="SHARED123"
+        )
+        # A second get-or-create links the same physical identity to another entry.
+        same_shared = self._seed_device(
+            hass, other_entry, "SHARED123", serial_number="SHARED123"
+        )
+        assert same_shared.id == shared.id
+        current_entity = self._seed_entity(
+            hass, mock_config_entry, shared.id, "current_shared_power"
+        )
+        other_entity = self._seed_entity(
+            hass, other_entry, shared.id, "other_shared_power"
+        )
+        coordinator = self._coordinator(
+            {"devices": {}, "device_info": {}, "parameters": {}}
+        )
+
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.EG4DataUpdateCoordinator",
+                return_value=coordinator,
+            ),
+            patch.object(
+                hass.config_entries, "async_forward_entry_setups", new=AsyncMock()
+            ),
+        ):
+            assert await async_setup_entry(hass, mock_config_entry)
+
+        surviving = dr.async_get(hass).async_get_device({(DOMAIN, "SHARED123")})
+        assert surviving is not None
+        assert surviving.config_entries == {other_entry.entry_id}
+        assert er.async_get(hass).async_get(current_entity.entity_id) is None
+        assert er.async_get(hass).async_get(other_entity.entity_id) is not None
+
+    async def test_entry_removal_deletes_owned_records_but_not_shared_records(
+        self, hass: HomeAssistant, mock_config_entry
+    ) -> None:
+        """Deleting an entry purges its registry ownership without collateral loss."""
+        mock_config_entry.add_to_hass(hass)
+        other_entry = MockConfigEntry(
+            domain=DOMAIN, entry_id="other_entry", data={CONF_PLANT_ID: "other"}
+        )
+        other_entry.add_to_hass(hass)
+        exclusive = self._seed_device(
+            hass, mock_config_entry, "EXCLUSIVE123", serial_number="EXCLUSIVE123"
+        )
+        exclusive_entity = self._seed_entity(
+            hass, mock_config_entry, exclusive.id, "exclusive_power"
+        )
+        shared = self._seed_device(
+            hass, mock_config_entry, "SHARED123", serial_number="SHARED123"
+        )
+        self._seed_device(hass, other_entry, "SHARED123", serial_number="SHARED123")
+        current_shared_entity = self._seed_entity(
+            hass, mock_config_entry, shared.id, "current_shared_power"
+        )
+        other_shared_entity = self._seed_entity(
+            hass, other_entry, shared.id, "other_shared_power"
+        )
+        store = MagicMock()
+        store.async_remove = AsyncMock()
+
+        with patch("custom_components.eg4_web_monitor.Store", return_value=store):
+            await async_remove_entry(hass, mock_config_entry)
+
+        device_registry = dr.async_get(hass)
+        entity_registry = er.async_get(hass)
+        assert device_registry.async_get_device({(DOMAIN, "EXCLUSIVE123")}) is None
+        assert entity_registry.async_get(exclusive_entity.entity_id) is None
+        surviving = device_registry.async_get_device({(DOMAIN, "SHARED123")})
+        assert surviving is not None
+        assert surviving.config_entries == {other_entry.entry_id}
+        assert entity_registry.async_get(current_shared_entity.entity_id) is None
+        assert entity_registry.async_get(other_shared_entity.entity_id) is not None
 
 
 class TestSmartPortCleanupOnReboot:


### PR DESCRIPTION
## RCA

The pylxpweb logger is process-global, but each config-entry setup wrote its level directly. Load order therefore decided the effective preference, failed setup leaked the chosen level, and unload never reconciled the remaining entries.

Reconfigure reloads also retained registry records for serials and plants removed from configuration. Blind cleanup would be unsafe because local startup battery data is incomplete and a physical device can be shared by multiple entries.

## Changes

- Track per-entry library-debug ownership in Home Assistant scope; DEBUG wins if any loaded entry requests it, quiet entries compose at WARNING, failed setup rolls back, failed unload retains ownership, and the final unload restores the pre-integration level.
- After a successful first refresh, compare physical serial/station roots against current processed data, configured local transports, and authoritative cloud station membership.
- Prune only definitively absent roots and their descendant device tree; never infer missing batteries from the local static startup snapshot.
- Remove only this entries entities/config ownership from shared registry devices.
- On config-entry deletion, deterministically remove owned entity/device records after statistics purge while preserving identities owned by another entry.

## Verification

- 7 focused lifecycle regressions passed
- Full suite: 2550 passed, 3 skipped
- Ruff lint and format passed
- Strict mypy passed for all 41 integration source files
- Full prek suite passed
- git diff --check passed

Audit: #524
Tracking: eg4-06er.10