### PR TITLE
perf: scope coordinator listener fanout

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -36,7 +36,11 @@ from .const import (
     MANUFACTURER,
     SENSOR_TYPES,
 )
-from .coordinator import EG4DataUpdateCoordinator
+from .coordinator import (
+    STATION_LISTENER_CONTEXT,
+    EG4DataUpdateCoordinator,
+    device_listener_context,
+)
 from .utils import (
     async_write_with_cloud_fallback,
     clean_model_name,
@@ -80,7 +84,7 @@ class EG4DeviceEntity(CoordinatorEntity):
             coordinator: The data update coordinator.
             serial: The device serial number.
         """
-        super().__init__(coordinator)
+        super().__init__(coordinator, context=device_listener_context(serial))
         self.coordinator: EG4DataUpdateCoordinator = coordinator
         self._serial = serial
 
@@ -137,7 +141,7 @@ class EG4BatteryEntity(CoordinatorEntity):
             parent_serial: The serial number of the parent inverter device.
             battery_key: The unique key identifying this battery.
         """
-        super().__init__(coordinator)
+        super().__init__(coordinator, context=device_listener_context(parent_serial))
         self.coordinator: EG4DataUpdateCoordinator = coordinator
         self._parent_serial = parent_serial
         self._battery_key = battery_key
@@ -192,7 +196,7 @@ class EG4StationEntity(CoordinatorEntity):
         Args:
             coordinator: The data update coordinator.
         """
-        super().__init__(coordinator)
+        super().__init__(coordinator, context=STATION_LISTENER_CONTEXT)
         self.coordinator: EG4DataUpdateCoordinator = coordinator
 
     @property

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -18,7 +18,11 @@ else:
 
 from . import EG4ConfigEntry
 from .base_entity import EG4BatteryEntity, EG4DeviceEntity, EG4StationEntity
-from .coordinator import EG4DataUpdateCoordinator
+from .coordinator import (
+    DISCOVERY_LISTENER_CONTEXT,
+    EG4DataUpdateCoordinator,
+    listener_changed_device_items,
+)
 from .utils import (
     generate_entity_id,
     generate_unique_id,
@@ -132,7 +136,7 @@ async def async_setup_entry(
         if not coordinator.data or "devices" not in coordinator.data:
             return
         new_entities: list[ButtonEntity] = []
-        for serial, device_data in coordinator.data["devices"].items():
+        for serial, device_data in listener_changed_device_items(coordinator):
             known = known_battery_keys.setdefault(serial, set())
             for battery_key in device_data.get("batteries", {}):
                 if battery_key in known:
@@ -153,7 +157,9 @@ async def async_setup_entry(
             async_add_entities(new_entities)
 
     entry.async_on_unload(
-        coordinator.async_add_listener(_async_discover_battery_buttons)
+        coordinator.async_add_listener(
+            _async_discover_battery_buttons, DISCOVERY_LISTENER_CONTEXT
+        )
     )
 
 

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from copy import deepcopy
+from dataclasses import dataclass
 import logging
 import time
 from datetime import datetime, timedelta
@@ -114,20 +115,28 @@ from .utils import async_write_with_cloud_fallback
 
 _LOGGER = logging.getLogger(__name__)
 
-ListenerContext = tuple[str, str]
-STATION_LISTENER_CONTEXT: ListenerContext = ("station", "")
-DISCOVERY_LISTENER_CONTEXT: ListenerContext = ("discovery", "")
+
+@dataclass(frozen=True, slots=True)
+class _ListenerContext:
+    """Private runtime key for listener scopes owned by this integration."""
+
+    kind: str
+    serial: str = ""
 
 
-def device_listener_context(serial: str) -> ListenerContext:
+STATION_LISTENER_CONTEXT = _ListenerContext("station")
+DISCOVERY_LISTENER_CONTEXT = _ListenerContext("discovery")
+
+
+def device_listener_context(serial: str) -> _ListenerContext:
     """Return the listener context shared by one device and its descendants."""
-    return ("device", str(serial))
+    return _ListenerContext("device", str(serial))
 
 
 def _listener_contexts_for_data_change(
     old: dict[str, Any] | None,
     new: dict[str, Any],
-) -> set[ListenerContext] | None:
+) -> set[_ListenerContext] | None:
     """Return scoped listeners affected by a coordinator data transition.
 
     ``None`` means an unclassified/initial transition and therefore requests a
@@ -138,7 +147,7 @@ def _listener_contexts_for_data_change(
     if old is None:
         return None
 
-    contexts: set[ListenerContext] = set()
+    contexts: set[_ListenerContext] = set()
     old_devices = old.get("devices") or {}
     new_devices = new.get("devices") or {}
     changed_serials = {
@@ -184,9 +193,9 @@ def listener_changed_device_items(
     if not isinstance(active_contexts, set):
         return list(devices.items())
     changed_serials = {
-        serial
-        for kind, serial in active_contexts
-        if kind == "device" and serial in devices
+        context.serial
+        for context in active_contexts
+        if context.kind == "device" and context.serial in devices
     }
     return [(serial, devices[serial]) for serial in sorted(changed_serials)]
 
@@ -587,8 +596,8 @@ class EG4DataUpdateCoordinator(
         # smallest context they consume. Each refresh compares against a deep
         # pre-route snapshot because LOCAL carry-forward deliberately reuses
         # device dict objects and may mutate them while marking link failures.
-        self._pending_listener_contexts: set[ListenerContext] | None = None
-        self._active_listener_contexts: set[ListenerContext] | None = None
+        self._pending_listener_contexts: set[_ListenerContext] | None = None
+        self._active_listener_contexts: set[_ListenerContext] | None = None
         self._last_listener_update_success: bool | None = None
 
         # Register shutdown listener to cancel background tasks on Home Assistant stop
@@ -619,10 +628,6 @@ class EG4DataUpdateCoordinator(
             previous_data = deepcopy(self.data)
         except Exception:  # pragma: no cover - defensive for future opaque values
             previous_data = None
-        # An exception before a new data snapshot is produced represents no
-        # value change. Availability transitions are handled at dispatch.
-        self._pending_listener_contexts = set()
-
         # Clear device_info caches at the start of each update cycle
         # so fresh data is used for any new entity registrations
         self.clear_device_info_caches()
@@ -671,10 +676,11 @@ class EG4DataUpdateCoordinator(
     def async_update_listeners(self) -> None:
         """Notify only listeners whose consumed coordinator scope changed.
 
-        Unscoped listeners retain Home Assistant's default always-notify
-        contract. Initial data and availability transitions always notify the
-        full graph. Scoped unchanged listeners are skipped, including on a
-        repeated failure after their unavailable state was already published.
+        Unscoped and foreign-context listeners retain Home Assistant's default
+        always-notify contract. Initial data and availability transitions always
+        notify the full graph. Only this integration's private scoped contexts
+        are filtered, including on a repeated failure after their unavailable
+        state was already published.
         """
         contexts = self._pending_listener_contexts
         availability_changed = (
@@ -686,11 +692,15 @@ class EG4DataUpdateCoordinator(
         selected_contexts = contexts if contexts is not None else set()
         try:
             for update_callback, context in list(self._listeners.values()):
-                if notify_all or context is None or context in selected_contexts:
+                if (
+                    notify_all
+                    or not isinstance(context, _ListenerContext)
+                    or context in selected_contexts
+                ):
                     update_callback()
         finally:
             self._last_listener_update_success = self.last_update_success
-            self._pending_listener_contexts = set()
+            self._pending_listener_contexts = None
             self._active_listener_contexts = None
 
     @callback

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for EG4 Web Monitor integration using pylxpweb device objects."""
 
 import asyncio
+from copy import deepcopy
 import logging
 import time
 from datetime import datetime, timedelta
@@ -9,7 +10,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.storage import Store
@@ -112,6 +113,83 @@ from .const.sensors import SENSOR_TYPES
 from .utils import async_write_with_cloud_fallback
 
 _LOGGER = logging.getLogger(__name__)
+
+ListenerContext = tuple[str, str]
+STATION_LISTENER_CONTEXT: ListenerContext = ("station", "")
+DISCOVERY_LISTENER_CONTEXT: ListenerContext = ("discovery", "")
+
+
+def device_listener_context(serial: str) -> ListenerContext:
+    """Return the listener context shared by one device and its descendants."""
+    return ("device", str(serial))
+
+
+def _listener_contexts_for_data_change(
+    old: dict[str, Any] | None,
+    new: dict[str, Any],
+) -> set[ListenerContext] | None:
+    """Return scoped listeners affected by a coordinator data transition.
+
+    ``None`` means an unclassified/initial transition and therefore requests a
+    full dispatch. The coordinator-level ``last_update`` timestamp is ignored:
+    it changes on every fastest-transport tick but no entity reads it directly.
+    Device timestamps remain inside their device records and are compared.
+    """
+    if old is None:
+        return None
+
+    contexts: set[ListenerContext] = set()
+    old_devices = old.get("devices") or {}
+    new_devices = new.get("devices") or {}
+    changed_serials = {
+        str(serial)
+        for serial in old_devices.keys() | new_devices.keys()
+        if old_devices.get(serial) != new_devices.get(serial)
+    }
+
+    old_parameters = old.get("parameters") or {}
+    new_parameters = new.get("parameters") or {}
+    changed_serials.update(
+        str(serial)
+        for serial in old_parameters.keys() | new_parameters.keys()
+        if old_parameters.get(serial) != new_parameters.get(serial)
+    )
+
+    contexts.update(device_listener_context(serial) for serial in changed_serials)
+    if changed_serials:
+        contexts.add(DISCOVERY_LISTENER_CONTEXT)
+
+    if old.get("station") != new.get("station"):
+        contexts.add(STATION_LISTENER_CONTEXT)
+
+    scoped_keys = {"devices", "parameters", "station", "last_update"}
+    old_unscoped = {key: value for key, value in old.items() if key not in scoped_keys}
+    new_unscoped = {key: value for key, value in new.items() if key not in scoped_keys}
+    if old_unscoped != new_unscoped:
+        return None
+
+    return contexts
+
+
+def listener_changed_device_items(
+    coordinator: "EG4DataUpdateCoordinator",
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return only device records selected for the active listener dispatch.
+
+    Outside a filtered dispatch (including simple coordinator doubles in unit
+    tests), return every device to preserve the historical discovery contract.
+    """
+    devices = (coordinator.data or {}).get("devices", {})
+    active_contexts = getattr(coordinator, "_active_listener_contexts", None)
+    if not isinstance(active_contexts, set):
+        return list(devices.items())
+    changed_serials = {
+        serial
+        for kind, serial in active_contexts
+        if kind == "device" and serial in devices
+    }
+    return [(serial, devices[serial]) for serial in sorted(changed_serials)]
+
 
 PV_STRING_LIFETIME_STORAGE_VERSION = 1
 PV_STRING_LIFETIME_STORAGE_KEY = f"{DOMAIN}_pv_string_lifetime"
@@ -505,6 +583,14 @@ class EG4DataUpdateCoordinator(
             update_interval=update_interval,
         )
 
+        # Listener fan-out accounting. Device/station entities register the
+        # smallest context they consume. Each refresh compares against a deep
+        # pre-route snapshot because LOCAL carry-forward deliberately reuses
+        # device dict objects and may mutate them while marking link failures.
+        self._pending_listener_contexts: set[ListenerContext] | None = None
+        self._active_listener_contexts: set[ListenerContext] | None = None
+        self._last_listener_update_success: bool | None = None
+
         # Register shutdown listener to cancel background tasks on Home Assistant stop
         # Initialize flag before registering to ensure it exists
         self._shutdown_listener_fired = False
@@ -529,6 +615,14 @@ class EG4DataUpdateCoordinator(
             ConfigEntryAuthFailed: If authentication fails (always immediate).
             UpdateFailed: If connection or API errors occur after 3 consecutive failures.
         """
+        try:
+            previous_data = deepcopy(self.data)
+        except Exception:  # pragma: no cover - defensive for future opaque values
+            previous_data = None
+        # An exception before a new data snapshot is produced represents no
+        # value change. Availability transitions are handled at dispatch.
+        self._pending_listener_contexts = set()
+
         # Clear device_info caches at the start of each update cycle
         # so fresh data is used for any new entity registrations
         self.clear_device_info_caches()
@@ -552,6 +646,9 @@ class EG4DataUpdateCoordinator(
                         if key in sensors and sensors[key] == 0:
                             sensors[key] = None
 
+            self._pending_listener_contexts = _listener_contexts_for_data_change(
+                previous_data, data
+            )
             return data
         except ConfigEntryAuthFailed:
             raise
@@ -563,8 +660,54 @@ class EG4DataUpdateCoordinator(
                     self._consecutive_update_failures,
                     err,
                 )
-                return cast(dict[str, Any], self.data)
+                cached_data = cast(dict[str, Any], self.data)
+                self._pending_listener_contexts = _listener_contexts_for_data_change(
+                    previous_data, cached_data
+                )
+                return cached_data
             raise
+
+    @callback
+    def async_update_listeners(self) -> None:
+        """Notify only listeners whose consumed coordinator scope changed.
+
+        Unscoped listeners retain Home Assistant's default always-notify
+        contract. Initial data and availability transitions always notify the
+        full graph. Scoped unchanged listeners are skipped, including on a
+        repeated failure after their unavailable state was already published.
+        """
+        contexts = self._pending_listener_contexts
+        availability_changed = (
+            self._last_listener_update_success is None
+            or self._last_listener_update_success != self.last_update_success
+        )
+        notify_all = availability_changed or contexts is None
+        self._active_listener_contexts = None if notify_all else contexts
+        selected_contexts = contexts if contexts is not None else set()
+        try:
+            for update_callback, context in list(self._listeners.values()):
+                if notify_all or context is None or context in selected_contexts:
+                    update_callback()
+        finally:
+            self._last_listener_update_success = self.last_update_success
+            self._pending_listener_contexts = set()
+            self._active_listener_contexts = None
+
+    @callback
+    def async_set_updated_data(self, data: dict[str, Any]) -> None:
+        """Set externally supplied data while retaining scoped dispatch semantics."""
+        try:
+            previous_data = deepcopy(self.data)
+        except Exception:  # pragma: no cover - defensive for future opaque values
+            previous_data = None
+        self._pending_listener_contexts = _listener_contexts_for_data_change(
+            previous_data, data
+        )
+        super().async_set_updated_data(data)
+
+    def iter_listener_changed_devices(self) -> list[tuple[str, dict[str, Any]]]:
+        """Return device records relevant to the current discovery callback."""
+        return listener_changed_device_items(self)
 
     async def _route_update_by_connection_type(self) -> dict[str, Any]:
         """Route to the appropriate update method based on connection type."""
@@ -707,6 +850,10 @@ class EG4DataUpdateCoordinator(
             return
         params = self.data.setdefault("parameters", {}).setdefault(serial, {})
         params.update(values)
+        self._pending_listener_contexts = {
+            device_listener_context(serial),
+            DISCOVERY_LISTENER_CONTEXT,
+        }
         self.async_update_listeners()
 
     def note_ac_couple_soc_written(
@@ -801,6 +948,10 @@ class EG4DataUpdateCoordinator(
         store[key] = value
         store["fetched_at"] = now
         device[spec.store_key] = store
+        self._pending_listener_contexts = {
+            device_listener_context(serial),
+            DISCOVERY_LISTENER_CONTEXT,
+        }
         self.async_update_listeners()
 
     def _has_modbus_transport(self) -> bool:

--- a/custom_components/eg4_web_monitor/sensor.py
+++ b/custom_components/eg4_web_monitor/sensor.py
@@ -32,7 +32,11 @@ from .const import (
     THREE_PHASE_ONLY_SENSORS,
     VOLT_WATT_SENSORS,
 )
-from .coordinator import EG4DataUpdateCoordinator
+from .coordinator import (
+    DISCOVERY_LISTENER_CONTEXT,
+    EG4DataUpdateCoordinator,
+    listener_changed_device_items,
+)
 from .coordinator_mappings import GRIDBOSS_SMART_PORT_DYNAMIC_KEYS
 from .utils import is_supported_control_model
 
@@ -268,7 +272,7 @@ async def async_setup_entry(
         if not coordinator.data or "devices" not in coordinator.data:
             return
         new_entities: list[SensorEntity] = []
-        for serial, device_data in coordinator.data["devices"].items():
+        for serial, device_data in listener_changed_device_items(coordinator):
             if device_data.get("type") != "inverter":
                 continue
             for battery_key, battery_sensors in device_data.get(
@@ -291,7 +295,11 @@ async def async_setup_entry(
             )
             async_add_entities(new_entities, True)
 
-    entry.async_on_unload(coordinator.async_add_listener(_async_discover_new_batteries))
+    entry.async_on_unload(
+        coordinator.async_add_listener(
+            _async_discover_new_batteries, DISCOVERY_LISTENER_CONTEXT
+        )
+    )
 
     # Track known smart port sensor keys for late registration.
     # Smart port power keys are excluded from static entity creation because
@@ -313,7 +321,7 @@ async def async_setup_entry(
         if not coordinator.data or "devices" not in coordinator.data:
             return
         new_entities: list[SensorEntity] = []
-        for serial, device_data in coordinator.data["devices"].items():
+        for serial, device_data in listener_changed_device_items(coordinator):
             if device_data.get("type") != "gridboss":
                 continue
             known = known_smart_port_keys.setdefault(serial, set())
@@ -339,7 +347,9 @@ async def async_setup_entry(
             async_add_entities(new_entities, True)
 
     entry.async_on_unload(
-        coordinator.async_add_listener(_async_discover_smart_port_sensors)
+        coordinator.async_add_listener(
+            _async_discover_smart_port_sensors, DISCOVERY_LISTENER_CONTEXT
+        )
     )
 
     # Track known device sensor keys for late registration.
@@ -380,7 +390,7 @@ async def async_setup_entry(
         if not coordinator.data or "devices" not in coordinator.data:
             return
         new_entities: list[SensorEntity] = []
-        for serial, device_data in coordinator.data["devices"].items():
+        for serial, device_data in listener_changed_device_items(coordinator):
             dtype = device_data.get("type", "unknown")
             if dtype not in ("inverter", "gridboss", "parallel_group"):
                 continue
@@ -425,7 +435,9 @@ async def async_setup_entry(
             async_add_entities(new_entities, True)
 
     entry.async_on_unload(
-        coordinator.async_add_listener(_async_discover_device_sensors)
+        coordinator.async_add_listener(
+            _async_discover_device_sensors, DISCOVERY_LISTENER_CONTEXT
+        )
     )
 
     # Track known battery bank sensor keys for late registration.
@@ -453,7 +465,7 @@ async def async_setup_entry(
         if not coordinator.data or "devices" not in coordinator.data:
             return
         new_entities: list[SensorEntity] = []
-        for serial, device_data in coordinator.data["devices"].items():
+        for serial, device_data in listener_changed_device_items(coordinator):
             if device_data.get("type") != "inverter":
                 continue
             known = known_bank_sensor_keys.setdefault(serial, set())
@@ -478,7 +490,9 @@ async def async_setup_entry(
             async_add_entities(new_entities, True)
 
     entry.async_on_unload(
-        coordinator.async_add_listener(_async_discover_battery_bank_sensors)
+        coordinator.async_add_listener(
+            _async_discover_battery_bank_sensors, DISCOVERY_LISTENER_CONTEXT
+        )
     )
 
 

--- a/custom_components/eg4_web_monitor/update.py
+++ b/custom_components/eg4_web_monitor/update.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ENTITY_PREFIX
-from .coordinator import EG4DataUpdateCoordinator
+from .coordinator import EG4DataUpdateCoordinator, device_listener_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class EG4FirmwareUpdateEntity(
 
     def __init__(self, coordinator: EG4DataUpdateCoordinator, serial: str) -> None:
         """Initialize the update entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, context=device_listener_context(serial))
         self._serial = serial
 
         # Get device data for naming

--- a/tests/test_coordinator_listener_fanout.py
+++ b/tests/test_coordinator_listener_fanout.py
@@ -1,7 +1,10 @@
 """Regression and benchmark coverage for coordinator listener fan-out."""
 
+import asyncio
 from copy import deepcopy
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.eg4_web_monitor.base_entity import (
     EG4BatteryEntity,
@@ -23,7 +26,7 @@ def _bare_coordinator(data: dict | None = None) -> EG4DataUpdateCoordinator:
     coordinator = object.__new__(EG4DataUpdateCoordinator)
     coordinator.data = data
     coordinator._listeners = {}
-    coordinator._pending_listener_contexts = set()
+    coordinator._pending_listener_contexts = None
     coordinator._active_listener_contexts = None
     coordinator._last_listener_update_success = True
     coordinator.last_update_success = True
@@ -136,12 +139,33 @@ def test_unchanged_tick_skips_scoped_discovery_and_entity_work() -> None:
         2: (discovery_callback, DISCOVERY_LISTENER_CONTEXT),
         3: (unscoped_callback, None),
     }
+    coordinator._pending_listener_contexts = set()
 
     coordinator.async_update_listeners()
 
     entity_callback.assert_not_called()
     discovery_callback.assert_not_called()
     unscoped_callback.assert_called_once_with()
+
+
+def test_foreign_listener_context_retains_default_fanout() -> None:
+    """Contexts outside this integration's namespace remain safety listeners."""
+    coordinator = _bare_coordinator({"devices": {"FAST": {"sensors": {}}}})
+    foreign_hashable_callback = MagicMock()
+    foreign_unhashable_callback = MagicMock()
+    coordinator._listeners = {
+        1: (foreign_hashable_callback, ("foreign_consumer", "opaque_scope")),
+        2: (foreign_unhashable_callback, {"opaque": "scope"}),
+    }
+    coordinator._pending_listener_contexts = {
+        device_listener_context("FAST"),
+        DISCOVERY_LISTENER_CONTEXT,
+    }
+
+    coordinator.async_update_listeners()
+
+    foreign_hashable_callback.assert_called_once_with()
+    foreign_unhashable_callback.assert_called_once_with()
 
 
 def test_availability_transition_notifies_every_listener_once() -> None:
@@ -162,9 +186,55 @@ def test_availability_transition_notifies_every_listener_once() -> None:
 
     scoped_callback.reset_mock()
     unscoped_callback.reset_mock()
+    # Home Assistant suppresses listener dispatch after a repeated failure.
+    # Explicitly stage an unchanged result to exercise the defensive branch.
+    coordinator._pending_listener_contexts = set()
     coordinator.async_update_listeners()
     scoped_callback.assert_not_called()
     unscoped_callback.assert_called_once_with()
+
+
+def test_idle_public_listener_dispatch_retains_default_fanout() -> None:
+    """A public dispatch outside a classified refresh must notify all listeners."""
+    coordinator = _bare_coordinator()
+    scoped_callback = MagicMock()
+    coordinator._listeners = {
+        1: (scoped_callback, device_listener_context("SLOW")),
+    }
+
+    coordinator.async_update_listeners()
+
+    scoped_callback.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_inflight_refresh_does_not_mask_public_listener_dispatch() -> None:
+    """Awaiting transport I/O must not expose an empty scope to other dispatches."""
+    data = {"devices": {"SLOW": {"sensors": {"power": 200}}}}
+    coordinator = _bare_coordinator(data)
+    coordinator._consecutive_update_failures = 0
+    coordinator.clear_device_info_caches = MagicMock()
+    route_started = asyncio.Event()
+    release_route = asyncio.Event()
+
+    async def _route_update() -> dict:
+        route_started.set()
+        await release_route.wait()
+        return deepcopy(data)
+
+    coordinator._route_update_by_connection_type = _route_update
+    scoped_callback = MagicMock()
+    coordinator._listeners = {
+        1: (scoped_callback, device_listener_context("SLOW")),
+    }
+
+    refresh = asyncio.create_task(coordinator._async_update_data())
+    await route_started.wait()
+    coordinator.async_update_listeners()
+    release_route.set()
+
+    assert await refresh == data
+    scoped_callback.assert_called_once_with()
 
 
 def test_changed_device_iteration_is_limited_during_discovery_dispatch() -> None:

--- a/tests/test_coordinator_listener_fanout.py
+++ b/tests/test_coordinator_listener_fanout.py
@@ -1,0 +1,220 @@
+"""Regression and benchmark coverage for coordinator listener fan-out."""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+from custom_components.eg4_web_monitor.base_entity import (
+    EG4BatteryEntity,
+    EG4DeviceEntity,
+    EG4StationEntity,
+)
+from custom_components.eg4_web_monitor.coordinator import (
+    DISCOVERY_LISTENER_CONTEXT,
+    STATION_LISTENER_CONTEXT,
+    EG4DataUpdateCoordinator,
+    _listener_contexts_for_data_change,
+    device_listener_context,
+)
+from custom_components.eg4_web_monitor.update import EG4FirmwareUpdateEntity
+
+
+def _bare_coordinator(data: dict | None = None) -> EG4DataUpdateCoordinator:
+    """Create only the listener-facing portion of a coordinator."""
+    coordinator = object.__new__(EG4DataUpdateCoordinator)
+    coordinator.data = data
+    coordinator._listeners = {}
+    coordinator._pending_listener_contexts = set()
+    coordinator._active_listener_contexts = None
+    coordinator._last_listener_update_success = True
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def test_changed_data_contexts_ignore_tick_metadata_and_carried_device() -> None:
+    """Only a materially changed device is selected on a fastest-transport tick."""
+    old = {
+        "devices": {
+            "FAST": {"sensors": {"power": 100, "last_polled": "t1"}},
+            "SLOW": {"sensors": {"power": 200, "last_polled": "t0"}},
+        },
+        "parameters": {"FAST": {"mode": 1}, "SLOW": {"mode": 2}},
+        "station": {"name": "Plant"},
+        "last_update": "tick-1",
+        "connection_type": "local",
+    }
+    new = deepcopy(old)
+    new["last_update"] = "tick-2"
+    new["devices"]["FAST"]["sensors"]["power"] = 101
+
+    assert _listener_contexts_for_data_change(old, new) == {
+        device_listener_context("FAST"),
+        DISCOVERY_LISTENER_CONTEXT,
+    }
+
+
+def test_parameter_station_and_unknown_top_level_changes_are_not_suppressed() -> None:
+    """Parameter, station, and unclassified transitions reach their consumers."""
+    old = {
+        "devices": {"A": {"sensors": {"power": 1}}},
+        "parameters": {"A": {"mode": 1}},
+        "station": {"name": "Old"},
+        "last_update": "tick-1",
+        "connection_type": "local",
+    }
+
+    parameter_new = deepcopy(old)
+    parameter_new["parameters"]["A"]["mode"] = 2
+    assert _listener_contexts_for_data_change(old, parameter_new) == {
+        device_listener_context("A"),
+        DISCOVERY_LISTENER_CONTEXT,
+    }
+
+    station_new = deepcopy(old)
+    station_new["station"]["name"] = "New"
+    assert _listener_contexts_for_data_change(old, station_new) == {
+        STATION_LISTENER_CONTEXT
+    }
+
+    unknown_new = deepcopy(old)
+    unknown_new["connection_type"] = "hybrid"
+    assert _listener_contexts_for_data_change(old, unknown_new) is None
+
+
+def test_listener_fanout_benchmark_skips_unchanged_device_callbacks() -> None:
+    """A 300-entity mixed tick calls 150 changed entities, not all 300."""
+    coordinator = _bare_coordinator(
+        {
+            "devices": {
+                "FAST": {"sensors": {"power": 101}},
+                "SLOW": {"sensors": {"power": 200}},
+            }
+        }
+    )
+    fast_callbacks = [MagicMock() for _ in range(150)]
+    slow_callbacks = [MagicMock() for _ in range(150)]
+    discovery_callback = MagicMock()
+    unscoped_callback = MagicMock()
+    listener_id = 0
+    for callback in fast_callbacks:
+        listener_id += 1
+        coordinator._listeners[listener_id] = (
+            callback,
+            device_listener_context("FAST"),
+        )
+    for callback in slow_callbacks:
+        listener_id += 1
+        coordinator._listeners[listener_id] = (
+            callback,
+            device_listener_context("SLOW"),
+        )
+    coordinator._listeners[301] = (
+        discovery_callback,
+        DISCOVERY_LISTENER_CONTEXT,
+    )
+    coordinator._listeners[302] = (unscoped_callback, None)
+    coordinator._pending_listener_contexts = {
+        device_listener_context("FAST"),
+        DISCOVERY_LISTENER_CONTEXT,
+    }
+
+    coordinator.async_update_listeners()
+
+    assert sum(callback.call_count for callback in fast_callbacks) == 150
+    assert sum(callback.call_count for callback in slow_callbacks) == 0
+    discovery_callback.assert_called_once_with()
+    unscoped_callback.assert_called_once_with()
+
+
+def test_unchanged_tick_skips_scoped_discovery_and_entity_work() -> None:
+    """A carried-data-only tick retains unknown listeners but skips scoped work."""
+    coordinator = _bare_coordinator({"devices": {"SLOW": {"sensors": {}}}})
+    entity_callback = MagicMock()
+    discovery_callback = MagicMock()
+    unscoped_callback = MagicMock()
+    coordinator._listeners = {
+        1: (entity_callback, device_listener_context("SLOW")),
+        2: (discovery_callback, DISCOVERY_LISTENER_CONTEXT),
+        3: (unscoped_callback, None),
+    }
+
+    coordinator.async_update_listeners()
+
+    entity_callback.assert_not_called()
+    discovery_callback.assert_not_called()
+    unscoped_callback.assert_called_once_with()
+
+
+def test_availability_transition_notifies_every_listener_once() -> None:
+    """Failure/recovery transitions bypass value filtering; repeated failure does not."""
+    coordinator = _bare_coordinator()
+    scoped_callback = MagicMock()
+    unscoped_callback = MagicMock()
+    coordinator._listeners = {
+        1: (scoped_callback, device_listener_context("SLOW")),
+        2: (unscoped_callback, None),
+    }
+    coordinator.last_update_success = False
+
+    coordinator.async_update_listeners()
+
+    scoped_callback.assert_called_once_with()
+    unscoped_callback.assert_called_once_with()
+
+    scoped_callback.reset_mock()
+    unscoped_callback.reset_mock()
+    coordinator.async_update_listeners()
+    scoped_callback.assert_not_called()
+    unscoped_callback.assert_called_once_with()
+
+
+def test_changed_device_iteration_is_limited_during_discovery_dispatch() -> None:
+    """Discovery scans receive only serials changed in the active dispatch."""
+    coordinator = _bare_coordinator(
+        {
+            "devices": {
+                "FAST": {"sensors": {"power": 101}},
+                "SLOW": {"sensors": {"power": 200}},
+            }
+        }
+    )
+    seen: list[str] = []
+
+    def discovery_callback() -> None:
+        seen.extend(serial for serial, _ in coordinator.iter_listener_changed_devices())
+
+    coordinator._listeners = {1: (discovery_callback, DISCOVERY_LISTENER_CONTEXT)}
+    coordinator._pending_listener_contexts = {
+        device_listener_context("FAST"),
+        DISCOVERY_LISTENER_CONTEXT,
+    }
+
+    coordinator.async_update_listeners()
+
+    assert seen == ["FAST"]
+
+
+def test_entity_bases_register_device_and_station_contexts() -> None:
+    """High-cardinality read entities identify their smallest update scope."""
+    coordinator = MagicMock(spec=EG4DataUpdateCoordinator)
+    coordinator.data = {
+        "devices": {
+            "INV": {
+                "type": "inverter",
+                "model": "Test",
+                "sensors": {},
+                "batteries": {"BAT": {}},
+            }
+        }
+    }
+    coordinator.plant_id = "plant"
+
+    assert EG4DeviceEntity(coordinator, "INV").coordinator_context == (
+        device_listener_context("INV")
+    )
+    assert EG4BatteryEntity(coordinator, "INV", "BAT").coordinator_context == (
+        device_listener_context("INV")
+    )
+    assert EG4StationEntity(coordinator).coordinator_context == STATION_LISTENER_CONTEXT
+    assert EG4FirmwareUpdateEntity(
+        coordinator, "INV"
+    ).coordinator_context == device_listener_context("INV")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -96,7 +96,7 @@ class TestLateBatteryRegistration:
         # Store registered listeners so we can invoke them
         coord._listeners: list = []
 
-        def add_listener(callback):
+        def add_listener(callback, context=None):
             coord._listeners.append(callback)
             return lambda: coord._listeners.remove(callback)
 
@@ -285,7 +285,7 @@ class TestLateDeviceSensorRegistration:
         )
         coord._listeners: list = []
 
-        def add_listener(callback):
+        def add_listener(callback, context=None):
             coord._listeners.append(callback)
             return lambda: coord._listeners.remove(callback)
 
@@ -496,7 +496,7 @@ class TestSmartPortListenerOwnership:
         )
         coord._listeners: list = []
 
-        def add_listener(callback):
+        def add_listener(callback, context=None):
             coord._listeners.append(callback)
             return lambda: coord._listeners.remove(callback)
 


### PR DESCRIPTION
## RCA\n\nEvery coordinator refresh previously notified every registered listener, even when only one inverter changed or the refresh merely carried forward unchanged cached data. Late-discovery callbacks then rescanned the complete device collection. With hundreds of entities, routine polling therefore produced callback and discovery work proportional to the whole installation.\n\n## Fix\n\n- Route coordinator updates by station, discovery, and device listener contexts.\n- Preserve full fanout for initial data, availability transitions, unknown top-level changes, and deliberately unscoped listeners.\n- Detect carried-forward in-place mutations safely by snapshotting the previous coordinator data.\n- Limit late discovery to serials whose active device data changed.\n- Scope read entities and firmware updates to their source device.\n- Keep controls and optimistic entities unscoped so retention TTL and availability transitions cannot be skipped.\n- Scope manual parameter/cloud acknowledgements to the affected serial plus discovery.\n\n## Performance evidence\n\nA 300-listener regression test confirms that a FAST-only device change invokes the 150 FAST listeners while skipping all 150 SLOW listeners, while preserving discovery and unscoped safety listeners. A synthetic 10-device snapshot/compare benchmark with 500 sensors and 6 batteries per device measured about 1.568 ms for two deep copies plus comparison across 500 iterations; production performs one snapshot.\n\n## Verification\n\n- 2,550 passed, 3 skipped\n- focused coordinator coverage: 633 passed\n- focused platform coverage: 136 passed\n- strict mypy: 41 source files clean\n- Ruff lint and format checks pass\n- prek hooks pass\n- git diff --check passes\n\nBead: eg4-06er.11\n\nThis PR is intentionally isolated and remains a draft for review.