### PR TITLE
fix: bound and deduplicate cloud polling

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -1555,7 +1555,9 @@ class EG4BaseSwitch(EG4OptimisticEntity, SwitchEntity):
                 register is firmware-rejected, #296).
             disable_method: Method to call when turning off (same forms).
             turn_on: True to enable, False to disable.
-            refresh_params: If True, refresh parameters instead of just data.
+            refresh_params: If True, perform one targeted parameter refresh.
+                Runtime/status actions retain the pre-delay inverter refresh
+                followed by their full coordinator refresh.
             api_delay: Seconds to wait for API to propagate changes (default 1.0).
             enable_kwargs: Optional keyword arguments passed to the enable method
                 on the turn-on path only (the disable method is always called with
@@ -1638,7 +1640,7 @@ class EG4BaseSwitch(EG4OptimisticEntity, SwitchEntity):
             turn_on,
             do_write=do_write,
             do_refresh=do_refresh,
-            pre_delay_refresh=pre_delay_refresh,
+            pre_delay_refresh=None if refresh_params else pre_delay_refresh,
             api_delay=api_delay,
             seed_param_key=seed_param_key,
             refresh_after_write=refresh_after_write,

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -251,10 +251,12 @@ class EG4RefreshButton(EG4DeviceEntity, ButtonEntity):
                 # inverter.refresh(force=True, include_parameters=True) and
                 # stores the fresh parameters; link-down handling lives in
                 # pylxpweb's _fetch_parameters guard (cloud fallback in
-                # HYBRID, clean skip in LOCAL — no hang risk).  The private
-                # method is used instead of async_refresh_device_parameters()
-                # because the public wrapper triggers its own coordinator
-                # refresh (double-read) and this button does its own
+                # HYBRID, clean skip in LOCAL — no hang risk). The private
+                # method's include_runtime_data=True path is intentional: the
+                # public parameter wrapper now performs only a narrow holding-
+                # register fetch and in-place publication, while this explicit
+                # Refresh button promises fresh runtime, energy, battery, and
+                # parameter data. This button also performs its own
                 # completeness check: refresh() gathers its fetch tasks with
                 # return_exceptions=True, so read failures never raise — they
                 # surface only as parameters_complete=False.

--- a/custom_components/eg4_web_monitor/button.py
+++ b/custom_components/eg4_web_monitor/button.py
@@ -262,7 +262,9 @@ class EG4RefreshButton(EG4DeviceEntity, ButtonEntity):
                     "Force-refreshing inverter %s including parameters",
                     self._serial,
                 )
-                await self.coordinator._refresh_device_parameters(self._serial)
+                await self.coordinator._refresh_device_parameters(
+                    self._serial, include_runtime_data=True
+                )
                 inverter = self.coordinator.get_inverter_object(self._serial)
                 incomplete = inverter is not None and not getattr(
                     inverter, "parameters_complete", True

--- a/custom_components/eg4_web_monitor/cloud_requests.py
+++ b/custom_components/eg4_web_monitor/cloud_requests.py
@@ -1,0 +1,79 @@
+"""Coordinator-owned concurrency controls for pylxpweb cloud requests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pylxpweb import LuxpowerClient
+
+CloudRequest = Callable[..., Awaitable[dict[str, Any]]]
+
+
+class CloudRequestLimiter:
+    """Bound one client's request chains without deadlocking recursive retries.
+
+    pylxpweb performs retry and re-authentication by recursively calling the
+    client's private ``_request`` method.  A plain semaphore wrapper would
+    acquire a slot twice in the same task and can deadlock when every slot is
+    occupied by a retrying request.  The context variable makes a request
+    *chain* re-entrant while independently-created requests still consume one
+    slot each.
+
+    The limiter belongs to one ``LuxpowerClient``.  It is deliberately not
+    stored in ``hass.data``: separate config entries keep separate clients and
+    unloading one entry cannot own or cancel another entry's requests.
+    """
+
+    def __init__(self, request: CloudRequest, *, limit: int) -> None:
+        if limit < 1:
+            raise ValueError("Cloud request limit must be at least one")
+        self._request = request
+        self._semaphore = asyncio.Semaphore(limit)
+        self._request_owner: ContextVar[asyncio.Task[Any] | None] = ContextVar(
+            f"eg4_cloud_request_{id(self)}", default=None
+        )
+
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        """Run one pylxpweb request chain inside the account budget."""
+        kwargs = {
+            "data": data,
+            "cache_key": cache_key,
+            "cache_endpoint": cache_endpoint,
+            "_retry_count": _retry_count,
+        }
+        current_task = asyncio.current_task()
+        if current_task is not None and self._request_owner.get() is current_task:
+            return await self._request(method, endpoint, **kwargs)
+
+        async with self._semaphore:
+            token = self._request_owner.set(current_task)
+            try:
+                return await self._request(method, endpoint, **kwargs)
+            finally:
+                self._request_owner.reset(token)
+
+
+def install_cloud_request_limiter(
+    client: LuxpowerClient, *, limit: int
+) -> CloudRequestLimiter:
+    """Install a per-client limiter at pylxpweb's common request boundary."""
+    limiter = CloudRequestLimiter(client._request, limit=limit)
+    # pylxpweb's endpoint objects resolve ``client._request`` dynamically, and
+    # its retries recurse through the same attribute.  Binding on the instance
+    # therefore covers Station.load cache warming and every standard endpoint
+    # without replacing the HA-owned aiohttp session.
+    setattr(client, "_request", limiter.request)
+    return limiter

--- a/custom_components/eg4_web_monitor/cloud_requests.py
+++ b/custom_components/eg4_web_monitor/cloud_requests.py
@@ -5,12 +5,123 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
-from typing import Any, TYPE_CHECKING
+from typing import Any, Coroutine, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
     from pylxpweb import LuxpowerClient
 
 CloudRequest = Callable[..., Awaitable[dict[str, Any]]]
+FirmwareStatusFetch = Callable[[], Coroutine[Any, Any, Any]]
+CloudAccountKey = tuple[str, str, bool]
+FirmwareStatusKey = CloudAccountKey
+
+_CLOUD_REQUEST_BUDGETS = "eg4_web_monitor_cloud_request_budgets"
+_FIRMWARE_STATUS_FLIGHTS = "eg4_web_monitor_firmware_status_flights"
+_PYLXPWEB_LOGIN_ENDPOINT = "/WManage/api/login"
+_FIRMWARE_FLIGHT_CLOSE_TIMEOUT = 1.0
+
+
+class SharedCloudRequestBudget:
+    """One HA-local request-chain budget shared by an exact cloud account."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant | None,
+        key: CloudAccountKey | None,
+        *,
+        limit: int,
+    ) -> None:
+        if limit < 1:
+            raise ValueError("Cloud request limit must be at least one")
+        self._hass = hass
+        self.key = key
+        self.limit = limit
+        self._semaphore = asyncio.Semaphore(limit)
+        self.ref_count = 0
+        self._leases = 0
+        self._accepting = False
+
+    @classmethod
+    def local(cls, *, limit: int) -> SharedCloudRequestBudget:
+        """Create an unmanaged budget for direct limiter/unit-test use."""
+        budget = cls(None, None, limit=limit)
+        budget.register()
+        return budget
+
+    def register(self) -> None:
+        """Register one config-entry/client owner."""
+        self.ref_count += 1
+        self._accepting = True
+
+    def release_owner(self) -> bool:
+        """Release one owner while retaining active/queued lease accounting."""
+        if self.ref_count <= 0:
+            return False
+        self.ref_count -= 1
+        if self.ref_count == 0:
+            # Existing leases drain normally. New work from a closing client is
+            # refused unless a replacement entry registers this same retained
+            # budget before the final lease leaves.
+            self._accepting = False
+        self._remove_if_idle()
+        return True
+
+    async def async_acquire(self) -> None:
+        """Acquire one chain slot while keeping queued work in lifecycle state."""
+        if not self._accepting:
+            raise RuntimeError("Cloud request budget owner has been released")
+        self._leases += 1
+        try:
+            await self._semaphore.acquire()
+        except BaseException:
+            self._leases -= 1
+            self._remove_if_idle()
+            raise
+
+    def release_slot(self) -> None:
+        """Return one acquired slot and retire an unowned idle registry entry."""
+        self._semaphore.release()
+        self._leases -= 1
+        self._remove_if_idle()
+
+    def _remove_if_idle(self) -> None:
+        """Remove final-owner state only after every active/queued chain drains."""
+        if self.ref_count > 0 or self._leases > 0:
+            return
+        self._accepting = False
+        hass = self._hass
+        key = self.key
+        if hass is None or key is None:
+            return
+        registry = hass.data.get(_CLOUD_REQUEST_BUDGETS)
+        if isinstance(registry, dict) and registry.get(key) is self:
+            registry.pop(key, None)
+            if not registry:
+                hass.data.pop(_CLOUD_REQUEST_BUDGETS, None)
+
+
+class _CloudRequestLease:
+    """Reference-count one admitted semaphore slot across a request chain."""
+
+    def __init__(self, budget: SharedCloudRequestBudget) -> None:
+        self._budget = budget
+        self._references = 1
+
+    def retain(self) -> bool:
+        """Keep an active slot admitted for a child request task."""
+        if self._references == 0:
+            return False
+        self._references += 1
+        return True
+
+    def release(self) -> None:
+        """Return the budget slot after the final chain owner leaves."""
+        if self._references <= 0:
+            raise RuntimeError("Cloud request lease released more than once")
+        self._references -= 1
+        if self._references == 0:
+            self._budget.release_slot()
 
 
 class CloudRequestLimiter:
@@ -23,18 +134,39 @@ class CloudRequestLimiter:
     *chain* re-entrant while independently-created requests still consume one
     slot each.
 
-    The limiter belongs to one ``LuxpowerClient``.  It is deliberately not
-    stored in ``hass.data``: separate config entries keep separate clients and
-    unloading one entry cannot own or cancel another entry's requests.
+    Each client retains its own original request callable and re-entrancy
+    contexts, while clients for separate plants on the same account share only
+    the semaphore budget. The shared budget owns and cancels no request task.
     """
 
-    def __init__(self, request: CloudRequest, *, limit: int) -> None:
-        if limit < 1:
-            raise ValueError("Cloud request limit must be at least one")
+    def __init__(
+        self,
+        request: CloudRequest,
+        *,
+        limit: int | None = None,
+        budget: SharedCloudRequestBudget | None = None,
+        authentication_task_getter: Callable[[], asyncio.Task[Any] | None]
+        | None = None,
+    ) -> None:
+        if budget is None:
+            if limit is None:
+                raise ValueError("A cloud request limit or shared budget is required")
+            budget = SharedCloudRequestBudget.local(limit=limit)
+        elif limit is not None and limit != budget.limit:
+            raise ValueError("Cloud request limit does not match shared budget")
         self._request = request
-        self._semaphore = asyncio.Semaphore(limit)
+        self._budget = budget
+        self._authentication_task_getter = authentication_task_getter
+        self._auth_task_leases: dict[asyncio.Task[Any], _CloudRequestLease] = {}
+        self._closed = False
         self._request_owner: ContextVar[asyncio.Task[Any] | None] = ContextVar(
             f"eg4_cloud_request_{id(self)}", default=None
+        )
+        self._request_lease: ContextVar[_CloudRequestLease | None] = ContextVar(
+            f"eg4_cloud_request_lease_{id(self)}", default=None
+        )
+        self._auth_chain_owner: ContextVar[asyncio.Task[Any] | None] = ContextVar(
+            f"eg4_cloud_auth_chain_{id(self)}", default=None
         )
 
     async def request(
@@ -48,6 +180,8 @@ class CloudRequestLimiter:
         _retry_count: int = 0,
     ) -> dict[str, Any]:
         """Run one pylxpweb request chain inside the account budget."""
+        if self._closed:
+            raise RuntimeError("Cloud request limiter has been released")
         kwargs = {
             "data": data,
             "cache_key": cache_key,
@@ -57,23 +191,371 @@ class CloudRequestLimiter:
         current_task = asyncio.current_task()
         if current_task is not None and self._request_owner.get() is current_task:
             return await self._request(method, endpoint, **kwargs)
+        if current_task is not None and self._auth_chain_owner.get() is current_task:
+            return await self._request(method, endpoint, **kwargs)
 
-        async with self._semaphore:
-            token = self._request_owner.set(current_task)
+        # pylxpweb's reactive authentication creates a child task after an
+        # ordinary request receives an unauthenticated response. ContextVars
+        # are copied into that child, but exact-task re-entrancy intentionally
+        # rejects the inherited parent owner. When every request slot is held
+        # by a parent awaiting the shared authentication task, login would
+        # otherwise wait forever for one of those same parents to release.
+        # Promote only pylxpweb's exact login boundary; the task also performs
+        # account discovery before it completes, so retain admission for the
+        # remainder of this short-lived auth task's context.
+        inherited_owner = self._request_owner.get()
+        inherited_login = (
+            current_task is not None
+            and inherited_owner is not None
+            and inherited_owner is not current_task
+            and method.upper() == "POST"
+            and endpoint == _PYLXPWEB_LOGIN_ENDPOINT
+        )
+        inherited_lease = self._request_lease.get()
+        if inherited_login and current_task is not None:
+            reservation = self._auth_task_leases.get(current_task)
+            if reservation is None:
+                if inherited_lease is None or not inherited_lease.retain():
+                    # A future client implementation may hide or replace its
+                    # auth task before a cancelling parent can reserve the
+                    # slot. Never queue login behind parents that can all be
+                    # waiting on it; fail the attempt so they unwind and retry.
+                    raise RuntimeError(
+                        "Reactive authentication lost its parent request admission"
+                    )
+                reservation = inherited_lease
+                self._auth_task_leases[current_task] = reservation
+                current_task.add_done_callback(self._auth_task_finished)
+            # login() is only the first phase of pylxpweb's shielded auth task;
+            # account discovery and retry backoff continue after this wrapper
+            # returns. Keep the inherited parent admission until that *task*
+            # finishes, otherwise canceled parents release all three slots and
+            # later work can run alongside the still-live auth request.
+            self._auth_chain_owner.set(current_task)
+            return await self._request(method, endpoint, **kwargs)
+
+        await self._budget.async_acquire()
+        lease = _CloudRequestLease(self._budget)
+        try:
+            # The owner can unload while this chain is queued. Its lease must
+            # remain counted until admission so a replacement entry reuses the
+            # draining semaphore, but the detached client must not begin new
+            # network I/O after close().
+            if self._closed:
+                raise RuntimeError("Cloud request limiter has been released")
+            owner_token = self._request_owner.set(current_task)
+            lease_token = self._request_lease.set(lease)
             try:
                 return await self._request(method, endpoint, **kwargs)
+            except asyncio.CancelledError:
+                self._reserve_lease_for_auth_task(lease, current_task)
+                raise
             finally:
-                self._request_owner.reset(token)
+                self._request_lease.reset(lease_token)
+                self._request_owner.reset(owner_token)
+        finally:
+            lease.release()
+
+    def _reserve_lease_for_auth_task(
+        self,
+        lease: _CloudRequestLease,
+        current_task: asyncio.Task[Any] | None,
+    ) -> None:
+        """Hand one cancelling parent's slot to its pending shared auth task."""
+        if current_task is None or current_task.cancelling() == 0:
+            return
+        getter = self._authentication_task_getter
+        if getter is None:
+            return
+        try:
+            auth_task = getter()
+        except Exception:
+            return
+        if auth_task is None or auth_task.done() or auth_task in self._auth_task_leases:
+            return
+        if not lease.retain():
+            return
+        self._auth_task_leases[auth_task] = lease
+        auth_task.add_done_callback(self._auth_task_finished)
+
+    def _auth_task_finished(self, task: asyncio.Task[Any]) -> None:
+        """Release the one account slot reserved for a complete auth task."""
+        lease = self._auth_task_leases.pop(task, None)
+        if lease is not None:
+            lease.release()
+
+    def close(self) -> None:
+        """Refuse new work from this client without affecting sibling clients."""
+        self._closed = True
 
 
 def install_cloud_request_limiter(
-    client: LuxpowerClient, *, limit: int
+    client: LuxpowerClient,
+    *,
+    limit: int | None = None,
+    budget: SharedCloudRequestBudget | None = None,
 ) -> CloudRequestLimiter:
     """Install a per-client limiter at pylxpweb's common request boundary."""
-    limiter = CloudRequestLimiter(client._request, limit=limit)
+
+    def _authentication_task() -> asyncio.Task[Any] | None:
+        task = getattr(client, "_authentication_task", None)
+        return task if isinstance(task, asyncio.Task) else None
+
+    limiter = CloudRequestLimiter(
+        client._request,
+        limit=limit,
+        budget=budget,
+        authentication_task_getter=_authentication_task,
+    )
     # pylxpweb's endpoint objects resolve ``client._request`` dynamically, and
     # its retries recurse through the same attribute.  Binding on the instance
     # therefore covers Station.load cache warming and every standard endpoint
     # without replacing the HA-owned aiohttp session.
     setattr(client, "_request", limiter.request)
     return limiter
+
+
+def acquire_shared_cloud_request_budget(
+    hass: HomeAssistant,
+    *,
+    username: str,
+    base_url: str,
+    verify_ssl: bool,
+    limit: int,
+) -> SharedCloudRequestBudget:
+    """Acquire one HA-local raw request budget for an exact cloud account."""
+    key = (username, base_url.rstrip("/"), verify_ssl)
+    registry: dict[CloudAccountKey, SharedCloudRequestBudget] = hass.data.setdefault(
+        _CLOUD_REQUEST_BUDGETS, {}
+    )
+    budget = registry.get(key)
+    if budget is None:
+        budget = SharedCloudRequestBudget(hass, key, limit=limit)
+        registry[key] = budget
+    elif budget.limit != limit:
+        raise ValueError("Cloud request limit does not match existing account budget")
+    budget.register()
+    return budget
+
+
+def release_shared_cloud_request_budget(
+    hass: HomeAssistant, budget: SharedCloudRequestBudget
+) -> None:
+    """Release one account-budget owner; active and queued chains drain safely."""
+    del hass  # Budget retains the exact HA registry it belongs to.
+    budget.release_owner()
+
+
+class SharedFirmwareStatusFlight:
+    """Account-scoped ownership for pylxpweb's firmware progress endpoint.
+
+    Firmware progress is account-wide, but pylxpweb exposes the getter through
+    each client and device. Config entries for separate plants on the same
+    account therefore need one shared request. The state lives in one Home
+    Assistant instance and is reference-counted so unloading one plant cannot
+    cancel a request still owned by another.
+    """
+
+    def __init__(self, hass: HomeAssistant, key: FirmwareStatusKey) -> None:
+        self._hass = hass
+        self.key = key
+        self._owners: dict[object, FirmwareStatusFetch] = {}
+        self.task: asyncio.Task[Any] | None = None
+        self._task_owner: object | None = None
+        self._active_batches = 0
+        self._task_waiters: dict[asyncio.Task[Any], int] = {}
+        self._retired_tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def ref_count(self) -> int:
+        """Return the number of config entries sharing this account state."""
+        return len(self._owners)
+
+    def register(self, fetch: FirmwareStatusFetch) -> object:
+        """Register one config entry and its client-bound status getter."""
+        owner = object()
+        self._owners[owner] = fetch
+        return owner
+
+    async def run(self, owner: object) -> Any:
+        """Join the current account request, transferring from closing clients."""
+        while True:
+            fetch = self._owners.get(owner)
+            if fetch is None:
+                raise RuntimeError("Firmware status owner has been released")
+
+            task = self.task
+            if task is None or (task.done() and self._active_batches == 0):
+                task = self._hass.async_create_task(fetch())
+                self.task = task
+                self._task_owner = owner
+                task.add_done_callback(self._task_finished)
+
+            # A cancelled device/coordinator waiter must not cancel the raw
+            # request while another plant or sibling device still consumes it.
+            # Once the final waiter leaves, cancel raw work so a breaker timeout
+            # cannot strand one cloud-budget slot in client backoff.
+            self._task_waiters[task] = self._task_waiters.get(task, 0) + 1
+            retry_with_surviving_owner = False
+            try:
+                result = await asyncio.shield(task)
+            except asyncio.CancelledError:
+                caller = asyncio.current_task()
+                caller_was_cancelled = caller is not None and caller.cancelling() > 0
+                retry_with_surviving_owner = (
+                    not caller_was_cancelled
+                    and task in self._retired_tasks
+                    and owner in self._owners
+                )
+                if not retry_with_surviving_owner:
+                    raise
+            except Exception:
+                retry_with_surviving_owner = (
+                    task in self._retired_tasks and owner in self._owners
+                )
+                if not retry_with_surviving_owner:
+                    raise
+            else:
+                if task not in self._retired_tasks:
+                    return result
+                retry_with_surviving_owner = owner in self._owners
+                if not retry_with_surviving_owner:
+                    raise asyncio.CancelledError
+            finally:
+                remaining = self._task_waiters[task] - 1
+                if remaining:
+                    self._task_waiters[task] = remaining
+                else:
+                    self._task_waiters.pop(task, None)
+                    if task.done():
+                        self._retired_tasks.discard(task)
+                self._discard_unobserved_task()
+
+            # Releasing the client that created a raw request deliberately
+            # retires that task. Its own waiters still observe cancellation,
+            # but a waiter belonging to another registered config entry loops
+            # here and starts a replacement through its own live client. This
+            # transfer is internal to the flight, so it cannot count as a
+            # connectivity failure in the caller's supplemental breaker.
+            if retry_with_surviving_owner:
+                continue
+
+    def begin_batch(self) -> None:
+        """Keep a fast completed result joinable for one prefetch batch."""
+        self._active_batches += 1
+
+    def end_batch(self) -> None:
+        """Release one prefetch batch and its completed single-flight result."""
+        if self._active_batches > 0:
+            self._active_batches -= 1
+        self._discard_unobserved_task()
+
+    def _discard_unobserved_task(self) -> None:
+        """Clear a result or cancel raw work after its final consumer leaves."""
+        if self._active_batches > 0:
+            return
+        task = self.task
+        if task is None or self._task_waiters.get(task, 0) > 0:
+            return
+        self.task = None
+        self._task_owner = None
+        if not task.done():
+            task.cancel()
+
+    def _task_finished(self, task: asyncio.Task[Any]) -> None:
+        """Consume terminal errors and clear an unbatched task owner."""
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+        if self.task is task and self._active_batches == 0:
+            self.task = None
+            self._task_owner = None
+        if not self._task_waiters.get(task, 0):
+            self._retired_tasks.discard(task)
+
+    def release(self, owner: object) -> bool:
+        """Release one owner and retire raw work tied to its closing client."""
+        if self._owners.pop(owner, None) is None:
+            return False
+
+        task = self.task
+        if (
+            self._owners
+            and task is not None
+            and not task.done()
+            and self._task_owner is owner
+        ):
+            # async_unload_entry closes this owner's pylxpweb client immediately
+            # after coordinator shutdown. Keeping a task bound to that client
+            # would let client.close cancel a shared auth dependency underneath
+            # another plant. Retire synchronously; surviving waiters recognize
+            # this exact cancellation and transparently retry through their own
+            # registered getter.
+            self.task = None
+            self._task_owner = None
+            self._retired_tasks.add(task)
+            task.cancel()
+        elif task is not None and task.done() and self._task_owner is owner:
+            # A completed batch result no longer depends on its originating
+            # client and remains safe for sibling callers to consume.
+            self._task_owner = None
+        return True
+
+    async def async_close(self) -> None:
+        """Cancel the raw request when the final config-entry owner unloads."""
+        tasks = set(self._retired_tasks)
+        if self.task is not None:
+            tasks.add(self.task)
+        self.task = None
+        self._task_owner = None
+        self._active_batches = 0
+        self._owners.clear()
+        if not tasks:
+            return
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        # Third-party cancellation should be prompt, but unload must remain
+        # bounded even if a future pylxpweb coroutine suppresses cancellation.
+        await asyncio.wait(tasks, timeout=_FIRMWARE_FLIGHT_CLOSE_TIMEOUT)
+
+
+def acquire_shared_firmware_status(
+    hass: HomeAssistant,
+    *,
+    username: str,
+    base_url: str,
+    verify_ssl: bool,
+    fetch: FirmwareStatusFetch,
+) -> tuple[SharedFirmwareStatusFlight, object]:
+    """Acquire one HA-local firmware flight for an exact cloud account."""
+    key = (username, base_url.rstrip("/"), verify_ssl)
+    registry: dict[FirmwareStatusKey, SharedFirmwareStatusFlight] = (
+        hass.data.setdefault(_FIRMWARE_STATUS_FLIGHTS, {})
+    )
+    flight = registry.get(key)
+    if flight is None:
+        flight = SharedFirmwareStatusFlight(hass, key)
+        registry[key] = flight
+    return flight, flight.register(fetch)
+
+
+async def release_shared_firmware_status(
+    hass: HomeAssistant, flight: SharedFirmwareStatusFlight, owner: object
+) -> None:
+    """Release one entry owner, cancelling only after the last owner leaves."""
+    if not flight.release(owner):
+        return
+    if flight.ref_count > 0:
+        return
+
+    # Remove synchronously before awaiting cancellation. A replacement entry
+    # racing an unload acquires a fresh state and cannot inherit a cancelling
+    # task from the final owner of the old state.
+    registry = hass.data.get(_FIRMWARE_STATUS_FLIGHTS)
+    if isinstance(registry, dict) and registry.get(flight.key) is flight:
+        registry.pop(flight.key, None)
+        if not registry:
+            hass.data.pop(_FIRMWARE_STATUS_FLIGHTS, None)
+    await flight.async_close()

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
-from collections.abc import Awaitable, Callable, Collection, Coroutine
+from collections.abc import Awaitable, Callable, Collection
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from homeassistant.config_entries import ConfigEntry
@@ -46,6 +46,7 @@ from .const import (
     CONTROL_MODE_SOC,
     CONTROL_MODE_VOLTAGE,
     DEFAULT_CONTROL_MODE,
+    DEFAULT_BASE_URL,
     DEFAULT_MODBUS_BLOCK_SIZE,
     PARAM_FUNC_BAT_CHARGE_CONTROL,
     PARAM_FUNC_BAT_DISCHARGE_CONTROL,
@@ -84,12 +85,21 @@ from .const import (
     DEFAULT_PARAMETER_REFRESH_INTERVAL,
     DEFAULT_SENSOR_UPDATE_INTERVAL_HTTP,
     DEFAULT_SENSOR_UPDATE_INTERVAL_LOCAL,
+    DEFAULT_VERIFY_SSL,
     DOMAIN,
     HYBRID_LOCAL_DONGLE,
     HYBRID_LOCAL_MODBUS,
 )
 from .battery_migration import async_migrate_battery_keys
-from .cloud_requests import CloudRequestLimiter, install_cloud_request_limiter
+from .cloud_requests import (
+    CloudRequestLimiter,
+    SharedCloudRequestBudget,
+    SharedFirmwareStatusFlight,
+    acquire_shared_cloud_request_budget,
+    acquire_shared_firmware_status,
+    install_cloud_request_limiter,
+    release_shared_cloud_request_budget,
+)
 from .coordinator_mappings import (
     _derive_model_from_family,
     _parse_inverter_family,
@@ -172,23 +182,18 @@ class EG4DataUpdateCoordinator(
         # Initialize HTTP client for HTTP and Hybrid modes
         self.client: LuxpowerClient | None = None
         self._cloud_request_limiter: CloudRequestLimiter | None = None
+        self._cloud_request_budget: SharedCloudRequestBudget | None = None
+        self._cloud_request_budget_released = True
+        cloud_base_url = entry.data.get(CONF_BASE_URL, DEFAULT_BASE_URL)
+        cloud_verify_ssl = entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         if self.connection_type in (CONNECTION_TYPE_HTTP, CONNECTION_TYPE_HYBRID):
             self.client = LuxpowerClient(
                 username=entry.data[CONF_USERNAME],
                 password=entry.data[CONF_PASSWORD],
-                base_url=entry.data.get(
-                    CONF_BASE_URL, "https://monitor.eg4electronics.com"
-                ),
-                verify_ssl=entry.data.get(CONF_VERIFY_SSL, True),
+                base_url=cloud_base_url,
+                verify_ssl=cloud_verify_ssl,
                 session=aiohttp_client.async_get_clientsession(hass),
                 iana_timezone=iana_timezone,
-            )
-            # pylxpweb's Station and device refresh methods create their own
-            # nested gather() fanout.  Bound the shared request boundary, not
-            # just the later per-device mapping stage, so cold-cache startup,
-            # parameter reads, and supplemental fetches share one budget.
-            self._cloud_request_limiter = install_cloud_request_limiter(
-                self.client, limit=3
             )
 
         # Modbus input-register read block size (#254): preset option mapped
@@ -325,6 +330,7 @@ class EG4DataUpdateCoordinator(
 
         # Background task tracking for proper cleanup
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._background_scheduling_stopped = False
         self._shutdown_listener_fired: bool = False
 
         # One missing-parameter loader per coordinator. Repeated update cycles
@@ -336,23 +342,12 @@ class EG4DataUpdateCoordinator(
         self._missing_parameter_pending_data: dict[str, Any] | None = None
 
         # Firmware progress is an account-wide endpoint even though pylxpweb
-        # exposes it on every device.  Replace only this coordinator's client
-        # endpoint with a cancellation-shielded single-flight wrapper; no task
-        # or result is shared across config entries.
-        self._firmware_status_fetch: Callable[[], Coroutine[Any, Any, Any]] | None = (
-            None
-        )
-        self._firmware_status_task: asyncio.Task[Any] | None = None
-        self._firmware_status_batch_active = False
+        # exposes it on every device. Entries for separate plants on the same
+        # account share a cancellation-shielded, refcounted single flight.
+        self._firmware_status_flight: SharedFirmwareStatusFlight | None = None
+        self._firmware_status_owner: object | None = None
+        self._firmware_status_released = True
         self._firmware_prefetched_device_ids: set[int] = set()
-        if self.client is not None:
-            firmware_endpoint = self.client.api.firmware
-            self._firmware_status_fetch = firmware_endpoint.get_firmware_update_status
-            setattr(
-                firmware_endpoint,
-                "get_firmware_update_status",
-                self._get_firmware_update_status_shared,
-            )
 
         # Track availability state for Silver tier logging requirement
         self._last_available_state: bool = True
@@ -539,6 +534,11 @@ class EG4DataUpdateCoordinator(
         super().__init__(
             hass,
             _LOGGER,
+            # Delay ConfigEntry's unload callback until every fallible setup
+            # step succeeds. Passing the entry here would retain a partially
+            # constructed coordinator if the listener/shared registration
+            # below raised.
+            config_entry=None,
             name=DOMAIN,
             update_interval=update_interval,
         )
@@ -551,6 +551,73 @@ class EG4DataUpdateCoordinator(
                 "homeassistant_stop", self._async_handle_shutdown
             )
         )
+
+        # Account-scoped registrations are deliberately the final constructor
+        # step. DataUpdateCoordinator initialization and event-bus listener
+        # setup can raise; acquiring shared owners before those operations
+        # leaked an unreachable owner into hass.data after setup failed.
+        if self.client is not None:
+            budget: SharedCloudRequestBudget | None = None
+            limiter: CloudRequestLimiter | None = None
+            try:
+                firmware_endpoint = self.client.api.firmware
+                firmware_fetch = firmware_endpoint.get_firmware_update_status
+                budget = acquire_shared_cloud_request_budget(
+                    hass,
+                    username=str(entry.data[CONF_USERNAME]),
+                    base_url=cloud_base_url,
+                    verify_ssl=cloud_verify_ssl,
+                    limit=3,
+                )
+                # pylxpweb's Station and device refresh methods create their
+                # own nested gather() fanout. Bound the common request boundary
+                # so all plants on this exact account share three request
+                # chains across startup, parameters, and supplemental reads.
+                limiter = install_cloud_request_limiter(
+                    self.client,
+                    budget=budget,
+                )
+                setattr(
+                    firmware_endpoint,
+                    "get_firmware_update_status",
+                    self._get_firmware_update_status_shared,
+                )
+                firmware_flight, firmware_owner = acquire_shared_firmware_status(
+                    hass,
+                    username=str(entry.data[CONF_USERNAME]),
+                    base_url=cloud_base_url,
+                    verify_ssl=cloud_verify_ssl,
+                    fetch=firmware_fetch,
+                )
+            except BaseException:
+                if limiter is not None:
+                    limiter.close()
+                if budget is not None:
+                    release_shared_cloud_request_budget(hass, budget)
+                remove_listener = self._shutdown_listener_remove
+                if remove_listener is not None:
+                    try:
+                        remove_listener()
+                    except ValueError:
+                        pass
+                    self._shutdown_listener_remove = None
+                raise
+
+            # No operation that can fail follows the firmware-owner acquire.
+            # This makes construction transactional without needing async
+            # cleanup from this synchronous initializer.
+            self._cloud_request_budget = budget
+            self._cloud_request_limiter = limiter
+            self._cloud_request_budget_released = False
+            self._firmware_status_flight = firmware_flight
+            self._firmware_status_owner = firmware_owner
+            self._firmware_status_released = False
+
+        # Match DataUpdateCoordinator's normal ownership contract only after
+        # construction is complete; ConfigEntry.async_on_unload is a plain
+        # in-memory append and this is intentionally the final operation.
+        self.config_entry = entry
+        entry.async_on_unload(self.async_shutdown)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from appropriate transport based on connection type.

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
-from collections.abc import Awaitable, Callable, Collection
+from collections.abc import Awaitable, Callable, Collection, Coroutine
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from homeassistant.config_entries import ConfigEntry
@@ -89,6 +89,7 @@ from .const import (
     HYBRID_LOCAL_MODBUS,
 )
 from .battery_migration import async_migrate_battery_keys
+from .cloud_requests import CloudRequestLimiter, install_cloud_request_limiter
 from .coordinator_mappings import (
     _derive_model_from_family,
     _parse_inverter_family,
@@ -170,6 +171,7 @@ class EG4DataUpdateCoordinator(
 
         # Initialize HTTP client for HTTP and Hybrid modes
         self.client: LuxpowerClient | None = None
+        self._cloud_request_limiter: CloudRequestLimiter | None = None
         if self.connection_type in (CONNECTION_TYPE_HTTP, CONNECTION_TYPE_HYBRID):
             self.client = LuxpowerClient(
                 username=entry.data[CONF_USERNAME],
@@ -180,6 +182,13 @@ class EG4DataUpdateCoordinator(
                 verify_ssl=entry.data.get(CONF_VERIFY_SSL, True),
                 session=aiohttp_client.async_get_clientsession(hass),
                 iana_timezone=iana_timezone,
+            )
+            # pylxpweb's Station and device refresh methods create their own
+            # nested gather() fanout.  Bound the shared request boundary, not
+            # just the later per-device mapping stage, so cold-cache startup,
+            # parameter reads, and supplemental fetches share one budget.
+            self._cloud_request_limiter = install_cloud_request_limiter(
+                self.client, limit=3
             )
 
         # Modbus input-register read block size (#254): preset option mapped
@@ -318,6 +327,33 @@ class EG4DataUpdateCoordinator(
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._shutdown_listener_fired: bool = False
 
+        # One missing-parameter loader per coordinator. Repeated update cycles
+        # reuse this task instead of queuing identical forced reads behind the
+        # dependency's parameter locks.
+        self._missing_parameter_refresh_task: asyncio.Task[None] | None = None
+        self._missing_parameter_active_serials: set[str] = set()
+        self._missing_parameter_pending_serials: set[str] = set()
+        self._missing_parameter_pending_data: dict[str, Any] | None = None
+
+        # Firmware progress is an account-wide endpoint even though pylxpweb
+        # exposes it on every device.  Replace only this coordinator's client
+        # endpoint with a cancellation-shielded single-flight wrapper; no task
+        # or result is shared across config entries.
+        self._firmware_status_fetch: Callable[[], Coroutine[Any, Any, Any]] | None = (
+            None
+        )
+        self._firmware_status_task: asyncio.Task[Any] | None = None
+        self._firmware_status_batch_active = False
+        self._firmware_prefetched_device_ids: set[int] = set()
+        if self.client is not None:
+            firmware_endpoint = self.client.api.firmware
+            self._firmware_status_fetch = firmware_endpoint.get_firmware_update_status
+            setattr(
+                firmware_endpoint,
+                "get_firmware_update_status",
+                self._get_firmware_update_status_shared,
+            )
+
         # Track availability state for Silver tier logging requirement
         self._last_available_state: bool = True
 
@@ -417,7 +453,9 @@ class EG4DataUpdateCoordinator(
             CONF_DATA_VALIDATION, False
         )
 
-        # Semaphore to limit concurrent API calls and prevent rate limiting
+        # Bound per-device mapping/side-fetch processing. Raw pylxpweb request
+        # chains have their own account budget installed above; this semaphore
+        # alone cannot see refresh()'s nested gather() calls.
         self._api_semaphore = asyncio.Semaphore(3)
 
         # Consecutive update failure counter for stale data tolerance
@@ -657,7 +695,7 @@ class EG4DataUpdateCoordinator(
         """
         inverter = self.get_inverter_object(serial)
         if inverter and not self.is_transport_link_down(serial):
-            await inverter.refresh(force=True, include_parameters=True)
+            await inverter._fetch_parameters()
 
     def params_are_local_raw(
         self, serial: str, *, include_configured: bool = False

--- a/custom_components/eg4_web_monitor/coordinator_http.py
+++ b/custom_components/eg4_web_monitor/coordinator_http.py
@@ -775,6 +775,14 @@ class HTTPUpdateMixin(_MixinBase):
                 "ymd": today_ymd,
             }
 
+        # Firmware availability checks are device-specific, but progress comes
+        # from one account-wide endpoint.  Run the two stages separately so all
+        # progress callers overlap and the client single-flight can share one
+        # response even when there are more devices than mapping semaphore slots.
+        firmware_devices: list[Any] = list(self.station.all_inverters)
+        firmware_devices.extend(self.station.all_mid_devices)
+        await self._prefetch_firmware_update_info(firmware_devices)
+
         # Process all inverters concurrently with semaphore to prevent rate limiting
         async def process_inverter_with_semaphore(
             inv: "BaseInverter",
@@ -1339,11 +1347,8 @@ class HTTPUpdateMixin(_MixinBase):
                 len(inverters_needing_params),
                 inverters_needing_params,
             )
-            task = self.hass.async_create_task(
-                self._refresh_missing_parameters(inverters_needing_params, processed)
+            self._schedule_missing_parameter_refresh(
+                inverters_needing_params, processed
             )
-            self._background_tasks.add(task)
-            task.add_done_callback(self._remove_task_from_set)
-            task.add_done_callback(self._log_task_exception)
 
         return processed

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -46,6 +46,13 @@ from .const import (
     MANUFACTURER,
     operating_state_slug,
 )
+from .cloud_requests import (
+    CloudRequestLimiter,
+    SharedCloudRequestBudget,
+    SharedFirmwareStatusFlight,
+    release_shared_cloud_request_budget,
+    release_shared_firmware_status,
+)
 from .coordinator_mappings import (
     CLOUD_SUPPLEMENTAL_LOST_KEYS,
     SMART_PORT_VALIDATED_KEY,
@@ -80,6 +87,11 @@ _LOGGER = logging.getLogger(__name__)
 # timeout is treated as a failed read (carry-forward). Full backoff-domain
 # isolation is a pylxpweb architectural item deliberately not attempted here.
 QUICK_CHARGE_CLOUD_STATUS_TIMEOUT = 10.0
+
+# Firmware progress is a supplemental cloud read just like quick-charge
+# status. Bound it independently so client backoff cannot monopolize a
+# coordinator update slot.
+FIRMWARE_UPDATE_CLOUD_TIMEOUT = 10.0
 
 # Portal event-log poll throttle (#327).  Events are pushed to the cloud
 # out-of-band by the device (some never surface in registers), so the Last
@@ -712,10 +724,14 @@ if TYPE_CHECKING:
         _missing_parameter_active_serials: set[str]
         _missing_parameter_pending_serials: set[str]
         _missing_parameter_pending_data: dict[str, Any] | None
-        _firmware_status_fetch: Callable[[], Coroutine[Any, Any, Any]] | None
-        _firmware_status_task: asyncio.Task[Any] | None
-        _firmware_status_batch_active: bool
+        _cloud_request_limiter: CloudRequestLimiter | None
+        _cloud_request_budget: SharedCloudRequestBudget | None
+        _cloud_request_budget_released: bool
+        _firmware_status_flight: SharedFirmwareStatusFlight | None
+        _firmware_status_owner: object | None
+        _firmware_status_released: bool
         _firmware_prefetched_device_ids: set[int]
+        _background_scheduling_stopped: bool
         _http_polling_interval: int
         _local_transport_configs: list[dict[str, Any]]
         _local_transports_attached: bool
@@ -766,6 +782,7 @@ if TYPE_CHECKING:
 
         # ── DataUpdateCoordinator / coordinator.py methods ──
         def get_inverter_object(self, serial: str) -> BaseInverter | None: ...
+        def async_update_listeners(self) -> None: ...
         async def async_request_refresh(self) -> None: ...
         def _rebuild_inverter_cache(self) -> None: ...
 
@@ -817,11 +834,13 @@ if TYPE_CHECKING:
         ) -> None: ...
         def _schedule_missing_parameter_refresh(
             self, inverter_serials: list[str], processed_data: dict[str, Any]
-        ) -> asyncio.Task[None]: ...
+        ) -> asyncio.Task[None] | None: ...
 
         # ── BackgroundTaskMixin methods ──
         def _remove_task_from_set(self, task: asyncio.Task[Any]) -> None: ...
         def _log_task_exception(self, task: asyncio.Task[Any]) -> None: ...
+        def _release_shared_cloud_request_budget(self) -> None: ...
+        async def _release_shared_firmware_status(self) -> None: ...
 
         # ── DSTSyncMixin methods ──
         def _should_sync_dst(self) -> bool: ...
@@ -1021,6 +1040,13 @@ class DeviceProcessingMixin(_MixinBase):
                 _SIDEFETCH_BREAKER_COOLDOWN,
             )
 
+    def _sidefetch_note_inconclusive(self) -> None:
+        """Return an inconclusive half-open probe to a bounded open state."""
+        if not self._sidefetch_half_open:
+            return
+        self._sidefetch_half_open = False
+        self._sidefetch_open_until = time.monotonic() + _SIDEFETCH_BREAKER_COOLDOWN
+
     @staticmethod
     def _discard_skipped_awaitable(call: "Awaitable[Any]") -> None:
         """Dispose of a never-to-be-awaited call without asyncio complaints.
@@ -1045,7 +1071,7 @@ class DeviceProcessingMixin(_MixinBase):
 
     async def _breakered_cloud_call(
         self,
-        call: "Awaitable[Any]",
+        call: "Awaitable[Any] | Callable[[], Awaitable[Any]]",
         *,
         timeout: float,
         classify: "Callable[[Any], bool | None] | None" = None,
@@ -1072,12 +1098,16 @@ class DeviceProcessingMixin(_MixinBase):
         getter swallows its internal per-range errors). Sites with such
         shapes pass ``classify``: return True for reachability proven, False
         for a connectivity failure to count, None for no evidence either way.
+        A zero-argument factory may be supplied instead of an already-created
+        awaitable when constructing the operation itself schedules work (for
+        example ``asyncio.gather``); the factory runs only after admission.
         """
         now = time.monotonic()
         open_until = self._sidefetch_open_until
         if open_until is not None:
             if now < open_until:
-                self._discard_skipped_awaitable(call)
+                if not callable(call):
+                    self._discard_skipped_awaitable(call)
                 raise _CloudSidefetchSkipped(
                     f"cloud side-fetch skipped, breaker open for another "
                     f"{open_until - now:.0f}s (portal unreachable)"
@@ -1088,7 +1118,13 @@ class DeviceProcessingMixin(_MixinBase):
             self._sidefetch_open_until = None
             self._sidefetch_half_open = True
         try:
-            result = await asyncio.wait_for(call, timeout=timeout)
+            awaitable = call() if callable(call) else call
+            result = await asyncio.wait_for(awaitable, timeout=timeout)
+        except asyncio.CancelledError:
+            # Cancellation says nothing about portal connectivity. A cancelled
+            # half-open probe still needs a bounded state before propagating.
+            self._sidefetch_note_inconclusive()
+            raise
         except SIDEFETCH_CONNECTIVITY_ERRORS:
             self._sidefetch_note_connectivity_failure()
             raise
@@ -1103,7 +1139,12 @@ class DeviceProcessingMixin(_MixinBase):
                 self._sidefetch_note_reachable()
             elif verdict is False:
                 self._sidefetch_note_connectivity_failure()
-            # None: ambiguous result — no evidence in either direction.
+            elif self._sidefetch_half_open:
+                # The probe completed but supplied no connectivity evidence.
+                # It cannot close the breaker, and leaving half_open=True with
+                # no deadline would admit every later side-fetch indefinitely.
+                # Return to OPEN for one cooldown without counting a failure.
+                self._sidefetch_note_inconclusive()
             return result
 
     def _get_device_grid_type(self, serial: str) -> str | None:
@@ -2183,9 +2224,15 @@ class DeviceProcessingMixin(_MixinBase):
         if id(device) in self._firmware_prefetched_device_ids:
             return self._extract_firmware_update_info(device)
         try:
-            await device.check_firmware_updates()
+            await self._breakered_cloud_call(
+                lambda: device.check_firmware_updates(),
+                timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+            )
             if hasattr(device, "get_firmware_update_progress"):
-                await device.get_firmware_update_progress()
+                await self._breakered_cloud_call(
+                    lambda: device.get_firmware_update_progress(),
+                    timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+                )
         except Exception as e:
             _LOGGER.debug(
                 "Could not refresh firmware updates for %s (using last cached state): %s",
@@ -2196,36 +2243,50 @@ class DeviceProcessingMixin(_MixinBase):
         return self._extract_firmware_update_info(device)
 
     async def _get_firmware_update_status_shared(self) -> Any:
-        """Share one in-flight account status request across device callers.
+        """Join one in-flight status request shared by this cloud account.
 
         The completed response is intentionally not cached here. pylxpweb owns
         its per-device 10-second/5-minute freshness policy, and firmware install
         orchestration must be able to observe idle -> active transitions without
-        an integration-side stale result. Only overlapping callers are coalesced.
+        an integration-side stale result. A prefetch batch retains a fast result
+        only long enough for all sibling device calls to join it.
         """
-        task = self._firmware_status_task
-        if task is None or (task.done() and not self._firmware_status_batch_active):
-            fetch = self._firmware_status_fetch
-            if fetch is None:
-                raise RuntimeError("Firmware status endpoint is not initialized")
-            task = self.hass.async_create_task(fetch())
-            self._firmware_status_task = task
-            self._background_tasks.add(task)
-            task.add_done_callback(self._remove_task_from_set)
-            task.add_done_callback(self._clear_firmware_status_task)
-            task.add_done_callback(self._log_task_exception)
+        flight = self._firmware_status_flight
+        owner = self._firmware_status_owner
+        if flight is None or owner is None:
+            raise RuntimeError("Firmware status endpoint is not initialized")
+        return await flight.run(owner)
 
-        # A cancelled inverter-processing waiter must not cancel the one raw
-        # account request that sibling devices still await.
-        return await asyncio.shield(task)
+    async def _release_shared_firmware_status(self) -> None:
+        """Release this config entry's account-wide firmware flight owner."""
+        if self._firmware_status_released:
+            return
+        self._firmware_status_released = True
+        flight = self._firmware_status_flight
+        owner = self._firmware_status_owner
+        self._firmware_status_flight = None
+        self._firmware_status_owner = None
+        if flight is not None and owner is not None:
+            await release_shared_firmware_status(self.hass, flight, owner)
 
-    def _clear_firmware_status_task(self, task: asyncio.Task[Any]) -> None:
-        """Release the single-flight slot if *task* is still its owner."""
-        if (
-            self._firmware_status_task is task
-            and not self._firmware_status_batch_active
-        ):
-            self._firmware_status_task = None
+    def _release_shared_cloud_request_budget(self) -> None:
+        """Release this entry without disrupting draining account requests."""
+        if self._cloud_request_budget_released:
+            return
+        self._cloud_request_budget_released = True
+
+        limiter = self._cloud_request_limiter
+        self._cloud_request_limiter = None
+        if limiter is not None:
+            # Refuse request chains that begin after this client's unload.
+            # Chains already active or queued retain leases in the shared
+            # budget and drain normally.
+            limiter.close()
+
+        budget = self._cloud_request_budget
+        self._cloud_request_budget = None
+        if budget is not None:
+            release_shared_cloud_request_budget(self.hass, budget)
 
     async def _prefetch_firmware_update_info(self, devices: Collection[Any]) -> None:
         """Align device firmware polls so account progress is fetched once."""
@@ -2238,7 +2299,10 @@ class DeviceProcessingMixin(_MixinBase):
 
         async def _check(device: Any) -> None:
             try:
-                await device.check_firmware_updates()
+                await self._breakered_cloud_call(
+                    lambda: device.check_firmware_updates(),
+                    timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+                )
             except Exception as err:
                 _LOGGER.debug(
                     "Could not refresh firmware availability for %s "
@@ -2257,7 +2321,10 @@ class DeviceProcessingMixin(_MixinBase):
 
         async def _progress(device: Any) -> None:
             try:
-                await device.get_firmware_update_progress()
+                await self._breakered_cloud_call(
+                    lambda: device.get_firmware_update_progress(),
+                    timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
+                )
             except Exception as err:
                 _LOGGER.debug(
                     "Could not refresh firmware progress for %s "
@@ -2266,14 +2333,14 @@ class DeviceProcessingMixin(_MixinBase):
                     err,
                 )
 
-        self._firmware_status_batch_active = True
+        flight = self._firmware_status_flight
+        if flight is not None:
+            flight.begin_batch()
         try:
             await asyncio.gather(*(_progress(device) for device in progress_devices))
         finally:
-            self._firmware_status_batch_active = False
-            task = self._firmware_status_task
-            if task is not None and task.done():
-                self._firmware_status_task = None
+            if flight is not None:
+                flight.end_batch()
         self._firmware_prefetched_device_ids.update(map(id, firmware_devices))
 
     async def _process_inverter_object(
@@ -3928,14 +3995,39 @@ class ParameterManagementMixin(_MixinBase):
             results = await asyncio.gather(*refresh_tasks, return_exceptions=True)
 
             success_count = 0
+            refreshed_serials: list[str] = []
             for i, result in enumerate(results):
                 serial = inverter_serials[i]
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
                     _LOGGER.error(
                         "Failed to refresh parameters for %s: %s", serial, result
                     )
-                else:
-                    success_count += 1
+                    continue
+                if result is not True:
+                    _LOGGER.debug(
+                        "Parameter refresh for %s produced no cache update", serial
+                    )
+                    continue
+
+                refreshed_serials.append(serial)
+                inverter = self.get_inverter_object(serial)
+                if (
+                    inverter is not None
+                    and getattr(inverter, "parameters_complete", True) is False
+                ):
+                    _LOGGER.debug(
+                        "Parameter refresh incomplete for device %s; retaining "
+                        "last-known values",
+                        serial,
+                    )
+                    continue
+                success_count += 1
+
+            # All successful sibling cache mutations are already in place, so
+            # publish them together. Under #532 this selects every changed
+            # device plus discovery; before #532 it remains one ordinary full
+            # listener dispatch. Never dispatch once per inverter.
+            self._publish_parameter_updates(refreshed_serials)
 
             _LOGGER.debug(
                 "Successfully refreshed parameters for %d/%d inverters",
@@ -3985,6 +4077,38 @@ class ParameterManagementMixin(_MixinBase):
             serial,
         )
 
+    def _publish_parameter_updates(self, serials: Collection[str]) -> None:
+        """Publish cache mutations once, scoped when #532 is present.
+
+        The listener-context attributes are feature-detected so this seam is
+        safe both before and after the callback-churn work lands. Without that
+        work, Home Assistant performs one ordinary listener dispatch. With it,
+        only the changed devices and discovery listener contexts are selected.
+        """
+        changed_serials = set(serials)
+        if not changed_serials:
+            return
+        if hasattr(self, "_pending_listener_contexts"):
+            selected_contexts: set[Any] = set()
+            listeners = getattr(self, "_listeners", {})
+            values = listeners.values() if hasattr(listeners, "values") else ()
+            for registration in values:
+                if not isinstance(registration, tuple) or len(registration) < 2:
+                    continue
+                context = registration[1]
+                kind = getattr(context, "kind", None)
+                if kind == "discovery" or (
+                    kind == "device"
+                    and getattr(context, "serial", None) in changed_serials
+                ):
+                    selected_contexts.add(context)
+            setattr(self, "_pending_listener_contexts", selected_contexts)
+        self.async_update_listeners()
+
+    def _publish_device_parameter_update(self, serial: str) -> None:
+        """Publish one serial through the shared batched dispatch seam."""
+        self._publish_parameter_updates((serial,))
+
     async def async_refresh_device_parameters(self, serial: str) -> bool:
         """Public method to refresh parameters for a specific device.
 
@@ -4020,7 +4144,8 @@ class ParameterManagementMixin(_MixinBase):
                     "last-known values",
                     serial,
                 )
-            await self.async_request_refresh()
+            if refreshed:
+                self._publish_device_parameter_update(serial)
         except Exception as e:
             _LOGGER.error("Failed to refresh parameters for device %s: %s", serial, e)
             return False
@@ -4043,16 +4168,24 @@ class ParameterManagementMixin(_MixinBase):
         Returns:
             True only when the parameter cache was actually updated. Every
             early return is a silent no-op that refreshed nothing — an
-            unknown serial, no coordinator data to write into, or an empty
-            parameter payload — and must not be reported as a completed
-            refresh, or the #362 post-write contract ("True means the refresh
-            completed") breaks exactly where it matters (#485).
+            unknown serial, missing coordinator data, or empty parameter set
+            must not be reported as completed, or the #362 post-write contract
+            ("True means the refresh completed") breaks where it matters
+            (#485).
         """
         try:
             inverter = self.get_inverter_object(serial)
             if not inverter:
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
                 return False
+
+            # Snapshot the integration write generation before entering the
+            # device read. When #527's seed envelope is present, the narrow
+            # fetch must reconcile any acknowledged write that raced it.
+            current_generation = getattr(self, "_parameter_write_generation", 0)
+            parameter_read_generation = (
+                current_generation if isinstance(current_generation, int) else 0
+            )
 
             if include_runtime_data:
                 # The explicit device Refresh button promises a full refresh;
@@ -4075,7 +4208,23 @@ class ParameterManagementMixin(_MixinBase):
                 if "parameters" not in self.data:
                     self.data["parameters"] = {}
 
-                self.data["parameters"][serial] = inverter.parameters
+                parameter_values = dict(inverter.parameters)
+                read_complete = (
+                    getattr(inverter, "parameters_complete", True) is not False
+                )
+                reconcile = getattr(self, "_reconcile_parameter_read", None)
+                write_seeds = getattr(self, "_parameter_write_seeds", None)
+                if isinstance(write_seeds, dict) and callable(reconcile):
+                    parameter_values = reconcile(
+                        serial,
+                        parameter_values,
+                        read_complete=read_complete,
+                        read_generation=parameter_read_generation,
+                        # pylxpweb sticky carry-forward keys in a partial read
+                        # are not proof their register ranges were observed.
+                        observed_keys=parameter_values if read_complete else (),
+                    )
+                self.data["parameters"][serial] = parameter_values
                 return True
 
             _LOGGER.warning(
@@ -4115,8 +4264,13 @@ class ParameterManagementMixin(_MixinBase):
 
     def _schedule_missing_parameter_refresh(
         self, inverter_serials: list[str], processed_data: dict[str, Any]
-    ) -> asyncio.Task[None]:
+    ) -> asyncio.Task[None] | None:
         """Return the one active missing-parameter loader for this entry."""
+        if self._background_scheduling_stopped:
+            self._missing_parameter_pending_serials.clear()
+            self._missing_parameter_pending_data = None
+            return None
+
         existing = self._missing_parameter_refresh_task
         if existing is not None and not existing.done():
             # Device discovery can grow while an earlier batch is still in
@@ -4158,9 +4312,12 @@ class ParameterManagementMixin(_MixinBase):
         self._missing_parameter_refresh_task = None
         self._missing_parameter_active_serials.clear()
 
-        if task.cancelled():
-            # Shutdown owns the cancellation; never resurrect work while an
-            # entry is unloading.
+        if task.cancelled() or self._background_scheduling_stopped:
+            # Shutdown owns both cancellation and terminal scheduling state;
+            # never resurrect queued work while an entry is unloading. The
+            # explicit flag also covers a task that completed normally just
+            # before shutdown took its cancellation snapshot but whose done
+            # callback runs while that snapshot is being gathered.
             self._missing_parameter_pending_serials.clear()
             self._missing_parameter_pending_data = None
             return
@@ -4323,13 +4480,21 @@ class BackgroundTaskMixin(_MixinBase):
 
     async def _cancel_background_tasks(self) -> None:
         """Cancel all background tasks and wait for them to finish."""
-        for task in self._background_tasks:
-            if not task.done():
-                task.cancel()
+        # Close the producer before snapshotting consumers. A normally-finished
+        # missing-parameter task can still have queued done callbacks; without
+        # this terminal gate, that callback can enqueue its pending successor
+        # while gather() yields and the subsequent clear() silently untracks it.
+        self._background_scheduling_stopped = True
+        self._missing_parameter_pending_serials.clear()
+        self._missing_parameter_pending_data = None
 
-        if self._background_tasks:
-            await asyncio.gather(*self._background_tasks, return_exceptions=True)
-            self._background_tasks.clear()
+        while self._background_tasks:
+            tasks = tuple(self._background_tasks)
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._background_tasks.difference_update(tasks)
 
     async def _async_handle_shutdown(self, event: Any) -> None:
         """Handle Home Assistant stop event to cancel background tasks.
@@ -4350,6 +4515,8 @@ class BackgroundTaskMixin(_MixinBase):
             _LOGGER.debug("Cancelled debounced refresh")
 
         await self._cancel_background_tasks()
+        self._release_shared_cloud_request_budget()
+        await self._release_shared_firmware_status()
         _LOGGER.debug("All background tasks cancelled and cleaned up")
 
     async def async_shutdown(self) -> None:
@@ -4384,6 +4551,8 @@ class BackgroundTaskMixin(_MixinBase):
 
         # 3. Cancel our background tasks (parameter loads, DST sync, etc.)
         await self._cancel_background_tasks()
+        self._release_shared_cloud_request_budget()
+        await self._release_shared_firmware_status()
 
         # 4. Call base class shutdown to set _shutdown_requested, unsub
         #    the refresh timer, and shut down the debounced refresh.

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -216,6 +216,35 @@ def _classify_store_limits(limits: Any) -> bool | None:
     return None
 
 
+async def _async_drain_teardown(teardown: Awaitable[None]) -> None:
+    """Finish one owned teardown before propagating caller cancellation."""
+    teardown_future = asyncio.ensure_future(teardown)
+    caller_cancellation: asyncio.CancelledError | None = None
+
+    # asyncio.wait observes completion without cancelling the owned teardown
+    # when this caller is cancelled. Recreate only waiters, never the teardown,
+    # so repeated cancellation cannot skip a later cleanup stage.
+    while not teardown_future.done():
+        try:
+            await asyncio.wait({teardown_future})
+        except asyncio.CancelledError as err:
+            if caller_cancellation is None:
+                caller_cancellation = err
+
+    teardown_error: BaseException | None = None
+    try:
+        teardown_future.result()
+    except BaseException as err:
+        teardown_error = err
+
+    if caller_cancellation is not None:
+        if teardown_error is not None:
+            raise caller_cancellation from teardown_error
+        raise caller_cancellation
+    if teardown_error is not None:
+        raise teardown_error
+
+
 class _CloudSidefetchSkipped(Exception):
     """Raised in place of a side-fetch's cloud call while the breaker is open.
 
@@ -4497,6 +4526,10 @@ class BackgroundTaskMixin(_MixinBase):
             self._background_tasks.difference_update(tasks)
 
     async def _async_handle_shutdown(self, event: Any) -> None:
+        """Drain the full HA-stop sequence before cancellation propagates."""
+        await _async_drain_teardown(self._async_handle_shutdown_work(event))
+
+    async def _async_handle_shutdown_work(self, event: Any) -> None:
         """Handle Home Assistant stop event to cancel background tasks.
 
         When this fires, the listener auto-removes itself from the event bus.
@@ -4520,6 +4553,10 @@ class BackgroundTaskMixin(_MixinBase):
         _LOGGER.debug("All background tasks cancelled and cleaned up")
 
     async def async_shutdown(self) -> None:
+        """Drain the full unload sequence before cancellation propagates."""
+        await _async_drain_teardown(self._async_shutdown_work())
+
+    async def _async_shutdown_work(self) -> None:
         """Clean up transports, background tasks, and event listeners on shutdown.
 
         Transport disconnection happens FIRST so that any in-flight

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -708,6 +708,14 @@ if TYPE_CHECKING:
         _pv_string_lifetime_store_lock: asyncio.Lock
         _background_tasks: set[asyncio.Task[Any]]
         _api_semaphore: asyncio.Semaphore
+        _missing_parameter_refresh_task: asyncio.Task[None] | None
+        _missing_parameter_active_serials: set[str]
+        _missing_parameter_pending_serials: set[str]
+        _missing_parameter_pending_data: dict[str, Any] | None
+        _firmware_status_fetch: Callable[[], Coroutine[Any, Any, Any]] | None
+        _firmware_status_task: asyncio.Task[Any] | None
+        _firmware_status_batch_active: bool
+        _firmware_prefetched_device_ids: set[int]
         _http_polling_interval: int
         _local_transport_configs: list[dict[str, Any]]
         _local_transports_attached: bool
@@ -776,6 +784,9 @@ if TYPE_CHECKING:
         async def _process_mid_device_object(
             self, mid_device: "MIDDevice"
         ) -> dict[str, Any]: ...
+        async def _prefetch_firmware_update_info(
+            self, devices: Collection[Any]
+        ) -> None: ...
         @staticmethod
         def _extract_inverter_features(
             inverter: BaseInverter,
@@ -798,10 +809,15 @@ if TYPE_CHECKING:
         # ── ParameterManagementMixin methods ──
         def _should_refresh_parameters(self) -> bool: ...
         async def _hourly_parameter_refresh(self) -> None: ...
-        async def _refresh_device_parameters(self, serial: str) -> bool: ...
+        async def _refresh_device_parameters(
+            self, serial: str, *, include_runtime_data: bool = False
+        ) -> bool: ...
         async def _refresh_missing_parameters(
             self, inverter_serials: list[str], processed_data: dict[str, Any]
         ) -> None: ...
+        def _schedule_missing_parameter_refresh(
+            self, inverter_serials: list[str], processed_data: dict[str, Any]
+        ) -> asyncio.Task[None]: ...
 
         # ── BackgroundTaskMixin methods ──
         def _remove_task_from_set(self, task: asyncio.Task[Any]) -> None: ...
@@ -2164,6 +2180,8 @@ class DeviceProcessingMixin(_MixinBase):
         """
         if not hasattr(device, "check_firmware_updates"):
             return None
+        if id(device) in self._firmware_prefetched_device_ids:
+            return self._extract_firmware_update_info(device)
         try:
             await device.check_firmware_updates()
             if hasattr(device, "get_firmware_update_progress"):
@@ -2176,6 +2194,87 @@ class DeviceProcessingMixin(_MixinBase):
             )
         # Extract from the device's cached state regardless of refresh outcome.
         return self._extract_firmware_update_info(device)
+
+    async def _get_firmware_update_status_shared(self) -> Any:
+        """Share one in-flight account status request across device callers.
+
+        The completed response is intentionally not cached here. pylxpweb owns
+        its per-device 10-second/5-minute freshness policy, and firmware install
+        orchestration must be able to observe idle -> active transitions without
+        an integration-side stale result. Only overlapping callers are coalesced.
+        """
+        task = self._firmware_status_task
+        if task is None or (task.done() and not self._firmware_status_batch_active):
+            fetch = self._firmware_status_fetch
+            if fetch is None:
+                raise RuntimeError("Firmware status endpoint is not initialized")
+            task = self.hass.async_create_task(fetch())
+            self._firmware_status_task = task
+            self._background_tasks.add(task)
+            task.add_done_callback(self._remove_task_from_set)
+            task.add_done_callback(self._clear_firmware_status_task)
+            task.add_done_callback(self._log_task_exception)
+
+        # A cancelled inverter-processing waiter must not cancel the one raw
+        # account request that sibling devices still await.
+        return await asyncio.shield(task)
+
+    def _clear_firmware_status_task(self, task: asyncio.Task[Any]) -> None:
+        """Release the single-flight slot if *task* is still its owner."""
+        if (
+            self._firmware_status_task is task
+            and not self._firmware_status_batch_active
+        ):
+            self._firmware_status_task = None
+
+    async def _prefetch_firmware_update_info(self, devices: Collection[Any]) -> None:
+        """Align device firmware polls so account progress is fetched once."""
+        firmware_devices = [
+            device for device in devices if hasattr(device, "check_firmware_updates")
+        ]
+        self._firmware_prefetched_device_ids.clear()
+        if not firmware_devices:
+            return
+
+        async def _check(device: Any) -> None:
+            try:
+                await device.check_firmware_updates()
+            except Exception as err:
+                _LOGGER.debug(
+                    "Could not refresh firmware availability for %s "
+                    "(using last cached state): %s",
+                    getattr(device, "serial_number", "?"),
+                    err,
+                )
+
+        await asyncio.gather(*(_check(device) for device in firmware_devices))
+
+        progress_devices = [
+            device
+            for device in firmware_devices
+            if hasattr(device, "get_firmware_update_progress")
+        ]
+
+        async def _progress(device: Any) -> None:
+            try:
+                await device.get_firmware_update_progress()
+            except Exception as err:
+                _LOGGER.debug(
+                    "Could not refresh firmware progress for %s "
+                    "(using last cached state): %s",
+                    getattr(device, "serial_number", "?"),
+                    err,
+                )
+
+        self._firmware_status_batch_active = True
+        try:
+            await asyncio.gather(*(_progress(device) for device in progress_devices))
+        finally:
+            self._firmware_status_batch_active = False
+            task = self._firmware_status_task
+            if task is not None and task.done():
+                self._firmware_status_task = None
+        self._firmware_prefetched_device_ids.update(map(id, firmware_devices))
 
     async def _process_inverter_object(
         self, inverter: "BaseInverter"
@@ -3927,7 +4026,9 @@ class ParameterManagementMixin(_MixinBase):
             return False
         return refreshed and not incomplete
 
-    async def _refresh_device_parameters(self, serial: str) -> bool:
+    async def _refresh_device_parameters(
+        self, serial: str, *, include_runtime_data: bool = False
+    ) -> bool:
         """Refresh parameters for a specific device using device object.
 
         Link-down handling is delegated to pylxpweb's ``_fetch_parameters``
@@ -3953,8 +4054,19 @@ class ParameterManagementMixin(_MixinBase):
                 _LOGGER.warning("Cannot find inverter object for serial %s", serial)
                 return False
 
-            # Use force=True to bypass cache when refreshing parameters after changes
-            await inverter.refresh(force=True, include_parameters=True)
+            if include_runtime_data:
+                # The explicit device Refresh button promises a full refresh;
+                # preserve that user-facing behavior while routine parameter
+                # jobs and post-write verification use the narrow default.
+                await inverter.refresh(force=True, include_parameters=True)
+            else:
+                # Fetch only holding parameters. ``refresh(force=True,
+                # include_parameters=True)`` also expires and concurrently
+                # fetches runtime, energy, and battery data in pylxpweb, turning
+                # one post-write verification into roughly six cloud calls.
+                # This is the dependency's same locked parameter implementation,
+                # invoked directly so its runtime caches are untouched.
+                await inverter._fetch_parameters()
 
             if hasattr(inverter, "parameters") and inverter.parameters:
                 if not self.data:
@@ -4000,6 +4112,63 @@ class ParameterManagementMixin(_MixinBase):
             await self.async_request_refresh()
         except Exception as e:
             _LOGGER.error("Error during missing parameter refresh: %s", e)
+
+    def _schedule_missing_parameter_refresh(
+        self, inverter_serials: list[str], processed_data: dict[str, Any]
+    ) -> asyncio.Task[None]:
+        """Return the one active missing-parameter loader for this entry."""
+        existing = self._missing_parameter_refresh_task
+        if existing is not None and not existing.done():
+            # Device discovery can grow while an earlier batch is still in
+            # flight. Preserve only genuinely new serials for the next batch;
+            # the active serials must not be re-enqueued by the refresh this
+            # task requests on completion, or a failed read loops forever.
+            new_serials = set(inverter_serials).difference(
+                self._missing_parameter_active_serials,
+                self._missing_parameter_pending_serials,
+            )
+            if new_serials:
+                self._missing_parameter_pending_serials.update(new_serials)
+                self._missing_parameter_pending_data = processed_data
+            _LOGGER.debug(
+                "Missing-parameter refresh already in flight; sharing it for %s",
+                inverter_serials,
+            )
+            return existing
+
+        serials = set(inverter_serials)
+        serials.update(self._missing_parameter_pending_serials)
+        self._missing_parameter_pending_serials.clear()
+        self._missing_parameter_pending_data = None
+        self._missing_parameter_active_serials = serials
+        task = self.hass.async_create_task(
+            self._refresh_missing_parameters(sorted(serials), processed_data)
+        )
+        self._missing_parameter_refresh_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._remove_task_from_set)
+        task.add_done_callback(self._clear_missing_parameter_refresh_task)
+        task.add_done_callback(self._log_task_exception)
+        return task
+
+    def _clear_missing_parameter_refresh_task(self, task: asyncio.Task[None]) -> None:
+        """Release the missing-parameter single-flight owner."""
+        if self._missing_parameter_refresh_task is not task:
+            return
+        self._missing_parameter_refresh_task = None
+        self._missing_parameter_active_serials.clear()
+
+        if task.cancelled():
+            # Shutdown owns the cancellation; never resurrect work while an
+            # entry is unloading.
+            self._missing_parameter_pending_serials.clear()
+            self._missing_parameter_pending_data = None
+            return
+
+        if self._missing_parameter_pending_serials:
+            pending_data = self._missing_parameter_pending_data
+            if pending_data is not None:
+                self._schedule_missing_parameter_refresh([], pending_data)
 
     async def _hourly_parameter_refresh(self) -> None:
         """Perform hourly parameter refresh for all inverters.

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import math
-from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
@@ -268,15 +267,6 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             self.serial,
         )
 
-    @abstractmethod
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        """Return tuple of related entity types for parameter refresh."""
-
-    def _related_entity_predicate(self) -> Callable[[Any], bool]:
-        """Return the entity-selection predicate for parameter refreshes."""
-        related_types = self._get_related_entity_types()
-        return lambda entity: isinstance(entity, related_types)
-
     # ── Value read helpers ──────────────────────────────────────────
 
     def _params_are_local_raw(self) -> bool:
@@ -484,7 +474,6 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             success = await method(**(cloud_kwargs or {}))
             if not success:
                 raise HomeAssistantError(f"Failed to set {label}")
-            await inverter.refresh()
 
         with optimistic_value_context(self, value, label) as write:
             await async_write_with_cloud_fallback(
@@ -533,7 +522,6 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             )
             if not result.success:
                 raise HomeAssistantError(f"Failed to set {label}")
-            await self.coordinator.refresh_inverter_params_if_linked(self.serial)
 
         with optimistic_value_context(self, value, label) as write:
             await async_write_with_cloud_fallback(
@@ -547,12 +535,12 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             write.refresh_ok = await self._refresh_related_entities()
 
     async def _refresh_related_entities(self) -> bool:
-        """Refresh parameters for all inverters and update related entities.
+        """Refresh and publish parameters for only this entity's inverter.
 
         Returns:
-            True when every device's parameter refresh completed; False when
-            any of them failed or this method raised. Errors are logged,
-            never raised (#362/#379): a post-write caller must be able to
+            True when this device's parameter refresh completed; False when
+            it failed or this method raised. Errors are logged, never raised
+            (#362/#379): a post-write caller must be able to
             tell "write+refresh ok" from "write ok, refresh failed" — the old
             swallow-and-return-None contract made a failed refresh look
             identical to success, so the number entity cleared its optimistic
@@ -560,29 +548,10 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
             write the device had acknowledged.
         """
         try:
-            refreshed = await self.coordinator.refresh_all_device_parameters()
-            platform = self.platform
-            if platform is not None:
-                is_related_entity = self._related_entity_predicate()
-                related_entities = [
-                    entity
-                    for entity in platform.entities.values()
-                    if is_related_entity(entity)
-                ]
-                _LOGGER.info(
-                    "Updating %d related entities after parameter refresh",
-                    len(related_entities),
-                )
-                update_tasks = [
-                    entity.async_update()  # type: ignore[attr-defined]
-                    for entity in related_entities
-                ]
-                await asyncio.gather(*update_tasks, return_exceptions=True)
-                await self.coordinator.async_request_refresh()
+            return await self.coordinator.async_refresh_device_parameters(self.serial)
         except Exception as e:
-            _LOGGER.error("Failed to refresh parameters and entities: %s", e)
+            _LOGGER.error("Failed to refresh parameters for %s: %s", self.serial, e)
             return False
-        return refreshed
 
 
 # ── Platform setup ───────────────────────────────────────────────────
@@ -778,9 +747,6 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-charging"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (SystemChargeSOCLimitNumber,)
-
     @property
     def native_value(self) -> float | None:
         """Return the current System Charge SOC limit (reads params first)."""
@@ -819,7 +785,6 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
             )
             if not result.success:
                 raise HomeAssistantError(f"Failed to set SOC limit to {int_value}%")
-            await self.coordinator.refresh_inverter_params_if_linked(self.serial)
 
         label = f"system charge SOC limit to {int_value}%"
         with optimistic_value_context(self, value, label) as write:
@@ -928,9 +893,6 @@ class QuickChargeDurationNumber(RestoreNumber, EG4BaseNumberEntity):
             last_data = await self.async_get_last_number_data()
             restored = getattr(last_data, "native_value", None)
         self._seed_restored_preference(restored)
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (QuickChargeDurationNumber,)
 
     @property
     def native_value(self) -> float | None:
@@ -1045,9 +1007,6 @@ class ACChargePowerNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-charging-medium"
         self._attr_native_precision = 1
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargePowerNumber, PVChargePowerNumber)
-
     @property
     def native_value(self) -> float | None:
         """Return the current AC charge power in kW.
@@ -1106,9 +1065,6 @@ class PVChargePowerNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "kW"
         self._attr_icon = "mdi:solar-power"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargePowerNumber, PVChargePowerNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -1195,9 +1151,6 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
             # write-less config entity is opt-in. Users who attach cloud
             # credentials (or want the read-only view) can enable it.
             self._attr_entity_registry_enabled_default = False
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (GridPeakShavingPowerNumber,)
 
     @property
     def native_value(self) -> float | None:
@@ -1290,7 +1243,6 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
                 raise HomeAssistantError(
                     f"Failed to set grid peak shaving power to {value:.1f} kW"
                 )
-            await inverter.refresh()
             write.refresh_ok = await self._refresh_related_entities()
 
 
@@ -1320,9 +1272,6 @@ class ACChargeSOCLimitNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "%"
         self._attr_icon = "mdi:battery-charging-medium"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargeSOCLimitNumber, OnGridSOCCutoffNumber, OffGridSOCCutoffNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -1378,9 +1327,6 @@ class ACChargeStartBatterySOCNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "%"
         self._attr_icon = "mdi:battery-charging-low"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargeStartBatterySOCNumber, ACChargeEndBatterySOCNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -1455,9 +1401,6 @@ class ACChargeEndBatterySOCNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-charging-high"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargeStartBatterySOCNumber, ACChargeEndBatterySOCNumber)
-
     @property
     def native_value(self) -> float | None:
         """Return the SOC that stops AC charging (whole percent, both paths)."""
@@ -1508,7 +1451,6 @@ async def _write_cloud_named_parameter(
     result = await client.api.control.write_parameter(entity.serial, param, str(value))
     if not result.success:
         raise HomeAssistantError(error_message)
-    await entity.coordinator.refresh_inverter_params_if_linked(entity.serial)
 
 
 class ACCoupleSOCNumberBase(EG4BaseNumberEntity):
@@ -1543,9 +1485,6 @@ class ACCoupleSOCNumberBase(EG4BaseNumberEntity):
     _store_key: str
     _cloud_method: str
     _label: str
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACCoupleStartSOCNumber, ACCoupleEndSOCNumber)
 
     @property
     def _stored_value(self) -> int | None:
@@ -1836,9 +1775,6 @@ class SmartLoadNumber(EG4BaseNumberEntity):
         self._attr_icon = spec.icon
         self._attr_native_precision = spec.precision
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (SmartLoadNumber,)
-
     @property
     def _stored_value(self) -> float | None:
         """This setting's value from the coordinator's ``smart_load`` store."""
@@ -1957,9 +1893,6 @@ class GridSellBackPowerNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:transmission-tower-export"
         self._attr_native_precision = 1
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (GridSellBackPowerNumber,)
-
     @property
     def native_value(self) -> float | None:
         """Return the current grid sell back power in kW.
@@ -2035,7 +1968,6 @@ class GridSellBackPowerNumber(EG4BaseNumberEntity):
                 raise HomeAssistantError(
                     f"Failed to set grid sell back power to {value:.1f} kW"
                 )
-            await self.coordinator.refresh_inverter_params_if_linked(self.serial)
             write.refresh_ok = await self._refresh_related_entities()
 
 
@@ -2074,9 +2006,6 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "W"
         self._attr_icon = "mdi:transmission-tower-import"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (StartDischargePowerNumber, StartChargePowerNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -2169,9 +2098,6 @@ class StartChargePowerNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-arrow-up"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (StartDischargePowerNumber, StartChargePowerNumber)
-
     @property
     def native_value(self) -> float | None:
         """Return the current threshold in watts (signed decode)."""
@@ -2240,13 +2166,6 @@ class ForcedDischargePowerNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "kW"
         self._attr_icon = "mdi:battery-arrow-down"
         self._attr_native_precision = 1
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (
-            ForcedDischargePowerNumber,
-            ForcedDischargeSOCLimitNumber,
-            StopDischargeVoltageNumber,
-        )
 
     @property
     def native_value(self) -> float | None:
@@ -2329,13 +2248,6 @@ class ForcedDischargeSOCLimitNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-20"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (
-            ForcedDischargePowerNumber,
-            ForcedDischargeSOCLimitNumber,
-            StopDischargeVoltageNumber,
-        )
-
     @property
     def native_value(self) -> float | None:
         """Return the current forced discharge SOC limit."""
@@ -2403,13 +2315,6 @@ class StopDischargeVoltageNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "V"
         self._attr_icon = "mdi:battery-arrow-down-outline"
         self._attr_native_precision = 1
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (
-            ForcedDischargePowerNumber,
-            ForcedDischargeSOCLimitNumber,
-            StopDischargeVoltageNumber,
-        )
 
     @property
     def native_value(self) -> float | None:
@@ -2479,9 +2384,6 @@ class OnGridSOCCutoffNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-alert"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargeSOCLimitNumber, OnGridSOCCutoffNumber, OffGridSOCCutoffNumber)
-
     @property
     def native_value(self) -> float | None:
         """Return the current on-grid SOC cutoff (reads from battery_soc_limits dict)."""
@@ -2530,9 +2432,6 @@ class OffGridSOCCutoffNumber(EG4BaseNumberEntity):
         self._attr_icon = "mdi:battery-outline"
         self._attr_native_precision = 0
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (ACChargeSOCLimitNumber, OnGridSOCCutoffNumber, OffGridSOCCutoffNumber)
-
     @property
     def native_value(self) -> float | None:
         """Return the current off-grid SOC cutoff (reads from battery_soc_limits dict)."""
@@ -2578,9 +2477,6 @@ class BatteryChargeCurrentNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "A"
         self._attr_icon = "mdi:battery-plus"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (BatteryChargeCurrentNumber, BatteryDischargeCurrentNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -2628,9 +2524,6 @@ class BatteryDischargeCurrentNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "A"
         self._attr_icon = "mdi:battery-minus"
         self._attr_native_precision = 0
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (BatteryChargeCurrentNumber, BatteryDischargeCurrentNumber)
 
     @property
     def native_value(self) -> float | None:
@@ -2683,9 +2576,6 @@ class SystemChargeVoltLimitNumber(EG4BaseNumberEntity):
         self._attr_native_unit_of_measurement = "V"
         self._attr_icon = "mdi:battery-charging"
         self._attr_native_precision = 1
-
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        return (SystemChargeVoltLimitNumber,)
 
     @property
     def native_value(self) -> float | None:
@@ -2877,13 +2767,6 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
         self._attr_icon = spec.icon
         self._attr_native_precision = spec.precision
 
-    def _get_related_entity_types(self) -> tuple[type, ...]:
-        # Contract-only: satisfies the base class's abstract method but is
-        # never consulted — _related_entity_predicate below narrows the
-        # refresh to spec.related_group instead (an isinstance check alone
-        # would over-refresh every voltage spec at once).
-        return (EG4VoltageNumber,)
-
     def _volts_from_spec_param(self, raw: Any) -> float:
         """Normalize a voltage parameter to volts using the spec's threshold.
 
@@ -2952,11 +2835,4 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
             register=spec.register,
             label=spec.name,
             cloud_write=cloud_write,
-        )
-
-    def _related_entity_predicate(self) -> Callable[[Any], bool]:
-        """Select voltage entities in this spec's parameter refresh group."""
-        return lambda entity: (
-            isinstance(entity, EG4VoltageNumber)
-            and entity._spec.key in self._spec.related_group
         )

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -2035,9 +2035,7 @@ class GridSellBackPowerNumber(EG4BaseNumberEntity):
                 raise HomeAssistantError(
                     f"Failed to set grid sell back power to {value:.1f} kW"
                 )
-            inverter = self.coordinator.get_inverter_object(self.serial)
-            if inverter:
-                await inverter.refresh(force=True, include_parameters=True)
+            await self.coordinator.refresh_inverter_params_if_linked(self.serial)
             write.refresh_ok = await self._refresh_related_entities()
 
 

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -265,8 +265,6 @@ class EG4OperatingModeSelect(EG4BaseSelect):
             if not success:
                 raise HomeAssistantError(f"Failed to set operating mode to {option}")
 
-            # Refresh inverter data
-            await inverter.refresh()
         except Exception as e:
             _LOGGER.error(
                 "Failed to set operating mode to %s for device %s: %s",
@@ -384,7 +382,6 @@ class EG4PVInputModeSelect(EG4BaseSelect):
                 )
                 if not result.success:
                     raise HomeAssistantError(f"Failed to set PV input mode to {option}")
-                await self.coordinator.refresh_inverter_params_if_linked(self._serial)
 
             await async_write_with_cloud_fallback(
                 self.coordinator,
@@ -655,7 +652,6 @@ class EG4BatteryControlModeSelect(EG4BaseSelect):
                     raise HomeAssistantError(
                         f"Failed to set {self._control_name} to {option}"
                     )
-                await self.coordinator.refresh_inverter_params_if_linked(self._serial)
 
             await async_write_with_cloud_fallback(
                 self.coordinator,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,7 +225,16 @@ def wire_coordinator_write_helpers(coordinator: MagicMock) -> None:
     async def _refresh_if_linked(target: str) -> None:
         inv = coordinator.get_inverter_object(target)
         if inv and not coordinator.is_transport_link_down(target):
-            await inv.refresh(force=True, include_parameters=True)
+            fetch_parameters = inv._fetch_parameters
+            # Most entity tests use intentionally loose MagicMock inverter
+            # doubles. Teach that shared scaffold the new targeted async seam
+            # without giving every unrelated entity test dependency internals.
+            if isinstance(fetch_parameters, MagicMock) and not isinstance(
+                fetch_parameters, AsyncMock
+            ):
+                fetch_parameters = AsyncMock()
+                inv._fetch_parameters = fetch_parameters
+            await fetch_parameters()
 
     def _params_local_raw(target: str, *, include_configured: bool = False) -> bool:
         if coordinator.is_local_only():

--- a/tests/test_base_entity_envelope.py
+++ b/tests/test_base_entity_envelope.py
@@ -170,7 +170,7 @@ async def test_switch_success_order_and_state_writes(
     refresh_params: bool,
     final_refresh: str,
 ) -> None:
-    """Switch writes seed and pre-refresh before delay and final refresh."""
+    """Switches perform one refresh appropriate to their backing state."""
     events: list[str] = []
     entity, _coordinator, inverter = _make_entity(events)
     inverter.enable_test = AsyncMock(side_effect=lambda: events.append("write") or True)
@@ -186,15 +186,23 @@ async def test_switch_success_order_and_state_writes(
         seed_param_key="FUNC_TEST",
     )
 
-    assert events == [
+    expected = [
         "optimistic-set",
         "write",
         "seed",
-        "inverter-refresh",
-        "sleep",
-        final_refresh,
-        "clear",
     ]
+    if not refresh_params:
+        expected.append("inverter-refresh")
+    expected.extend(["sleep", final_refresh, "clear"])
+    assert events == expected
+    if refresh_params:
+        inverter.refresh.assert_not_awaited()
+        _coordinator.async_refresh.assert_not_awaited()
+        _coordinator.async_refresh_device_parameters.assert_awaited_once_with(SERIAL)
+    else:
+        inverter.refresh.assert_awaited_once_with()
+        _coordinator.async_refresh.assert_awaited_once_with()
+        _coordinator.async_refresh_device_parameters.assert_not_awaited()
     _assert_state_write_counts(entity, optimistic_value=True, clear_count=1)
     entity._seed_cloud_written_parameter.assert_called_once_with("FUNC_TEST", True)
     base_entity_module.asyncio.sleep.assert_awaited_once_with(0.25)
@@ -489,7 +497,6 @@ async def test_switch_write_ok_refresh_reports_failure_retains_optimistic(
         "optimistic-set",
         "write",
         "seed",
-        "inverter-refresh",
         "sleep",
         "parameter-refresh",
     ]

--- a/tests/test_battery_control_mode.py
+++ b/tests/test_battery_control_mode.py
@@ -410,3 +410,5 @@ class TestBatteryControlSelects:
         coordinator.client.api.control.control_function.assert_awaited_once_with(
             "1234567890", "FUNC_BAT_DISCHARGE_CONTROL", False
         )
+        coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
+        coordinator.refresh_all_device_parameters.assert_awaited_once_with()

--- a/tests/test_button_entities.py
+++ b/tests/test_button_entities.py
@@ -71,7 +71,9 @@ class TestEG4RefreshButton:
 
         # The inverter path delegates to the coordinator's force refresh
         # (which includes holding-register parameters).
-        coordinator._refresh_device_parameters.assert_awaited_once_with("1234567890")
+        coordinator._refresh_device_parameters.assert_awaited_once_with(
+            "1234567890", include_runtime_data=True
+        )
         coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -121,7 +123,7 @@ class TestEG4RefreshButton:
         guard (pylxpweb#206, in the b24 floor pinned by manifest.json):
         it skips the local Modbus read (no hang risk) and falls back to
         cloud named-parameter reads in HYBRID.  A coordinator-side gate
-        would block exactly that fallback, so refresh() must still be
+        would block exactly that fallback, so the full refresh must still be
         awaited with force + parameters even when the link is down.
         """
         coordinator = MagicMock()

--- a/tests/test_cloud_fanout.py
+++ b/tests/test_cloud_fanout.py
@@ -1,0 +1,464 @@
+"""Regression tests for bounded and deduplicated cloud polling (eg4-06er.5)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pylxpweb.models import FirmwareUpdateInfo, FirmwareUpdateStatus
+
+from custom_components.eg4_web_monitor.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_DST_SYNC,
+    CONF_LIBRARY_DEBUG,
+    CONF_LOCAL_TRANSPORTS,
+    CONF_PLANT_ID,
+    CONNECTION_TYPE_HTTP,
+    CONNECTION_TYPE_LOCAL,
+    DOMAIN,
+)
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
+from tests.conftest import make_real_inverter
+
+
+def _http_entry(entry_id: str = "cloud_fanout") -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EG4 - Cloud fanout",
+        data={
+            CONF_USERNAME: "test",
+            CONF_PASSWORD: "test",
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP,
+            CONF_PLANT_ID: "12345",
+            CONF_DST_SYNC: False,
+            CONF_LIBRARY_DEBUG: False,
+        },
+        entry_id=entry_id,
+    )
+
+
+def _local_entry(entry_id: str = "parameter_only") -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EG4 - Parameter only",
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL,
+            CONF_LOCAL_TRANSPORTS: [],
+            CONF_DST_SYNC: False,
+            CONF_LIBRARY_DEBUG: False,
+        },
+        entry_id=entry_id,
+    )
+
+
+class _CountingClient:
+    """Small client double whose request method exposes real concurrency."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+        self.calls = 0
+        self._request_started = asyncio.Event()
+        self._release_requests = asyncio.Event()
+        self.api = SimpleNamespace(
+            firmware=SimpleNamespace(
+                get_firmware_update_status=AsyncMock(return_value=object())
+            )
+        )
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, endpoint, data, cache_key, cache_endpoint, _retry_count
+        self.calls += 1
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        self._request_started.set()
+        try:
+            await self._release_requests.wait()
+        finally:
+            self.active -= 1
+        return {"success": True}
+
+
+class _ColdCacheInverter:
+    """A cold inverter refresh fans out runtime, energy, and battery calls."""
+
+    def __init__(self, client: _CountingClient, serial: str) -> None:
+        self._client = client
+        self.serial_number = serial
+
+    async def refresh(self) -> None:
+        await asyncio.gather(
+            self._client._request("POST", f"/{self.serial_number}/runtime"),
+            self._client._request("POST", f"/{self.serial_number}/energy"),
+            self._client._request("POST", f"/{self.serial_number}/battery"),
+        )
+
+
+class _RecursiveRetryClient:
+    """Client double that retries through its own patched request attribute."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.api = SimpleNamespace(
+            firmware=SimpleNamespace(
+                get_firmware_update_status=AsyncMock(return_value=object())
+            )
+        )
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        self.calls += 1
+        await asyncio.sleep(0)
+        if _retry_count == 0:
+            return await self._request(
+                method,
+                endpoint,
+                data=data,
+                cache_key=cache_key,
+                cache_endpoint=cache_endpoint,
+                _retry_count=1,
+            )
+        return {"success": True}
+
+
+async def test_cold_cache_station_fanout_is_bounded_at_request_boundary(hass):
+    """Station-level gather cannot exceed the per-account request budget."""
+    client = _CountingClient()
+    entry = _http_entry()
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        EG4DataUpdateCoordinator(hass, entry)
+
+    inverters = [_ColdCacheInverter(client, f"INV{i}") for i in range(5)]
+    refresh = asyncio.gather(*(inverter.refresh() for inverter in inverters))
+    await client._request_started.wait()
+    await asyncio.sleep(0)
+
+    # Fifteen cold-cache legs are created together, but only three may enter
+    # pylxpweb's request chain at once.
+    assert client.calls == 3
+    assert client.peak == 3
+
+    client._release_requests.set()
+    await refresh
+    assert client.calls == 15
+    assert client.peak == 3
+
+
+async def test_request_budget_releases_a_slot_when_a_waiter_is_cancelled(hass):
+    """Cancellation cannot leak a request slot or strand queued requests."""
+    client = _CountingClient()
+    entry = _http_entry("cloud_cancel")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        EG4DataUpdateCoordinator(hass, entry)
+
+    tasks = [
+        asyncio.create_task(client._request("POST", f"/{index}")) for index in range(4)
+    ]
+    await client._request_started.wait()
+    await asyncio.sleep(0)
+    assert client.calls == 3
+
+    tasks[0].cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await tasks[0]
+    await asyncio.sleep(0)
+    assert client.calls == 4
+
+    client._release_requests.set()
+    await asyncio.gather(*tasks[1:])
+    assert client.active == 0
+
+
+async def test_request_budget_is_reentrant_for_dependency_retries(hass):
+    """Three occupied slots can all recurse for retry without deadlocking."""
+    client = _RecursiveRetryClient()
+    entry = _http_entry("cloud_retry")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        EG4DataUpdateCoordinator(hass, entry)
+
+    results = await asyncio.wait_for(
+        asyncio.gather(*(client._request("POST", f"/{index}") for index in range(6))),
+        timeout=1,
+    )
+    assert results == [{"success": True}] * 6
+    assert client.calls == 12
+
+
+async def test_parameter_verification_fetches_parameters_only(hass):
+    """A post-write verification must not force runtime/energy/battery reads."""
+    entry = _local_entry()
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    inverter = MagicMock()
+    inverter.parameters = {"HOLD_AC_CHARGE_POWER_CMD": 50}
+    inverter.parameters_complete = True
+    inverter._fetch_parameters = AsyncMock()
+    inverter.refresh = AsyncMock()
+    coordinator._inverter_cache = {"INV1": inverter}
+    coordinator.data = {"devices": {"INV1": {"type": "inverter"}}}
+
+    assert await coordinator._refresh_device_parameters("INV1") is True
+    inverter._fetch_parameters.assert_awaited_once_with()
+    inverter.refresh.assert_not_awaited()
+
+
+async def test_missing_parameter_refresh_job_is_single_flight(hass):
+    """Repeated update cycles share one coordinator-owned missing-data job."""
+    entry = _local_entry("missing_singleflight")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_refresh(serials: list[str], processed_data: dict[str, Any]) -> None:
+        del serials, processed_data
+        started.set()
+        await release.wait()
+
+    coordinator._refresh_missing_parameters = AsyncMock(side_effect=_slow_refresh)
+    first_data: dict[str, Any] = {"parameters": {}}
+    second_data: dict[str, Any] = {"parameters": {}}
+
+    first = coordinator._schedule_missing_parameter_refresh(["INV1"], first_data)
+    await started.wait()
+    second = coordinator._schedule_missing_parameter_refresh(["INV1"], second_data)
+
+    assert second is first
+    assert coordinator._refresh_missing_parameters.await_count == 1
+
+    release.set()
+    await first
+    await asyncio.sleep(0)
+    assert first not in coordinator._background_tasks
+
+
+async def test_cancelled_missing_parameter_job_does_not_resurrect(hass):
+    """Unload cancellation clears ownership and never starts queued work."""
+    entry = _local_entry("missing_cancel")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    started = asyncio.Event()
+
+    async def _blocked_refresh(
+        serials: list[str], processed_data: dict[str, Any]
+    ) -> None:
+        del serials, processed_data
+        started.set()
+        await asyncio.Event().wait()
+
+    coordinator._refresh_missing_parameters = AsyncMock(side_effect=_blocked_refresh)
+    task = coordinator._schedule_missing_parameter_refresh(["INV1"], {"parameters": {}})
+    await started.wait()
+    coordinator._schedule_missing_parameter_refresh(
+        ["INV1", "INV2"], {"parameters": {}}
+    )
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+
+    assert coordinator._missing_parameter_refresh_task is None
+    assert coordinator._missing_parameter_pending_serials == set()
+    assert coordinator._refresh_missing_parameters.await_count == 1
+
+
+async def test_new_missing_serial_is_queued_behind_active_singleflight(hass):
+    """A newly discovered inverter is delayed, not dropped or overlapped."""
+    entry = _local_entry("missing_queue")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_finished = asyncio.Event()
+    batches: list[list[str]] = []
+
+    async def _refresh(serials: list[str], processed_data: dict[str, Any]) -> None:
+        del processed_data
+        batches.append(serials)
+        if len(batches) == 1:
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_finished.set()
+
+    coordinator._refresh_missing_parameters = AsyncMock(side_effect=_refresh)
+    first = coordinator._schedule_missing_parameter_refresh(
+        ["INV1"], {"parameters": {}}
+    )
+    await first_started.wait()
+    shared = coordinator._schedule_missing_parameter_refresh(
+        ["INV1", "INV2"], {"parameters": {}}
+    )
+    assert shared is first
+
+    release_first.set()
+    await first
+    await second_finished.wait()
+    second = coordinator._missing_parameter_refresh_task
+    if second is not None:
+        await second
+    assert batches == [["INV1"], ["INV2"]]
+
+
+async def test_firmware_account_status_is_single_flight_and_shielded(hass):
+    """All device polls share one status request; one cancelled waiter is isolated."""
+    client = _CountingClient()
+    status_started = asyncio.Event()
+    status_release = asyncio.Event()
+    response = object()
+
+    async def _status() -> object:
+        status_started.set()
+        await status_release.wait()
+        return response
+
+    original_status = AsyncMock(side_effect=_status)
+    client.api.firmware.get_firmware_update_status = original_status
+    entry = _http_entry("firmware_singleflight")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    shared_status = client.api.firmware.get_firmware_update_status
+    first = asyncio.create_task(shared_status())
+    second = asyncio.create_task(shared_status())
+    await status_started.wait()
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    # Cancelling one consumer does not cancel the coordinator-owned request.
+    assert original_status.await_count == 1
+    assert not second.done()
+    status_release.set()
+    assert await second is response
+    await asyncio.sleep(0)
+    assert coordinator._firmware_status_task is None
+
+
+async def test_firmware_prefetch_deduplicates_multi_inverter_status_calls(hass):
+    """Real pylxpweb devices align on one account-wide progress call."""
+    client = _CountingClient()
+    response = FirmwareUpdateStatus(
+        receiving=False,
+        progressing=False,
+        fileReady=False,
+        deviceInfos=[],
+    )
+    original_status = AsyncMock(return_value=response)
+    client.api.firmware.get_firmware_update_status = original_status
+    entry = _http_entry("firmware_prefetch")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    devices = []
+    for index in range(7):
+        device = make_real_inverter(serial_number=f"INV{index}", client=client)
+        device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="1.0.0",
+            latest_version="1.0.0",
+            title="Firmware",
+        )
+        # Availability stays inside its 24-hour cache, while progress is past
+        # its idle five-minute TTL and therefore reaches the account endpoint.
+        device._firmware_update_cache_time = datetime.now() - timedelta(minutes=6)
+        devices.append(device)
+
+    await coordinator._prefetch_firmware_update_info(devices)
+
+    assert original_status.await_count == 1
+    assert all(device.firmware_update_in_progress is False for device in devices)
+
+
+async def test_firmware_singleflight_is_owned_by_one_config_entry(hass):
+    """Unloading one entry cannot cancel another entry's status request."""
+    clients = [_CountingClient(), _CountingClient()]
+    starts = [asyncio.Event(), asyncio.Event()]
+    releases = [asyncio.Event(), asyncio.Event()]
+    originals: list[AsyncMock] = []
+
+    for index, client in enumerate(clients):
+
+        async def _status(index: int = index) -> int:
+            starts[index].set()
+            await releases[index].wait()
+            return index
+
+        original = AsyncMock(side_effect=_status)
+        originals.append(original)
+        client.api.firmware.get_firmware_update_status = original
+
+    coordinators: list[EG4DataUpdateCoordinator] = []
+    for index, client in enumerate(clients):
+        entry = _http_entry(f"firmware_owner_{index}")
+        entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=client,
+        ):
+            coordinators.append(EG4DataUpdateCoordinator(hass, entry))
+
+    waiters = [
+        asyncio.create_task(client.api.firmware.get_firmware_update_status())
+        for client in clients
+    ]
+    await asyncio.gather(*(started.wait() for started in starts))
+
+    await coordinators[0]._cancel_background_tasks()
+    result = await asyncio.gather(waiters[0], return_exceptions=True)
+    assert isinstance(result[0], asyncio.CancelledError)
+    assert not waiters[1].done()
+    assert originals[0].await_count == 1
+    assert originals[1].await_count == 1
+
+    releases[1].set()
+    assert await waiters[1] == 1

--- a/tests/test_cloud_fanout.py
+++ b/tests/test_cloud_fanout.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.config_entries import current_entry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pylxpweb.models import FirmwareUpdateInfo, FirmwareUpdateStatus
 
+import custom_components.eg4_web_monitor.coordinator as coordinator_module
+from custom_components.eg4_web_monitor.cloud_requests import (
+    acquire_shared_cloud_request_budget,
+    install_cloud_request_limiter,
+    release_shared_cloud_request_budget,
+)
 from custom_components.eg4_web_monitor.const import (
     CONF_CONNECTION_TYPE,
     CONF_DST_SYNC,
@@ -27,20 +35,33 @@ from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinat
 from tests.conftest import make_real_inverter
 
 
-def _http_entry(entry_id: str = "cloud_fanout") -> MockConfigEntry:
+def _http_entry(
+    entry_id: str = "cloud_fanout",
+    *,
+    username: str = "test",
+    plant_id: str = "12345",
+) -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="EG4 - Cloud fanout",
         data={
-            CONF_USERNAME: "test",
+            CONF_USERNAME: username,
             CONF_PASSWORD: "test",
             CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP,
-            CONF_PLANT_ID: "12345",
+            CONF_PLANT_ID: plant_id,
             CONF_DST_SYNC: False,
             CONF_LIBRARY_DEBUG: False,
         },
         entry_id=entry_id,
     )
+
+
+class _ListenerScope:
+    """Hashable stand-in for #532's private listener context."""
+
+    def __init__(self, kind: str, serial: str = "") -> None:
+        self.kind = kind
+        self.serial = serial
 
 
 def _local_entry(entry_id: str = "parameter_only") -> MockConfigEntry:
@@ -94,6 +115,52 @@ class _CountingClient:
         return {"success": True}
 
 
+class _AccountRequestCounter:
+    """Aggregate request concurrency across multiple pylxpweb clients."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+        self.calls = 0
+        self.three_started = asyncio.Event()
+        self.release = asyncio.Event()
+
+
+class _AccountCountingClient:
+    """Client double backed by an account-wide concurrency counter."""
+
+    def __init__(self, counter: _AccountRequestCounter) -> None:
+        self.counter = counter
+        self.api = SimpleNamespace(
+            firmware=SimpleNamespace(
+                get_firmware_update_status=AsyncMock(return_value=object())
+            )
+        )
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, endpoint, data, cache_key, cache_endpoint, _retry_count
+        counter = self.counter
+        counter.calls += 1
+        counter.active += 1
+        counter.peak = max(counter.peak, counter.active)
+        if counter.active >= 3:
+            counter.three_started.set()
+        try:
+            await counter.release.wait()
+        finally:
+            counter.active -= 1
+        return {"success": True}
+
+
 class _ColdCacheInverter:
     """A cold inverter refresh fans out runtime, energy, and battery calls."""
 
@@ -144,6 +211,223 @@ class _RecursiveRetryClient:
         return {"success": True}
 
 
+class _ReactiveAuthTaskClient:
+    """Model pylxpweb #261's child auth task under saturated parent calls."""
+
+    def __init__(self) -> None:
+        self.parents_started = 0
+        self.all_parents_started = asyncio.Event()
+        self.auth_task: asyncio.Task[dict[str, Any]] | None = None
+        self._authentication_task: asyncio.Task[dict[str, Any]] | None = None
+        self.login_calls = 0
+        self.detect_calls = 0
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, data, cache_key, cache_endpoint, _retry_count
+        if endpoint.startswith("/parent/"):
+            self.parents_started += 1
+            if self.parents_started == 3:
+                self.all_parents_started.set()
+            await self.all_parents_started.wait()
+            task = self.auth_task
+            if task is None:
+                task = asyncio.create_task(self._request("POST", "/WManage/api/login"))
+                self.auth_task = task
+                self._authentication_task = task
+            await asyncio.shield(task)
+            return {"success": True}
+        if endpoint == "/WManage/api/login":
+            self.login_calls += 1
+            # login() performs ordinary account-level detection before the
+            # client-owned authentication task completes.
+            await self._request("POST", "/auth/account-detection")
+            return {"success": True}
+        if endpoint == "/auth/account-detection":
+            self.detect_calls += 1
+            return {"success": True}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+
+class _LingeringReactiveAuthClient:
+    """Keep pylxpweb's shielded auth task alive after all parents cancel."""
+
+    def __init__(self, *, detect_after_login: bool = True) -> None:
+        self.detect_after_login = detect_after_login
+        self.parents_started = 0
+        self.all_parents_started = asyncio.Event()
+        self.auth_task: asyncio.Task[dict[str, Any]] | None = None
+        self._authentication_task: asyncio.Task[dict[str, Any]] | None = None
+        self.auth_started = asyncio.Event()
+        self.auth_release = asyncio.Event()
+        self.ordinary_started = 0
+        self.two_ordinary_started = asyncio.Event()
+        self.three_ordinary_started = asyncio.Event()
+        self.ordinary_release = asyncio.Event()
+        self.active_raw = 0
+        self.peak_raw = 0
+
+    def _enter_raw(self) -> None:
+        self.active_raw += 1
+        self.peak_raw = max(self.peak_raw, self.active_raw)
+
+    def _leave_raw(self) -> None:
+        self.active_raw -= 1
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, data, cache_key, cache_endpoint, _retry_count
+        if endpoint.startswith("/parent/"):
+            self.parents_started += 1
+            if self.parents_started == 3:
+                self.all_parents_started.set()
+            await self.all_parents_started.wait()
+            task = self.auth_task
+            if task is None:
+                task = asyncio.create_task(self._request("POST", "/WManage/api/login"))
+                self.auth_task = task
+                self._authentication_task = task
+            await asyncio.shield(task)
+            return {"success": True}
+        if endpoint == "/WManage/api/login":
+            self._enter_raw()
+            self.auth_started.set()
+            try:
+                await self.auth_release.wait()
+            finally:
+                self._leave_raw()
+            # pylxpweb continues in the same authentication task after login.
+            if self.detect_after_login:
+                await self._request("POST", "/auth/account-detection")
+            return {"success": True}
+        if endpoint == "/auth/account-detection":
+            return {"success": True}
+        if endpoint.startswith("/ordinary/"):
+            self._enter_raw()
+            self.ordinary_started += 1
+            if self.ordinary_started == 2:
+                self.two_ordinary_started.set()
+            if self.ordinary_started == 3:
+                self.three_ordinary_started.set()
+            try:
+                await self.ordinary_release.wait()
+            finally:
+                self._leave_raw()
+            return {"success": True}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+
+class _DelayedReactiveAuthClient:
+    """Delay exact login until its origin parent's admission has retired."""
+
+    def __init__(self) -> None:
+        self.parents_started = 0
+        self.three_parents_started = asyncio.Event()
+        self.four_parents_started = asyncio.Event()
+        self.auth_prework_started = asyncio.Event()
+        self.allow_login = asyncio.Event()
+        self.auth_task: asyncio.Task[dict[str, Any]] | None = None
+        self._authentication_task: asyncio.Task[dict[str, Any]] | None = None
+        self.login_calls = 0
+        self.active_parents = 0
+        self.peak_parents = 0
+
+    async def _authenticate(self) -> dict[str, Any]:
+        self.auth_prework_started.set()
+        await self.allow_login.wait()
+        return await self._request("POST", "/WManage/api/login")
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, data, cache_key, cache_endpoint, _retry_count
+        if endpoint.startswith("/parent/"):
+            self.active_parents += 1
+            self.peak_parents = max(self.peak_parents, self.active_parents)
+            try:
+                self.parents_started += 1
+                if endpoint == "/parent/0":
+                    self.auth_task = asyncio.create_task(self._authenticate())
+                    self._authentication_task = self.auth_task
+                    # pylxpweb #261 consumes the shared task's terminal
+                    # exception in its own done callback even when the origin
+                    # parent canceled its shielded waiter.
+                    self.auth_task.add_done_callback(
+                        lambda task: None if task.cancelled() else task.exception()
+                    )
+                if self.parents_started == 3:
+                    self.three_parents_started.set()
+                if self.parents_started == 4:
+                    self.four_parents_started.set()
+                await self.three_parents_started.wait()
+                while self.auth_task is None:
+                    await asyncio.sleep(0)
+                await asyncio.shield(self.auth_task)
+                return {"success": True}
+            finally:
+                self.active_parents -= 1
+        if endpoint == "/WManage/api/login":
+            self.login_calls += 1
+            return {"success": True}
+        if endpoint == "/ordinary/recovery":
+            return {"success": True}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+
+class _InheritedOrdinaryChildClient:
+    """Prove an unrelated descendant does not inherit limiter admission."""
+
+    def __init__(self) -> None:
+        self.child_created = asyncio.Event()
+        self.child_started = asyncio.Event()
+        self.release_parent = asyncio.Event()
+        self.child_task: asyncio.Task[dict[str, Any]] | None = None
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None = None,
+        cache_key: str | None = None,
+        cache_endpoint: str | None = None,
+        _retry_count: int = 0,
+    ) -> dict[str, Any]:
+        del method, data, cache_key, cache_endpoint, _retry_count
+        if endpoint == "/parent":
+            self.child_task = asyncio.create_task(self._request("POST", "/child"))
+            self.child_created.set()
+            await self.release_parent.wait()
+            return {"success": True}
+        if endpoint == "/child":
+            self.child_started.set()
+            return {"success": True}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+
 async def test_cold_cache_station_fanout_is_bounded_at_request_boundary(hass):
     """Station-level gather cannot exceed the per-account request budget."""
     client = _CountingClient()
@@ -170,6 +454,95 @@ async def test_cold_cache_station_fanout_is_bounded_at_request_boundary(hass):
     await refresh
     assert client.calls == 15
     assert client.peak == 3
+
+
+async def test_same_account_entries_share_one_raw_request_budget(hass):
+    """Two plant clients on one account have one aggregate three-chain cap."""
+    counter = _AccountRequestCounter()
+    clients = [_AccountCountingClient(counter), _AccountCountingClient(counter)]
+    coordinators: list[EG4DataUpdateCoordinator] = []
+    requests: list[asyncio.Task[dict[str, Any]]] = []
+    for index, client in enumerate(clients):
+        entry = _http_entry(
+            f"shared_budget_{index}",
+            username="shared-budget-account",
+            plant_id=f"plant-{index}",
+        )
+        entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=client,
+        ):
+            coordinators.append(EG4DataUpdateCoordinator(hass, entry))
+
+    try:
+        requests = [
+            asyncio.create_task(client._request("POST", f"/{client_index}/{call}"))
+            for client_index, client in enumerate(clients)
+            for call in range(4)
+        ]
+        await asyncio.wait_for(counter.three_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        assert counter.calls == 3
+        assert counter.peak == 3
+    finally:
+        counter.release.set()
+        await asyncio.gather(*requests, return_exceptions=True)
+        for coordinator in coordinators:
+            coordinator._release_shared_cloud_request_budget()
+        await asyncio.gather(
+            *(
+                coordinator._release_shared_firmware_status()
+                for coordinator in coordinators
+            )
+        )
+
+
+async def test_different_accounts_have_independent_raw_request_budgets(hass):
+    """Unrelated cloud accounts can each consume their full three-chain cap."""
+    counters = [_AccountRequestCounter(), _AccountRequestCounter()]
+    clients = [_AccountCountingClient(counter) for counter in counters]
+    coordinators: list[EG4DataUpdateCoordinator] = []
+    requests: list[asyncio.Task[dict[str, Any]]] = []
+    for index, client in enumerate(clients):
+        entry = _http_entry(
+            f"isolated_budget_{index}",
+            username=f"isolated-budget-account-{index}",
+            plant_id=f"plant-{index}",
+        )
+        entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=client,
+        ):
+            coordinators.append(EG4DataUpdateCoordinator(hass, entry))
+
+    try:
+        requests = [
+            asyncio.create_task(client._request("POST", f"/{index}/{call}"))
+            for index, client in enumerate(clients)
+            for call in range(3)
+        ]
+        await asyncio.wait_for(
+            asyncio.gather(*(counter.three_started.wait() for counter in counters)),
+            timeout=1,
+        )
+
+        assert [counter.calls for counter in counters] == [3, 3]
+        assert [counter.peak for counter in counters] == [3, 3]
+    finally:
+        for counter in counters:
+            counter.release.set()
+        await asyncio.gather(*requests, return_exceptions=True)
+        for coordinator in coordinators:
+            coordinator._release_shared_cloud_request_budget()
+        await asyncio.gather(
+            *(
+                coordinator._release_shared_firmware_status()
+                for coordinator in coordinators
+            )
+        )
 
 
 async def test_request_budget_releases_a_slot_when_a_waiter_is_cancelled(hass):
@@ -222,6 +595,410 @@ async def test_request_budget_is_reentrant_for_dependency_retries(hass):
     assert client.calls == 12
 
 
+async def test_replacement_reuses_budget_while_released_client_drains(hass):
+    """Reload shares draining leases and drops queued work from the old client."""
+    counter = _AccountRequestCounter()
+    clients = [_AccountCountingClient(counter), _AccountCountingClient(counter)]
+    coordinators: list[EG4DataUpdateCoordinator] = []
+    old_requests: list[asyncio.Task[dict[str, Any]]] = []
+    replacement_requests: list[asyncio.Task[dict[str, Any]]] = []
+
+    old_entry = _http_entry(
+        "shared_budget_old",
+        username="reload-budget-account",
+        plant_id="old-plant",
+    )
+    old_entry.add_to_hass(hass)
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=clients[0],
+    ):
+        old_coordinator = EG4DataUpdateCoordinator(hass, old_entry)
+    coordinators.append(old_coordinator)
+    budget = old_coordinator._cloud_request_budget
+    assert budget is not None
+
+    try:
+        # Three requests enter and a fourth becomes an old-client waiter.
+        old_requests = [
+            asyncio.create_task(clients[0]._request("POST", f"/old/{index}"))
+            for index in range(4)
+        ]
+        await asyncio.wait_for(counter.three_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert counter.calls == 3
+
+        # Unloading the final owner closes that client but retains the budget
+        # because all four active/queued chains still hold lifecycle leases.
+        old_coordinator._release_shared_cloud_request_budget()
+        assert budget.ref_count == 0
+        assert "eg4_web_monitor_cloud_request_budgets" in hass.data
+
+        replacement_entry = _http_entry(
+            "shared_budget_replacement",
+            username="reload-budget-account",
+            plant_id="replacement-plant",
+        )
+        replacement_entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=clients[1],
+        ):
+            replacement = EG4DataUpdateCoordinator(hass, replacement_entry)
+        coordinators.append(replacement)
+
+        assert replacement._cloud_request_budget is budget
+        assert budget.ref_count == 1
+        replacement_requests = [
+            asyncio.create_task(clients[1]._request("POST", f"/new/{index}"))
+            for index in range(3)
+        ]
+        await asyncio.sleep(0)
+        assert counter.calls == 3
+        assert counter.peak == 3
+
+        counter.release.set()
+        old_results = await asyncio.gather(*old_requests, return_exceptions=True)
+        replacement_results = await asyncio.gather(*replacement_requests)
+
+        # The old queued call consumes/relinquishes its accounted lease after
+        # admission, but the post-acquire close check prevents detached-client
+        # I/O. Only the three active old calls and three replacement calls run.
+        assert old_results[:3] == [{"success": True}] * 3
+        assert isinstance(old_results[3], RuntimeError)
+        assert replacement_results == [{"success": True}] * 3
+        assert counter.calls == 6
+        assert counter.peak == 3
+
+        replacement._release_shared_cloud_request_budget()
+        assert budget.ref_count == 0
+        assert "eg4_web_monitor_cloud_request_budgets" not in hass.data
+    finally:
+        counter.release.set()
+        await asyncio.gather(
+            *old_requests,
+            *replacement_requests,
+            return_exceptions=True,
+        )
+        for coordinator in coordinators:
+            coordinator._release_shared_cloud_request_budget()
+        await asyncio.gather(
+            *(
+                coordinator._release_shared_firmware_status()
+                for coordinator in coordinators
+            )
+        )
+
+
+async def test_constructor_failure_leaves_no_shared_owners_or_unload_callback(hass):
+    """Fallible setup completes before account owners and unload retention."""
+    client = _CountingClient()
+    entry = _http_entry("constructor_rollback", username="constructor-account")
+    entry.add_to_hass(hass)
+    initial_callbacks = tuple(getattr(entry, "_on_unload", None) or ())
+    context_token = current_entry.set(entry)
+    try:
+        with (
+            patch(
+                "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+                return_value=client,
+            ),
+            patch.object(
+                type(hass.bus),
+                "async_listen_once",
+                side_effect=RuntimeError("listener setup failed"),
+            ),
+            pytest.raises(RuntimeError, match="listener setup failed"),
+        ):
+            EG4DataUpdateCoordinator(hass, entry)
+    finally:
+        current_entry.reset(context_token)
+
+    assert tuple(getattr(entry, "_on_unload", None) or ()) == initial_callbacks
+    assert "eg4_web_monitor_cloud_request_budgets" not in hass.data
+    assert "eg4_web_monitor_firmware_status_flights" not in hass.data
+
+
+async def test_saturated_budget_admits_shared_reactive_auth_child_chain(hass):
+    """Three parents awaiting #261's auth task cannot consume its login slot."""
+    client = _ReactiveAuthTaskClient()
+    budget = acquire_shared_cloud_request_budget(
+        hass,
+        username="reactive-auth-account",
+        base_url="https://monitor.eg4electronics.com",
+        verify_ssl=True,
+        limit=3,
+    )
+    limiter = install_cloud_request_limiter(  # type: ignore[arg-type]
+        client,
+        budget=budget,
+    )
+
+    requests = [
+        asyncio.create_task(client._request("POST", f"/parent/{index}"))
+        for index in range(3)
+    ]
+    try:
+        results = await asyncio.wait_for(asyncio.gather(*requests), timeout=1)
+        assert results == [{"success": True}] * 3
+        assert client.login_calls == 1
+        assert client.detect_calls == 1
+    finally:
+        for request in requests:
+            if not request.done():
+                request.cancel()
+        if client.auth_task is not None and not client.auth_task.done():
+            client.auth_task.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+        if client.auth_task is not None:
+            await asyncio.gather(client.auth_task, return_exceptions=True)
+        limiter.close()
+        release_shared_cloud_request_budget(hass, budget)
+
+
+async def test_lingering_auth_retains_admission_after_parents_cancel(hass):
+    """A shielded auth task cannot become a fourth raw account operation."""
+    client = _LingeringReactiveAuthClient()
+    budget = acquire_shared_cloud_request_budget(
+        hass,
+        username="lingering-auth-account",
+        base_url="https://monitor.eg4electronics.com",
+        verify_ssl=True,
+        limit=3,
+    )
+    limiter = install_cloud_request_limiter(  # type: ignore[arg-type]
+        client,
+        budget=budget,
+    )
+    parents = [
+        asyncio.create_task(client._request("POST", f"/parent/{index}"))
+        for index in range(3)
+    ]
+    ordinary: list[asyncio.Task[dict[str, Any]]] = []
+    try:
+        await asyncio.wait_for(client.auth_started.wait(), timeout=1)
+        for parent in parents:
+            parent.cancel()
+        parent_results = await asyncio.gather(*parents, return_exceptions=True)
+        assert all(
+            isinstance(result, asyncio.CancelledError) for result in parent_results
+        )
+        assert client.auth_task is not None
+        assert not client.auth_task.done()
+
+        ordinary = [
+            asyncio.create_task(client._request("POST", f"/ordinary/{index}"))
+            for index in range(3)
+        ]
+        await asyncio.wait_for(client.two_ordinary_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        # The auth child retains one admitted parent lease until the whole
+        # client-owned task finishes, leaving exactly two slots for new work.
+        assert client.ordinary_started == 2
+        assert not client.three_ordinary_started.is_set()
+        assert client.active_raw == 3
+        assert client.peak_raw == 3
+
+        client.auth_release.set()
+        await asyncio.wait_for(client.three_ordinary_started.wait(), timeout=1)
+        assert await client.auth_task == {"success": True}
+        assert client.peak_raw == 3
+
+        client.ordinary_release.set()
+        assert await asyncio.gather(*ordinary) == [{"success": True}] * 3
+        assert client.active_raw == 0
+    finally:
+        client.auth_release.set()
+        client.ordinary_release.set()
+        for task in (*parents, *ordinary):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*parents, *ordinary, return_exceptions=True)
+        if client.auth_task is not None:
+            await asyncio.gather(client.auth_task, return_exceptions=True)
+        limiter.close()
+        release_shared_cloud_request_budget(hass, budget)
+
+
+async def test_auth_reservation_survives_final_owner_reload(hass):
+    """A replacement reuses the budget until a released owner's auth drains."""
+    username = "auth-reload-account"
+    base_url = "https://monitor.eg4electronics.com"
+    old_client = _LingeringReactiveAuthClient(detect_after_login=False)
+    budget = acquire_shared_cloud_request_budget(
+        hass,
+        username=username,
+        base_url=base_url,
+        verify_ssl=True,
+        limit=3,
+    )
+    old_limiter = install_cloud_request_limiter(  # type: ignore[arg-type]
+        old_client,
+        budget=budget,
+    )
+    parents = [
+        asyncio.create_task(old_client._request("POST", f"/parent/{index}"))
+        for index in range(3)
+    ]
+    replacement_client = _CountingClient()
+    replacement_limiter = None
+    replacement_requests: list[asyncio.Task[dict[str, Any]]] = []
+    replacement_budget = None
+    try:
+        await asyncio.wait_for(old_client.auth_started.wait(), timeout=1)
+        for parent in parents:
+            parent.cancel()
+        await asyncio.gather(*parents, return_exceptions=True)
+        assert old_client.auth_task is not None
+        assert not old_client.auth_task.done()
+
+        old_limiter.close()
+        release_shared_cloud_request_budget(hass, budget)
+        assert budget.ref_count == 0
+        assert "eg4_web_monitor_cloud_request_budgets" in hass.data
+
+        replacement_budget = acquire_shared_cloud_request_budget(
+            hass,
+            username=username,
+            base_url=base_url,
+            verify_ssl=True,
+            limit=3,
+        )
+        assert replacement_budget is budget
+        replacement_limiter = install_cloud_request_limiter(
+            replacement_client,  # type: ignore[arg-type]
+            budget=replacement_budget,
+        )
+        replacement_requests = [
+            asyncio.create_task(
+                replacement_client._request("POST", f"/replacement/{index}")
+            )
+            for index in range(3)
+        ]
+        await replacement_client._request_started.wait()
+        await asyncio.sleep(0)
+
+        # The old auth reservation consumes one account slot, so only two
+        # replacement requests enter until that task finishes.
+        assert replacement_client.calls == 2
+        assert replacement_client.peak == 2
+
+        old_client.auth_release.set()
+        assert await old_client.auth_task == {"success": True}
+        for _ in range(10):
+            if replacement_client.calls == 3:
+                break
+            await asyncio.sleep(0)
+        assert replacement_client.calls == 3
+        assert replacement_client.peak == 3
+
+        replacement_client._release_requests.set()
+        assert await asyncio.gather(*replacement_requests) == [{"success": True}] * 3
+        replacement_limiter.close()
+        release_shared_cloud_request_budget(hass, replacement_budget)
+        assert "eg4_web_monitor_cloud_request_budgets" not in hass.data
+    finally:
+        old_client.auth_release.set()
+        replacement_client._release_requests.set()
+        for task in (*parents, *replacement_requests):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*parents, *replacement_requests, return_exceptions=True)
+        if old_client.auth_task is not None:
+            await asyncio.gather(old_client.auth_task, return_exceptions=True)
+        old_limiter.close()
+        release_shared_cloud_request_budget(hass, budget)
+        if replacement_limiter is not None:
+            replacement_limiter.close()
+        if replacement_budget is not None:
+            release_shared_cloud_request_budget(hass, replacement_budget)
+
+
+async def test_delayed_auth_claims_cancelled_parent_reservation(hass):
+    """Delayed login keeps one origin slot and transparently avoids deadlock."""
+    client = _DelayedReactiveAuthClient()
+    budget = acquire_shared_cloud_request_budget(
+        hass,
+        username="retired-auth-account",
+        base_url="https://monitor.eg4electronics.com",
+        verify_ssl=True,
+        limit=3,
+    )
+    limiter = install_cloud_request_limiter(  # type: ignore[arg-type]
+        client,
+        budget=budget,
+    )
+    parents = [
+        asyncio.create_task(client._request("POST", f"/parent/{index}"))
+        for index in range(3)
+    ]
+    fourth: asyncio.Task[dict[str, Any]] | None = None
+    try:
+        await asyncio.wait_for(client.auth_prework_started.wait(), timeout=1)
+        await asyncio.wait_for(client.three_parents_started.wait(), timeout=1)
+
+        # Parent zero created the auth task. Its cancellation hands one lease
+        # reference to that pending task before the parent drops its own; a
+        # fourth parent therefore remains queued instead of preempting login.
+        parents[0].cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await parents[0]
+        fourth = asyncio.create_task(client._request("POST", "/parent/3"))
+        await asyncio.sleep(0)
+        assert not client.four_parents_started.is_set()
+
+        client.allow_login.set()
+        await asyncio.wait_for(client.four_parents_started.wait(), timeout=1)
+        remaining = await asyncio.wait_for(
+            asyncio.gather(*parents[1:], fourth),
+            timeout=1,
+        )
+
+        assert remaining == [{"success": True}] * 3
+        assert client.auth_task is not None
+        assert await client.auth_task == {"success": True}
+        assert client.login_calls == 1
+        assert client.peak_parents == 3
+
+        # All parent/reservation references have unwound, so a later refresh
+        # is admitted rather than inheriting a leaked lifecycle lease.
+        assert await asyncio.wait_for(
+            client._request("POST", "/ordinary/recovery"), timeout=1
+        ) == {"success": True}
+    finally:
+        client.allow_login.set()
+        if fourth is not None and not fourth.done():
+            fourth.cancel()
+        for parent in parents:
+            if not parent.done():
+                parent.cancel()
+        await asyncio.gather(
+            *parents, *([fourth] if fourth else []), return_exceptions=True
+        )
+        if client.auth_task is not None:
+            await asyncio.gather(client.auth_task, return_exceptions=True)
+        limiter.close()
+        release_shared_cloud_request_budget(hass, budget)
+        assert "eg4_web_monitor_cloud_request_budgets" not in hass.data
+
+
+async def test_inherited_unrelated_child_remains_inside_request_budget():
+    """Only the exact auth chain, not arbitrary descendants, bypasses admission."""
+    client = _InheritedOrdinaryChildClient()
+    install_cloud_request_limiter(client, limit=1)  # type: ignore[arg-type]
+    parent = asyncio.create_task(client._request("POST", "/parent"))
+    await client.child_created.wait()
+    await asyncio.sleep(0)
+
+    assert not client.child_started.is_set()
+    client.release_parent.set()
+    await parent
+    assert client.child_task is not None
+    await client.child_task
+    assert client.child_started.is_set()
+
+
 async def test_parameter_verification_fetches_parameters_only(hass):
     """A post-write verification must not force runtime/energy/battery reads."""
     entry = _local_entry()
@@ -239,6 +1016,190 @@ async def test_parameter_verification_fetches_parameters_only(hass):
     assert await coordinator._refresh_device_parameters("INV1") is True
     inverter._fetch_parameters.assert_awaited_once_with()
     inverter.refresh.assert_not_awaited()
+
+
+async def test_targeted_parameter_refresh_does_not_poll_sibling_or_schedule_tick(
+    hass,
+):
+    """Post-write verification mutates one serial and publishes once in place."""
+    entry = _local_entry("parameter_target")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    target = MagicMock()
+    target.parameters = {"HOLD_AC_CHARGE_POWER_CMD": 75}
+    target.parameters_complete = True
+    target._fetch_parameters = AsyncMock()
+    sibling = MagicMock()
+    sibling.parameters = {"HOLD_AC_CHARGE_POWER_CMD": 20}
+    sibling.parameters_complete = True
+    sibling._fetch_parameters = AsyncMock()
+    coordinator._inverter_cache = {"INV1": target, "INV2": sibling}
+    coordinator.data = {
+        "devices": {
+            "INV1": {"type": "inverter"},
+            "INV2": {"type": "inverter"},
+        },
+        "parameters": {
+            "INV1": {"HOLD_AC_CHARGE_POWER_CMD": 50},
+            "INV2": {"HOLD_AC_CHARGE_POWER_CMD": 20},
+        },
+    }
+    coordinator.async_update_listeners = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+
+    assert await coordinator.async_refresh_device_parameters("INV1") is True
+
+    target._fetch_parameters.assert_awaited_once_with()
+    sibling._fetch_parameters.assert_not_awaited()
+    coordinator.async_update_listeners.assert_called_once_with()
+    coordinator.async_request_refresh.assert_not_awaited()
+    assert coordinator.data["parameters"]["INV2"] == {"HOLD_AC_CHARGE_POWER_CMD": 20}
+
+
+async def test_parameter_publication_selects_target_and_discovery_contexts(hass):
+    """The #532 listener seam scopes and dispatches one serial when available."""
+    entry = _local_entry("parameter_publish")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    context_factory = getattr(coordinator_module, "device_listener_context", None)
+    if callable(context_factory):
+        # Post-#532 merge validation: use the integration's exact private
+        # context class so its isinstance-based dispatcher is exercised.
+        target = context_factory("INV1")
+        sibling = context_factory("INV2")
+        discovery = coordinator_module.DISCOVERY_LISTENER_CONTEXT
+        station = coordinator_module.STATION_LISTENER_CONTEXT
+    else:
+        # Standalone #533 validation before #532 lands: pin the context values
+        # selected by the feature-detected publication seam.
+        target = _ListenerScope("device", "INV1")
+        sibling = _ListenerScope("device", "INV2")
+        discovery = _ListenerScope("discovery")
+        station = _ListenerScope("station")
+    coordinator._pending_listener_contexts = set()
+    callbacks = {
+        name: MagicMock() for name in ("target", "sibling", "discovery", "station")
+    }
+    coordinator._listeners = {
+        "target": (callbacks["target"], target),
+        "sibling": (callbacks["sibling"], sibling),
+        "discovery": (callbacks["discovery"], discovery),
+        "station": (callbacks["station"], station),
+    }
+    if callable(context_factory):
+        coordinator._last_listener_update_success = coordinator.last_update_success
+        coordinator._publish_device_parameter_update("INV1")
+        callbacks["target"].assert_called_once_with()
+        callbacks["discovery"].assert_called_once_with()
+        callbacks["sibling"].assert_not_called()
+        callbacks["station"].assert_not_called()
+    else:
+        selected: list[set[Any]] = []
+        coordinator.async_update_listeners = MagicMock(
+            side_effect=lambda: selected.append(
+                set(coordinator._pending_listener_contexts)
+            )
+        )
+        coordinator._publish_device_parameter_update("INV1")
+        assert selected == [{target, discovery}]
+
+
+async def test_group_parameter_refresh_publishes_all_devices_once(hass):
+    """A parallel-group refresh dispatches all changed siblings in one batch."""
+    entry = _local_entry("group_parameter_publish")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    coordinator.data = {
+        "devices": {
+            "INV1": {"type": "inverter"},
+            "INV2": {"type": "inverter"},
+        }
+    }
+    coordinator._refresh_device_parameters = AsyncMock(return_value=True)
+    context_factory = getattr(coordinator_module, "device_listener_context", None)
+    if callable(context_factory):
+        first = context_factory("INV1")
+        second = context_factory("INV2")
+        discovery = coordinator_module.DISCOVERY_LISTENER_CONTEXT
+        station = coordinator_module.STATION_LISTENER_CONTEXT
+    else:
+        first = _ListenerScope("device", "INV1")
+        second = _ListenerScope("device", "INV2")
+        discovery = _ListenerScope("discovery")
+        station = _ListenerScope("station")
+    coordinator._pending_listener_contexts = set()
+    callbacks = {
+        name: MagicMock() for name in ("first", "second", "discovery", "station")
+    }
+    coordinator._listeners = {
+        "first": (callbacks["first"], first),
+        "second": (callbacks["second"], second),
+        "discovery": (callbacks["discovery"], discovery),
+        "station": (callbacks["station"], station),
+    }
+
+    if callable(context_factory):
+        coordinator._last_listener_update_success = coordinator.last_update_success
+        assert await coordinator.refresh_all_device_parameters() is True
+        callbacks["first"].assert_called_once_with()
+        callbacks["second"].assert_called_once_with()
+        callbacks["discovery"].assert_called_once_with()
+        callbacks["station"].assert_not_called()
+    else:
+        selected: list[set[Any]] = []
+        coordinator.async_update_listeners = MagicMock(
+            side_effect=lambda: selected.append(
+                set(coordinator._pending_listener_contexts)
+            )
+        )
+        assert await coordinator.refresh_all_device_parameters() is True
+        assert selected == [{first, second, discovery}]
+
+
+async def test_narrow_parameter_fetch_preserves_generation_reconcile_seam(hass):
+    """A stale narrow read cannot overwrite a write acknowledged mid-read."""
+    entry = _local_entry("parameter_generation")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    read_started = asyncio.Event()
+    release_read = asyncio.Event()
+
+    inverter = MagicMock()
+    inverter.parameters = {"HOLD_CHG_POWER_PERCENT_CMD": 60}
+    inverter.parameters_complete = True
+
+    async def _stale_fetch() -> None:
+        read_started.set()
+        await release_read.wait()
+        inverter.parameters = {"HOLD_CHG_POWER_PERCENT_CMD": 60}
+
+    inverter._fetch_parameters = AsyncMock(side_effect=_stale_fetch)
+    coordinator._inverter_cache = {"INV1": inverter}
+    coordinator.data = {
+        "devices": {"INV1": {"type": "inverter"}},
+        "parameters": {"INV1": {"HOLD_CHG_POWER_PERCENT_CMD": 60}},
+    }
+    coordinator._parameter_write_generation = 7
+    coordinator._parameter_write_seeds = {}
+    reconcile = MagicMock(return_value={"HOLD_CHG_POWER_PERCENT_CMD": 90})
+    coordinator._reconcile_parameter_read = reconcile
+
+    refresh = asyncio.create_task(coordinator._refresh_device_parameters("INV1"))
+    await read_started.wait()
+    coordinator._parameter_write_generation = 8
+    coordinator.data["parameters"]["INV1"] = {"HOLD_CHG_POWER_PERCENT_CMD": 90}
+    release_read.set()
+
+    assert await refresh is True
+    assert coordinator.data["parameters"]["INV1"] == {"HOLD_CHG_POWER_PERCENT_CMD": 90}
+    reconcile.assert_called_once_with(
+        "INV1",
+        {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+        read_complete=True,
+        read_generation=7,
+        observed_keys={"HOLD_CHG_POWER_PERCENT_CMD": 60},
+    )
 
 
 async def test_missing_parameter_refresh_job_is_single_flight(hass):
@@ -300,6 +1261,57 @@ async def test_cancelled_missing_parameter_job_does_not_resurrect(hass):
     assert coordinator._missing_parameter_refresh_task is None
     assert coordinator._missing_parameter_pending_serials == set()
     assert coordinator._refresh_missing_parameters.await_count == 1
+
+
+async def test_completed_missing_parameter_callback_cannot_reschedule_during_shutdown(
+    hass,
+):
+    """A done callback racing the shutdown snapshot cannot orphan its next batch."""
+    entry = _local_entry("missing_shutdown_callback")
+    entry.add_to_hass(hass)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def _finish_normally(
+        serials: list[str], processed_data: dict[str, Any]
+    ) -> None:
+        del serials, processed_data
+        started.set()
+        await finish.wait()
+
+    coordinator._refresh_missing_parameters = AsyncMock(side_effect=_finish_normally)
+    first = coordinator._schedule_missing_parameter_refresh(
+        ["INV1"], {"parameters": {}}
+    )
+    assert first is not None
+    await started.wait()
+    coordinator._schedule_missing_parameter_refresh(
+        ["INV1", "INV2"], {"parameters": {}}
+    )
+
+    try:
+        finish.set()
+        # The task finishes in this loop turn. Its done callbacks are queued
+        # behind this test's continuation, reproducing shutdown observing a
+        # done task whose rescheduling callback has not run yet.
+        await asyncio.sleep(0)
+        assert first.done()
+        assert coordinator._missing_parameter_refresh_task is first
+
+        await coordinator._cancel_background_tasks()
+        await asyncio.sleep(0)
+
+        assert coordinator._refresh_missing_parameters.await_count == 1
+        assert coordinator._missing_parameter_refresh_task is None
+        assert coordinator._missing_parameter_pending_serials == set()
+        assert coordinator._missing_parameter_pending_data is None
+        assert coordinator._background_tasks == set()
+    finally:
+        remaining = coordinator._missing_parameter_refresh_task
+        if remaining is not None and not remaining.done():
+            remaining.cancel()
+            await asyncio.gather(remaining, return_exceptions=True)
 
 
 async def test_new_missing_serial_is_queued_behind_active_singleflight(hass):
@@ -377,7 +1389,75 @@ async def test_firmware_account_status_is_single_flight_and_shielded(hass):
     status_release.set()
     assert await second is response
     await asyncio.sleep(0)
-    assert coordinator._firmware_status_task is None
+    assert coordinator._firmware_status_flight is not None
+    assert coordinator._firmware_status_flight.task is None
+    await coordinator._release_shared_firmware_status()
+
+
+async def test_firmware_singleflight_cancels_raw_after_final_waiter_leaves(hass):
+    """A timed-out/cancelled lone consumer cannot orphan a cloud request slot."""
+    client = _CountingClient()
+    status_started = asyncio.Event()
+    raw_cancelled = asyncio.Event()
+
+    async def _status() -> None:
+        status_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raw_cancelled.set()
+            raise
+
+    client.api.firmware.get_firmware_update_status = AsyncMock(side_effect=_status)
+    entry = _http_entry("firmware_last_waiter")
+    entry.add_to_hass(hass)
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    waiter = asyncio.create_task(client.api.firmware.get_firmware_update_status())
+    await status_started.wait()
+    flight = coordinator._firmware_status_flight
+    assert flight is not None
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    await raw_cancelled.wait()
+    await asyncio.sleep(0)
+
+    assert flight.task is None
+    await coordinator._release_shared_firmware_status()
+
+
+async def test_firmware_prefetch_does_not_start_getters_when_breaker_is_open(hass):
+    """A pre-opened supplemental breaker admits no firmware coroutine body."""
+    client = _CountingClient()
+    original_status = AsyncMock(return_value=object())
+    client.api.firmware.get_firmware_update_status = original_status
+    entry = _http_entry("firmware_open_breaker")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    device = make_real_inverter(serial_number="INV1", client=client)
+    check = AsyncMock(wraps=device.check_firmware_updates)
+    progress = AsyncMock(wraps=device.get_firmware_update_progress)
+    device.check_firmware_updates = check
+    device.get_firmware_update_progress = progress
+    coordinator._sidefetch_open_until = time.monotonic() + 60
+
+    await coordinator._prefetch_firmware_update_info([device])
+
+    check.assert_not_called()
+    progress.assert_not_called()
+    original_status.assert_not_awaited()
+    await coordinator._release_shared_firmware_status()
 
 
 async def test_firmware_prefetch_deduplicates_multi_inverter_status_calls(hass):
@@ -417,20 +1497,21 @@ async def test_firmware_prefetch_deduplicates_multi_inverter_status_calls(hass):
 
     assert original_status.await_count == 1
     assert all(device.firmware_update_in_progress is False for device in devices)
+    await coordinator._release_shared_firmware_status()
 
 
-async def test_firmware_singleflight_is_owned_by_one_config_entry(hass):
-    """Unloading one entry cannot cancel another entry's status request."""
+async def test_firmware_singleflight_is_shared_by_same_account_entries(hass):
+    """Two plants on one account share status while retaining safe ownership."""
     clients = [_CountingClient(), _CountingClient()]
-    starts = [asyncio.Event(), asyncio.Event()]
-    releases = [asyncio.Event(), asyncio.Event()]
+    status_started = asyncio.Event()
+    status_release = asyncio.Event()
     originals: list[AsyncMock] = []
 
     for index, client in enumerate(clients):
 
         async def _status(index: int = index) -> int:
-            starts[index].set()
-            await releases[index].wait()
+            status_started.set()
+            await status_release.wait()
             return index
 
         original = AsyncMock(side_effect=_status)
@@ -439,7 +1520,11 @@ async def test_firmware_singleflight_is_owned_by_one_config_entry(hass):
 
     coordinators: list[EG4DataUpdateCoordinator] = []
     for index, client in enumerate(clients):
-        entry = _http_entry(f"firmware_owner_{index}")
+        entry = _http_entry(
+            f"firmware_owner_{index}",
+            username="shared-account",
+            plant_id=f"plant-{index}",
+        )
         entry.add_to_hass(hass)
         with patch(
             "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
@@ -451,14 +1536,179 @@ async def test_firmware_singleflight_is_owned_by_one_config_entry(hass):
         asyncio.create_task(client.api.firmware.get_firmware_update_status())
         for client in clients
     ]
-    await asyncio.gather(*(started.wait() for started in starts))
+    try:
+        await status_started.wait()
+        await asyncio.sleep(0)
 
-    await coordinators[0]._cancel_background_tasks()
-    result = await asyncio.gather(waiters[0], return_exceptions=True)
-    assert isinstance(result[0], asyncio.CancelledError)
-    assert not waiters[1].done()
-    assert originals[0].await_count == 1
-    assert originals[1].await_count == 1
+        assert sum(original.await_count for original in originals) == 1
+        flight = coordinators[0]._firmware_status_flight
+        assert flight is not None
+        assert coordinators[1]._firmware_status_flight is flight
+        assert flight.ref_count == 2
+        winner = next(
+            index
+            for index, original in enumerate(originals)
+            if original.await_count == 1
+        )
+        released = 1 - winner
 
-    releases[1].set()
-    assert await waiters[1] == 1
+        waiters[released].cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiters[released]
+        await coordinators[released]._release_shared_firmware_status()
+
+        assert flight.ref_count == 1
+        assert flight.task is not None
+        assert not flight.task.cancelled()
+        assert not waiters[winner].done()
+
+        status_release.set()
+        assert await waiters[winner] == winner
+        await coordinators[winner]._release_shared_firmware_status()
+        assert flight.ref_count == 0
+        assert flight.task is None
+    finally:
+        status_release.set()
+        await asyncio.gather(*waiters, return_exceptions=True)
+        for coordinator in coordinators:
+            release = getattr(coordinator, "_release_shared_firmware_status", None)
+            if release is not None:
+                await release()
+
+
+@pytest.mark.parametrize("transform_retirement", [False, True])
+async def test_firmware_singleflight_transfers_when_origin_entry_unloads(
+    hass, transform_retirement: bool
+):
+    """A surviving plant retries instead of inheriting its peer's closing client."""
+    clients = [_CountingClient(), _CountingClient()]
+    auth_dependency = asyncio.create_task(asyncio.Event().wait())
+    origin_started = asyncio.Event()
+    origin_cancelled = asyncio.Event()
+
+    async def _close_origin_client() -> None:
+        auth_dependency.cancel()
+        await asyncio.gather(auth_dependency, return_exceptions=True)
+
+    origin_close = AsyncMock(side_effect=_close_origin_client)
+    setattr(clients[0], "close", origin_close)
+
+    async def _origin_status() -> str:
+        origin_started.set()
+        try:
+            # Model pylxpweb #261: the status request is owned by client A and
+            # awaits that client's shielded authentication task. client.close
+            # cancels the auth task immediately after coordinator shutdown.
+            await asyncio.shield(auth_dependency)
+        except asyncio.CancelledError:
+            origin_cancelled.set()
+            if transform_retirement:
+                # A future dependency may translate cancellation while
+                # unwinding client shutdown. Surviving owners must identify
+                # the deliberately retired task, not one exception shape.
+                raise RuntimeError("origin client retired") from None
+            raise
+        return "origin"
+
+    originals = [
+        AsyncMock(side_effect=_origin_status),
+        AsyncMock(return_value="survivor"),
+    ]
+    coordinators: list[EG4DataUpdateCoordinator] = []
+    waiters: list[asyncio.Task[Any]] = []
+    for index, (client, original) in enumerate(zip(clients, originals, strict=True)):
+        client.api.firmware.get_firmware_update_status = original
+        entry = _http_entry(
+            f"firmware_transfer_{index}",
+            username="shared-transfer-account",
+            plant_id=f"plant-{index}",
+        )
+        entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=client,
+        ):
+            coordinators.append(EG4DataUpdateCoordinator(hass, entry))
+
+    try:
+        waiters.append(
+            asyncio.create_task(clients[0].api.firmware.get_firmware_update_status())
+        )
+        await origin_started.wait()
+        waiters.append(
+            asyncio.create_task(
+                coordinators[1]._breakered_cloud_call(
+                    lambda: clients[1].api.firmware.get_firmware_update_status(),
+                    timeout=1,
+                )
+            )
+        )
+        await asyncio.sleep(0)
+        originals[1].assert_not_awaited()
+
+        # Coordinator shutdown precedes client.close. Releasing client A must
+        # retire A's raw flight so B can retry through its own bound getter.
+        await coordinators[0]._release_shared_firmware_status()
+        await clients[0].close()  # type: ignore[attr-defined]
+        await asyncio.wait_for(origin_cancelled.wait(), timeout=1)
+
+        expected_origin_error = (
+            RuntimeError if transform_retirement else asyncio.CancelledError
+        )
+        with pytest.raises(expected_origin_error):
+            await waiters[0]
+        assert await waiters[1] == "survivor"
+        originals[0].assert_awaited_once_with()
+        originals[1].assert_awaited_once_with()
+        origin_close.assert_awaited_once_with()
+        assert coordinators[1]._sidefetch_consecutive_failures == 0
+        assert coordinators[1]._sidefetch_open_until is None
+    finally:
+        auth_dependency.cancel()
+        await asyncio.gather(auth_dependency, *waiters, return_exceptions=True)
+        await asyncio.gather(
+            *(
+                coordinator._release_shared_firmware_status()
+                for coordinator in coordinators
+            )
+        )
+
+
+async def test_firmware_singleflight_does_not_cross_cloud_accounts(hass):
+    """Account identity remains an isolation boundary for status requests."""
+    clients = [_CountingClient(), _CountingClient()]
+    originals = [AsyncMock(return_value=index) for index in range(2)]
+    coordinators: list[EG4DataUpdateCoordinator] = []
+
+    for index, (client, original) in enumerate(zip(clients, originals, strict=True)):
+        client.api.firmware.get_firmware_update_status = original
+        entry = _http_entry(
+            f"firmware_account_{index}",
+            username=f"account-{index}",
+            plant_id=f"plant-{index}",
+        )
+        entry.add_to_hass(hass)
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+            return_value=client,
+        ):
+            coordinators.append(EG4DataUpdateCoordinator(hass, entry))
+
+    try:
+        results = await asyncio.gather(
+            *(client.api.firmware.get_firmware_update_status() for client in clients)
+        )
+
+        assert results == [0, 1]
+        assert [original.await_count for original in originals] == [1, 1]
+        assert (
+            coordinators[0]._firmware_status_flight
+            is not coordinators[1]._firmware_status_flight
+        )
+    finally:
+        await asyncio.gather(
+            *(
+                coordinator._release_shared_firmware_status()
+                for coordinator in coordinators
+            )
+        )

--- a/tests/test_cloud_fanout.py
+++ b/tests/test_cloud_fanout.py
@@ -722,8 +722,9 @@ async def test_constructor_failure_leaves_no_shared_owners_or_unload_callback(ha
 @pytest.mark.parametrize(
     "shutdown_method", ["async_shutdown", "_async_handle_shutdown"]
 )
+@pytest.mark.parametrize("cancel_stage", ["disconnect", "background"])
 async def test_early_shutdown_cancellation_drains_shared_account_owners(
-    hass, shutdown_method: str
+    hass, shutdown_method: str, cancel_stage: str
 ):
     """Unload/HA-stop cancellation cannot skip account-registry release."""
     client = _CountingClient()
@@ -741,20 +742,25 @@ async def test_early_shutdown_cancellation_drains_shared_account_owners(
     assert "eg4_web_monitor_cloud_request_budgets" in hass.data
     assert "eg4_web_monitor_firmware_status_flights" in hass.data
 
-    disconnect_started = asyncio.Event()
-    release_disconnect = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
     events: list[str] = []
     original_budget_release = coordinator._release_shared_cloud_request_budget
     original_firmware_release = coordinator._release_shared_firmware_status
 
     async def _blocked_disconnect() -> None:
         events.append("disconnect-start")
-        disconnect_started.set()
-        await release_disconnect.wait()
+        if cancel_stage == "disconnect":
+            cleanup_started.set()
+            await release_cleanup.wait()
         events.append("disconnect-end")
 
     async def _background_cleanup() -> None:
-        events.append("background-cleanup")
+        events.append("background-start")
+        if cancel_stage == "background":
+            cleanup_started.set()
+            await release_cleanup.wait()
+        events.append("background-end")
 
     def _release_budget() -> None:
         events.append("budget-release")
@@ -794,12 +800,12 @@ async def test_early_shutdown_cancellation_drains_shared_account_owners(
                 if shutdown_method == "_async_handle_shutdown"
                 else shutdown()
             )
-            await disconnect_started.wait()
+            await cleanup_started.wait()
 
             shutdown_task.cancel()
             await asyncio.sleep(0)
             shutdown_task.cancel()
-            release_disconnect.set()
+            release_cleanup.set()
 
             with pytest.raises(asyncio.CancelledError):
                 await shutdown_task
@@ -807,7 +813,8 @@ async def test_early_shutdown_cancellation_drains_shared_account_owners(
         assert events == [
             "disconnect-start",
             "disconnect-end",
-            "background-cleanup",
+            "background-start",
+            "background-end",
             "budget-release",
             "firmware-release",
         ]
@@ -816,7 +823,7 @@ async def test_early_shutdown_cancellation_drains_shared_account_owners(
         assert coordinator._cloud_request_budget_released
         assert coordinator._firmware_status_released
     finally:
-        release_disconnect.set()
+        release_cleanup.set()
         if shutdown_task is not None and not shutdown_task.done():
             shutdown_task.cancel()
         if shutdown_task is not None:

--- a/tests/test_cloud_fanout.py
+++ b/tests/test_cloud_fanout.py
@@ -719,6 +719,112 @@ async def test_constructor_failure_leaves_no_shared_owners_or_unload_callback(ha
     assert "eg4_web_monitor_firmware_status_flights" not in hass.data
 
 
+@pytest.mark.parametrize(
+    "shutdown_method", ["async_shutdown", "_async_handle_shutdown"]
+)
+async def test_early_shutdown_cancellation_drains_shared_account_owners(
+    hass, shutdown_method: str
+):
+    """Unload/HA-stop cancellation cannot skip account-registry release."""
+    client = _CountingClient()
+    entry = _http_entry(
+        f"cancel_{shutdown_method}",
+        username=f"cancel-account-{shutdown_method}",
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "custom_components.eg4_web_monitor.coordinator.LuxpowerClient",
+        return_value=client,
+    ):
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+
+    assert "eg4_web_monitor_cloud_request_budgets" in hass.data
+    assert "eg4_web_monitor_firmware_status_flights" in hass.data
+
+    disconnect_started = asyncio.Event()
+    release_disconnect = asyncio.Event()
+    events: list[str] = []
+    original_budget_release = coordinator._release_shared_cloud_request_budget
+    original_firmware_release = coordinator._release_shared_firmware_status
+
+    async def _blocked_disconnect() -> None:
+        events.append("disconnect-start")
+        disconnect_started.set()
+        await release_disconnect.wait()
+        events.append("disconnect-end")
+
+    async def _background_cleanup() -> None:
+        events.append("background-cleanup")
+
+    def _release_budget() -> None:
+        events.append("budget-release")
+        original_budget_release()
+
+    async def _release_firmware() -> None:
+        events.append("firmware-release")
+        await original_firmware_release()
+
+    shutdown_task: asyncio.Task[None] | None = None
+    try:
+        with (
+            patch.object(
+                coordinator,
+                "_disconnect_all_transports",
+                side_effect=_blocked_disconnect,
+            ),
+            patch.object(
+                coordinator,
+                "_cancel_background_tasks",
+                side_effect=_background_cleanup,
+            ),
+            patch.object(
+                coordinator,
+                "_release_shared_cloud_request_budget",
+                side_effect=_release_budget,
+            ),
+            patch.object(
+                coordinator,
+                "_release_shared_firmware_status",
+                side_effect=_release_firmware,
+            ),
+        ):
+            shutdown = getattr(coordinator, shutdown_method)
+            shutdown_task = asyncio.create_task(
+                shutdown(None)
+                if shutdown_method == "_async_handle_shutdown"
+                else shutdown()
+            )
+            await disconnect_started.wait()
+
+            shutdown_task.cancel()
+            await asyncio.sleep(0)
+            shutdown_task.cancel()
+            release_disconnect.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await shutdown_task
+
+        assert events == [
+            "disconnect-start",
+            "disconnect-end",
+            "background-cleanup",
+            "budget-release",
+            "firmware-release",
+        ]
+        assert "eg4_web_monitor_cloud_request_budgets" not in hass.data
+        assert "eg4_web_monitor_firmware_status_flights" not in hass.data
+        assert coordinator._cloud_request_budget_released
+        assert coordinator._firmware_status_released
+    finally:
+        release_disconnect.set()
+        if shutdown_task is not None and not shutdown_task.done():
+            shutdown_task.cancel()
+        if shutdown_task is not None:
+            await asyncio.gather(shutdown_task, return_exceptions=True)
+        original_budget_release()
+        await original_firmware_release()
+
+
 async def test_saturated_budget_admits_shared_reactive_auth_child_chain(hass):
     """Three parents awaiting #261's auth task cannot consume its login slot."""
     client = _ReactiveAuthTaskClient()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9293,7 +9293,7 @@ class TestACCoupleSOCStore:
         # reads — the AC couple keys are gone.
         inverter = MagicMock()
         inverter.serial_number = self.SERIAL
-        inverter.refresh = AsyncMock()
+        inverter._fetch_parameters = AsyncMock()
         inverter.parameters = {"HOLD_AC_CHARGE_POWER_CMD": 60}
         with patch.object(coordinator, "get_inverter_object", return_value=inverter):
             # The REAL refresh — the exact production wipe path.

--- a/tests/test_coordinator_hybrid.py
+++ b/tests/test_coordinator_hybrid.py
@@ -261,6 +261,10 @@ class TestCoordinatorHybridInit:
     def mock_hass(self) -> MagicMock:
         """Create a mock Home Assistant instance."""
         hass = MagicMock()
+        # Shared cloud request/firmware ownership uses HA's dictionary-backed
+        # runtime data registry; model that concrete contract instead of
+        # allowing MagicMock.setdefault() to fabricate phantom owners.
+        hass.data = {}
         hass.config.time_zone = "America/Los_Angeles"
         hass.bus.async_listen_once = MagicMock()
         return hass

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -3843,8 +3843,8 @@ class TestLinkDownParameterRefreshGate:
         range fails, exposing the failure only through
         ``parameters_complete=False``.  The public wrapper must not report that
         as a completed refresh: its boolean drives the acknowledged-write
-        retention envelope (#362). The coordinator refresh side effect remains
-        intact for older callers that ignore the boolean.
+        retention envelope (#362). The partial cache mutation is published in
+        place without scheduling a duplicate full coordinator cycle.
         """
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
@@ -3862,6 +3862,7 @@ class TestLinkDownParameterRefreshGate:
             "devices": {"INV1": {"type": "inverter"}},
             "parameters": {"INV1": {"FUNC_TEST": True}},
         }
+        coordinator.async_update_listeners = MagicMock()
         coordinator.async_request_refresh = AsyncMock()
 
         result = await coordinator.async_refresh_device_parameters("INV1")
@@ -3869,7 +3870,8 @@ class TestLinkDownParameterRefreshGate:
         assert result is False
         incomplete._fetch_parameters.assert_awaited_once_with()
         incomplete.refresh.assert_not_awaited()
-        coordinator.async_request_refresh.assert_awaited_once_with()
+        coordinator.async_update_listeners.assert_called_once_with()
+        coordinator.async_request_refresh.assert_not_awaited()
 
     async def test_incomplete_fetch_logs_at_debug_not_warning(
         self, hass, local_config_entry, caplog: pytest.LogCaptureFixture

--- a/tests/test_coordinator_local.py
+++ b/tests/test_coordinator_local.py
@@ -3739,7 +3739,7 @@ class TestLinkDownParameterRefreshGate:
     cleanly in LOCAL (parameters_complete=False).  The coordinator-side hard
     skip that preceded it (codex P1 on PR #301) blocked exactly that cloud
     fallback and was removed in #322 — down-link serials must still be
-    refreshed with force + parameters."""
+    refreshed through the targeted parameter fetch."""
 
     @staticmethod
     def _fake_inverter(*, link_down: bool, parameters: dict | None = None):
@@ -3747,6 +3747,7 @@ class TestLinkDownParameterRefreshGate:
         inv.transport = object()
         inv.transport_link_down = link_down
         inv.refresh = AsyncMock()
+        inv._fetch_parameters = AsyncMock()
         inv.parameters = parameters or {}
         return inv
 
@@ -3770,8 +3771,10 @@ class TestLinkDownParameterRefreshGate:
 
         await coordinator.refresh_all_device_parameters()
 
-        down.refresh.assert_awaited_once_with(force=True, include_parameters=True)
-        up.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+        down._fetch_parameters.assert_awaited_once_with()
+        up._fetch_parameters.assert_awaited_once_with()
+        down.refresh.assert_not_awaited()
+        up.refresh.assert_not_awaited()
         assert coordinator.data["parameters"]["UP1"] == {"HOLD_X": 1}
         assert coordinator.data["parameters"]["DOWN1"] == {"HOLD_Y": 2}
 
@@ -3828,7 +3831,8 @@ class TestLinkDownParameterRefreshGate:
         result = await coordinator.async_refresh_device_parameters("DOWN1")
 
         assert result is True
-        down.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+        down._fetch_parameters.assert_awaited_once_with()
+        down.refresh.assert_not_awaited()
 
     async def test_async_refresh_device_parameters_reports_incomplete_fetch(
         self, hass, local_config_entry
@@ -3849,10 +3853,10 @@ class TestLinkDownParameterRefreshGate:
         )
         incomplete.parameters_complete = True
 
-        async def _soft_fail_parameter_fetch(**_kwargs: Any) -> None:
+        async def _soft_fail_parameter_fetch() -> None:
             incomplete.parameters_complete = False
 
-        incomplete.refresh = AsyncMock(side_effect=_soft_fail_parameter_fetch)
+        incomplete._fetch_parameters = AsyncMock(side_effect=_soft_fail_parameter_fetch)
         coordinator._inverter_cache = {"INV1": incomplete}
         coordinator.data = {
             "devices": {"INV1": {"type": "inverter"}},
@@ -3863,7 +3867,8 @@ class TestLinkDownParameterRefreshGate:
         result = await coordinator.async_refresh_device_parameters("INV1")
 
         assert result is False
-        incomplete.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+        incomplete._fetch_parameters.assert_awaited_once_with()
+        incomplete.refresh.assert_not_awaited()
         coordinator.async_request_refresh.assert_awaited_once_with()
 
     async def test_incomplete_fetch_logs_at_debug_not_warning(
@@ -3957,7 +3962,9 @@ class TestLinkDownParameterRefreshGate:
         local_config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, local_config_entry)
         broken = self._fake_inverter(link_down=False)
-        broken.refresh = AsyncMock(side_effect=ConnectionError("refresh died"))
+        broken._fetch_parameters = AsyncMock(
+            side_effect=ConnectionError("refresh died")
+        )
         coordinator._inverter_cache = {"INV1": broken}
         coordinator.data = {"devices": {"INV1": {"type": "inverter"}}}
         coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_coordinator_write_helpers.py
+++ b/tests/test_coordinator_write_helpers.py
@@ -68,22 +68,22 @@ def test_require_client_raises_exact_message(real_coordinator):
 
 async def test_refresh_if_linked_calls_refresh_when_linked(real_coordinator):
     inv = MagicMock()
-    inv.refresh = AsyncMock()
+    inv._fetch_parameters = AsyncMock()
     real_coordinator.get_inverter_object = MagicMock(return_value=inv)
     real_coordinator.is_transport_link_down = MagicMock(return_value=False)
     await real_coordinator.refresh_inverter_params_if_linked("123")
-    inv.refresh.assert_awaited_once_with(force=True, include_parameters=True)
+    inv._fetch_parameters.assert_awaited_once_with()
     real_coordinator.get_inverter_object.assert_called_once_with("123")
     real_coordinator.is_transport_link_down.assert_called_once_with("123")
 
 
 async def test_refresh_if_linked_skips_when_link_down(real_coordinator):
     inv = MagicMock()
-    inv.refresh = AsyncMock()
+    inv._fetch_parameters = AsyncMock()
     real_coordinator.get_inverter_object = MagicMock(return_value=inv)
     real_coordinator.is_transport_link_down = MagicMock(return_value=True)
     await real_coordinator.refresh_inverter_params_if_linked("123")
-    inv.refresh.assert_not_awaited()
+    inv._fetch_parameters.assert_not_awaited()
 
 
 async def test_refresh_if_linked_skips_when_no_inverter(real_coordinator):

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -1,7 +1,9 @@
 """Tests for EG4 number entities and shared read/write helpers."""
 
-import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from homeassistant.components.number import RestoreNumber
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -70,6 +72,7 @@ def _mock_coordinator(
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator.async_refresh_device_parameters = AsyncMock(return_value=True)
     coordinator.refresh_all_device_parameters = AsyncMock()
     coordinator.write_named_parameter = AsyncMock()
     coordinator.write_raw_parameter = AsyncMock()
@@ -124,6 +127,104 @@ def _prep(entity: object) -> None:
     entity.entity_id = "number.test_entity"  # type: ignore[attr-defined]
     entity.platform = None  # type: ignore[attr-defined]
     entity.async_write_ha_state = MagicMock()  # type: ignore[attr-defined]
+
+
+def _track_one_targeted_parameter_fetch(
+    coordinator: MagicMock, serial: str = "1234567890"
+) -> MagicMock:
+    """Make the coordinator's public refresh seam perform one narrow read."""
+    inverter = coordinator.get_inverter_object(serial)
+    inverter._fetch_parameters = AsyncMock()
+
+    async def _refresh(target: str) -> bool:
+        assert target == serial
+        await inverter._fetch_parameters()
+        return True
+
+    coordinator.async_refresh_device_parameters = AsyncMock(side_effect=_refresh)
+    return inverter
+
+
+@pytest.mark.asyncio
+async def test_post_write_refresh_is_serial_scoped_without_entity_fanout() -> None:
+    """A number write publishes one serial without polling every related entity."""
+    coordinator = _mock_coordinator(serial="INV1")
+    entity = SystemChargeSOCLimitNumber(coordinator, "INV1")
+    _prep(entity)
+
+    related_entities = [MagicMock(spec=SystemChargeSOCLimitNumber) for _ in range(300)]
+    for related in related_entities:
+        related.async_update = AsyncMock()
+    entity.platform = SimpleNamespace(
+        entities={str(index): related for index, related in enumerate(related_entities)}
+    )
+
+    assert await entity._refresh_related_entities() is True
+
+    coordinator.async_refresh_device_parameters.assert_awaited_once_with("INV1")
+    coordinator.refresh_all_device_parameters.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_awaited()
+    assert all(related.async_update.await_count == 0 for related in related_entities)
+
+
+@pytest.mark.asyncio
+async def test_generic_cloud_method_performs_one_narrow_post_write_fetch() -> None:
+    """Generic inverter-method writes do not broad-refresh before verification."""
+    coordinator = _mock_coordinator(has_local=False, has_http=True)
+    inverter = _track_one_targeted_parameter_fetch(coordinator)
+    entity = ACChargePowerNumber(coordinator, "1234567890")
+    _prep(entity)
+
+    await entity.async_set_native_value(5.0)
+
+    inverter.set_ac_charge_power.assert_awaited_once_with(power_kw=5.0)
+    inverter._fetch_parameters.assert_awaited_once_with()
+    inverter.refresh.assert_not_awaited()
+    coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
+    coordinator.refresh_all_device_parameters.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_direct_cloud_method_performs_one_narrow_post_write_fetch() -> None:
+    """Direct cloud setter paths share the same one-read verification cadence."""
+    coordinator = _mock_coordinator(
+        has_local=False,
+        has_http=True,
+        parameters={PARAM_FUNC_GRID_PEAK_SHAVING: True},
+    )
+    inverter = _track_one_targeted_parameter_fetch(coordinator)
+    entity = GridPeakShavingPowerNumber(coordinator, "1234567890")
+    _prep(entity)
+
+    await entity.async_set_native_value(5.0)
+
+    inverter.set_grid_peak_shaving_power.assert_awaited_once_with(power_kw=5.0)
+    inverter._fetch_parameters.assert_awaited_once_with()
+    inverter.refresh.assert_not_awaited()
+    coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
+    coordinator.refresh_all_device_parameters.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_named_cloud_write_performs_one_narrow_post_write_fetch() -> None:
+    """Generic named writes do not perform a hidden pre-verification fetch."""
+    coordinator = _mock_coordinator(has_local=False, has_http=True)
+    coordinator.client.api.control.write_parameter = AsyncMock(
+        return_value=MagicMock(success=True)
+    )
+    inverter = _track_one_targeted_parameter_fetch(coordinator)
+    entity = StartDischargePowerNumber(coordinator, "1234567890")
+    _prep(entity)
+
+    await entity.async_set_native_value(150)
+
+    coordinator.client.api.control.write_parameter.assert_awaited_once_with(
+        "1234567890", "HOLD_P_TO_USER_START_DISCHG", "150"
+    )
+    inverter._fetch_parameters.assert_awaited_once_with()
+    inverter.refresh.assert_not_awaited()
+    coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
+    coordinator.refresh_all_device_parameters.assert_not_awaited()
 
 
 # ── Platform setup ───────────────────────────────────────────────────

--- a/tests/test_number_voltage_spec.py
+++ b/tests/test_number_voltage_spec.py
@@ -52,6 +52,7 @@ def _mock_coordinator(*, parameters: dict[str, Any]) -> MagicMock:
     coordinator.has_http_api = MagicMock(return_value=True)
     coordinator.is_transport_link_down = MagicMock(return_value=False)
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.async_refresh_device_parameters = AsyncMock(return_value=True)
     coordinator.refresh_all_device_parameters = AsyncMock()
     coordinator.refresh_inverter_params_if_linked = AsyncMock()
     result = MagicMock(success=True)
@@ -399,7 +400,7 @@ async def test_pv_start_voltage_write_dispatch_uses_named_cloud_route() -> None:
     coordinator.client.api.control.write_parameter = write_parameter
     await kwargs["cloud_write"]()
     write_parameter.assert_awaited_once_with(SERIAL, PARAM_HOLD_START_PV_VOLT, "140")
-    coordinator.refresh_inverter_params_if_linked.assert_awaited_once_with(SERIAL)
+    coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -446,34 +447,19 @@ async def test_pv_start_voltage_named_cloud_write_failure_raises() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("source_key", "expected_updated"),
+    "source_key",
     [
-        (
-            "on_grid_cutoff_voltage",
-            {"on_grid_cutoff_voltage", "off_grid_cutoff_voltage"},
-        ),
-        (
-            "off_grid_cutoff_voltage",
-            {"on_grid_cutoff_voltage", "off_grid_cutoff_voltage"},
-        ),
-        (
-            "ac_charge_start_voltage",
-            {"ac_charge_start_voltage", "ac_charge_end_voltage"},
-        ),
-        (
-            "ac_charge_end_voltage",
-            {"ac_charge_start_voltage", "ac_charge_end_voltage"},
-        ),
-        (
-            "pv_start_voltage",
-            {"pv_start_voltage"},
-        ),
+        "on_grid_cutoff_voltage",
+        "off_grid_cutoff_voltage",
+        "ac_charge_start_voltage",
+        "ac_charge_end_voltage",
+        "pv_start_voltage",
     ],
 )
-async def test_voltage_number_refresh_fanout_is_pair_scoped(
-    source_key: str, expected_updated: set[str]
+async def test_voltage_number_refresh_is_serial_scoped_without_entity_fanout(
+    source_key: str,
 ) -> None:
-    """A write refreshes its voltage pair without crossing pair boundaries."""
+    """Every voltage write delegates one serial and polls no entity objects."""
     coordinator = _mock_coordinator(parameters={})
     coordinator.is_local_only.return_value = False
     entities = {
@@ -497,8 +483,8 @@ async def test_voltage_number_refresh_fanout_is_pair_scoped(
         value = 52.0
     await entities[source_key].async_set_native_value(value)
 
-    for key, entity in entities.items():
-        if key in expected_updated:
-            entity.async_update.assert_awaited_once()
-        else:
-            entity.async_update.assert_not_awaited()
+    coordinator.async_refresh_device_parameters.assert_awaited_once_with(SERIAL)
+    coordinator.refresh_all_device_parameters.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_awaited()
+    for entity in entities.values():
+        entity.async_update.assert_not_awaited()

--- a/tests/test_optimistic_retention.py
+++ b/tests/test_optimistic_retention.py
@@ -11,8 +11,8 @@ bounded by ``RETAINED_OPTIMISTIC_TTL`` so a firmware-silently-NAKed write
 - ``select.py`` — all four selects cleared their optimistic state BEFORE (or
   regardless of) the post-write refresh and discarded its result.
 - ``number.py`` — ``optimistic_value_context`` cleared in a ``finally``, so a
-  failed refresh reverted the UI the same way; ``refresh_all_device_parameters``
-  swallowed failures and reported nothing at all.
+  failed refresh reverted the UI the same way; the post-write parameter
+  refresh outcome must drive its bounded retention envelope.
 - ``time.py`` — retention existed since PR #283 but was UNBOUNDED, so a silent
   NAK plus one failed refresh showed a wrong value indefinitely.
 
@@ -414,7 +414,7 @@ class TestNumberRetainsAcknowledgedWrite:
     async def test_retains_on_failed_refresh(self):
         """Write ack'd + refresh failed → the written value stays published."""
         coordinator = _coordinator(
-            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_all_ok=False
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_device_ok=False
         )
         entity = self._entity(coordinator)
         assert entity.native_value == 80
@@ -428,7 +428,7 @@ class TestNumberRetainsAcknowledgedWrite:
     async def test_clears_on_successful_refresh(self):
         """A completed refresh settles on coordinator data as before."""
         coordinator = _coordinator(
-            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_all_ok=True
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_device_ok=True
         )
         entity = self._entity(coordinator)
 
@@ -459,7 +459,7 @@ class TestNumberRetainsAcknowledgedWrite:
     async def test_retention_expires_after_ttl(self, caplog):
         """Number retention is bounded, exactly like the switch's."""
         coordinator = _coordinator(
-            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_all_ok=False
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_device_ok=False
         )
         entity = self._entity(coordinator)
         await entity.async_set_native_value(95)
@@ -476,7 +476,7 @@ class TestNumberRetainsAcknowledgedWrite:
     async def test_retention_clears_when_device_confirms(self):
         """Fresh data carrying the written value ends retention."""
         coordinator = _coordinator(
-            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_all_ok=False
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 80}, refresh_device_ok=False
         )
         entity = self._entity(coordinator)
         await entity.async_set_native_value(95)
@@ -589,7 +589,7 @@ class TestRefreshAllDeviceParametersReportsOutcome:
         config_entry.add_to_hass(hass)
         coordinator = EG4DataUpdateCoordinator(hass, config_entry)
         coordinator.data = {"devices": {SERIAL: {"type": "inverter"}}}
-        coordinator._refresh_device_parameters = AsyncMock()
+        coordinator._refresh_device_parameters = AsyncMock(return_value=True)
         coordinator.async_request_refresh = AsyncMock()
 
         assert await coordinator.refresh_all_device_parameters() is True
@@ -609,11 +609,29 @@ class TestRefreshAllDeviceParametersReportsOutcome:
             }
         }
         coordinator._refresh_device_parameters = AsyncMock(
-            side_effect=[None, RuntimeError("range timeout")]
+            side_effect=[True, RuntimeError("range timeout")]
         )
         coordinator.async_request_refresh = AsyncMock()
 
         assert await coordinator.refresh_all_device_parameters() is False
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_a_device_updates_no_cache(
+        self, hass, config_entry
+    ):
+        """A silent no-op cannot be counted as a completed group refresh."""
+        from custom_components.eg4_web_monitor.coordinator import (
+            EG4DataUpdateCoordinator,
+        )
+
+        config_entry.add_to_hass(hass)
+        coordinator = EG4DataUpdateCoordinator(hass, config_entry)
+        coordinator.data = {"devices": {SERIAL: {"type": "inverter"}}}
+        coordinator._refresh_device_parameters = AsyncMock(return_value=False)
+        coordinator.async_update_listeners = MagicMock()
+
+        assert await coordinator.refresh_all_device_parameters() is False
+        coordinator.async_update_listeners.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reports_failure_when_no_devices_are_known(self, hass, config_entry):

--- a/tests/test_select_entities.py
+++ b/tests/test_select_entities.py
@@ -197,6 +197,10 @@ class TestOperatingModeSelect:
 
         inverter = coordinator.get_inverter_object("1234567890")
         inverter.set_operating_mode.assert_called_once_with(OperatingMode.NORMAL)
+        inverter.refresh.assert_not_awaited()
+        coordinator.async_refresh_device_parameters.assert_awaited_once_with(
+            "1234567890"
+        )
 
     @pytest.mark.asyncio
     async def test_select_standby(self):
@@ -542,6 +546,10 @@ class TestPVInputModeSelectFallback:
         coordinator.write_named_parameter.assert_awaited_once()
         coordinator.client.api.control.write_parameter.assert_called_once_with(
             "1234567890", "HOLD_PV_INPUT_MODE", "1"
+        )
+        coordinator.refresh_inverter_params_if_linked.assert_not_awaited()
+        coordinator.async_refresh_device_parameters.assert_awaited_once_with(
+            "1234567890"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -4668,7 +4668,7 @@ class TestKnownStateWorkingModeParity:
             },
         }
         inverter = MagicMock()
-        inverter.refresh = AsyncMock()
+        inverter._fetch_parameters = AsyncMock()
         inverter.parameters = {"FUNC_BUZZER_EN": True}
         coordinator.get_inverter_object = MagicMock(return_value=inverter)
 
@@ -4683,7 +4683,7 @@ class TestKnownStateWorkingModeParity:
             assert switch.is_on is True, mode_key
 
         assert await coordinator._refresh_device_parameters("1234567890") is True
-        inverter.refresh.assert_awaited_once()
+        inverter._fetch_parameters.assert_awaited_once()
         entity_coordinator.data["parameters"]["1234567890"] = coordinator.data[
             "parameters"
         ]["1234567890"]


### PR DESCRIPTION
## Summary

- enforce one Home Assistant-local, exact-account cloud request budget across every config entry/plant for that account; nested pylxpweb startup, refresh, parameter, and supplemental fanout is capped at three request chains in aggregate
- make pylxpweb #261 reactive authentication re-entrant without deadlock or capacity escape by handing one admitted parent lease to the shared auth task until login, account detection, and retry/backoff finish
- replace broad post-write refreshes with serial-scoped parameter reads and one in-place listener publication; parallel-group refreshes publish all changed siblings in one batch
- single-flight missing-parameter jobs and account-wide firmware progress, with shutdown/reload-safe ownership transfer and bounded cleanup
- preserve the explicit Refresh button's full runtime/energy/battery/parameter behavior while removing duplicate number/select prefetches

This closes bead `eg4-06er.5` (PERF-01..03 and reconciliation findings).

## Root cause analysis

1. `_api_semaphore` guarded per-device mapping only after pylxpweb had entered `Station.load()` / `Station.refresh_all_data()`. Their nested gathers created runtime, energy, battery, parameter, and supplemental HTTP calls before the integration semaphore could see them, so concurrency scaled with inverter and entry count.
2. Parameter verification called broad `refresh(force=True, include_parameters=True)` or performed entity-level prefetch plus coordinator refresh. A holding-register write therefore re-read unrelated runtime/energy/battery data, refreshed sibling devices, and could dispatch listeners repeatedly.
3. Missing-parameter scheduling used callback-driven follow-up tasks without a terminal shutdown gate. A normally completed task's queued done callback could recreate work after shutdown had snapshotted the task set.
4. Firmware progress is account-wide, but pylxpweb exposes it per device/client. Aligned cache expiry caused one raw status call per inverter and separate entries for the same account duplicated it again. Unloading the originating client could also invalidate a flight still awaited by a sibling entry.
5. pylxpweb #261 creates a shielded authentication child task. A plain semaphore deadlocks when three admitted parents await that child; a bare login bypass can instead outlive canceled parents and transiently permit a fourth raw operation.

## Implementation details

### Account request budget

- `CloudRequestLimiter` wraps each client's common `_request` boundary, while `SharedCloudRequestBudget` stores only the semaphore/lifecycle state in `hass.data`, keyed by normalized `(username, base_url, verify_ssl)`.
- queued and active chains hold lifecycle leases. Final-owner unload removes registry state only after every lease drains, so a replacement entry racing old work reuses the same semaphore.
- limiter close is checked both before and after admission: queued work remains counted for reload safety but cannot begin I/O through a detached client.
- recursive pylxpweb retries remain exact-task re-entrant.
- reactive auth uses a ref-counted lease plus feature-detected `client._authentication_task` handoff. At most one slot is reserved per auth task; the first actually-canceling parent lends it, exact login claims it, and the task-done callback releases it after the full auth chain. Unrelated child tasks never inherit admission.

### Parameters and publication

- narrow verification calls pylxpweb's locked `_fetch_parameters()` path and mutates only the target serial's parameter cache.
- the read snapshots the #527 write generation and feature-detects `_reconcile_parameter_read()` so a stale response cannot overwrite a command acknowledged while the read was in flight.
- one serial update publishes the serial plus discovery context when #532 is present; a group update batches every successful serial plus discovery. Pre-#532 code falls back to one ordinary listener dispatch.
- false/no-op/partial sibling reads now make all-device verification report failure while still publishing successful sibling mutations once.
- parameter-backed number/select writers no longer prefetch or request broad coordinator updates. Runtime/status-backed controls retain their required full refresh.

### Firmware and background lifecycle

- firmware status flights are account-scoped, cancellation-shielded, reference-counted, and use each surviving owner's own client-bound fetch provider.
- unloading the flight's originating client retires that raw task; surviving waiters transparently retry through a live owner without charging the supplemental breaker.
- breaker calls remain lazy and timeout-bounded for #518 compatibility; timeout/cancellation/half-open inconclusive outcomes do not fabricate breaker success.
- missing-parameter work is single-flight with a pending serial queue. Shutdown closes the producer first and drains tracked tasks until stable, preventing done-callback resurrection.
- shared registry acquisition and ConfigEntry unload registration occur only at the final successful constructor stage. Constructor failure leaves no budget owner, firmware owner, event listener, or partial coordinator unload callback.

## Regression evidence

Focused models cover:

- 15 simultaneous cold-cache legs capped at peak 3
- two plants on one account capped at aggregate 3; different accounts independently reach 3
- final-owner reload with 3 active + 1 queued old request: replacement reuses the same budget, queued detached-client work performs no I/O, aggregate peak remains 3
- saturated reactive auth completes without deadlock; arbitrary inherited children remain queued
- cancellation of all three auth parents leaves exactly one auth reservation, admits only two new calls, and never exceeds peak 3
- delayed login after origin-parent cancellation claims the reserved lease, keeps a fourth parent queued, and completes transparently without loop errors
- final-owner reload during lingering auth reuses the exact budget until auth drains, then removes registry state after the replacement unloads
- constructor failure leaves no shared registry or ConfigEntry callback
- serial-only and parallel-group parameter publication; #527 generation reconciliation; #532 scoped listener dispatch
- shutdown/done-callback race; firmware breaker-open lazy admission; same-account flight sharing; origin unload transfer under cancellation and transformed errors

Local verification at `18617d4`:

- `pytest -q tests`: **2577 passed, 3 skipped**
- `pytest -q tests/test_cloud_fanout.py`: **29 passed**
- strict mypy: **42 source files, no issues**
- `ruff check .` and `ruff format --check .`: **passed**
- `prek run --all-files`: **all hooks passed**
- `git diff --check`: **passed**
- independent review: actual pylxpweb #261 concurrency/lifecycle reproductions and **628 touched tests passed**

## Composition with open prerequisite PRs

This branch is isolated on current `main` (`90c9807`). Recommended composition order is **#527 → #518 → #532 → #533**. When resolving:

- preserve #527's parameter write generation/seeds and this PR's generation snapshot + `_reconcile_parameter_read()` call around narrow reads
- preserve #518's lazy breaker call factory/timeout semantics and this PR's firmware prefetch coverage and account flight
- preserve #532's exact listener context type/constants and this PR's single serial/group publication selection

The tests feature-detect those seams so this PR remains independently testable before the other branches land.

## Deliberate boundaries

- the limiter covers pylxpweb's standard `_request` path. Direct-session plant-region/export helpers are outside periodic polling fanout and remain unchanged.
- completed firmware status is not integration-cached; pylxpweb remains authoritative for freshness and idle/active transitions.
- private `_request` / `_fetch_parameters` seams are contract-tested because the pinned dependency currently exposes no public middleware or parameter-only refresh API.
