### PR TITLE
fix: converge late control discovery and identities

### DIFF
--- a/custom_components/eg4_web_monitor/base_entity.py
+++ b/custom_components/eg4_web_monitor/base_entity.py
@@ -471,7 +471,7 @@ class EG4BaseSensor(EG4DeviceEntity):
             )
         elif device_type == "parallel_group":
             self._attr_entity_id = (
-                f"sensor.{ENTITY_PREFIX}_parallel_group_{self._sensor_key}"
+                f"sensor.{ENTITY_PREFIX}_{self._serial}_{self._sensor_key}"
             )
         else:
             model_clean = clean_model_name(model, use_underscores=True)
@@ -780,6 +780,30 @@ class EG4OptimisticEntity(CoordinatorEntity):
         self._pre_write_state: Any = None
         self._retention_expires: float = 0.0
         self._retained_action: str = ""
+        # Directly-constructed entities remain supported by default.  Platform
+        # discovery overrides this bit and keeps it current as late model/family
+        # metadata arrives or disappears.
+        self._control_discovery_supported = True
+
+    def _set_control_discovery_supported(self, supported: bool) -> None:
+        """Set whether this entity is in the platform's current candidate set."""
+        self._control_discovery_supported = supported
+
+    def _control_device_available(self, expected_type: str = "inverter") -> bool:
+        """Return whether a discovered control still has an applicable device."""
+        devices = (self.coordinator.data or {}).get("devices", {})
+        device_data = devices.get(self._retention_serial)
+        return bool(
+            self.coordinator.last_update_success
+            and self._control_discovery_supported
+            and device_data
+            and device_data.get("type") == expected_type
+            and "error" not in device_data
+        )
+
+    def _stable_control_unique_id(self, entity_key: str) -> str:
+        """Build a registry identity from immutable device identity and purpose."""
+        return generate_unique_id(self._retention_serial.lower(), entity_key)
 
     # ── Subclass hooks ──────────────────────────────────────────────
 
@@ -1005,8 +1029,6 @@ class EG4BaseNumber(EG4OptimisticEntity):
     Attributes:
         coordinator: The data update coordinator managing device data.
         serial: The device serial number.
-        _model: The device model name.
-        _clean_model: Cleaned model name for entity IDs.
         _optimistic_value: Temporary value for immediate UI feedback.
     """
 
@@ -1023,10 +1045,6 @@ class EG4BaseNumber(EG4OptimisticEntity):
         self.coordinator: EG4DataUpdateCoordinator = coordinator
         self.serial = serial
         self._optimistic_value: float | None = None
-
-        # Get device info for subclasses
-        self._model = _get_model_from_coordinator(coordinator, serial)
-        self._clean_model = clean_model_name(self._model, use_underscores=True)
 
         # Device info
         self._attr_device_info = coordinator.get_device_info(serial)
@@ -1047,7 +1065,7 @@ class EG4BaseNumber(EG4OptimisticEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return bool(self.coordinator.last_update_success)
+        return self._control_device_available()
 
     def _get_inverter_or_raise(self) -> Any:
         """Get inverter device object or raise HomeAssistantError.
@@ -1097,8 +1115,6 @@ class EG4BaseTime(EG4OptimisticEntity):
     Attributes:
         coordinator: The data update coordinator managing device data.
         serial: The device serial number.
-        _model: The device model name.
-        _clean_model: Cleaned model name for unique IDs.
         _optimistic_value: Temporary value for immediate UI feedback.
     """
 
@@ -1115,10 +1131,6 @@ class EG4BaseTime(EG4OptimisticEntity):
         self.coordinator: EG4DataUpdateCoordinator = coordinator
         self.serial = serial
         self._optimistic_value: dt_time | None = None
-
-        # Get device info for subclasses
-        self._model = _get_model_from_coordinator(coordinator, serial)
-        self._clean_model = clean_model_name(self._model, use_underscores=True)
 
         # Device info
         self._attr_device_info = coordinator.get_device_info(serial)
@@ -1139,7 +1151,7 @@ class EG4BaseTime(EG4OptimisticEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return bool(self.coordinator.last_update_success)
+        return self._control_device_available()
 
     @property
     def _parameter_data(self) -> dict[str, Any]:
@@ -1334,10 +1346,7 @@ class EG4BaseSwitch(EG4OptimisticEntity, SwitchEntity):
             True if the coordinator is healthy and the device is an inverter,
             False otherwise.
         """
-        return bool(
-            self.coordinator.last_update_success
-            and self._device_data.get("type") == "inverter"
-        )
+        return self._control_device_available()
 
     def _get_inverter_or_raise(self) -> Any:
         """Get inverter device object or raise HomeAssistantError.

--- a/custom_components/eg4_web_monitor/control_discovery.py
+++ b/custom_components/eg4_web_monitor/control_discovery.py
@@ -1,0 +1,189 @@
+"""Low-churn runtime discovery for capability-gated control entities.
+
+Control capabilities arrive in stages: the first coordinator snapshot can know
+that a device exists before pylxpweb has resolved its inverter family, model, or
+local transport.  Requiring a config-entry reload at that boundary is both
+surprising and racy.  This module keeps one capability signature per platform,
+rebuilds candidates only when that signature changes, and preserves entities
+that have already been registered while marking them unsupported.
+"""
+
+from collections.abc import Callable, Hashable, Mapping, Sequence
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .base_entity import EG4OptimisticEntity
+from .const import DOMAIN
+from .coordinator import EG4DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+_UNSET = object()
+
+EntityFactory = Callable[[], Sequence[EG4OptimisticEntity]]
+ExtraSignatureFactory = Callable[[], Any]
+
+
+def _freeze(value: Any) -> Hashable:
+    """Convert nested capability metadata into a deterministic hashable value."""
+    if isinstance(value, Mapping):
+        return tuple(sorted((str(key), _freeze(item)) for key, item in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted(repr(_freeze(item)) for item in value))
+    if value is None or isinstance(value, (str, int, float, bool, bytes)):
+        return value
+    return repr(value)
+
+
+def control_capability_signature(
+    coordinator: EG4DataUpdateCoordinator,
+    extra_signature: ExtraSignatureFactory | None = None,
+) -> Hashable:
+    """Return only metadata that can change the set of control entities.
+
+    Fast sensor/parameter values are intentionally excluded.  Rebuilding every
+    control object on every coordinator poll would turn late discovery into a
+    persistent allocation and registry-lookup cost.
+    """
+    devices = (coordinator.data or {}).get("devices", {})
+    device_signature = tuple(
+        sorted(
+            (
+                str(serial),
+                _freeze(device_data.get("type")),
+                _freeze(device_data.get("model")),
+                _freeze(device_data.get("features")),
+            )
+            for serial, device_data in devices.items()
+        )
+    )
+    extra = _freeze(extra_signature()) if extra_signature is not None else None
+    return device_signature, extra
+
+
+def _migrate_model_prefixed_unique_ids(
+    hass: HomeAssistant,
+    config_entry: Any,
+    platform: str,
+    entities: list[EG4OptimisticEntity],
+) -> None:
+    """Migrate ``{model}_{serial}_{key}`` IDs to ``{serial}_{key}`` in place.
+
+    Number and time entities historically embedded the discovered model.  A
+    model transition therefore registered a second entity.  Matching the full
+    new unique ID as a suffix is unambiguous for a config entry; ambiguous
+    legacy data is left untouched rather than guessed at destructively.
+    """
+    entry_id = getattr(config_entry, "entry_id", None)
+    if not isinstance(entry_id, str):
+        return
+
+    registry = er.async_get(hass)
+    registry_entries = [
+        entry
+        for entry in er.async_entries_for_config_entry(registry, entry_id)
+        if entry.domain == platform and entry.platform == DOMAIN
+    ]
+
+    for entity in entities:
+        unique_id = entity.unique_id
+        if not unique_id:
+            continue
+        if registry.async_get_entity_id(platform, DOMAIN, unique_id) is not None:
+            continue
+
+        suffix = f"_{unique_id}"
+        matches = [
+            entry for entry in registry_entries if entry.unique_id.endswith(suffix)
+        ]
+        if len(matches) == 1:
+            legacy = matches[0]
+            registry.async_update_entity(legacy.entity_id, new_unique_id=unique_id)
+            _LOGGER.info(
+                "Migrated %s control identity %s -> %s",
+                platform,
+                legacy.unique_id,
+                unique_id,
+            )
+        elif len(matches) > 1:
+            _LOGGER.warning(
+                "Not migrating ambiguous %s control identity ending in %s: %s",
+                platform,
+                unique_id,
+                [entry.entity_id for entry in matches],
+            )
+
+
+def setup_control_entity_discovery(
+    hass: HomeAssistant,
+    config_entry: Any,
+    coordinator: EG4DataUpdateCoordinator,
+    async_add_entities: AddEntitiesCallback,
+    entity_factory: EntityFactory,
+    *,
+    platform: str,
+    extra_signature: ExtraSignatureFactory | None = None,
+    migrate_model_prefix: bool = False,
+    update_before_add: bool = False,
+) -> None:
+    """Add current controls and converge their active set on later updates."""
+    known_entities: dict[str, EG4OptimisticEntity] = {}
+    previous_signature: object = _UNSET
+
+    @callback
+    def _rediscover_controls() -> None:
+        nonlocal previous_signature
+        signature = control_capability_signature(coordinator, extra_signature)
+        if signature == previous_signature:
+            return
+
+        candidates = entity_factory()
+        active_ids = {
+            unique_id
+            for entity in candidates
+            if (unique_id := entity.unique_id) is not None
+        }
+        for unique_id, entity in known_entities.items():
+            entity._set_control_discovery_supported(unique_id in active_ids)
+
+        new_by_id: dict[str, EG4OptimisticEntity] = {}
+        for entity in candidates:
+            unique_id = entity.unique_id
+            if (
+                unique_id is None
+                or unique_id in known_entities
+                or unique_id in new_by_id
+            ):
+                continue
+            entity._set_control_discovery_supported(True)
+            new_by_id[unique_id] = entity
+
+        if not new_by_id:
+            previous_signature = signature
+            return
+        new_entities = list(new_by_id.values())
+        if migrate_model_prefix:
+            _migrate_model_prefixed_unique_ids(
+                hass, config_entry, platform, new_entities
+            )
+        _LOGGER.info(
+            "Discovered %d new %s control entities (%d active, %d retained)",
+            len(new_entities),
+            platform,
+            len(active_ids),
+            len(known_entities) + len(new_entities),
+        )
+        async_add_entities(new_entities, update_before_add=update_before_add)
+        known_entities.update(new_by_id)
+        previous_signature = signature
+
+    # Register before adding entities so the capability callback runs before
+    # their CoordinatorEntity listeners on each update.  Availability therefore
+    # converges in the same tick rather than one poll later.
+    config_entry.async_on_unload(coordinator.async_add_listener(_rediscover_controls))
+    _rediscover_controls()

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -138,6 +138,7 @@ from .const import (
     is_control_active,
 )
 from .coordinator import EG4DataUpdateCoordinator
+from .control_discovery import setup_control_entity_discovery
 from .utils import (
     async_write_with_cloud_fallback,
     flag_offgrid_control_suppression,
@@ -588,14 +589,12 @@ class EG4BaseNumberEntity(EG4BaseNumber, NumberEntity):
 # ── Platform setup ───────────────────────────────────────────────────
 
 
-async def async_setup_entry(
+def _create_number_entities(
     hass: HomeAssistant,
-    config_entry: EG4ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up EG4 Web Monitor number entities from a config entry."""
-    coordinator = config_entry.runtime_data
-    entities: list[NumberEntity] = []
+    coordinator: EG4DataUpdateCoordinator,
+) -> list[EG4BaseNumberEntity]:
+    """Build controls applicable to the coordinator's current capabilities."""
+    entities: list[EG4BaseNumberEntity] = []
 
     for serial, device_data in (coordinator.data or {}).get("devices", {}).items():
         device_type = device_data.get("type")
@@ -658,11 +657,10 @@ async def async_setup_entry(
                 # switch.py.
                 offgrid = is_offgrid_family(device_data)
                 if offgrid:
-                    # Suffix-based probe: number unique IDs embed the model
-                    # slug ({clean_model}_{serial}_{key}), and registry
-                    # entries from a misdetected-model era (e.g. "unknown",
-                    # #219/#222) carry legacy prefixes — all variants end
-                    # with {serial}_{key}.
+                    # Suffix-based probe matches current stable IDs and legacy
+                    # model-prefixed IDs from a misdetected-model era (e.g.
+                    # "unknown", #219/#222). All variants end in
+                    # {serial}_{key}.
                     flag_offgrid_control_suppression(
                         hass,
                         serial,
@@ -748,9 +746,45 @@ async def async_setup_entry(
                     if coordinator.has_local_register_path(serial):
                         entities.append(StartChargePowerNumber(coordinator, serial))
 
-    if entities:
-        _LOGGER.info("Setup complete: %d number entities created", len(entities))
-        async_add_entities(entities, update_before_add=False)
+    return entities
+
+
+def _number_route_signature(coordinator: EG4DataUpdateCoordinator) -> object:
+    """Return transport state that can change the number candidate set."""
+    serials = (coordinator.data or {}).get("devices", {})
+    return (
+        bool(coordinator.has_http_api()),
+        bool(coordinator.is_local_only()),
+        tuple(
+            sorted(
+                (
+                    str(serial),
+                    bool(coordinator.has_configured_local_transport(serial)),
+                    bool(coordinator.has_local_register_path(serial)),
+                )
+                for serial in serials
+            )
+        ),
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: EG4ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up and continuously converge EG4 number entities."""
+    coordinator = config_entry.runtime_data
+    setup_control_entity_discovery(
+        hass,
+        config_entry,
+        coordinator,
+        async_add_entities,
+        lambda: _create_number_entities(hass, coordinator),
+        platform="number",
+        extra_signature=lambda: _number_route_signature(coordinator),
+        migrate_model_prefix=True,
+    )
 
 
 # ── Entity classes ───────────────────────────────────────────────────
@@ -768,9 +802,7 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "System Charge SOC Limit"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_system_charge_soc_limit"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("system_charge_soc_limit")
         self._attr_native_min_value = SYSTEM_CHARGE_SOC_LIMIT_MIN
         self._attr_native_max_value = SYSTEM_CHARGE_SOC_LIMIT_MAX
         self._attr_native_step = SYSTEM_CHARGE_SOC_LIMIT_STEP
@@ -857,9 +889,7 @@ class QuickChargeDurationNumber(RestoreNumber, EG4BaseNumberEntity):
         """Initialize the Quick Charge Duration number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Quick Charge Duration"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_quick_charge_duration"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("quick_charge_duration")
         self._attr_native_min_value = QUICK_CHARGE_DURATION_MIN
         self._attr_native_max_value = QUICK_CHARGE_DURATION_MAX
         self._attr_native_step = QUICK_CHARGE_DURATION_STEP
@@ -1037,7 +1067,7 @@ class ACChargePowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "AC Charge Power"
-        self._attr_unique_id = f"{self._clean_model}_{serial.lower()}_ac_charge_power"
+        self._attr_unique_id = self._stable_control_unique_id("ac_charge_power")
         self._attr_native_min_value = AC_CHARGE_POWER_MIN
         self._attr_native_max_value = AC_CHARGE_POWER_MAX
         self._attr_native_step = AC_CHARGE_POWER_STEP
@@ -1099,7 +1129,7 @@ class PVChargePowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "PV Charge Power"
-        self._attr_unique_id = f"{self._clean_model}_{serial.lower()}_pv_charge_power"
+        self._attr_unique_id = self._stable_control_unique_id("pv_charge_power")
         self._attr_native_min_value = PV_CHARGE_POWER_MIN
         self._attr_native_max_value = PV_CHARGE_POWER_MAX
         self._attr_native_step = PV_CHARGE_POWER_STEP
@@ -1179,9 +1209,7 @@ class GridPeakShavingPowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Grid Peak Shaving Power"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_grid_peak_shaving_power"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("grid_peak_shaving_power")
         self._attr_native_min_value = GRID_PEAK_SHAVING_POWER_MIN
         self._attr_native_max_value = GRID_PEAK_SHAVING_POWER_MAX
         self._attr_native_step = GRID_PEAK_SHAVING_POWER_STEP
@@ -1311,9 +1339,7 @@ class ACChargeSOCLimitNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "AC Charge SOC Limit"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_ac_charge_soc_limit"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("ac_charge_soc_limit")
         self._attr_native_min_value = AC_CHARGE_SOC_LIMIT_MIN
         self._attr_native_max_value = AC_CHARGE_SOC_LIMIT_MAX
         self._attr_native_step = AC_CHARGE_SOC_LIMIT_STEP
@@ -1369,8 +1395,8 @@ class ACChargeStartBatterySOCNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "AC Charge Start Battery SOC"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_ac_charge_start_battery_soc"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "ac_charge_start_battery_soc"
         )
         self._attr_native_min_value = AC_CHARGE_BATTERY_SOC_MIN
         self._attr_native_max_value = AC_CHARGE_BATTERY_SOC_MAX
@@ -1445,8 +1471,8 @@ class ACChargeEndBatterySOCNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "AC Charge End Battery SOC"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_ac_charge_end_battery_soc"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "ac_charge_end_battery_soc"
         )
         self._attr_native_min_value = AC_CHARGE_BATTERY_SOC_MIN
         self._attr_native_max_value = AC_CHARGE_BATTERY_SOC_MAX
@@ -1635,9 +1661,7 @@ class ACCoupleStartSOCNumber(ACCoupleSOCNumberBase):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_translation_key = "ac_couple_start_soc"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_ac_couple_start_soc"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("ac_couple_start_soc")
         self._attr_native_min_value = AC_COUPLE_SOC_MIN
         self._attr_native_max_value = AC_COUPLE_SOC_MAX
         self._attr_native_step = AC_COUPLE_SOC_STEP
@@ -1664,7 +1688,7 @@ class ACCoupleEndSOCNumber(ACCoupleSOCNumberBase):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_translation_key = "ac_couple_end_soc"
-        self._attr_unique_id = f"{self._clean_model}_{serial.lower()}_ac_couple_end_soc"
+        self._attr_unique_id = self._stable_control_unique_id("ac_couple_end_soc")
         self._attr_native_min_value = AC_COUPLE_SOC_MIN
         self._attr_native_max_value = AC_COUPLE_SOC_MAX
         self._attr_native_step = AC_COUPLE_SOC_STEP
@@ -1826,9 +1850,7 @@ class SmartLoadNumber(EG4BaseNumberEntity):
         self._spec = spec
         super().__init__(coordinator, serial)
         self._attr_translation_key = spec.translation_key
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_{spec.unique_id_suffix}"
-        )
+        self._attr_unique_id = self._stable_control_unique_id(spec.unique_id_suffix)
         self._attr_native_min_value = spec.min_value
         self._attr_native_max_value = spec.max_value
         self._attr_native_step = spec.step
@@ -1947,9 +1969,7 @@ class GridSellBackPowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_translation_key = "grid_sell_back_power"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_grid_sell_back_power"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("grid_sell_back_power")
         self._attr_native_min_value = GRID_SELL_BACK_POWER_MIN
         self._attr_native_max_value = GRID_SELL_BACK_POWER_MAX
         self._attr_native_step = GRID_SELL_BACK_POWER_STEP
@@ -2067,8 +2087,8 @@ class StartDischargePowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_translation_key = "start_discharge_power_threshold"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_start_discharge_power_threshold"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "start_discharge_power_threshold"
         )
         self._attr_native_min_value = START_DISCHARGE_POWER_MIN
         self._attr_native_max_value = START_DISCHARGE_POWER_MAX
@@ -2161,8 +2181,8 @@ class StartChargePowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_translation_key = "start_charge_power_threshold"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_start_charge_power_threshold"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "start_charge_power_threshold"
         )
         self._attr_native_min_value = START_CHARGE_POWER_MIN
         self._attr_native_max_value = START_CHARGE_POWER_MAX
@@ -2233,9 +2253,7 @@ class ForcedDischargePowerNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Forced Discharge Power"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_forced_discharge_power"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("forced_discharge_power")
         self._attr_native_min_value = FORCED_DISCHARGE_POWER_MIN
         self._attr_native_max_value = FORCED_DISCHARGE_POWER_MAX
         self._attr_native_step = FORCED_DISCHARGE_POWER_STEP
@@ -2321,8 +2339,8 @@ class ForcedDischargeSOCLimitNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Forced Discharge SOC Limit"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_forced_discharge_soc_limit"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "forced_discharge_soc_limit"
         )
         self._attr_native_min_value = FORCED_DISCHARGE_SOC_LIMIT_MIN
         self._attr_native_max_value = FORCED_DISCHARGE_SOC_LIMIT_MAX
@@ -2396,9 +2414,7 @@ class StopDischargeVoltageNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Stop Discharge Voltage"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_stop_discharge_voltage"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("stop_discharge_voltage")
         self._attr_native_min_value = STOP_DISCHARGE_VOLTAGE_MIN
         self._attr_native_max_value = STOP_DISCHARGE_VOLTAGE_MAX
         self._attr_native_step = STOP_DISCHARGE_VOLTAGE_STEP
@@ -2471,9 +2487,7 @@ class OnGridSOCCutoffNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "On-Grid SOC Cut-Off"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_on_grid_soc_cutoff"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("on_grid_soc_cutoff")
         self._attr_native_min_value = SOC_LIMIT_MIN
         self._attr_native_max_value = SOC_LIMIT_MAX
         self._attr_native_step = SOC_LIMIT_STEP
@@ -2522,9 +2536,7 @@ class OffGridSOCCutoffNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Off-Grid SOC Cut-Off"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_off_grid_soc_cutoff"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("off_grid_soc_cutoff")
         self._attr_native_min_value = SOC_LIMIT_MIN
         self._attr_native_max_value = SOC_LIMIT_MAX
         self._attr_native_step = SOC_LIMIT_STEP
@@ -2571,9 +2583,7 @@ class BatteryChargeCurrentNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Battery Charge Current"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_battery_charge_current"
-        )
+        self._attr_unique_id = self._stable_control_unique_id("battery_charge_current")
         self._attr_native_min_value = BATTERY_CURRENT_MIN
         self._attr_native_max_value = BATTERY_CURRENT_MAX
         self._attr_native_step = BATTERY_CURRENT_STEP
@@ -2621,8 +2631,8 @@ class BatteryDischargeCurrentNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "Battery Discharge Current"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_battery_discharge_current"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "battery_discharge_current"
         )
         self._attr_native_min_value = BATTERY_CURRENT_MIN
         self._attr_native_max_value = BATTERY_CURRENT_MAX
@@ -2676,8 +2686,8 @@ class SystemChargeVoltLimitNumber(EG4BaseNumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, serial)
         self._attr_name = "System Charge Voltage Limit"
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_system_charge_volt_limit"
+        self._attr_unique_id = self._stable_control_unique_id(
+            "system_charge_volt_limit"
         )
         self._attr_native_min_value = SYSTEM_CHARGE_VOLT_LIMIT_MIN
         self._attr_native_max_value = SYSTEM_CHARGE_VOLT_LIMIT_MAX
@@ -2869,9 +2879,7 @@ class EG4VoltageNumber(EG4BaseNumberEntity):
         self._control_key = spec.control_key
         super().__init__(coordinator, serial)
         self._attr_name = spec.name
-        self._attr_unique_id = (
-            f"{self._clean_model}_{serial.lower()}_{spec.unique_id_suffix}"
-        )
+        self._attr_unique_id = self._stable_control_unique_id(spec.unique_id_suffix)
         self._attr_native_min_value = spec.min_value
         self._attr_native_max_value = spec.max_value
         self._attr_native_step = spec.step

--- a/custom_components/eg4_web_monitor/select.py
+++ b/custom_components/eg4_web_monitor/select.py
@@ -16,6 +16,7 @@ from .const import (
     PARAM_FUNC_BAT_DISCHARGE_CONTROL,
     PARAM_HOLD_PV_INPUT_MODE,
 )
+from .control_discovery import setup_control_entity_discovery
 from .coordinator import EG4DataUpdateCoordinator
 from .base_entity import EG4BaseSelect, _get_model_from_coordinator
 from .utils import (
@@ -72,19 +73,14 @@ _STATUS_TO_SELECT = {
 }
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: EG4ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up EG4 Web Monitor select entities."""
-    coordinator: EG4DataUpdateCoordinator = entry.runtime_data
-
+def _create_select_entities(
+    coordinator: EG4DataUpdateCoordinator,
+) -> list[EG4BaseSelect]:
+    """Build controls applicable to the coordinator's current capabilities."""
     entities: list[EG4BaseSelect] = []
 
     if not coordinator.data or "devices" not in coordinator.data:
-        _LOGGER.warning("No device data available for select setup")
-        return
+        return entities
 
     # Create select entities for compatible devices
     for serial, device_data in coordinator.data["devices"].items():
@@ -145,11 +141,24 @@ async def async_setup_entry(
                 device_type,
             )
 
-    if entities:
-        _LOGGER.info("Setup complete: %d select entities created", len(entities))
-        async_add_entities(entities)
-    else:
-        _LOGGER.debug("No select entities created - no compatible devices found")
+    return entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: EG4ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up and continuously converge EG4 select entities."""
+    coordinator: EG4DataUpdateCoordinator = entry.runtime_data
+    setup_control_entity_discovery(
+        hass,
+        entry,
+        coordinator,
+        async_add_entities,
+        lambda: _create_select_entities(coordinator),
+        platform="select",
+    )
 
 
 class EG4OperatingModeSelect(EG4BaseSelect):
@@ -228,14 +237,7 @@ class EG4OperatingModeSelect(EG4BaseSelect):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if not self.coordinator.last_update_success:
-            return False
-        # Check if the device supports operating mode control
-        if self.coordinator.data and "devices" in self.coordinator.data:
-            device_data = self.coordinator.data["devices"].get(self._serial, {})
-            # Only available for inverter devices (not GridBOSS)
-            return bool(device_data.get("type") == "inverter")
-        return False
+        return self._control_device_available()
 
     async def async_select_option(self, option: str) -> None:
         """Change the operating mode using device object method."""
@@ -344,12 +346,7 @@ class EG4PVInputModeSelect(EG4BaseSelect):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if not self.coordinator.last_update_success:
-            return False
-        if self.coordinator.data and "devices" in self.coordinator.data:
-            device_data = self.coordinator.data["devices"].get(self._serial, {})
-            return bool(device_data.get("type") == "inverter")
-        return False
+        return self._control_device_available()
 
     async def async_select_option(self, option: str) -> None:
         """Change the PV input mode via local Modbus or cloud API."""
@@ -473,12 +470,7 @@ class EG4SmartPortModeSelect(EG4BaseSelect):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if not self.coordinator.last_update_success:
-            return False
-        if self.coordinator.data and "devices" in self.coordinator.data:
-            device_data = self.coordinator.data["devices"].get(self._serial, {})
-            return bool(device_data.get("type") == DEVICE_TYPE_GRIDBOSS)
-        return False
+        return self._control_device_available(DEVICE_TYPE_GRIDBOSS)
 
     async def async_select_option(self, option: str) -> None:
         """Change the smart port mode via local Modbus or cloud API."""
@@ -617,12 +609,7 @@ class EG4BatteryControlModeSelect(EG4BaseSelect):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if not self.coordinator.last_update_success:
-            return False
-        if self.coordinator.data and "devices" in self.coordinator.data:
-            device_data = self.coordinator.data["devices"].get(self._serial, {})
-            return bool(device_data.get("type") == "inverter")
-        return False
+        return self._control_device_available()
 
     async def async_select_option(self, option: str) -> None:
         """Change the battery control mode via local Modbus or cloud API."""

--- a/custom_components/eg4_web_monitor/switch.py
+++ b/custom_components/eg4_web_monitor/switch.py
@@ -43,6 +43,7 @@ from .const import (
     WORKING_MODES,
 )
 from .coordinator import EG4DataUpdateCoordinator
+from .control_discovery import setup_control_entity_discovery
 from .utils import (
     flag_offgrid_control_suppression,
     is_family_control_supported,
@@ -161,32 +162,19 @@ def _local_params_can_carry(param: str) -> bool:
 MAX_PARALLEL_UPDATES = 3
 
 
-async def async_setup_entry(
+def _create_switch_entities(
     hass: HomeAssistant,
-    entry: EG4ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up EG4 Web Monitor switch entities."""
-    coordinator: EG4DataUpdateCoordinator = entry.runtime_data
-
-    entities: list[SwitchEntity] = []
+    coordinator: EG4DataUpdateCoordinator,
+) -> list[EG4BaseSwitch]:
+    """Build device switches applicable to current capabilities and routes."""
+    entities: list[EG4BaseSwitch] = []
 
     if not coordinator.data:
-        _LOGGER.warning("No coordinator data available for switch setup")
-        return
-
-    # Create station DST switch if station data is available
-    if "station" in coordinator.data:
-        entities.append(EG4DSTSwitch(coordinator))
+        return entities
 
     # Skip device switches if no devices data
     if "devices" not in coordinator.data:
-        _LOGGER.warning(
-            "No device data for switch setup, creating station switches only"
-        )
-        if entities:
-            async_add_entities(entities, True)
-        return
+        return entities
 
     # Create switch entities for compatible devices
     for serial, device_data in coordinator.data["devices"].items():
@@ -390,8 +378,52 @@ async def async_setup_entry(
                         )
                     )
 
-    if entities:
-        async_add_entities(entities)
+    return entities
+
+
+def _switch_route_signature(coordinator: EG4DataUpdateCoordinator) -> object:
+    """Return transport/cache state that can change switch candidates."""
+    serials = (coordinator.data or {}).get("devices", {})
+    return (
+        bool(coordinator.has_http_api()),
+        bool(coordinator.is_local_only()),
+        tuple(
+            sorted(
+                (
+                    str(serial),
+                    bool(coordinator.has_configured_local_transport(serial)),
+                    bool(
+                        coordinator.params_are_local_raw(
+                            serial, include_configured=True
+                        )
+                    ),
+                )
+                for serial in serials
+            )
+        ),
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: EG4ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up station switches and continuously converge device switches."""
+    coordinator: EG4DataUpdateCoordinator = entry.runtime_data
+
+    if coordinator.data and "station" in coordinator.data:
+        async_add_entities([EG4DSTSwitch(coordinator)], update_before_add=True)
+
+    setup_control_entity_discovery(
+        hass,
+        entry,
+        coordinator,
+        async_add_entities,
+        lambda: _create_switch_entities(hass, coordinator),
+        platform="switch",
+        extra_signature=lambda: _switch_route_signature(coordinator),
+    )
 
 
 # Bound (seconds) on how long the Quick Charge switch distrusts a FRESH but

--- a/custom_components/eg4_web_monitor/time.py
+++ b/custom_components/eg4_web_monitor/time.py
@@ -54,6 +54,7 @@ from pylxpweb.endpoints.control import ControlEndpoints
 from . import EG4ConfigEntry
 from .base_entity import EG4BaseTime
 from .const import SCHEDULE_TIME_TYPES, ScheduleTimeSpec
+from .control_discovery import setup_control_entity_discovery
 from .coordinator import EG4DataUpdateCoordinator
 from .utils import (
     async_write_with_cloud_fallback,
@@ -111,24 +112,12 @@ def _schedule_supported(spec: ScheduleTimeSpec, device_data: dict[str, Any]) -> 
     return not (spec.gate == "control_grid_tied" and is_offgrid_family(device_data))
 
 
-async def async_setup_entry(
+def _create_time_entities(
     hass: HomeAssistant,
-    config_entry: EG4ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up EG4 Web Monitor time entities from a config entry."""
-    coordinator = config_entry.runtime_data
-    entities: list[TimeEntity] = []
-
-    global _logged_missing_write_time
-    if not _SUPPORTS_WRITE_TIME and not _logged_missing_write_time:
-        _logged_missing_write_time = True
-        _LOGGER.info(
-            "Installed pylxpweb lacks write_time_parameter; Generator/Off-Grid/"
-            "Peak Shaving schedule time entities are not created (upgrade pylxpweb "
-            "to enable them)"
-        )
-
+    coordinator: EG4DataUpdateCoordinator,
+) -> list[EG4ScheduleTimeEntity]:
+    """Build schedules applicable to the coordinator's current capabilities."""
+    entities: list[EG4ScheduleTimeEntity] = []
     for serial, device_data in (coordinator.data or {}).get("devices", {}).items():
         if device_data.get("type") != "inverter":
             continue
@@ -145,9 +134,8 @@ async def async_setup_entry(
         # beta.20/21 before the family gate landed (#295 live report: cloud
         # REMOTE_SET_ERROR + portal absence). One-shot Repairs notice for
         # anyone who had one registered — same machinery as the #307 Battery
-        # Backup gate. Suffix-based probe: time unique IDs embed the model
-        # slug ({clean_model}_{serial}_{key}); all variants end with
-        # {serial}_{key}.
+        # Backup gate. The suffix probe matches current stable IDs and legacy
+        # model-prefixed IDs; every variant ends with {serial}_{key}.
         if is_offgrid_family(device_data):
             flag_offgrid_control_suppression(
                 hass,
@@ -162,9 +150,35 @@ async def async_setup_entry(
                 issue_key="offgrid_forced_charge_times_removed",
             )
 
-    if entities:
-        _LOGGER.info("Setup complete: %d time entities created", len(entities))
-        async_add_entities(entities, update_before_add=False)
+    return entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: EG4ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up and continuously converge EG4 schedule time entities."""
+    coordinator = config_entry.runtime_data
+
+    global _logged_missing_write_time
+    if not _SUPPORTS_WRITE_TIME and not _logged_missing_write_time:
+        _logged_missing_write_time = True
+        _LOGGER.info(
+            "Installed pylxpweb lacks write_time_parameter; Generator/Off-Grid/"
+            "Peak Shaving schedule time entities are not created (upgrade pylxpweb "
+            "to enable them)"
+        )
+
+    setup_control_entity_discovery(
+        hass,
+        config_entry,
+        coordinator,
+        async_add_entities,
+        lambda: _create_time_entities(hass, coordinator),
+        platform="time",
+        migrate_model_prefix=True,
+    )
 
 
 class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
@@ -205,7 +219,7 @@ class EG4ScheduleTimeEntity(EG4BaseTime, TimeEntity):
         boundary = "end" if is_end else "start"
         key = f"{spec.key}_{boundary}_time_{window}"
         self._attr_translation_key = key
-        self._attr_unique_id = f"{self._clean_model}_{serial.lower()}_{key}"
+        self._attr_unique_id = self._stable_control_unique_id(key)
         self._attr_icon = "mdi:clock-end" if is_end else "mdi:clock-start"
         # All schedule time entities are opt-in (registry-disabled by default).
         self._attr_entity_registry_enabled_default = False

--- a/custom_components/eg4_web_monitor/utils.py
+++ b/custom_components/eg4_web_monitor/utils.py
@@ -379,15 +379,14 @@ def flag_offgrid_control_suppression(
     pruning. The issue is one per (issue_key, serial); re-creating it with
     the same issue_id is an idempotent update.
 
-    Matching is suffix-based rather than exact: number unique IDs embed the
-    model slug (``{clean_model}_{serial}_{key}``), and devices that were once
-    misdetected (e.g. the pre-beta.2 ``unknown`` model era, #219/#222) carry
-    legacy prefixes in the registry. All variants end with
-    ``{serial}_{control_key}``, which is what the suffixes pin. The serial
-    boundary is enforced (PR #332 review): a suffix matches only as the
-    whole unique ID or preceded by ``_``, so a serial that happens to be
-    the tail of a longer sibling's serial (``1234567890`` vs
-    ``91234567890``) cannot false-positive another device's entities.
+    Matching is suffix-based rather than exact: current control identities are
+    ``{serial}_{key}``, while number/time entities registered before the stable
+    identity migration can retain a model prefix (including the pre-beta.2
+    ``unknown`` model era, #219/#222). The serial boundary is enforced (PR
+    #332 review): a suffix matches only as the whole unique ID or preceded by
+    ``_``, so a serial that happens to be the tail of a longer sibling's serial
+    (``1234567890`` vs ``91234567890``) cannot false-positive another device's
+    entities.
 
     Args:
         hass: Home Assistant instance.

--- a/tests/test_control_discovery.py
+++ b/tests/test_control_discovery.py
@@ -1,0 +1,394 @@
+"""Regression tests for late control discovery and stable control identities."""
+
+from datetime import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+import custom_components.eg4_web_monitor.switch as switch_module
+from custom_components.eg4_web_monitor.const import DOMAIN
+from custom_components.eg4_web_monitor.number import (
+    ACChargePowerNumber,
+    GridPeakShavingPowerNumber,
+    QuickChargeDurationNumber,
+    async_setup_entry as async_setup_number,
+)
+from custom_components.eg4_web_monitor.select import (
+    EG4OperatingModeSelect,
+    async_setup_entry as async_setup_select,
+)
+from custom_components.eg4_web_monitor.sensor import EG4InverterSensor
+from custom_components.eg4_web_monitor.switch import (
+    EG4OffGridModeSwitch,
+    EG4QuickChargeSwitch,
+    EG4WorkingModeSwitch,
+    async_setup_entry as async_setup_switch,
+)
+from custom_components.eg4_web_monitor.time import (
+    EG4ScheduleTimeEntity,
+    async_setup_entry as async_setup_time,
+)
+from tests.test_number_entities import _mock_coordinator as _number_coordinator
+from tests.test_select_entities import _mock_coordinator as _select_coordinator
+from tests.test_switch_entities import _mock_coordinator as _switch_coordinator
+from tests.test_time_entities import (
+    _entity as _time_entity,
+    _mock_coordinator as _time_coordinator,
+)
+
+SERIAL = "1234567890"
+UNKNOWN_FEATURES = {"inverter_family": "UNKNOWN"}
+HYBRID_FEATURES = {"inverter_family": "EG4_HYBRID"}
+
+
+def _coordinator_for(platform: str) -> MagicMock:
+    """Build a control coordinator whose model and family begin unknown."""
+    if platform == "switch":
+        return _switch_coordinator(
+            model="Mystery Inverter", device_data={"features": UNKNOWN_FEATURES}
+        )
+    if platform == "number":
+        coordinator = _number_coordinator(model="Mystery Inverter")
+    elif platform == "select":
+        coordinator = _select_coordinator(model="Mystery Inverter")
+    else:
+        coordinator = _time_coordinator(model="Mystery Inverter")
+    coordinator.data["devices"][SERIAL]["features"] = dict(UNKNOWN_FEATURES)
+    return coordinator
+
+
+def _setup_for(platform: str) -> tuple[Any, type[Any]]:
+    """Return the setup callable and one representative entity class."""
+    return {
+        "switch": (async_setup_switch, EG4OffGridModeSwitch),
+        "number": (async_setup_number, ACChargePowerNumber),
+        "select": (async_setup_select, EG4OperatingModeSelect),
+        "time": (async_setup_time, EG4ScheduleTimeEntity),
+    }[platform]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ("switch", "number", "select", "time"))
+async def test_controls_converge_across_late_discovery_and_removal(hass, platform):
+    """All control platforms follow unknown -> known -> absent transitions.
+
+    Discovery must happen from a coordinator update without reloading the config
+    entry. Controls that later become inapplicable stay registered but become
+    unavailable; restoring the capability reuses the original registry identity.
+    """
+    coordinator = _coordinator_for(platform)
+    setup, representative_type = _setup_for(platform)
+    callbacks = []
+    coordinator.async_add_listener.side_effect = lambda callback: (
+        callbacks.append(callback) or (lambda: None)
+    )
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    batches: list[list[Any]] = []
+    entities: list[Any] = []
+
+    def add_entities(new_entities, **_kwargs):
+        batch = list(new_entities)
+        batches.append(batch)
+        entities.extend(batch)
+
+    await setup(hass, entry, add_entities)
+
+    assert not any(isinstance(entity, representative_type) for entity in entities)
+    assert len(callbacks) == 1
+    entry.async_on_unload.assert_called_once()
+
+    device_data = coordinator.data["devices"][SERIAL]
+    device_data["features"] = dict(HYBRID_FEATURES)
+    callbacks[0]()
+
+    representative = next(
+        entity for entity in entities if isinstance(entity, representative_type)
+    )
+    if platform == "time":
+        # Schedule availability also requires a decoded value. Keep that
+        # independent condition satisfied while exercising discovery support.
+        representative._optimistic_value = time(1, 0)
+    assert representative.available
+    unique_id = representative.unique_id
+    batch_count = len(batches)
+
+    # An unchanged high-frequency coordinator tick must be a no-op.
+    callbacks[0]()
+    assert len(batches) == batch_count
+
+    # A capability downgrade prunes the control from the active set without
+    # removing its registry identity or leaving an actionable stale control.
+    device_data["features"] = dict(UNKNOWN_FEATURES)
+    callbacks[0]()
+    assert not representative.available
+
+    # Capability recovery reuses the same entity; no duplicate is added.
+    device_data["features"] = dict(HYBRID_FEATURES)
+    callbacks[0]()
+    assert representative.available
+    assert [entity.unique_id for entity in entities].count(unique_id) == 1
+
+    # Device removal is handled identically on every control platform.
+    coordinator.data["devices"].pop(SERIAL)
+    callbacks[0]()
+    assert not representative.available
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ("switch", "number", "select", "time"))
+async def test_controls_discover_when_initial_snapshot_has_no_devices(hass, platform):
+    """Platform setup with no data still installs the late-discovery listener."""
+    coordinator = _coordinator_for(platform)
+    late_data = coordinator.data
+    late_data["devices"][SERIAL]["features"] = dict(HYBRID_FEATURES)
+    coordinator.data = None
+    callbacks = []
+    coordinator.async_add_listener.side_effect = lambda callback: (
+        callbacks.append(callback) or (lambda: None)
+    )
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    entities: list[Any] = []
+    setup, representative_type = _setup_for(platform)
+
+    await setup(hass, entry, lambda new, **_kwargs: entities.extend(new))
+
+    assert not entities
+    assert len(callbacks) == 1
+    coordinator.data = late_data
+    callbacks[0]()
+    assert any(isinstance(entity, representative_type) for entity in entities)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ("switch", "number", "time"))
+async def test_family_specific_controls_become_inapplicable_without_duplicates(
+    hass, platform
+):
+    """A family change prunes only invalid controls and can later recover them."""
+    coordinator = _coordinator_for(platform)
+    coordinator.data["devices"][SERIAL]["features"] = dict(HYBRID_FEATURES)
+    setup, _representative_type = _setup_for(platform)
+    callbacks = []
+    coordinator.async_add_listener.side_effect = lambda callback: (
+        callbacks.append(callback) or (lambda: None)
+    )
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    entities: list[Any] = []
+    await setup(hass, entry, lambda new, **_kwargs: entities.extend(new))
+
+    if platform == "switch":
+        target = next(
+            entity
+            for entity in entities
+            if isinstance(entity, EG4WorkingModeSwitch)
+            and entity._mode_config["param"] == "FUNC_GRID_PEAK_SHAVING"
+        )
+        survivor = next(
+            entity for entity in entities if isinstance(entity, EG4OffGridModeSwitch)
+        )
+    elif platform == "number":
+        target = next(
+            entity
+            for entity in entities
+            if isinstance(entity, GridPeakShavingPowerNumber)
+        )
+        survivor = next(
+            entity for entity in entities if isinstance(entity, ACChargePowerNumber)
+        )
+    else:
+        target = next(
+            entity
+            for entity in entities
+            if isinstance(entity, EG4ScheduleTimeEntity)
+            and entity._attr_translation_key == "forced_discharge_start_time_1"
+        )
+        survivor = next(
+            entity
+            for entity in entities
+            if isinstance(entity, EG4ScheduleTimeEntity)
+            and entity._attr_translation_key == "ac_charge_start_time_1"
+        )
+        target._optimistic_value = time(1, 0)
+        survivor._optimistic_value = time(1, 0)
+
+    assert target.available
+    assert survivor.available
+    target_id = target.unique_id
+
+    coordinator.data["devices"][SERIAL]["features"] = {"inverter_family": "EG4_OFFGRID"}
+    callbacks[0]()
+
+    assert not target.available
+    assert survivor.available
+
+    coordinator.data["devices"][SERIAL]["features"] = dict(HYBRID_FEATURES)
+    callbacks[0]()
+
+    assert target.available
+    assert [entity.unique_id for entity in entities].count(target_id) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ("switch", "number"))
+async def test_transport_gated_controls_are_discovered_after_route_recovery(
+    hass, platform
+):
+    """Configured local transport recovery adds route-gated controls live."""
+    if platform == "switch":
+        coordinator = _switch_coordinator(
+            has_http=False,
+            has_local=False,
+            transport_attached=False,
+            model="FlexBOSS21",
+        )
+        expected_type = EG4QuickChargeSwitch
+    else:
+        coordinator = _number_coordinator(
+            has_http=False, has_local=False, model="FlexBOSS21"
+        )
+        expected_type = QuickChargeDurationNumber
+
+    callbacks = []
+    coordinator.async_add_listener.side_effect = lambda callback: (
+        callbacks.append(callback) or (lambda: None)
+    )
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    entities: list[Any] = []
+    setup, _representative_type = _setup_for(platform)
+    await setup(hass, entry, lambda new, **_kwargs: entities.extend(new))
+    assert not any(isinstance(entity, expected_type) for entity in entities)
+
+    coordinator.has_configured_local_transport.return_value = True
+    if platform == "number":
+        coordinator.has_local_register_path.return_value = True
+    callbacks[0]()
+
+    assert sum(isinstance(entity, expected_type) for entity in entities) == 1
+
+
+@pytest.mark.asyncio
+async def test_fast_parameter_ticks_do_not_rebuild_control_candidates(hass) -> None:
+    """Ordinary value updates avoid control construction and registry work."""
+    coordinator = _switch_coordinator(model="FlexBOSS21")
+    callbacks = []
+    coordinator.async_add_listener.side_effect = lambda callback: (
+        callbacks.append(callback) or (lambda: None)
+    )
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+
+    with patch(
+        "custom_components.eg4_web_monitor.switch._create_switch_entities",
+        wraps=switch_module._create_switch_entities,
+    ) as factory:
+        await async_setup_switch(hass, entry, lambda _new, **_kwargs: None)
+        assert factory.call_count == 1
+
+        coordinator.data["parameters"][SERIAL]["FUNC_GREEN_EN"] = True
+        callbacks[0]()
+
+        assert factory.call_count == 1
+
+
+def test_number_unique_id_is_independent_of_model_discovery() -> None:
+    """A model upgrade cannot create a second number registry identity."""
+    unknown = ACChargePowerNumber(
+        _number_coordinator(model="Unknown"), SERIAL
+    ).unique_id
+    known = ACChargePowerNumber(
+        _number_coordinator(model="FlexBOSS21"), SERIAL
+    ).unique_id
+
+    assert unknown == known == f"{SERIAL}_ac_charge_power"
+
+
+def test_time_unique_id_is_independent_of_model_discovery() -> None:
+    """A model upgrade cannot create a second schedule registry identity."""
+    unknown = _time_entity(_time_coordinator(model="Unknown")).unique_id
+    known = _time_entity(_time_coordinator(model="FlexBOSS21")).unique_id
+
+    assert unknown == known == f"{SERIAL}_ac_charge_start_time_1"
+
+
+def test_parallel_group_suggested_ids_include_group_identity() -> None:
+    """Parallel groups never compete for the same suggested entity ID."""
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_device_info.return_value = None
+    coordinator.data = {
+        "devices": {
+            "parallel_group_a": {"type": "parallel_group", "model": "Parallel"},
+            "parallel_group_b": {"type": "parallel_group", "model": "Parallel"},
+        }
+    }
+
+    group_a = EG4InverterSensor(
+        coordinator, "parallel_group_a", "pv_total_power", "parallel_group"
+    )
+    group_b = EG4InverterSensor(
+        coordinator, "parallel_group_b", "pv_total_power", "parallel_group"
+    )
+
+    assert group_a._attr_entity_id == "sensor.eg4_parallel_group_a_pv_total_power"
+    assert group_b._attr_entity_id == "sensor.eg4_parallel_group_b_pv_total_power"
+    assert group_a._attr_entity_id != group_b._attr_entity_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("platform", "setup", "coordinator", "legacy_unique_id", "new_unique_id"),
+    (
+        (
+            "number",
+            async_setup_number,
+            _number_coordinator,
+            f"flexboss21_{SERIAL}_ac_charge_power",
+            f"{SERIAL}_ac_charge_power",
+        ),
+        (
+            "time",
+            async_setup_time,
+            _time_coordinator,
+            f"flexboss21_{SERIAL}_ac_charge_start_time_1",
+            f"{SERIAL}_ac_charge_start_time_1",
+        ),
+    ),
+)
+async def test_model_prefixed_control_identity_is_migrated_in_place(
+    hass, platform, setup, coordinator, legacy_unique_id, new_unique_id
+):
+    """Legacy model-prefixed IDs preserve entity_id and user customization."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"{platform} migration",
+        data={},
+        entry_id=f"control-migration-{platform}",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = coordinator()
+    registry = er.async_get(hass)
+    legacy = registry.async_get_or_create(
+        platform,
+        DOMAIN,
+        legacy_unique_id,
+        config_entry=entry,
+        suggested_object_id=f"kept_{platform}_entity",
+    )
+
+    await setup(hass, entry, lambda _entities, **_kwargs: None)
+
+    migrated = registry.async_get(legacy.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == new_unique_id
+    assert registry.async_get_entity_id(platform, DOMAIN, legacy_unique_id) is None
+    assert (
+        registry.async_get_entity_id(platform, DOMAIN, new_unique_id)
+        == legacy.entity_id
+    )

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -170,8 +170,7 @@ class TestNumberPlatformSetup:
         voltage_entities = [e for e in entities if isinstance(e, EG4VoltageNumber)]
         assert len(voltage_entities) == 5
         assert {
-            entity.unique_id.removeprefix("flexboss21_1234567890_")
-            for entity in voltage_entities
+            entity.unique_id.removeprefix("1234567890_") for entity in voltage_entities
         } == {
             "on_grid_cutoff_voltage",
             "off_grid_cutoff_voltage",
@@ -2454,8 +2453,8 @@ class TestOffgridACChargeSOCWindow:
         coordinator = self._offgrid_coordinator()
         start = ACChargeStartBatterySOCNumber(coordinator, "1234567890")
         end = ACChargeEndBatterySOCNumber(coordinator, "1234567890")
-        assert start.unique_id == "12000xp_1234567890_ac_charge_start_battery_soc"
-        assert end.unique_id == "12000xp_1234567890_ac_charge_end_battery_soc"
+        assert start.unique_id == "1234567890_ac_charge_start_battery_soc"
+        assert end.unique_id == "1234567890_ac_charge_end_battery_soc"
         for entity in (start, end):
             assert entity.native_min_value == 0
             assert entity.native_max_value == 100
@@ -2785,8 +2784,8 @@ class TestACCoupleSOCWindow:
         coordinator = self._coordinator()
         start = ACCoupleStartSOCNumber(coordinator, self.SERIAL)
         end = ACCoupleEndSOCNumber(coordinator, self.SERIAL)
-        assert start.unique_id == "12000xp_1234567890_ac_couple_start_soc"
-        assert end.unique_id == "12000xp_1234567890_ac_couple_end_soc"
+        assert start.unique_id == "1234567890_ac_couple_start_soc"
+        assert end.unique_id == "1234567890_ac_couple_end_soc"
         assert start.translation_key == "ac_couple_start_soc"
         assert end.translation_key == "ac_couple_end_soc"
         for entity in (start, end):

--- a/tests/test_number_voltage_spec.py
+++ b/tests/test_number_voltage_spec.py
@@ -84,7 +84,7 @@ def _voltage_number(coordinator: MagicMock, key: str) -> EG4VoltageNumber:
             475,
             47.5,
             {
-                "unique_id": "flexboss21_abc123_on_grid_cutoff_voltage",
+                "unique_id": "abc123_on_grid_cutoff_voltage",
                 "name": "On-Grid Cut-Off Voltage",
                 "min": 40.0,
                 "max": 58.0,
@@ -100,7 +100,7 @@ def _voltage_number(coordinator: MagicMock, key: str) -> EG4VoltageNumber:
             480,
             48.0,
             {
-                "unique_id": "flexboss21_abc123_off_grid_cutoff_voltage",
+                "unique_id": "abc123_off_grid_cutoff_voltage",
                 "name": "Off-Grid Cut-Off Voltage",
                 "min": 40.0,
                 "max": 58.0,
@@ -116,7 +116,7 @@ def _voltage_number(coordinator: MagicMock, key: str) -> EG4VoltageNumber:
             520,
             52.0,
             {
-                "unique_id": "flexboss21_abc123_ac_charge_start_voltage",
+                "unique_id": "abc123_ac_charge_start_voltage",
                 "name": "AC Charge Start Voltage",
                 "min": 38,
                 "max": 60,
@@ -132,7 +132,7 @@ def _voltage_number(coordinator: MagicMock, key: str) -> EG4VoltageNumber:
             580,
             58.0,
             {
-                "unique_id": "flexboss21_abc123_ac_charge_end_voltage",
+                "unique_id": "abc123_ac_charge_end_voltage",
                 "name": "AC Charge End Voltage",
                 "min": 38,
                 "max": 60,
@@ -183,7 +183,7 @@ def test_pv_start_voltage_characterization() -> None:
     coordinator = _mock_coordinator(parameters={PARAM_HOLD_START_PV_VOLT: 1400})
     entity = _voltage_number(coordinator, "pv_start_voltage")
 
-    assert entity.unique_id == "flexboss21_abc123_pv_start_voltage"
+    assert entity.unique_id == "abc123_pv_start_voltage"
     assert entity._attr_name == "PV Start Voltage"
     assert entity._attr_native_min_value == 140
     assert entity._attr_native_max_value == 500

--- a/tests/test_time_entities.py
+++ b/tests/test_time_entities.py
@@ -600,26 +600,25 @@ class TestScheduleRegisterMapping:
         assert entity._cloud_time_param == f"HOLD_PEAK_SHAVING_{boundary}_TIME_{window}"
 
     def test_unique_ids(self):
-        """AC charge unique_ids stay exactly as shipped in #277 (zero churn);
-        new schedules follow the same pattern."""
+        """Schedule identities use immutable serial + purpose, never model."""
         coordinator = _mock_coordinator()
         assert (
             _entity(coordinator, window=1)._attr_unique_id
-            == "flexboss21_1234567890_ac_charge_start_time_1"
+            == "1234567890_ac_charge_start_time_1"
         )
         assert (
             _entity(coordinator, window=3, is_end=True)._attr_unique_id
-            == "flexboss21_1234567890_ac_charge_end_time_3"
+            == "1234567890_ac_charge_end_time_3"
         )
         assert (
             _entity(coordinator, schedule="ac_first", window=2)._attr_unique_id
-            == "flexboss21_1234567890_ac_first_start_time_2"
+            == "1234567890_ac_first_start_time_2"
         )
         assert (
             _entity(
                 coordinator, schedule="forced_discharge", window=1, is_end=True
             )._attr_unique_id
-            == "flexboss21_1234567890_forced_discharge_end_time_1"
+            == "1234567890_forced_discharge_end_time_1"
         )
 
     @pytest.mark.parametrize("schedule", SCHEDULE_KEYS)


### PR DESCRIPTION
## Scope

Implements bead `eg4-06er.4` from the integration audit in draft #524. This PR is isolated on the latest `origin/main` and does not depend on any unmerged PR.

## RCA

Four related one-shot assumptions caused the control graph to diverge from coordinator truth:

1. `switch`, `number`, `select`, and `time` only evaluated device model/family/features during platform setup. pylxpweb can publish a device before its family/model and configured local route have converged, so a valid control discovered later required a config-entry reload.
2. The setup gates were not retained as an availability contract. A known entity could remain actionable after its device disappeared or after a later family transition made that specific control invalid. Number/time bases checked only coordinator success and did not verify device presence at all.
3. Parallel-group sensor unique IDs included the group, but suggested entity IDs did not. Groups A/B therefore proposed the same object ID and relied on HA's order-dependent `_2` collision suffix.
4. Number/time unique IDs embedded the mutable model slug. `Unknown -> FlexBOSS21` therefore represented one physical control as a new registry identity.
5. A naive runtime fix would rebuild every control and query the registry on every fast coordinator tick, shifting the setup race into persistent callback churn.

## Implementation

- Adds one shared runtime control-discovery tracker used by all four control platforms.
- Installs the listener even when the initial snapshot has no data/devices.
- Signs only capability inputs (`type`, `model`, `features`) plus platform-specific transport-route state. Fast sensor/parameter ticks return before candidate construction or registry work.
- Adds newly valid controls without reload. Already-known identities are retained; when a capability/device disappears they become unavailable in the same coordinator tick, and capability recovery reuses the same object/identity without duplication.
- Makes switch/select/number/time availability consistently require coordinator health, the expected live device type, no device error, and current discovery applicability.
- Changes number/time registry identities to immutable `{serial}_{purpose}` and migrates a single legacy `{model}_{serial}_{purpose}` entry in place before entity registration, preserving entity ID and customization. Ambiguous legacy matches are logged and left untouched rather than guessed at destructively.
- Includes the parallel-group serial (`parallel_group_a`, `parallel_group_b`, ...) in suggested sensor entity IDs.
- Leaves all read/write/register mapping logic unchanged; the existing family/route factories remain the source of truth, so late discovery cannot expose a control the current mapping gates reject.

## Transition and race coverage

New regressions cover:

- no-data startup -> late device discovery for switch/number/select/time;
- unknown -> known -> inapplicable -> recovered -> removed transitions for all four platforms;
- HYBRID -> EG4_OFFGRID pruning of specific switch/number/time grid-tied controls while family-valid siblings remain available;
- late configured-local-route recovery for Quick Charge switch/number controls;
- no duplicate add on recovery and no candidate rebuild on parameter-only fast ticks;
- model-independent number/time identities and in-place registry migration;
- deterministic suggested IDs for multiple parallel groups.

## Compatibility with concurrent drafts

- **#532 scoped coordinator fanout:** correctness is compatible if #532 lands first because this listener is intentionally unscoped and #532 always notifies unscoped safety listeners. This PR's capability signature keeps those calls low-churn. After rebasing onto #532, the optional merge-time optimization is to register the tracker with `DISCOVERY_LISTENER_CONTEXT`; that removes even the lightweight metadata scan on unrelated ticks. It is not used here because this PR must not depend on unmerged code.
- **#519:** touches `number.py` only in `async_added_to_hass()` to route optimistic retention through the coordinator handler. This PR changes platform setup/identity sections; the changes are complementary.
- **#533:** its `number.py` change is confined to a later post-write refresh path. This PR does not change that write behavior; expected overlap is line movement, not semantics.

## Verification

- `pytest -q tests`: **2562 passed, 3 skipped**
- focused control/platform regressions: **54 passed**
- Ruff lint: passed
- Ruff format: passed
- strict mypy: **42 source files clean**
- `prek run --all-files`: all hooks passed
- `git diff --check`: passed

The bare repository-root `pytest -q` command also collects the standalone `scripts/collision_test.py`, which parses pytest's `-q` argument as its integer round count and fails during collection. The maintained product suite is the explicit `tests/` scope above.
