### PR TITLE
fix: isolate cross-entry cloud cookies

### DIFF
--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -742,15 +742,15 @@ jobs:
         run: |
           echo "Checking websession injection support..."
 
-          # Check coordinator uses aiohttp session injection via async_get_clientsession
-          if ! grep -q "async_get_clientsession" custom_components/eg4_web_monitor/coordinator.py; then
+          # Cookie auth requires an isolated HA session per client/account.
+          if ! grep -q "async_create_clientsession" custom_components/eg4_web_monitor/coordinator.py; then
             echo "❌ Coordinator does not inject session"
             exit 1
           fi
           echo "✅ Coordinator injects Home Assistant session"
 
           # Check config flow uses session injection
-          if ! grep -q "async_get_clientsession" custom_components/eg4_web_monitor/_config_flow/__init__.py; then
+          if ! grep -q "async_create_clientsession" custom_components/eg4_web_monitor/_config_flow/__init__.py; then
             echo "❌ Config flow does not inject session"
             exit 1
           fi
@@ -764,7 +764,7 @@ jobs:
           echo "✅ LuxpowerClient API client is used"
 
           # Check that session is passed to LuxpowerClient
-          if ! grep -q "session=aiohttp_client" custom_components/eg4_web_monitor/coordinator.py; then
+          if ! grep -q "session=cloud_session" custom_components/eg4_web_monitor/coordinator.py; then
             echo "❌ Session not passed to LuxpowerClient"
             exit 1
           fi

--- a/custom_components/eg4_web_monitor/_config_flow/__init__.py
+++ b/custom_components/eg4_web_monitor/_config_flow/__init__.py
@@ -1390,29 +1390,44 @@ class EG4ConfigFlow(
 
     async def _test_cloud_credentials(self) -> None:
         """Test cloud credentials and load stations list."""
-        session = aiohttp_client.async_get_clientsession(self.hass)
         assert self._username is not None
         assert self._password is not None
-
-        async with LuxpowerClient(
-            username=self._username,
-            password=self._password,
-            base_url=self._base_url,
+        # Cookie-authenticated clients cannot use HA's process-wide default
+        # session: another account on the same origin would overwrite its
+        # domain cookie. The dedicated session still reuses HA's connector,
+        # resolver, SSL context, and user-agent. Config flows are not config
+        # entry setup, so explicitly detach instead of retaining the wrapper
+        # until Home Assistant stops.
+        session = aiohttp_client.async_create_clientsession(
+            self.hass,
             verify_ssl=self._verify_ssl,
-            session=session,
-        ) as client:
-            from pylxpweb.devices import Station
+            auto_cleanup=False,
+        )
+        try:
+            async with LuxpowerClient(
+                username=self._username,
+                password=self._password,
+                base_url=self._base_url,
+                verify_ssl=self._verify_ssl,
+                session=session,
+            ) as client:
+                from pylxpweb.devices import Station
 
-            stations = await Station.load_all(client)
-            # Normalize plant ids to str at the API boundary: pylxpweb returns
-            # Station.id as int, but the HA frontend submits form selections as
-            # str and CONF_PLANT_ID is stored as str (#275).
-            self._plants = [
-                {"plantId": str(station.id), "name": station.name}
-                for station in stations
-            ]
-            if not self._plants:
-                raise LuxpowerAPIError("No plants found for this account")
+                stations = await Station.load_all(client)
+                # Normalize plant ids to str at the API boundary: pylxpweb returns
+                # Station.id as int, but the HA frontend submits form selections as
+                # str and CONF_PLANT_ID is stored as str (#275).
+                self._plants = [
+                    {"plantId": str(station.id), "name": station.name}
+                    for station in stations
+                ]
+                if not self._plants:
+                    raise LuxpowerAPIError("No plants found for this account")
+        finally:
+            # The injected pylxpweb session is integration-owned; detach the
+            # wrapper while leaving Home Assistant's shared connector alive.
+            if not session.closed:
+                session.detach()
 
     def _build_entry_data(self) -> dict[str, Any]:
         """Build config entry data from current flow state."""

--- a/custom_components/eg4_web_monitor/_config_flow/__init__.py
+++ b/custom_components/eg4_web_monitor/_config_flow/__init__.py
@@ -65,6 +65,7 @@ from .schemas import (
     build_serial_schema,
 )
 from .serial_ports import build_port_selector_options, list_serial_ports
+from ..cloud_session import async_close_client_session
 from ..const import (
     BRAND_NAME,
     CONF_BASE_URL,
@@ -1403,31 +1404,34 @@ class EG4ConfigFlow(
             verify_ssl=self._verify_ssl,
             auto_cleanup=False,
         )
+        client: LuxpowerClient | None = None
         try:
-            async with LuxpowerClient(
+            client = LuxpowerClient(
                 username=self._username,
                 password=self._password,
                 base_url=self._base_url,
                 verify_ssl=self._verify_ssl,
                 session=session,
-            ) as client:
-                from pylxpweb.devices import Station
+            )
+            await client.login()
 
-                stations = await Station.load_all(client)
-                # Normalize plant ids to str at the API boundary: pylxpweb returns
-                # Station.id as int, but the HA frontend submits form selections as
-                # str and CONF_PLANT_ID is stored as str (#275).
-                self._plants = [
-                    {"plantId": str(station.id), "name": station.name}
-                    for station in stations
-                ]
-                if not self._plants:
-                    raise LuxpowerAPIError("No plants found for this account")
+            from pylxpweb.devices import Station
+
+            stations = await Station.load_all(client)
+            # Normalize plant ids to str at the API boundary: pylxpweb returns
+            # Station.id as int, but the HA frontend submits form selections as
+            # str and CONF_PLANT_ID is stored as str (#275).
+            self._plants = [
+                {"plantId": str(station.id), "name": station.name}
+                for station in stations
+            ]
+            if not self._plants:
+                raise LuxpowerAPIError("No plants found for this account")
         finally:
-            # The injected pylxpweb session is integration-owned; detach the
-            # wrapper while leaving Home Assistant's shared connector alive.
-            if not session.closed:
-                session.detach()
+            # Bind the client before login: cancellation during its shielded
+            # authentication must still drain client-owned work before this
+            # account-private cookie jar is detached.
+            await async_close_client_session(client, session)
 
     def _build_entry_data(self) -> dict[str, Any]:
         """Build config entry data from current flow state."""

--- a/custom_components/eg4_web_monitor/cloud_session.py
+++ b/custom_components/eg4_web_monitor/cloud_session.py
@@ -1,0 +1,61 @@
+"""Cancellation-safe cleanup for cookie-bearing cloud sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+import inspect
+from typing import Any, cast
+
+import aiohttp
+
+
+async def _async_drain_awaitable(awaitable: Awaitable[Any]) -> None:
+    """Wait for one cleanup operation despite repeated caller cancellation.
+
+    ``asyncio.wait`` observes completion without propagating caller cancellation
+    into the dependency-owned task. Catching cancellation lets us keep waiting
+    for that exact operation; the first cancellation is re-raised only after the
+    operation has settled. Retrieving the result also prevents an exceptional
+    cleanup task from becoming an unobserved task exception.
+    """
+    cleanup_future = asyncio.ensure_future(awaitable)
+    caller_cancellation: asyncio.CancelledError | None = None
+
+    while not cleanup_future.done():
+        try:
+            await asyncio.wait({cleanup_future})
+        except asyncio.CancelledError as err:
+            if caller_cancellation is None:
+                caller_cancellation = err
+
+    cleanup_error: BaseException | None = None
+    try:
+        cleanup_future.result()
+    except BaseException as err:  # includes child-task cancellation
+        cleanup_error = err
+
+    if caller_cancellation is not None:
+        if cleanup_error is not None:
+            raise caller_cancellation from cleanup_error
+        raise caller_cancellation
+    if cleanup_error is not None:
+        raise cleanup_error
+
+
+async def async_close_client_session(
+    client: object | None,
+    session: aiohttp.ClientSession | None,
+) -> None:
+    """Drain client-owned work before detaching its injected HA session."""
+    try:
+        close = getattr(client, "close", None)
+        if close is not None:
+            close_result: Any = close()
+            if inspect.isawaitable(close_result):
+                await _async_drain_awaitable(cast(Awaitable[Any], close_result))
+    finally:
+        # HA owns the connector. Detach releases only this wrapper and its
+        # account-private CookieJar after dependency-owned work has stopped.
+        if session is not None and not session.closed:
+            session.detach()

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -1,12 +1,14 @@
 """Data update coordinator for EG4 Web Monitor integration using pylxpweb device objects."""
 
 import asyncio
+import inspect
 import logging
 import time
 from datetime import datetime, timedelta
 from collections.abc import Awaitable, Callable, Collection
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -170,17 +172,34 @@ class EG4DataUpdateCoordinator(
 
         # Initialize HTTP client for HTTP and Hybrid modes
         self.client: LuxpowerClient | None = None
+        self._cloud_session: aiohttp.ClientSession | None = None
         if self.connection_type in (CONNECTION_TYPE_HTTP, CONNECTION_TYPE_HYBRID):
-            self.client = LuxpowerClient(
-                username=entry.data[CONF_USERNAME],
-                password=entry.data[CONF_PASSWORD],
-                base_url=entry.data.get(
-                    CONF_BASE_URL, "https://monitor.eg4electronics.com"
-                ),
-                verify_ssl=entry.data.get(CONF_VERIFY_SSL, True),
-                session=aiohttp_client.async_get_clientsession(hass),
-                iana_timezone=iana_timezone,
+            verify_ssl = entry.data.get(CONF_VERIFY_SSL, True)
+            cloud_session = aiohttp_client.async_create_clientsession(
+                hass,
+                verify_ssl=verify_ssl,
+                auto_cleanup=True,
             )
+            self._cloud_session = cloud_session
+            try:
+                self.client = LuxpowerClient(
+                    username=entry.data[CONF_USERNAME],
+                    password=entry.data[CONF_PASSWORD],
+                    base_url=entry.data.get(
+                        CONF_BASE_URL, "https://monitor.eg4electronics.com"
+                    ),
+                    verify_ssl=verify_ssl,
+                    session=cloud_session,
+                    iana_timezone=iana_timezone,
+                )
+            except BaseException:
+                # pylxpweb does not own injected sessions. If its synchronous
+                # constructor fails, no client exists to participate in later
+                # cleanup, so release this wrapper without closing HA's shared
+                # connector.
+                cloud_session.detach()
+                self._cloud_session = None
+                raise
 
         # Modbus input-register read block size (#254): preset option mapped
         # to pylxpweb's max registers per coalesced read. Conservative (40)
@@ -647,6 +666,39 @@ class EG4DataUpdateCoordinator(
                 "No local transport or cloud API available for parameter write."
             )
         return client
+
+    async def _async_close_cloud_session(self) -> None:
+        """Stop dependency-owned work, then detach the injected session."""
+        try:
+            # Current pylxpweb ignores injected sessions here; versions with
+            # auth single-flight also cancel their private auth task. That task
+            # must stop before its session is detached.
+            close = getattr(self.client, "close", None)
+            if close is not None:
+                close_result: Any = close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+        finally:
+            # HA owns the connector; detach closes only this account's session
+            # wrapper and private CookieJar.
+            cloud_session = self._cloud_session
+            self._cloud_session = None
+            if cloud_session is not None and not cloud_session.closed:
+                cloud_session.detach()
+
+    async def _async_handle_shutdown(self, event: Any) -> None:
+        """Release the cloud wrapper when Home Assistant stops without unload."""
+        try:
+            await super()._async_handle_shutdown(event)
+        finally:
+            await self._async_close_cloud_session()
+
+    async def async_shutdown(self) -> None:
+        """Shut down the coordinator and release its cookie-bearing session."""
+        try:
+            await super().async_shutdown()
+        finally:
+            await self._async_close_cloud_session()
 
     async def refresh_inverter_params_if_linked(self, serial: str) -> None:
         """Refresh a device's parameters after a cloud write, unless link is down.

--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -1,7 +1,6 @@
 """Data update coordinator for EG4 Web Monitor integration using pylxpweb device objects."""
 
 import asyncio
-import inspect
 import logging
 import time
 from datetime import datetime, timedelta
@@ -91,6 +90,7 @@ from .const import (
     HYBRID_LOCAL_MODBUS,
 )
 from .battery_migration import async_migrate_battery_keys
+from .cloud_session import async_close_client_session
 from .coordinator_mappings import (
     _derive_model_from_family,
     _parse_inverter_family,
@@ -669,22 +669,9 @@ class EG4DataUpdateCoordinator(
 
     async def _async_close_cloud_session(self) -> None:
         """Stop dependency-owned work, then detach the injected session."""
-        try:
-            # Current pylxpweb ignores injected sessions here; versions with
-            # auth single-flight also cancel their private auth task. That task
-            # must stop before its session is detached.
-            close = getattr(self.client, "close", None)
-            if close is not None:
-                close_result: Any = close()
-                if inspect.isawaitable(close_result):
-                    await close_result
-        finally:
-            # HA owns the connector; detach closes only this account's session
-            # wrapper and private CookieJar.
-            cloud_session = self._cloud_session
-            self._cloud_session = None
-            if cloud_session is not None and not cloud_session.closed:
-                cloud_session.detach()
+        cloud_session = self._cloud_session
+        self._cloud_session = None
+        await async_close_client_session(self.client, cloud_session)
 
     async def _async_handle_shutdown(self, event: Any) -> None:
         """Release the cloud wrapper when Home Assistant stops without unload."""

--- a/tests/test_cloud_session_isolation.py
+++ b/tests/test_cloud_session_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -414,12 +415,61 @@ class _CookieWritingClient:
         self.connector = session.connector
         type(self).instances.append(self)
 
-    async def __aenter__(self) -> _CookieWritingClient:
+    async def login(self) -> None:
+        """Emulate the login side effect used by the production client."""
         _set_cookie(self.session, "account-b-session")
+
+    async def close(self) -> None:
+        """Injected sessions remain owned by the integration."""
+
+    async def __aenter__(self) -> _CookieWritingClient:
+        await self.login()
         return self
 
     async def __aexit__(self, *args) -> None:
         del args
+
+
+class _ShieldedAuthenticationClient:
+    """Client double whose login work deliberately outlives its caller."""
+
+    instances: list[_ShieldedAuthenticationClient] = []
+
+    def __init__(self, *args, session: ClientSession, **kwargs) -> None:
+        del args, kwargs
+        self.session = session
+        self.events: list[str] = []
+        self.authentication_started = asyncio.Event()
+        self.authentication_task: asyncio.Task[None] | None = None
+        type(self).instances.append(self)
+
+    async def _authenticate(self) -> None:
+        self.events.append("auth-start")
+        self.authentication_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            self.events.append("auth-end")
+
+    async def login(self) -> None:
+        self.authentication_task = asyncio.create_task(self._authenticate())
+        await asyncio.shield(self.authentication_task)
+
+    async def __aenter__(self) -> _ShieldedAuthenticationClient:
+        await self.login()
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        del args
+        await self.close()
+
+    async def close(self) -> None:
+        self.events.append("close-start")
+        task = self.authentication_task
+        if task is not None and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        self.events.append("close-end")
 
 
 async def test_config_flow_login_cannot_overwrite_loaded_account_cookie(
@@ -524,3 +574,122 @@ async def test_config_flow_uses_configured_unverified_connector(
     assert temporary_client.connector is unverified_default.connector
     assert temporary_client.connector is not verified_default.connector
     assert temporary_client.session.closed
+
+
+async def test_config_flow_cancellation_drains_shielded_login_before_detach(
+    hass: HomeAssistant,
+) -> None:
+    """Cancellation during login must not orphan auth on a detached session."""
+    flow = EG4ConfigFlow()
+    flow.hass = hass
+    flow._username = "account-b"
+    flow._password = "secret"
+    flow._base_url = BASE_URL
+    flow._verify_ssl = True
+    _ShieldedAuthenticationClient.instances.clear()
+
+    with patch(
+        "custom_components.eg4_web_monitor._config_flow.LuxpowerClient",
+        _ShieldedAuthenticationClient,
+    ):
+        validation_task = asyncio.create_task(flow._test_cloud_credentials())
+        while not _ShieldedAuthenticationClient.instances:
+            await asyncio.sleep(0)
+        client = _ShieldedAuthenticationClient.instances[-1]
+        await client.authentication_started.wait()
+
+        real_detach = client.session.detach
+
+        def _detach_session() -> None:
+            client.events.append("session-detach")
+            real_detach()
+
+        with patch.object(
+            client.session,
+            "detach",
+            new=MagicMock(side_effect=_detach_session),
+        ):
+            validation_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await validation_task
+
+    events_before_test_cleanup = list(client.events)
+    authentication_task = client.authentication_task
+    try:
+        assert events_before_test_cleanup == [
+            "auth-start",
+            "close-start",
+            "auth-end",
+            "close-end",
+            "session-detach",
+        ]
+        assert authentication_task is not None
+        assert authentication_task.done()
+        assert client.session.closed
+    finally:
+        if authentication_task is not None and not authentication_task.done():
+            authentication_task.cancel()
+            await asyncio.gather(authentication_task, return_exceptions=True)
+        if not client.session.closed:
+            client.session.detach()
+
+
+async def test_repeated_shutdown_cancellation_waits_for_close_before_detach(
+    hass: HomeAssistant,
+) -> None:
+    """A second cancellation must not detach beneath dependency cleanup."""
+    coordinator = EG4DataUpdateCoordinator(
+        hass, _http_entry("repeated-cancel", "account-a")
+    )
+    client = coordinator.require_client()
+    session = _client_session(coordinator)
+    default_session = aiohttp_client.async_get_clientsession(hass)
+    close_started = asyncio.Event()
+    allow_close = asyncio.Event()
+    events: list[str] = []
+    loop_errors: list[dict[str, object]] = []
+    loop = asyncio.get_running_loop()
+    previous_exception_handler = loop.get_exception_handler()
+    real_detach = session.detach
+
+    async def _close_client() -> None:
+        events.append("close-start")
+        close_started.set()
+        await allow_close.wait()
+        events.append("close-end")
+        raise ValueError("close failed after cancellation")
+
+    def _detach_session() -> None:
+        events.append("session-detach")
+        real_detach()
+
+    try:
+        loop.set_exception_handler(
+            lambda _loop, context: loop_errors.append(dict(context))
+        )
+        with (
+            patch.object(client, "close", new=AsyncMock(side_effect=_close_client)),
+            patch.object(session, "detach", new=MagicMock(side_effect=_detach_session)),
+        ):
+            shutdown_task = asyncio.create_task(coordinator.async_shutdown())
+            await close_started.wait()
+            shutdown_task.cancel()
+            await asyncio.sleep(0)
+            shutdown_task.cancel()
+            allow_close.set()
+
+            with pytest.raises(asyncio.CancelledError) as cancelled:
+                await shutdown_task
+
+        await asyncio.sleep(0)
+        assert events == ["close-start", "close-end", "session-detach"]
+        assert isinstance(cancelled.value.__cause__, ValueError)
+        assert loop_errors == []
+        assert session.closed
+        assert not default_session.closed
+        assert not default_session.connector.closed
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+        allow_close.set()
+        if not session.closed:
+            session.detach()

--- a/tests/test_cloud_session_isolation.py
+++ b/tests/test_cloud_session_isolation.py
@@ -1,0 +1,526 @@
+"""Regression tests for account-scoped cloud cookie sessions (eg4-06er.15)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiohttp import ClientSession
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    EVENT_HOMEASSISTANT_CLOSE,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+import pytest
+from yarl import URL
+
+from custom_components.eg4_web_monitor._config_flow import EG4ConfigFlow
+from custom_components.eg4_web_monitor.const import (
+    CONF_BASE_URL,
+    CONF_CONNECTION_TYPE,
+    CONF_DST_SYNC,
+    CONF_PLANT_ID,
+    CONF_VERIFY_SSL,
+    CONNECTION_TYPE_HTTP,
+    DOMAIN,
+)
+from custom_components.eg4_web_monitor.coordinator import EG4DataUpdateCoordinator
+from custom_components.eg4_web_monitor import async_unload_entry
+from pylxpweb.exceptions import LuxpowerAPIError
+
+
+BASE_URL = "https://monitor.eg4electronics.com"
+COOKIE_NAME = "JSESSIONID"
+
+
+def _http_entry(
+    entry_id: str, username: str, *, verify_ssl: bool = True
+) -> MockConfigEntry:
+    """Build one cloud entry on the shared EG4 origin."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=f"EG4 - {username}",
+        data={
+            CONF_USERNAME: username,
+            CONF_PASSWORD: "secret",
+            CONF_BASE_URL: BASE_URL,
+            CONF_VERIFY_SSL: verify_ssl,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_HTTP,
+            CONF_PLANT_ID: entry_id,
+            CONF_DST_SYNC: False,
+        },
+        entry_id=entry_id,
+    )
+
+
+def _client_session(coordinator: EG4DataUpdateCoordinator) -> ClientSession:
+    """Return the real session injected into pylxpweb."""
+    client = coordinator.require_client()
+    session = getattr(client, "_session", None)
+    assert isinstance(session, ClientSession)
+    return session
+
+
+def _set_cookie(session: ClientSession, value: str) -> None:
+    """Apply the cookie shape returned by a login on the common API origin."""
+    session.cookie_jar.update_cookies({COOKIE_NAME: value}, response_url=URL(BASE_URL))
+
+
+def _cookie_value(session: ClientSession) -> str:
+    """Read the cookie that would be sent to the common API origin."""
+    return session.cookie_jar.filter_cookies(URL(BASE_URL))[COOKIE_NAME].value
+
+
+async def test_loaded_accounts_keep_distinct_cookies_on_one_ha_connector(
+    hass: HomeAssistant,
+) -> None:
+    """A login for account B must not replace account A's domain cookie."""
+    entry_a = _http_entry("plant-a", "account-a")
+    entry_b = _http_entry("plant-b", "account-b")
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+    coordinator_a = EG4DataUpdateCoordinator(hass, entry_a)
+    coordinator_b = EG4DataUpdateCoordinator(hass, entry_b)
+    session_a = _client_session(coordinator_a)
+    session_b = _client_session(coordinator_b)
+    default_session = aiohttp_client.async_get_clientsession(hass)
+
+    try:
+        assert session_a is not session_b
+        assert session_a.cookie_jar is not session_b.cookie_jar
+        assert session_a is not default_session
+        assert session_b is not default_session
+        assert session_a.connector is default_session.connector
+        assert session_b.connector is default_session.connector
+
+        _set_cookie(session_a, "account-a-session")
+        _set_cookie(session_b, "account-b-session")
+
+        assert _cookie_value(session_a) == "account-a-session"
+        assert _cookie_value(session_b) == "account-b-session"
+    finally:
+        await coordinator_a.async_shutdown()
+        await coordinator_b.async_shutdown()
+
+
+async def test_coordinator_shutdown_detaches_only_its_private_session(
+    hass: HomeAssistant,
+) -> None:
+    """Unloading one entry must neither leak nor break another entry's session."""
+    entry_a = _http_entry("shutdown-a", "account-a")
+    entry_b = _http_entry("shutdown-b", "account-b")
+    coordinator_a = EG4DataUpdateCoordinator(hass, entry_a)
+    coordinator_b = EG4DataUpdateCoordinator(hass, entry_b)
+    session_a = _client_session(coordinator_a)
+    session_b = _client_session(coordinator_b)
+    default_session = aiohttp_client.async_get_clientsession(hass)
+
+    await coordinator_a.async_shutdown()
+    try:
+        assert session_a.closed
+        assert not session_b.closed
+        assert not default_session.closed
+        assert not default_session.connector.closed
+    finally:
+        await coordinator_b.async_shutdown()
+
+    assert session_b.closed
+    assert not default_session.closed
+    assert not default_session.connector.closed
+
+
+async def test_shutdown_closes_dependency_before_detaching_session(
+    hass: HomeAssistant,
+) -> None:
+    """Dependency-owned auth work must stop before its HTTP session disappears."""
+    coordinator = EG4DataUpdateCoordinator(
+        hass, _http_entry("shutdown-order", "account-a")
+    )
+    client = coordinator.require_client()
+    session = _client_session(coordinator)
+    real_detach = session.detach
+    events: list[str] = []
+
+    async def _close_client() -> None:
+        events.append("client-close")
+
+    def _detach_session() -> None:
+        events.append("session-detach")
+        real_detach()
+
+    with (
+        patch.object(client, "close", new=AsyncMock(side_effect=_close_client)),
+        patch.object(session, "detach", new=MagicMock(side_effect=_detach_session)),
+    ):
+        await coordinator.async_shutdown()
+
+    assert events == ["client-close", "session-detach"]
+    assert session.closed
+
+
+async def test_homeassistant_stop_detaches_private_session(
+    hass: HomeAssistant,
+) -> None:
+    """Core stop without entry unload must also release the session wrapper."""
+    coordinator = EG4DataUpdateCoordinator(
+        hass, _http_entry("homeassistant-stop", "account-a")
+    )
+    client = coordinator.require_client()
+    session = _client_session(coordinator)
+    default_session = aiohttp_client.async_get_clientsession(hass)
+    real_detach = session.detach
+    events: list[str] = []
+
+    async def _close_client() -> None:
+        events.append("client-close")
+
+    def _detach_session() -> None:
+        events.append("session-detach")
+        real_detach()
+
+    with (
+        patch.object(client, "close", new=AsyncMock(side_effect=_close_client)),
+        patch.object(session, "detach", new=MagicMock(side_effect=_detach_session)),
+    ):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+        assert events == ["client-close", "session-detach"]
+        assert session.closed
+        assert not default_session.closed
+        assert not default_session.connector.closed
+
+        # A later unload callback remains safe and does not detach twice.
+        await coordinator.async_shutdown()
+
+    assert events == ["client-close", "session-detach", "client-close"]
+
+
+async def test_entry_unload_detaches_injected_session(
+    hass: HomeAssistant,
+) -> None:
+    """The public integration unload path must release its injected session."""
+    entry = _http_entry("entry-unload", "account-a")
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    entry.runtime_data = coordinator
+    session = _client_session(coordinator)
+    default_session = aiohttp_client.async_get_clientsession(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_unload_platforms",
+        new=AsyncMock(return_value=True),
+    ):
+        assert await async_unload_entry(hass, entry)
+
+    assert session.closed
+    assert not default_session.closed
+    assert not default_session.connector.closed
+
+
+async def test_config_entry_setup_cleanup_detaches_cloud_session(
+    hass: HomeAssistant,
+) -> None:
+    """The coordinator's failed-setup callback must release its private wrapper."""
+    entry = _http_entry("failed-setup", "account-a")
+    token = config_entries.current_entry.set(entry)
+    try:
+        coordinator = EG4DataUpdateCoordinator(hass, entry)
+    finally:
+        config_entries.current_entry.reset(token)
+    session = _client_session(coordinator)
+
+    assert not session.closed
+    await entry._async_process_on_unload(hass)
+    assert session.closed
+
+    # The integration's explicit shutdown path is idempotent with HA cleanup.
+    await coordinator.async_shutdown()
+    assert session.closed
+
+
+async def test_unverified_entry_uses_ha_unverified_connector(
+    hass: HomeAssistant,
+) -> None:
+    """The entry's SSL policy must select the matching HA connector pool."""
+    entry = _http_entry("unverified", "account-a", verify_ssl=False)
+    coordinator = EG4DataUpdateCoordinator(hass, entry)
+    session = _client_session(coordinator)
+    unverified_default = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
+    verified_default = aiohttp_client.async_get_clientsession(hass, verify_ssl=True)
+
+    try:
+        assert session is not unverified_default
+        assert session.connector is unverified_default.connector
+        assert session.connector is not verified_default.connector
+    finally:
+        await coordinator.async_shutdown()
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+async def test_coordinator_passes_ssl_policy_to_private_session_factory(
+    hass: HomeAssistant, verify_ssl: bool
+) -> None:
+    """Both SSL policies must reach HA's isolated-session factory unchanged."""
+    from custom_components.eg4_web_monitor import coordinator as coordinator_module
+
+    real_create = aiohttp_client.async_create_clientsession
+    with patch.object(
+        coordinator_module.aiohttp_client,
+        "async_create_clientsession",
+        wraps=real_create,
+    ) as create_session:
+        coordinator = EG4DataUpdateCoordinator(
+            hass,
+            _http_entry(
+                f"ssl-policy-{verify_ssl}",
+                "account-a",
+                verify_ssl=verify_ssl,
+            ),
+        )
+
+    create_session.assert_called_once_with(
+        hass,
+        verify_ssl=verify_ssl,
+        auto_cleanup=True,
+    )
+    await coordinator.async_shutdown()
+
+
+async def test_client_constructor_failure_detaches_created_session(
+    hass: HomeAssistant,
+) -> None:
+    """A synchronous dependency constructor failure must not leak a session."""
+    from custom_components.eg4_web_monitor import coordinator as coordinator_module
+
+    entry = _http_entry("constructor-failure", "account-a")
+    created_sessions: list[ClientSession] = []
+    real_create = aiohttp_client.async_create_clientsession
+
+    def _capture_session(*args, **kwargs) -> ClientSession:
+        session = real_create(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    with (
+        patch.object(
+            coordinator_module.aiohttp_client,
+            "async_create_clientsession",
+            side_effect=_capture_session,
+        ),
+        patch.object(
+            coordinator_module,
+            "LuxpowerClient",
+            side_effect=RuntimeError("constructor failed"),
+        ),
+        pytest.raises(RuntimeError, match="constructor failed"),
+    ):
+        EG4DataUpdateCoordinator(hass, entry)
+
+    assert len(created_sessions) == 1
+    assert created_sessions[0].closed
+
+
+async def test_post_client_constructor_failure_uses_entry_cleanup_fallback(
+    hass: HomeAssistant,
+) -> None:
+    """A later coordinator constructor failure retains HA's detach fallback."""
+    from custom_components.eg4_web_monitor import coordinator as coordinator_module
+
+    entry = _http_entry("post-client-failure", "account-a")
+    created_sessions: list[ClientSession] = []
+    real_create = aiohttp_client.async_create_clientsession
+
+    def _capture_session(*args, **kwargs) -> ClientSession:
+        session = real_create(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    token = config_entries.current_entry.set(entry)
+    try:
+        with (
+            patch.object(
+                coordinator_module.aiohttp_client,
+                "async_create_clientsession",
+                side_effect=_capture_session,
+            ),
+            patch.object(
+                coordinator_module.DataUpdateCoordinator,
+                "__init__",
+                side_effect=RuntimeError("coordinator init failed"),
+            ),
+            pytest.raises(RuntimeError, match="coordinator init failed"),
+        ):
+            EG4DataUpdateCoordinator(hass, entry)
+    finally:
+        config_entries.current_entry.reset(token)
+
+    assert len(created_sessions) == 1
+    assert not created_sessions[0].closed
+    await entry._async_process_on_unload(hass)
+    assert created_sessions[0].closed
+
+
+async def test_post_client_constructor_failure_has_hass_close_fallback(
+    hass: HomeAssistant,
+) -> None:
+    """Outside entry context, HA close still detaches an orphaned wrapper."""
+    from custom_components.eg4_web_monitor import coordinator as coordinator_module
+
+    entry = _http_entry("post-client-close-fallback", "account-a")
+    created_sessions: list[ClientSession] = []
+    real_create = aiohttp_client.async_create_clientsession
+
+    def _capture_session(*args, **kwargs) -> ClientSession:
+        session = real_create(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    with (
+        patch.object(
+            coordinator_module.aiohttp_client,
+            "async_create_clientsession",
+            side_effect=_capture_session,
+        ),
+        patch.object(
+            coordinator_module.DataUpdateCoordinator,
+            "__init__",
+            side_effect=RuntimeError("coordinator init failed"),
+        ),
+        pytest.raises(RuntimeError, match="coordinator init failed"),
+    ):
+        EG4DataUpdateCoordinator(hass, entry)
+
+    assert len(created_sessions) == 1
+    assert not created_sessions[0].closed
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+    assert created_sessions[0].closed
+
+
+class _CookieWritingClient:
+    """Config-flow client double that emulates a successful account-B login."""
+
+    instances: list[_CookieWritingClient] = []
+
+    def __init__(self, *args, session: ClientSession, **kwargs) -> None:
+        del args, kwargs
+        self.session = session
+        self.connector = session.connector
+        type(self).instances.append(self)
+
+    async def __aenter__(self) -> _CookieWritingClient:
+        _set_cookie(self.session, "account-b-session")
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        del args
+
+
+async def test_config_flow_login_cannot_overwrite_loaded_account_cookie(
+    hass: HomeAssistant,
+) -> None:
+    """Temporary config-flow auth gets an isolated jar and immediate cleanup."""
+    coordinator = EG4DataUpdateCoordinator(
+        hass, _http_entry("loaded-account", "account-a")
+    )
+    loaded_session = _client_session(coordinator)
+    _set_cookie(loaded_session, "account-a-session")
+
+    flow = EG4ConfigFlow()
+    flow.hass = hass
+    flow._username = "account-b"
+    flow._password = "secret"
+    flow._base_url = BASE_URL
+    flow._verify_ssl = True
+    _CookieWritingClient.instances.clear()
+
+    try:
+        with (
+            patch(
+                "custom_components.eg4_web_monitor._config_flow.LuxpowerClient",
+                _CookieWritingClient,
+            ),
+            patch(
+                "pylxpweb.devices.Station.load_all",
+                new=AsyncMock(
+                    return_value=[SimpleNamespace(id="plant-b", name="Plant B")]
+                ),
+            ),
+        ):
+            await flow._test_cloud_credentials()
+
+        temporary_client = _CookieWritingClient.instances[-1]
+        assert temporary_client.session is not loaded_session
+        assert temporary_client.connector is loaded_session.connector
+        assert temporary_client.session.closed
+        assert not loaded_session.closed
+        assert _cookie_value(loaded_session) == "account-a-session"
+        assert flow._plants == [{"plantId": "plant-b", "name": "Plant B"}]
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_config_flow_failure_also_detaches_temporary_session(
+    hass: HomeAssistant,
+) -> None:
+    """A validation exception must not retain its cookie jar until HA stops."""
+    flow = EG4ConfigFlow()
+    flow.hass = hass
+    flow._username = "account-b"
+    flow._password = "secret"
+    flow._base_url = BASE_URL
+    flow._verify_ssl = True
+    _CookieWritingClient.instances.clear()
+
+    with (
+        patch(
+            "custom_components.eg4_web_monitor._config_flow.LuxpowerClient",
+            _CookieWritingClient,
+        ),
+        patch(
+            "pylxpweb.devices.Station.load_all",
+            new=AsyncMock(side_effect=LuxpowerAPIError("station load failed")),
+        ),
+        pytest.raises(LuxpowerAPIError, match="station load failed"),
+    ):
+        await flow._test_cloud_credentials()
+
+    assert _CookieWritingClient.instances[-1].session.closed
+
+
+async def test_config_flow_uses_configured_unverified_connector(
+    hass: HomeAssistant,
+) -> None:
+    """Temporary validation must honor the flow's configured SSL policy."""
+    flow = EG4ConfigFlow()
+    flow.hass = hass
+    flow._username = "account-b"
+    flow._password = "secret"
+    flow._base_url = BASE_URL
+    flow._verify_ssl = False
+    _CookieWritingClient.instances.clear()
+
+    unverified_default = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
+    verified_default = aiohttp_client.async_get_clientsession(hass, verify_ssl=True)
+    with (
+        patch(
+            "custom_components.eg4_web_monitor._config_flow.LuxpowerClient",
+            _CookieWritingClient,
+        ),
+        patch(
+            "pylxpweb.devices.Station.load_all",
+            new=AsyncMock(return_value=[SimpleNamespace(id="plant-b", name="Plant B")]),
+        ),
+    ):
+        await flow._test_cloud_credentials()
+
+    temporary_client = _CookieWritingClient.instances[-1]
+    assert temporary_client.connector is unverified_default.connector
+    assert temporary_client.connector is not verified_default.connector
+    assert temporary_client.session.closed

--- a/tests/validate_platinum_tier.py
+++ b/tests/validate_platinum_tier.py
@@ -87,8 +87,8 @@ def check_websession_injection() -> bool:
         coord_content = coord_file.read()
 
         # Check for session injection in coordinator
-        if "async_get_clientsession" in coord_content:
-            print("  ✅ Coordinator injects Home Assistant's aiohttp session")
+        if "async_create_clientsession" in coord_content:
+            print("  ✅ Coordinator injects an isolated Home Assistant session")
         else:
             print("  ❌ Coordinator does not inject session")
             return False
@@ -111,8 +111,8 @@ def check_websession_injection() -> bool:
         cf_content = cf_file.read()
 
         # Check for session injection in config flow
-        if "async_get_clientsession" in cf_content:
-            print("  ✅ Config flow injects Home Assistant's aiohttp session")
+        if "async_create_clientsession" in cf_content:
+            print("  ✅ Config flow injects an isolated Home Assistant session")
         else:
             print("  ❌ Config flow does not inject session")
             return False


### PR DESCRIPTION
## Summary

- give every coordinator/config-flow cloud client its own cookie jar while retaining Home Assistant's connector, resolver, SSL context, and user-agent
- pass `CONF_VERIFY_SSL` into Home Assistant's session factory so the injected session actually uses the selected SSL policy
- drain dependency-owned authentication work before detaching the private session on unload, Home Assistant stop, config-flow cancellation, and repeated shutdown cancellation
- retain Home Assistant's config-entry / `EVENT_HOMEASSISTANT_CLOSE` cleanup fallback for constructor failures
- update the Platinum validation checks to require the cookie-safe session factory

## Root cause

`async_get_clientsession(hass)` returns one process-wide session for each SSL/family tuple. aiohttp stores cookies by origin/domain/path, not by `LuxpowerClient`. Two EG4 accounts using the same portal origin therefore shared one `CookieJar`: account B's login replaced account A's session cookie while A's client still considered its independent two-hour expiry valid. Config-flow validation could overwrite a loaded entry in the same way.

The injected session also owns the effective connector. Passing `verify_ssl=False` only to `LuxpowerClient` had no effect because pylxpweb uses that flag when it creates a connector itself; the integration had already injected Home Assistant's default verified session.

Independent follow-up review found a second lifecycle defect: cancellation during `LuxpowerClient.__aenter__()` bypasses `__aexit__()`. pylxpweb #261 intentionally shields the client-owned authentication task, so the original config-flow `finally` could detach its session while authentication still used it. A second cancellation could similarly interrupt coordinator `client.close()` and jump directly to detach.

Home Assistant explicitly documents cookies as the case for [`async_create_clientsession`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession/). Its helper creates a distinct `ClientSession`/`CookieJar` but reuses Home Assistant's managed connector pool.

## Lifecycle contract

- coordinators use `async_create_clientsession(..., verify_ssl=..., auto_cleanup=True)` for a private jar plus config-entry / HA-close constructor-failure fallback
- normal unload and HA stop first run transport/background/request-budget/firmware cleanup, then call `LuxpowerClient.close()`, then detach only the session wrapper
- config-flow validation binds the client before explicit login and uses `auto_cleanup=False`
- one shared cleanup primitive waits for the exact client-close operation through repeated caller cancellations, observes its result/exception, detaches last, and propagates cancellation only after cleanup settles
- cancellation-neutral `asyncio.wait` avoids Python 3.14 event-loop leakage caused by repeatedly shielding a later-failing cleanup task
- detaching never closes Home Assistant's shared connector; repeated stop/unload cleanup is idempotent

## TDD and verification

The original cookie-isolation regressions failed before implementation. Two reviewer-follow-up cancellation regressions also failed on the first PR head and pass on `14b7488`:

- cancellation during config-flow login drains a shielded auth task before detach
- two caller cancellations plus a failing close preserve close-before-detach order, propagate cancellation with the cleanup error chained, and emit no event-loop error context

Final verification against pylxpweb PR #261 commit `61b7992`:

- `pytest -q tests`: **2,560 passed, 3 skipped**
- session isolation/lifecycle file: **17 passed**
- config/setup/coordinator compatibility selection: **597 passed**
- strict mypy: **42 source files clean**
- Ruff lint/format, `prek run --all-files`, and `git diff --check`: passed
- independent review: approved after **24 focused tests** plus adversarial close-error, child-cancellation, synchronous-close, repeated-cancellation, and event-loop leakage probes

## Composition boundaries

- **#520 setup unwind:** `coordinator.async_shutdown()` owns cloud auth/session cleanup. Its later defensive `client.close()` is idempotent; failed setup therefore drains before Home Assistant's session fallback callback.
- **#531 logging/registry lifecycle:** no state-key overlap. Its normal-unload `client.close()` is likewise a safe redundant close after coordinator shutdown.
- **#533 cloud fanout:** preserve the private session when reconciling the coordinator constructor. Its `super()` stop/shutdown path releases request-budget and firmware-flight ownership before client close/detach; constructor rollback retains Home Assistant's fallback.
- **pylxpweb #261 auth single-flight:** client-owned shielded authentication is cancelled/drained before detach. Focused and full integration suites load the exact PR source via `PYTHONPATH`.

Tracks bead `eg4-06er.15`. This PR is intentionally draft and unmerged.
