### PR TITLE
chore(release): 3.5.1-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1-beta.7] - 2026-08-03
+
+### Changed
+
+- **pylxpweb pin raised to [0.9.39b7](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.39b7)** — the library half of the same audit wave 3.5.1-beta.6 shipped, reviewed by the same four-model gate: atomic Quick Charge bitfield updates (a concurrent sibling-bit write can no longer be erased by a Quick Charge start/stop), coalesced cloud session renewal (one login instead of a herd when the session expires — this also activates the per-account request limiter's auth-task handoff from #533), corrected holding-register-120 field modeling (the AC-charge/discharge selectors were decoded and written at wrong bit positions on the local path), strict FC16 write-acknowledgement validation, and dongle TCP frame assembly with a terminal `async_shutdown()` — which activates the fast-teardown seam #529 already feature-detects, so unloading the integration no longer waits behind an in-flight dongle retry loop.
+
 ## [3.5.1-beta.6] - 2026-08-03
 
 This is a **hardening release**: alongside the diagnostics platform, it delivers the full remediation wave from a codebase-wide register, race and performance audit ([#524](https://github.com/joyfulhouse/eg4_web_monitor/pull/524) documents the findings) — nineteen reviewed PRs merged as one composed train and gated by a four-model adversarial review. Most fixes target failure windows (concurrent writes, stale polls, partial setup, shared gateways) rather than day-to-day behavior. The release was validated against live hardware in all three connection modes (Cloud/Local/Hybrid docker sweep: 572/592/630 entities, zero unavailable, values cross-checked against the production install and the EG4 portal).

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb>=0.9.39b6", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.6"
+  "requirements": ["pylxpweb>=0.9.39b7", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.5.1-beta.7"
 }

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -14,7 +14,7 @@ aiohttp>=3.10.0
 # Note: aiodns managed by homeassistant, pycares>=4.9.0 for Python 3.13
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
-pylxpweb>=0.9.39b6  # keep in sync with manifest.json
+pylxpweb>=0.9.39b7  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml


### PR DESCRIPTION
Cuts **v3.5.1-beta.7** — pin bump to **pylxpweb 0.9.39b7** ([release](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.9.39b7)), the library half of the audit wave shipped in 3.5.1-beta.6. No integration code changes.

Activates two already-shipped feature-detected seams: #529's dongle `async_shutdown()` fast teardown and #533's auth-task handoff in the per-account request limiter.

Validated: full eg4 suite against the published b7 wheel — 2736 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)