### PR TITLE
docs: EPS register firmware traces — off-grid and hybrid (#544 follow-up)

### DIFF
--- a/docs/reference/firmware/FIRMWARE_ACQUISITION.md
+++ b/docs/reference/firmware/FIRMWARE_ACQUISITION.md
@@ -198,5 +198,15 @@ Anchor conclusions to measurements:
 - Where a register's meaning is at stake, check the decode against a live capture or an issue
   report before publishing it.
 
-See [`OFFGRID_GENERATOR_REGISTERS.md`](OFFGRID_GENERATOR_REGISTERS.md) for a full worked analysis
-following this method.
+Worked analyses following this method:
+
+- [`OFFGRID_GENERATOR_REGISTERS.md`](OFFGRID_GENERATOR_REGISTERS.md) — input 123 is an ARM-local
+  1 Hz counter, not generator power (issue #544).
+- [`OFFGRID_EPS_REGISTERS.md`](OFFGRID_EPS_REGISTERS.md) — inputs 25/131/132 (EPS apparent power)
+  *are* genuine DSP measurements, traced parser → filter → publish → Modbus; inputs 21/22 (EPS S/T
+  voltage) are byte/bitfield composites and not voltages.
+
+A scanner that reports "no writers" is the trap to watch for: a base pointer held in a callee-saved
+register across a large function defeats naive literal tracking, and the resulting silence reads
+exactly like proof of absence. Confirm the scanner can see a known-good writer before trusting it
+on an unknown one.

--- a/docs/reference/firmware/FIRMWARE_ACQUISITION.md
+++ b/docs/reference/firmware/FIRMWARE_ACQUISITION.md
@@ -115,6 +115,25 @@ that the OTA chunk sizes are not uniform and a fixed-period rule silently corrup
 downstream. Reconstruct instead from the pcap's own chunk records via
 `scripts/extract_firmware_from_pcap.py`, which follows the transfer's sequence numbers.
 
+> **`extract_firmware_from_pcap.py` output is still framed.** The script reassembles the transfer;
+> it does not strip the transport framing. Its `.bin` is 353,026 bytes and its "vector table" reads
+> `SP=0x00059808` — the one-byte-shift signature. De-framing is a separate step, and it must use
+> each chunk's *actual* length:
+>
+> ```python
+> fp = extract_firmware_passes(pcap)[0]          # pass 0 = ARM App, pass 1 = C28x Para
+> out = bytearray()
+> for s in sorted(fp.chunks):
+>     p = fp.chunks[s].raw_payload[CHUNK_HEADER_SIZE:]
+>     assert p[0] == 0x08                        # OTA block prefix
+>     out += p[1:-2]                             # drop prefix + block checksum
+> del out[-4:]                                   # final chunk carried only the 4-byte fw-id
+> ```
+>
+> Chunk lengths in the 18kPV capture are `455×771, 4×259, 1×481, 1×703, 1×7` — not uniform, which
+> is exactly why a fixed period fails. The arithmetic predicts the target size exactly:
+> `455·768 + 4·256 + 478 + 700 = 351,642`.
+
 **How the block structure was established** (repeat if the format ever changes): diff the two model
 variants of the *same* App firmware. Differences appear in pairs at offsets 769,770 of each block at
 a 771 cadence — the model-keyed checksums, which reveal the period directly.
@@ -136,6 +155,38 @@ every instruction downstream while leaving the start of the image looking perfec
 None of this affects the portal-download route in §1, whose images never carry OTA framing.
 
 Portal-downloaded images (§1) are **already de-framed** — this section does not apply to them.
+
+---
+
+## 2a. ARM load base — derive it, never carry it over
+
+The load base differs per family, and using the wrong one does not fail loudly: every instruction
+boundary and every `LDR.W` literal resolution shifts, and the result disassembles into
+plausible-looking garbage.
+
+| Image | Family | Load base |
+|-------|--------|-----------|
+| `ceaa-07xx…` | EG4_OFFGRID (12000XP) | `0x08005000` |
+| `FAAB-27xx…App` | EG4_HYBRID (18kPV / FlexBOSS21) | **`0x08010000`** |
+| `IAAB-16xx…APP` | GridBOSS (POWER_HUB) | unverified — derive before use |
+
+To derive it, back-solve from a vector-table entry, since those handlers live inside the image.
+The default-handler pattern is the easiest anchor: find the `fe e7` (`b .`) self-loop run and match
+it to the NMI/HardFault vectors.
+
+```
+NMI vector 0x080132F1 -> handler 0x080132F0
+self-loop pair found at file offset 0x032F0
+base = 0x080132F0 - 0x032F0 = 0x08010000
+```
+
+Then confirm with a second, independent signal before trusting it:
+
+- **RAM-pointer density.** Count literal-pool words landing in `0x20000000–0x20050000`. The correct
+  base for the hybrid App yields 4,263; a wrong base collapses this.
+- **A known literal.** Decode a site whose operands are already documented and check the literals
+  resolve to the expected addresses. On the hybrid App, `0x080319DC` must resolve `0x2000EAE4` and
+  `0x2000EAE6` (see [`HYBRID_EPS_REGISTERS.md`](HYBRID_EPS_REGISTERS.md) §1).
 
 ---
 
@@ -205,6 +256,9 @@ Worked analyses following this method:
 - [`OFFGRID_EPS_REGISTERS.md`](OFFGRID_EPS_REGISTERS.md) — inputs 25/131/132 (EPS apparent power)
   *are* genuine DSP measurements, traced parser → filter → publish → Modbus; inputs 21/22 (EPS S/T
   voltage) are byte/bitfield composites and not voltages.
+- [`HYBRID_EPS_REGISTERS.md`](HYBRID_EPS_REGISTERS.md) — the same S/T voltage registers are junk on
+  EG4_HYBRID too (live-confirmed on two inverters), which matters because that is the
+  three-phase-capable family; also carries the corrected hybrid reconstruction recipe and load base.
 
 A scanner that reports "no writers" is the trap to watch for: a base pointer held in a callee-saved
 register across a large function defeats naive literal tracking, and the resulting silence reads

--- a/docs/reference/firmware/HYBRID_EPS_REGISTERS.md
+++ b/docs/reference/firmware/HYBRID_EPS_REGISTERS.md
@@ -1,0 +1,300 @@
+# Does EG4_HYBRID Carry the Same EPS Registers? — Firmware + Live Evidence
+
+**Question.** [`OFFGRID_EPS_REGISTERS.md`](OFFGRID_EPS_REGISTERS.md) showed that on the off-grid
+12000XP the EPS apparent-power registers are genuine DSP measurements while the legacy EPS **S/T
+voltage** registers are not voltages at all. Does the hybrid family (18kPV / FlexBOSS21,
+`FAAB-2727`) behave the same way?
+
+**Answer: no — the registers exist but mean different things, and two of them are not measurements.**
+
+| Reg | Sensor | EG4_OFFGRID | EG4_HYBRID |
+|---:|---|---|---|
+| 20 | `eps_voltage_r` | genuine | **genuine** (DSP word, used in real voltage arithmetic) |
+| 21/22 | `eps_voltage_s` / `eps_voltage_t` | byte/bitfield composites — not voltages | independent DSP words, but **voltage semantics unproven**; live values implausible |
+| 24 | `eps_power` | DSP word, 32-bit, ÷10 | DSP-fed via ARM mirror, 32-bit, ÷10 |
+| 25 | `eps_apparent_power` | **direct DSP measurement**, 16-bit whole VA | **ARM-computed estimate** `V × I ÷ 100`, clamped so S ≥ P |
+| 129/130 | EPS L1/L2 active power | DSP, 32-bit, ÷10 | DSP-fed, 16-bit, whole W |
+| 131 | `eps_l1_apparent_power` | **genuine apparent power** | DSP power quantity, **sign-split by direction — not apparent power** |
+| 132 | `eps_l2_apparent_power` | **genuine apparent power** | **an incrementing counter — not a measurement** |
+
+Register 132 on hybrid is the same class of defect as the register-123 generator-power bug in
+[#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544): a counter surfaced as an
+instantaneous power sensor. Unlike the S/T voltages, **it is exposed to users today** (§5).
+
+---
+
+## 1. Two method corrections that come first
+
+Both of these produce confident nonsense rather than loud failure. Both cost time in this session.
+
+### The hybrid image in `extracted/` is raw-framed, and the obvious de-frame is wrong
+
+`scripts/extract_firmware_from_pcap.py` reassembles the OTA transfer but **its output still carries
+the transport framing** — 353,026 bytes whose "vector table" reads `SP=0x00059808`, the classic
+one-byte shift. De-framing is a separate step, and the fixed-period rule warned about in
+[`FIRMWARE_ACQUISITION.md`](FIRMWARE_ACQUISITION.md) §2 corrupts everything past roughly `0xF100`
+while leaving the image start looking perfect.
+
+The working recipe strips framing **per actual chunk**:
+
+```python
+fp = extract_firmware_passes(pcap)[0]          # pass 0 = ARM App
+out = bytearray()
+for s in sorted(fp.chunks):
+    p = fp.chunks[s].raw_payload[CHUNK_HEADER_SIZE:]
+    assert p[0] == 0x08                        # OTA block prefix
+    out += p[1:-2]                             # drop prefix + block checksum
+del out[-4:]                                   # final chunk carried only the 4-byte fw-id
+```
+
+Chunk lengths are **not** uniform — `455×771, 4×259, 1×481, 1×703, 1×7` — which is exactly why a
+fixed period fails. The arithmetic predicts the target exactly:
+`455·768 + 4·256 + 478 + 700 = 351,642`.
+
+Verify all four:
+
+| Check | Value |
+|---|---|
+| Size | **351,642 bytes** |
+| SHA-256 | **`63d0efba3495a8c601b44c020ecd04aa1329abcbbb64148f5b43ab477149f4a2`** |
+| Vector table | SP `0x20000598`, Reset `0x0802B24D`, NMI `0x080132F1`, HardFault `0x080132F3` |
+| Cross-model | 18kPV and FlexBOSS21 captures reconstruct **byte-identically** |
+
+The cross-model check is the strongest available: two dongles, two pcaps, one identical binary.
+
+### The hybrid ARM load base is `0x08010000`, not `0x08005000`
+
+Carrying the off-grid base over shifts every instruction boundary and literal resolution, and
+disassembles into plausible garbage. Back-solve from a vector-table entry instead:
+
+```
+NMI vector 0x080132F1 -> handler 0x080132F0
+self-loop pair found at file offset 0x032F0
+base = 0x080132F0 - 0x032F0 = 0x08010000
+```
+
+Confirmations at `0x08010000` (none hold at `0x08005000`): `0x080132F0` = `70 47` (`BX LR`) with
+`fe e7` (`b .`) self-loops after it for HardFault; literal-pool words resolving into RAM jump to
+**4,263**; and the independently documented generator derivation at `0x080319DC` resolves its two
+literals to exactly `0x2000EAE4` / `0x2000EAE6`, matching
+[`OFFGRID_GENERATOR_REGISTERS.md`](OFFGRID_GENERATOR_REGISTERS.md) §8 derived in an earlier session
+from a different reconstruction.
+
+| Image | Family | Load base |
+|---|---|---|
+| `ceaa-07xx…` | EG4_OFFGRID (12000XP) | `0x08005000` |
+| `FAAB-27xx…App` | EG4_HYBRID (18kPV / FlexBOSS21) | `0x08010000` |
+
+---
+
+## 2. The FC04 path — and the decoy that nearly derailed this
+
+**FC04 input registers are served from a linear register image at `0x20009DBC`,** built by
+`0x080594D8` and emitted big-endian by the response loop at `0x0803FD7E`–`0x0803FDA0`, two bytes per
+register. Dispatch reaches it via `0x0803F050` → `0x0803FCCC` → `0x0803FD64`. There are no separate
+per-register handler functions as on off-grid; each register has an *emission site* inside the
+builder.
+
+> **The decoy.** This image also contains a second, unrelated serialiser that writes a byte-swapped
+> report frame into a buffer at `0x2000B6D4` (~187 two-byte slots, nine distinct literal-pool
+> entries hold its base). It looks exactly like a register image, and the generator trio appears to
+> land at slots `0xF0`/`0xF2`/`0xF4`/`0xF6` = registers 120–123 — which is very persuasive and
+> **wrong**. That buffer is the outbound cloud/dongle report with its own field order; `offset/2` is
+> *not* the Modbus register index.
+>
+> The tell was a contradiction that would not resolve: the slot at `0x28` (apparently register 20)
+> received only a single low byte and its high byte was never written, yet live `eps_voltage_r`
+> reads a full 2468. Chasing that down is what exposed the decoy. **When a mapping produces one
+> fact you cannot explain, stop and doubt the mapping — do not explain the fact away.**
+>
+> Everything derived from that buffer — including a five-branch "mode constant" story for the
+> reg-21 slot — describes the *report frame*, not the FC04 registers, and is not evidence about
+> register semantics.
+
+---
+
+## 3. Register sources on hybrid
+
+All addresses verified byte-for-byte against the image (SHA `63d0efba…`, base `0x08010000`).
+
+| Reg | Emission site | Literal pool → base | Width | Scaling |
+|---:|---|---|---|---|
+| 20 | `0x080596FC` `df f8 30 0d` | `0x0805A430` → `0x2000EAF8` | 16-bit | none (wire ×0.1 V) |
+| 21 | `0x08059712` `df f8 20 0d` | `0x0805A434` → `0x2000EB2C` | 16-bit | none (wire ×0.1 V) |
+| 22 | `0x08059728` `df f8 0c 0d` | `0x0805A438` → `0x2000EB2E` | 16-bit | none (wire ×0.1 V) |
+| 23 | `0x0805973E` `df f8 fc 0c` | `0x0805A43C` → `0x2000EB04` | 16-bit | none (wire ×0.01 Hz) |
+| 24 | `0x08059754` `df f8 e8 0c` | `0x0805A440` → `0x2000E92C` | 32-bit | signed ÷10 |
+| 25 | `0x08059770` `df f8 d0 0c` | `0x0805A444` → `0x2000E940` | 32-bit | signed ÷10 |
+| 129 | `0x0805A794` / `0x0805A8E8` | `0x2000EAEA` / `0x2000EAEC` | 16-bit | none, whole W |
+| 130 | `0x0805A7AA` / `0x0805A8FE` | `0x2000EAFE` / `0x2000EB00` | 16-bit | none, whole W |
+| 131 | `0x0805A7C0` / `0x0805A914` | `0x2000E8C0` / `0x2000E898` | 32-bit | ÷10 |
+| 132 | `0x0805A7EC` / `0x0805A930` | `0x0805B53C` → `0x2000D088` `+0` / `+2` | 16-bit | none |
+
+Registers 129–132 have **two source sets (A/B)** selected by a mode test at `0x0805A770`–`0x0805A790`
+(a flag byte at `0x2000E984` bit 0, and `0x2000D488+0xB2` bit 2). No register above is unimplemented.
+
+### Register 25 is computed, not measured
+
+```
+0x0804CE10  86 48 00 88     LDRH R0,[voltage]
+            80 49 09 88     LDRH R1,[current]
+            48 43           MULS R0,R1,R0        ; V × I
+            64 21           MOVS R1,#100
+            b0 fb f1 f0     UDIV R0,R0,R1        ; ÷ 100
+            75 49 08 60     STR  R0,[0x2000E88C]
+```
+
+Published to `0x2000E940` at `0x08019B4E`–`0x08019B58`, with fallback/clamp branches at
+`0x08019ED8`–`0x08019F00` that force **S ≥ P**. So hybrid's aggregate apparent power is a genuine
+physical estimate built from DSP voltage and current — but it is ARM arithmetic, not a DSP-measured
+S word as on off-grid. The `S ≥ P` relation on hybrid is *enforced by the firmware*, so unlike
+off-grid it is **not** independent evidence that the value is real.
+
+### Register 132 is a counter
+
+```
+0x080154F2  df f8 50 0b     LDR.W R0,[→ 0x2000D088]
+            00 88           LDRH  R0,[R0]
+            40 1c           ADDS  R0,R0,#1        ; increment
+            df f8 48 1b     LDR.W R1,[→ 0x2000D088]
+            08 80           STRH  R0,[R1]
+```
+
+`[0x2000D088+0]` increments only after an accumulator at `[+0xA0]` crosses `0x006DDD01`; the `+2`
+half does the same from `[+0xA8]` at `0x08015698`–`0x080156A4`. It is a persistent, thresholded
+event counter — the same shape as off-grid register 123. All nine literal-pool instances of
+`0x2000D088` were audited; every other write is initialisation, reset, or persistence restore
+(including one through a callee-saved `R8` held across a restore loop at `0x08057624` — the exact
+blind spot that produced a wrong "no writers" conclusion on the off-grid image).
+
+### Scaling asymmetry: absent on hybrid
+
+Off-grid stores P in deciwatts and S in whole VA, and normalises S by ×10 when building its report.
+Hybrid stores **both** P and S as 32-bit deci-units, divided by 10 at both the FC04 emission sites
+(`0x08059754` / `0x08059770`) and the outbound builder (`0x08031652` / `0x0803174A`). There is no
+×10 S normalisation anywhere. The two families genuinely differ here.
+
+---
+
+## 4. Live hardware
+
+From the maintainer's plant (HYBRID mode, `supports_three_phase = False`, `supports_split_phase = True`):
+
+| Sensor | 18kPV (`SN_11`) | FlexBOSS21 (`SN_13`) | Reading |
+|---|---:|---:|---|
+| `eps_voltage_l1` / `l2` | 122.6 / 123.5 V | 123.6 / 123.2 V | genuine |
+| `eps_voltage_r` | **246.8 V** | **247.6 V** | genuine — matches L1+L2 (246.1 / 246.8) |
+| `eps_voltage_s` | **256.0 V** | **4832.0 V** | implausible |
+| `eps_voltage_t` | **2054.4 V** | **2362.6 V** | implausible |
+| `eps_frequency` | 59.99 Hz | 59.99 Hz | genuine |
+| `eps_power`, `eps_apparent_power`, `_l1`, `_l2` | 0 | 0 | EPS idle — uninformative |
+
+Two units of the same family disagree by nearly 20× on `eps_voltage_s`, and no quantity on a
+120/240 V split-phase system reads 4832 V. Whatever registers 21/22 carry here, it is not
+S/T voltage on this hardware.
+
+The apparent-power sensors all read `0` because EPS output was idle — which is also exactly what a
+threshold-gated counter reads before its threshold is crossed. **The live data cannot distinguish
+the counter hypothesis from a working sensor; only the firmware does.**
+
+---
+
+## 5. Integration impact
+
+### Exposed today — `eps_apparent_power_l2` (register 132)
+
+```
+sensor.18kpv_4512670118_eps_apparent_power_l2         0 VA
+sensor.flexboss21_52842p0581_eps_apparent_power_l2    0 VA
+```
+
+Four such entities exist on the maintainer's system. They are backed by a counter. Once the
+firmware's accumulator threshold is crossed they will climb monotonically and never return to a
+plausible VA reading — presented with `VA` units and `measurement` state class, polluting long-term
+statistics. This is the [#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544) pattern
+on a different family.
+
+`eps_apparent_power_l1` (register 131) is a genuine DSP power quantity but is **sign-split into
+positive- and negative-direction fields**, which is incompatible with a non-negative apparent power;
+its B source zeroes the positive field when the value is negative (`0x0804D846`, `0x0804D850`). It
+should not be trusted as VA either, though it is less clearly wrong than 132.
+
+Suggested handling — mirroring the #544 fix rather than inventing a new mechanism: add registers
+131/132 to a hybrid-scoped exclusion so the two per-leg VA sensors are not created on EG4_HYBRID,
+fail-closed on unresolved family, exactly as `OFFGRID_EXCLUDED_SENSORS` does today. The aggregate
+`eps_apparent_power` (register 25) should **stay** — it is a real, if firmware-computed, estimate.
+
+### Latent, not exposed — `eps_voltage_s` / `eps_voltage_t`
+
+Both are in `THREE_PHASE_ONLY_SENSORS` and gated on `features["supports_three_phase"]`. Every unit
+observed reports `False`, so no entity is created and the implausible values stop at the
+coordinator's internal dict.
+
+The risk is nonetheless real and **greater than on off-grid**: EG4_HYBRID is precisely the
+three-phase-capable family, so on a genuinely three-phase hybrid the gate **opens**.
+
+Recommended posture:
+
+1. Do **not** relax `THREE_PHASE_ONLY_SENSORS` or the `supports_three_phase` gate for these keys.
+2. Treat three-phase hybrid as an **untested configuration** for EPS S/T voltage specifically.
+3. If a three-phase hybrid ever reports absurd `eps_voltage_s`/`_t`, this document is the
+   explanation, and the fix is to drop the sensors, not rescale them.
+
+Deliberately **not** done: removing 21/22 outright. On genuinely three-phase firmware these slots
+may well carry real R/S/T voltages — that is what the registers are for — and no three-phase
+hardware has been observed either way. Removing them would trade a latent bug for a certain
+regression on a configuration nobody has tested.
+
+---
+
+## 6. What is NOT established
+
+- **Registers 21/22 physical semantics — UNPROVEN.** The ARM image only copies them to FC04 and the
+  report frame; they are never used in voltage arithmetic (unlike register 20, which is multiplied
+  by current at `0x0804CE10`). They are assembled from adjacent bytes on one DSP receive page, so
+  they are coherent 16-bit DSP words, **not** off-grid-style composites. What the DSP puts there in
+  three-phase mode is unknown without the C28x image or readings from a live three-phase install.
+- **Register 131 — not proven to be apparent power, and not proven to be anything else.** The
+  sign-split writer argues against S; nothing identifies what it *is*.
+- **Register 25's accuracy is unvalidated.** `V × I ÷ 100` is dimensionally an apparent power, but
+  no live measurement with an actual EPS load has been taken on hybrid to check it against
+  `eps_power`. The firmware's own `S ≥ P` clamp means that relation cannot serve as a check.
+- **The `0x2000B6D4` report-frame field order is unmapped.** It is a real structure carrying real
+  values; nothing here establishes which field is which.
+
+---
+
+## 7. Corroboration
+
+The FC04 builder, the register table in §3, and the counter/estimate findings came from an
+independent adversarial pass (Codex `gpt-5.6-sol`, xhigh) working from the image alone; every
+instruction and literal-pool value cited was then re-verified byte-for-byte before being recorded
+here. That pass **refuted** an earlier conclusion of mine — a five-branch "mode constant" mechanism
+for register 21 — by showing I had traced the wrong buffer. The live-hardware evidence in §4 was
+gathered independently of both and depends on no firmware decode at all.
+
+Corrected in place rather than left standing: an earlier draft of this document asserted that
+hybrid registers 21/22 were byte composites "the same class of junk as off-grid". They are not.
+The *conclusion* that they are not usable S/T voltages survives — on live-data grounds — but the
+mechanism was wrong, and a wrong mechanism recorded as fact is how the `re/` artifacts became
+unusable in the first place.
+
+---
+
+## 8. Reproducing this
+
+```bash
+# 1. rebuild the hybrid ARM App correctly (per-chunk de-frame, §1)
+#    inputs: docs/reference/firmware/captures/{18kpv,flexboss21}_firmware_upgrade_complete.pcap
+#    verify: 351,642 bytes / sha256 63d0efba... / both captures byte-identical
+
+# 2. disassemble at the CORRECT base
+r2 -q -a arm -b 16 -m 0x08010000 -c "e asm.bits=16; s 0x08010000; pD 351642" hybrid_app.bin
+
+# 3. live cross-check (read-only HTTP, no Modbus contention)
+curl -s -H "Authorization: Bearer $HA_PROD_LONG_LIVED_TOKEN" \
+     "$HA_PROD_BASE_URL/api/diagnostics/config_entry/<entry_id>"
+```
+
+Stop the `homeassistant-dev` container before any local Modbus probing — production runs HYBRID and
+the gateway allows one connection.

--- a/docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
+++ b/docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
@@ -9,6 +9,11 @@ arrive over the inter-processor link, are filtered, and are published into the s
 feeds the already-proven active-power registers. They are *not* counters, constants, duplicates or
 aliases.
 
+> **Scope: this document is about the off-grid image only.** The identically-numbered registers mean
+> different things on EG4_HYBRID — there, 25 is an ARM-computed `V × I ÷ 100` estimate, 131 is a
+> sign-split directional power, and **132 is an incrementing counter**. See
+> [`HYBRID_EPS_REGISTERS.md`](HYBRID_EPS_REGISTERS.md). Do not carry conclusions across families.
+
 A second, unrelated finding fell out of the same trace: **inputs 21 and 22 — the legacy EPS
 *S-phase* and *T-phase* voltages — are not voltages at all** on this build. See §5.
 
@@ -229,6 +234,12 @@ for this family, and do not treat a three-phase off-grid variant as automaticall
 handler first.
 
 What inputs 21/22 actually carry is **UNPROVEN**; naming them needs the C28x transmit-side decode.
+
+> **These two registers are also unusable on EG4_HYBRID**, though for different reasons — there they
+> are coherent DSP words rather than composites, but nothing uses them as voltages and live readings
+> are implausible (`eps_voltage_s` = 256.0 V and 4832.0 V on two units). That family *can* be
+> three-phase, so the gate that permanently suppresses these sensors here is not guaranteed to
+> suppress them there. See [`HYBRID_EPS_REGISTERS.md`](HYBRID_EPS_REGISTERS.md).
 
 ---
 

--- a/docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
+++ b/docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
@@ -1,0 +1,273 @@
+# Off-Grid EPS Registers — What Input 25 / 131 / 132 Actually Are
+
+**Question** (issue [#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544) follow-up):
+after input register 123 turned out to be an ARM-local counter rather than generator power, is
+**EPS apparent power (VA)** genuine on the same platform, or another repurposed slot?
+
+**Answer: genuine.** Inputs 25, 131 and 132 are measured values that originate on the C28x DSP,
+arrive over the inter-processor link, are filtered, and are published into the same struct that
+feeds the already-proven active-power registers. They are *not* counters, constants, duplicates or
+aliases.
+
+A second, unrelated finding fell out of the same trace: **inputs 21 and 22 — the legacy EPS
+*S-phase* and *T-phase* voltages — are not voltages at all** on this build. See §5.
+
+Companion documents: [`OFFGRID_GENERATOR_REGISTERS.md`](OFFGRID_GENERATOR_REGISTERS.md) for the
+register-123 proof and the three-base structural argument; [`FIRMWARE_ACQUISITION.md`](FIRMWARE_ACQUISITION.md)
+for how to obtain and decode an image, and for the method rules every claim here follows.
+
+---
+
+## 1. Firmware analysed
+
+| | |
+|---|---|
+| Image | `ceaa-07xx_vE_260214_Br7k5_2` — ARM comms processor, 12000XP / `SNA_US_12K` |
+| Reported as | `ceaa-0709` (the `09` half is the separate C28x image) |
+| Size | 238,856 bytes |
+| SHA-256 | `d46f8b0c051e78c7e85adf2d4683dedae6489016cd563759d5edd2a487818624` |
+| Load base | `0x08005000` |
+| FC04 dispatcher | `0x0801DEEC` |
+
+---
+
+## 2. The six handlers
+
+All six resolve the **same** literal pool slot `0x0801EF50`, whose bytes are `e4 d0 00 20` =
+`0x2000D0E4` — the DSP power block, the same base as the hardware-measured registers 153
+(`ac_couple_power`) and 170 (`output_power`), and a different base from register 123's ARM-local
+counter.
+
+| Reg | pylxpweb name | Handler | Decoded source | Unit conversion |
+|----:|---------------|---------|----------------|-----------------|
+| 24 | `eps_power` | `0x0801E624` | `RAM32[0x2000D0E4 + 0x60]` = `0x2000D144` | `UDIV` by 10 |
+| **25** | **`eps_apparent_power`** | **`0x0801E634`** | **`RAM16[0x2000D0E4 + 0x88]` = `0x2000D16C`** | **none** |
+| 129 | `eps_l1_power` | `0x0801EA06` | `RAM32[0x2000D0E4 + 0x64]` = `0x2000D148` | `UDIV` by 10 |
+| 130 | `eps_l2_power` | `0x0801EA14` | `RAM32[0x2000D0E4 + 0x68]` = `0x2000D14C` | `UDIV` by 10 |
+| **131** | **`eps_l1_apparent_power`** | **`0x0801EA22`** | **`RAM16[0x2000D0E4 + 0x8A]` = `0x2000D16E`** | **none** |
+| **132** | **`eps_l2_apparent_power`** | **`0x0801EA2C`** | **`RAM16[0x2000D0E4 + 0x8C]` = `0x2000D170`** | **none** |
+
+```
+; register 25 — EPS apparent power
+0801E634  df f8 18 09   LDR.W  R0,[PC,#0x918]   ; Align(0x0801E638,4)+0x918 = 0x0801EF50 -> 0x2000D0E4
+0801E638  b0 f8 88 00   LDRH.W R0,[R0,#0x88]    ; -> RAM16[0x2000D16C]
+0801E63C  00 f0 85 bc   B.W    0x0801EF4A       ; common epilogue: UXTH R0,R0
+
+; register 24 — EPS active power, for contrast
+0801E624  df f8 28 09   LDR.W  R0,[PC,#0x928]   ; same pool slot -> 0x2000D0E4
+0801E628  00 6e         LDR    R0,[R0,#0x60]    ; -> RAM32[0x2000D144]
+0801E62A  0a 21         MOVS   R1,#10
+0801E62C  b0 fb f1 f0   UDIV   R0,R0,R1
+```
+
+The three apparent-power fields are **contiguous 16-bit slots** at `+0x88`, `+0x8A`, `+0x8C`
+(total, L1, L2) — a deliberate layout, read with plain `LDRH.W`. No byte-gluing, no bitfield
+masking, no shared address. Compare register 123's `RAM16[0x2000D6F0 + 0x1A]`, or registers 21/22
+in §5, where exactly those tell-tale shapes *do* appear.
+
+### The scaling asymmetry is real, and it is the firmware's own
+
+Active power is held internally in **deciwatts** and divided by 10 at the register boundary.
+Apparent power is held in **whole VA** and is not divided. That is not an inference — the firmware
+normalises in the opposite direction when it builds its own outbound report frame at `0x0800E3E6`,
+multiplying each apparent value by 10 to match the active-power scale:
+
+```
+0800E3E6  df f8 3c 23   LDR.W R2,[0x0800E724]      ; = 0x2000D0E4
+0800E3EA  13 6e         LDR   R3,[R2,#0x60]        ; P total  (deciwatts)
+0800E3EC  0b 64         STR   R3,[R1,#0x40]
+0800E3EE  02 f1 88 03   ADD.W R3,R2,#0x88          ; &S total
+0800E3F2  1c 88         LDRH  R4,[R3]              ; S total  (VA)
+0800E3F4  04 eb 84 05   ADD.W R5,R4,R4,LSL #2      ; R5 = S*5
+0800E3F8  6d 00         LSLS  R5,R5,#1             ; R5 = S*10  -> same deci-scale as P
+0800E3FA  0d 65         STR   R5,[R1,#0x50]
+0800E3FC  54 6e         LDR   R4,[R2,#0x64]        ; P L1
+0800E400  5d 88         LDRH  R5,[R3,#2]           ; S L1  -> also *10
+0800E40A  91 6e         LDR   R1,[R2,#0x68]        ; P L2
+0800E40E  9a 88         LDRH  R2,[R3,#4]           ; S L2  -> also *10
+```
+
+Three P/S pairs, total / L1 / L2, interleaved. The firmware itself treats `+0x88`/`+0x8A`/`+0x8C`
+as apparent power paired one-to-one with the active powers at `+0x60`/`+0x64`/`+0x68`.
+`LDRH` zero-extends, so the values are unsigned — correct for apparent power, and 16 bits caps at
+65,535 VA, far above a 12 kW unit's range.
+
+pylxpweb's map (`unit="VA"`, no scale factor) matches this exactly.
+
+---
+
+## 3. Provenance — the full chain from DSP to Modbus
+
+The decisive question is not "what address does the handler read" but "who writes it". For these
+six fields the chain is complete:
+
+```
+C28x DSP
+   │  inter-processor frame (CRC checked at 0x080275AE, dispatched via 0x0802677A)
+   ▼
+frame parser  0x08025AB8        R6 = 0x2000CE5C (receive block)
+   │  page 3  (CMP R0,#3 @ 0x08025D5E)   0x08025D74  STRH.W R0,[R6,#0x9C]   raw S total
+   │  page 12 (CMP R0,#12 @ 0x080265C6)  0x080265D6  STRH.W R0,[R6,#0xA0]   raw S L1
+   │                                     0x080265E8  STRH.W R0,[R6,#0xA2]   raw S L2
+   ▼
+filter / convert  0x08018D44     R7 = 0x2000CE5C (loaded @0x08018DAE)
+   │                             R6 = 0x2000D0E4 (loaded @0x08018D8C)
+   │  0x080191B0  LDRH.W R0,[R7,#0x9C]     ; read raw total
+   │  0x08019274  LDRH.W R0,[R7,#0xA0]     ; read raw L1
+   │  0x08019330  LDRH.W R0,[R7,#0xA2]     ; read raw L2
+   ▼
+publish into the power block  (in image order)
+      0x0801A2EC  STR    R0,[R6,#0x64]     P L1      ─┐
+      0x0801A2F8  STRH.W R0,[R6,#0x8A]     S L1       │ P and S published
+      0x0801A306  STR    R0,[R6,#0x68]     P L2       │ by the same routine,
+      0x0801A312  STRH.W R0,[R6,#0x8C]     S L2       │ alternating, through
+      0x0801A320  STR    R0,[R6,#0x60]     P total    │ the same filters
+      0x0801A32C  STRH.W R0,[R6,#0x88]     S total   ─┘
+   ▼
+FC04 handlers 0x0801E634 / 0x0801EA22 / 0x0801EA2C  (§2)
+```
+
+Active and apparent power travel the identical path. Whatever confidence register 24 deserves,
+registers 25/131/132 deserve the same.
+
+Two negative controls support the same conclusion:
+
+- **No ARM code computes these fields.** A whole-image scan for stores into `0x2000D0E4` at offsets
+  `0x60`, `0x64`, `0x68`, `0x88`, `0x8A`, `0x8C` finds only the six publishes above. Other offsets
+  in the same struct *are* ARM-written — `+0x08`/`+0x0A` receive the model's rated power
+  (`0x2710`=10000, `0x2EE0`=12000, `0x3138`=12600, `0x36B0`=14000, `0x3A98`=15000 W) at
+  `0x08012972`–`0x080129D8`. So the struct mixes ARM-authored limits with DSP-authored
+  measurements, and the six registers of interest sit firmly on the measurement side.
+- **The values are consumed as power.** `+0x60`/`+0x64`/`+0x68` are integrated into the EPS energy
+  accumulators at `0x080360B8`, `0x080360F0`, `0x08036124` — the source of `eps_energy` /
+  `eps_energy_lifetime`.
+
+> **Still unproven, and deliberately not claimed:** whether the C28x computes true-RMS apparent
+> power (`S = V_rms · I_rms`) or a simplified estimate. That lives in the C28x image, for which no
+> usable disassembler exists (see [`FIRMWARE_ACQUISITION.md`](FIRMWARE_ACQUISITION.md) §4). Nothing
+> in this document depends on the answer — "genuine measured quantity in VA" is established without
+> it.
+
+---
+
+## 4. Live cross-check
+
+From the #544 reporter's diagnostics (12000XP, HYBRID mode, real hardware):
+
+| Channel | P (W) | S (VA) | PF | S ≥ P |
+|---------|------:|-------:|----:|:-----:|
+| Total | 1104 | 1257 | 0.878 | ✓ |
+| L1 | 529 | 588 | 0.900 | ✓ |
+| L2 | 580 | 666 | 0.871 | ✓ |
+
+- Leg sums: `529 + 580 = 1109` vs total `1104` (0.45%); `588 + 666 = 1254` vs total `1257` (0.24%).
+  Small residuals are expected — the totals are received and filtered independently, not summed by
+  the handler.
+- Implied reactive power `√(S²−P²) = 601 VAR` — plausible for a residential load.
+- Implied leg currents `588/119.6 = 4.92 A` and `666/119.6 = 5.57 A` — plausible.
+- `S ≥ P` holds on every channel. A repurposed slot has no reason to respect that constraint;
+  register 123 did not (28,646 "W" against a 1.1 kW load).
+
+This is corroboration, not proof — but it is the kind that a wrong decode fails.
+
+---
+
+## 5. Second finding — EPS S/T voltages are not voltages
+
+The same walk shows that of the three legacy R/S/T EPS voltage registers, only **R** is real:
+
+| Reg | pylxpweb name | Decoded source | Verdict |
+|----:|---------------|----------------|---------|
+| 20 | `eps_voltage_r` | `RAM16[0x2000CE5C + 0x22]` = `0x2000CE7E` | genuine DSP field |
+| 21 | `eps_voltage_s` | `RAM8[0x2000CF37] \| (RAM8[0x2000CF34] << 8)` | **byte-pair composite — not a voltage** |
+| 22 | `eps_voltage_t` | `(RAM16[0x2000BB6A] & 0xFFF0) \| (RAM8[0x2000BB6C] & 0x0F)` | **bitfield merge — not a voltage** |
+
+```
+; register 21 — two unrelated bytes glued together (offsets differ by 3, not 1,
+;               so this cannot be a little-endian 16-bit field read)
+0801E5E8  df f8 68 09   LDR.W  R0,[PC,#0x968]      ; pool 0x0801EF54 -> 0x2000CE5C
+0801E5EC  90 f8 d8 10   LDRB.W R1,[R0,#0xD8]       ; 0x2000CF34
+0801E5F0  90 f8 db 00   LDRB.W R0,[R0,#0xDB]       ; 0x2000CF37
+0801E5F4  50 ea 01 20   ORRS.W R0,R0,R1,LSL #8
+
+; register 22 — masked 16-bit field OR'd with a nibble, from a fourth base entirely
+0801E5FC  df f8 60 29   LDR.W  R2,[PC,#0x960]      ; pool 0x0801EF60 -> 0x2000B910
+0801E600  b2 f8 5a 02   LDRH.W R0,[R2,#0x25A]      ; 0x2000BB6A
+0801E604  4f f6 f0 71   MOVW   R1,#0xFFF0
+0801E608  08 40         ANDS   R0,R0,R1
+0801E60A  92 f8 5c 12   LDRB.W R1,[R2,#0x25C]      ; 0x2000BB6C
+0801E60E  11 f0 0f 01   ANDS.W R1,R1,#0x0F
+0801E612  08 43         ORRS   R0,R0,R1
+```
+
+The composed bytes are written by *different pages* of the receive parser, which is what rules out
+their being one coherent field:
+
+| Component | Writer |
+|-----------|--------|
+| Reg 21 high byte (`+0xD8`) | `0x08025C7A  STRB.W R0,[R6,#0xD8]` (page 2) |
+| Reg 21 low byte (`+0xDB`) | `0x08025F44  STRB.W R1,[R0,#0xDB]` (page 5) |
+| Reg 22 upper 12 bits (`+0x25A`) | `0x08025E5C  STRH.W R0,[R1,#0x25A]` (page 4) |
+| Reg 22 low nibble (`+0x25C`) | `0x08025F72  STRB.W R0,[R6,#0x25C]` (page 5) |
+
+The reporter's live readings decode exactly as the handlers predict:
+
+| Sensor | Reading | Raw | Reads as |
+|--------|--------:|----:|----------|
+| `eps_voltage_r` | 239.0 V | 2390 = `0x0956` | a normal 16-bit word; matches L1+L2 = 119.6+119.6 = 239.2 V |
+| `eps_voltage_s` | 1004.8 V | 10048 = `0x2740` | bytes `0x27` and `0x40` |
+| `eps_voltage_t` | 417.8 V | 4178 = `0x1052` | `0x1050` plus nibble `0x2` |
+
+**Current exposure — no user-visible bug.** `eps_voltage_s` / `eps_voltage_t` are members of
+`THREE_PHASE_ONLY_SENSORS` (`const/device_types.py`) and are gated on
+`features["supports_three_phase"]`, which is `False` for this hardware. The bogus values reach the
+coordinator's internal sensor dict but no entity is created. Nothing needs fixing today.
+
+**What this is a warning about:** the gate is currently correct for an incidental reason (split
+phase), not because anyone knew the registers were junk. Do not relax `THREE_PHASE_ONLY_SENSORS`
+for this family, and do not treat a three-phase off-grid variant as automatically safe — verify the
+handler first.
+
+What inputs 21/22 actually carry is **UNPROVEN**; naming them needs the C28x transmit-side decode.
+
+---
+
+## 6. Corroboration
+
+Every claim was decoded twice — once by hand from the bytes, once by an independent reviewer
+(Codex `gpt-5.6-sol`, xhigh) instructed to refute rather than confirm, working from the image alone.
+
+| Claim | Verdict |
+|-------|---------|
+| Regs 24/25/129/130/131/132 all resolve pool slot `0x0801EF50` = `0x2000D0E4` | **CONFIRMED** (both decodes; pool bytes `e4 d0 00 20`) |
+| Reg 25 = `RAM16[0x2000D16C]`, 131 = `RAM16[0x2000D16E]`, 132 = `RAM16[0x2000D170]`, no scaling | **CONFIRMED** |
+| Active power divided by 10, apparent power not | **CONFIRMED** — and independently cross-checked by the `×10` normalisation at `0x0800E3F4` |
+| 131/132 are individually implemented, not aliases of each other or of 25 | **CONFIRMED** (full 245-case dispatcher walk incl. cases 520–598 found no other reader of those three addresses) |
+| The three apparent fields are DSP-sourced, ARM-filtered, not ARM-computed | **CONFIRMED** (parser → filter → publish chain in §3) |
+| No ARM code writes `+0x60/0x64/0x68/0x88/0x8A/0x8C` other than the publish sites | **CONFIRMED** (whole-image scan; contrast `+0x08`/`+0x0A` rated-power writes) |
+| The C28x computes true-RMS apparent power | **UNPROVEN** — not claimed; needs the DSP image |
+| Reg 20 genuine; regs 21/22 are composites, not voltages | **CONFIRMED** (both decodes; writers on different parser pages) |
+| What regs 21/22 actually carry | **UNPROVEN** |
+
+An earlier pass of mine reported "zero writers" for the power fields and nearly concluded the struct
+was DMA-filled. That was a tooling artefact — the base pointer is loaded once at `0x08018D8C` and
+held in `R6` across a ~6 kB function, which a naive literal-tracking scan drops. The reviewer found
+the publish sites; they were then verified byte-for-byte before being recorded here. **Absence of
+evidence from a scanner is not evidence of absence — confirm the scanner can see what it claims is
+missing.**
+
+---
+
+## 7. Reproducing this
+
+```bash
+# 1. download the off-grid pair (see FIRMWARE_ACQUISITION.md)
+uv run python scripts/download_inverter_firmware.py --device-type SNA_US_12K --out-dir /tmp/fw
+
+# 2. walk the FC04 dispatcher: registers 24/25/129/130/131/132 and 20/21/22
+uv run python scripts/walk_input_dispatch.py \
+    /tmp/fw/ceaa-07xx_vE_260214_Br7k5_2.bin --base 0x08005000 --start 0x0801DEEC
+```
+
+Both scripts are read-only and require no vendor tooling. The walk covers the contiguous chain only
+(166 cases, up to register 235); the handlers in this document all fall inside that range.

--- a/docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
+++ b/docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
@@ -16,6 +16,11 @@ different hardware without identifying the cause.
 > **Scope.** Everything below is the **EG4_OFFGRID** family (`SNA_US_12K`, firmware `ceaa-0709`).
 > On **EG4_HYBRID** register 123 is genuine — see [Family differential](#8-family-differential).
 > Do not generalise either finding to the other family.
+>
+> **A bogus register here does not make its neighbours bogus.** The follow-up trace in
+> [`OFFGRID_EPS_REGISTERS.md`](OFFGRID_EPS_REGISTERS.md) proves that EPS apparent power
+> (inputs 25/131/132) on the *same* image is a genuine DSP-sourced measurement — and that the
+> legacy EPS S/T voltages (inputs 21/22) are not. Each register needs its own decode.
 
 ---
 


### PR DESCRIPTION
## Why

Two follow-up questions from #544, answered from the firmware rather than by inference:

1. After input register 123 turned out to be an ARM-local counter, **is EPS apparent power genuine?** (reporter's question)
2. **Does EG4_HYBRID carry the same registers?** (maintainer's question)

## Answers

**Off-grid: apparent power is genuine.** Inputs 25/131/132 resolve the DSP power block (`0x2000D0E4` +`0x88`/`0x8A`/`0x8C`) and trace end to end — C28x frame → parser (`0x08025AB8`) → filter (`0x08018D44`) → publish (`0x0801A2EC..0x0801A32C`) → FC04. The publish routine writes active and apparent power *alternating*, through the same filters, so the two carry identical confidence. The W÷10 / VA×1 asymmetry is confirmed by the firmware's own ×10 normalisation at `0x0800E3F4`.

**Hybrid: same register numbers, different meanings — and one is not a measurement.**

| Reg | Off-grid | Hybrid |
|---|---|---|
| 25 | direct DSP apparent power | ARM-computed `V × I ÷ 100`, clamped so S ≥ P |
| 131 | genuine apparent power | DSP power **split by sign into direction fields** |
| 132 | genuine apparent power | **an incrementing threshold-gated counter** |

Register 132 is the #544 pattern on a different family, and unlike the S/T voltages **it is exposed today** — `eps_apparent_power_l2` exists on both of the maintainer's hybrid inverters, reading `0 VA` only because EPS is idle and the counter's threshold hasn't been crossed. The doc suggests handling that mirrors the #544 fix (hybrid-scoped exclusion for 131/132, keep aggregate 25). **No code change in this PR** — that's a separate decision.

**EPS S/T voltage (21/22) is unusable in both families**, for different reasons. Off-grid: byte/bitfield composites. Hybrid: coherent DSP words that nothing uses as voltages, reading 256.0 V and 4832.0 V on two units. Currently suppressed everywhere by the three-phase gate — but hybrid is the three-phase-*capable* family, so that gate can open. Deliberately left in place: on real three-phase firmware those slots may carry real voltages, and no such hardware exists to test against.

## Method corrections (both fail silently)

- **`extract_firmware_from_pcap.py` output is still OTA-framed.** De-frame per *actual* chunk length (`455×771, 4×259, 481, 703, 7`), not a fixed period. Verified: 351,642 bytes, sha256 `63d0efba…`, and the 18kPV and FlexBOSS21 captures reconstruct **byte-identically**.
- **The hybrid ARM load base is `0x08010000`**, not the off-grid `0x08005000`. Derive it by back-solving a vector-table entry; confirm via RAM-pointer density and a known literal.

## On rigour

Every cited instruction and literal was verified byte-for-byte against the images before being recorded, and both traces were run past an independent adversarial pass.

Two of my own conclusions were **refuted and corrected in place** rather than quietly dropped:

- Off-grid: I first reported *zero writers* for the power fields and nearly concluded the struct was DMA-filled. Tooling artefact — the base pointer is held in `R6` across a ~6 kB function.
- Hybrid: I traced a byte-swapped report frame at `0x2000B6D4` that looks exactly like a register image and built a whole mechanism on it. It's a decoy; FC04 actually serves from `0x20009DBC` via the builder at `0x080594D8`.

Both traps are now written into `FIRMWARE_ACQUISITION.md`, because a wrong mechanism recorded as fact is how the `re/` artifacts became unusable in the first place.

## Scope

Docs only. No code, no behaviour change, no pin change.

- **new** `OFFGRID_EPS_REGISTERS.md`, `HYBRID_EPS_REGISTERS.md`
- `FIRMWARE_ACQUISITION.md` — working de-frame recipe, ARM load bases, scanner blind-spot warning
- `OFFGRID_GENERATOR_REGISTERS.md` — cross-links, scope banner

Answer posted to the reporter: https://github.com/joyfulhouse/eg4_web_monitor/issues/544#issuecomment-5229089082

🤖 Generated with [Claude Code](https://claude.com/claude-code)