### PR TITLE
docs(llmwiki): operations chapter

### DIFF
--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -220,9 +220,11 @@ evidence, so they are graded separately.
    long syntax with `bind.create_host_path: false` — which it does not, though that too is only
    `asserted-unverified` against parent workspace `docker-compose.yaml:21-28`.
 
-Confirm the directory exists before switching. The hazard is latent rather than live: all four
-config directories are present today, so this bites a typo or a newly added mode, not the modes
-listed above.
+Confirm the directory exists before switching. The hazard is latent rather than triggered on every
+run: the script maps only the four known modes and rejects anything else with a usage message and
+`exit 1` — `asserted-unverified`, parent workspace `eg4-switch-mode.sh:20-43`. So what reaches the
+missing-directory case is a typo inside a `case` arm's directory name, a newly added mode, or a
+config directory that has been moved or never provisioned — not routine use of the four modes above.
 
 ## Operational hazards (do not skip)
 

--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -200,12 +200,29 @@ inside `- ./config-local-nomidbox:/config` (the next character there is `-`, not
 rewrites within the one `sed` invocation are idempotent for all four modes, so reordering the
 expressions would change nothing — `asserted-unverified` — `eg4-switch-mode.sh:49-54`.
 
-**Real hazard — missing config directory.** The script never checks that the target directory
-exists; it edits compose and runs `docker-compose up -d` regardless (`:49-68`,
-`verified-against-code`). Docker creates a missing bind-mount source as an empty directory, so a
-typo or an un-provisioned mode yields a **fresh, empty Home Assistant** — onboarding screen, no
-integration, no entities — rather than an error. Confirm the directory exists before switching —
-`inferred` from the absent check plus Docker's bind-mount auto-create behavior.
+**Real hazard — missing config directory.** Two claims stack here and they do not rest on the same
+evidence, so they are graded separately.
+
+1. **The script never checks that the target config directory exists.** `CONFIG_DIR` is assigned per
+   mode, echoed, substituted into the `sed` expressions, and then looked for in the compose file — it
+   is never tested against the filesystem. The `if grep -q "$CONFIG_DIR:/config"` at `:57` is easy to
+   misread as that check: it confirms the **edit landed in the YAML**, not that the directory is
+   there. So the script edits compose and runs `docker-compose up -d` regardless — `asserted-unverified`
+   — parent workspace `eg4-switch-mode.sh:20-31`, `:45`, `:49-54`, `:57-68`. True, and re-checked, but
+   the file is unversioned and unrecoverable, so it cannot carry a code grade
+   ([why](#the-parent-workspace-cannot-be-pinned)).
+
+2. **A missing directory therefore yields a fresh, empty Home Assistant** — onboarding screen, no
+   integration, no entities — rather than an error, because Docker creates a missing bind-mount source
+   as an empty directory. `inferred`, and stated as an inference rather than an observation: nobody
+   has recorded actually hitting this. It rests on Docker Engine's documented auto-create behavior
+   for **short-syntax** bind mounts, combined with claim 1. It would *not* hold if the mount used the
+   long syntax with `bind.create_host_path: false` — which it does not, though that too is only
+   `asserted-unverified` against parent workspace `docker-compose.yaml:21-28`.
+
+Confirm the directory exists before switching. The hazard is latent rather than live: all four
+config directories are present today, so this bites a typo or a newly added mode, not the modes
+listed above.
 
 ## Operational hazards (do not skip)
 

--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -1,0 +1,155 @@
+---
+canonical-for: local development setup, HA docker bind mounts, four-mode testing, mode switch hazards
+sources:
+  - /tmp/llmwiki-research/repo-operations.md
+  - docs/DEVELOPMENT.md
+  - CLAUDE.md
+  - ../docker-compose.yaml (parent homeassistant-dev)
+  - ../scripts/eg4-switch-mode.sh (parent homeassistant-dev)
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Dev environment
+
+How an agent develops against this two-repo stack: **eg4_web_monitor** (this repo) and **pylxpweb** (sibling library). Do not guess paths or modes — use the tables and commands below.
+
+## Python tooling (`uv`)
+
+**verified-against-code** — `docs/DEVELOPMENT.md:11-18`
+
+```bash
+git clone https://github.com/joyfulhouse/eg4_web_monitor.git
+cd eg4_web_monitor
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install -r tests/requirements-test.txt
+```
+
+Agent day-to-day commands prefer `uv run` (no activate required) — **verified-against-code** — `CLAUDE.md` Testing section / `prek.toml` mypy hook.
+
+Pinned quality tools — **verified-against-code** — `tests/requirements-test.txt:19-21`:
+
+| Package | Pin | Why |
+|---------|-----|-----|
+| `mypy` | `2.3.0` | Keep in sync with `quality-validation.yml` |
+| `ruff` | `0.15.5` | Keep in sync with `prek.toml` and CI; 0.16 broke CI (#482) |
+
+### pylxpweb sibling setup
+
+**verified-against-code** — pylxpweb `docs/DEVELOPMENT.md` (sibling repo):
+
+```bash
+cd ../python/pylxpweb   # relative to homeassistant-dev/
+uv sync
+uv run pytest
+uv run ruff check
+uv run ruff format
+uv run mypy
+```
+
+## Home Assistant docker container
+
+Lives in the **parent** repo `homeassistant-dev/` (sibling of this clone), not inside eg4_web_monitor.
+
+| Fact | Value | Grade |
+|------|-------|-------|
+| Compose file | `homeassistant-dev/docker-compose.yaml` | verified-against-code — compose L14–36 |
+| Service / container | `homeassistant` / `homeassistant-dev` | verified-against-code |
+| Image | `homeassistant/home-assistant:latest` | verified-against-code |
+| UI port | `8123` → http://localhost:8123 | verified-against-code |
+
+### Bind mounts (host → container)
+
+**verified-against-code** — `homeassistant-dev/docker-compose.yaml:24-28`
+
+| Host path (from `homeassistant-dev/`) | Container path | Purpose |
+|---------------------------------------|----------------|---------|
+| `./eg4_web_monitor/custom_components/eg4_web_monitor` | `/config/custom_components/eg4_web_monitor` | Live integration code |
+| `../python/pylxpweb/src/pylxpweb` | `/usr/local/lib/python3.13/site-packages/pylxpweb` | Live library source over site-packages |
+| Mode-selected `./config*` | `/config` | HA config directory (see modes below) |
+
+Code is bind-mounted; **Python import changes still require a container restart** because the interpreter already loaded modules — **verified-against-code** — `CLAUDE.md` Docker section.
+
+```bash
+# Soft restart after import changes (integration or pylxpweb)
+docker restart homeassistant-dev
+docker logs -f homeassistant-dev
+
+# Full recreate after compose edit / mode switch (script does this)
+cd ../   # homeassistant-dev/
+docker-compose down && docker-compose up -d
+```
+
+End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker mounts above, not HACS — **inferred** from `docs/DEVELOPMENT.md` + `hacs.json`.
+
+## Four test modes
+
+`CLAUDE.md` documents three modes. Compose and the switch script also support a fourth — **verified-against-code** — `homeassistant-dev/docker-compose.yaml:4-12`, `homeassistant-dev/scripts/eg4-switch-mode.sh:20-41`.
+
+| Mode | Config dir (from `homeassistant-dev/`) | Purpose |
+|------|------------------------------------------|---------|
+| `cloud` | `./config` | Baseline / reference |
+| `local` | `./config-local` | Local-only (Modbus TCP or WiFi dongle) |
+| `hybrid` | `./config-hybrid` | Local poll + cloud supplemental data |
+| `local-nomidbox` | `./config-local-nomidbox` | Local without GridBOSS (inverters only) |
+
+### Validation expectations
+
+**verified-against-code** — `CLAUDE.md` Multi-Mode Testing section:
+
+| Mode | Expectation |
+|------|-------------|
+| Cloud | Baseline; should match production |
+| Local | Must have **all entities present in cloud** (minimum parity) |
+| Hybrid | Polls locally with cloud supplemental data |
+| All | Small margin OK for live readings (cloud lag) |
+
+Configs share HA user accounts/UI (copied from `./config`); each config has the EG4 entry removed for fresh configuration — **verified-against-code** — `CLAUDE.md`.
+
+## Mode switch script
+
+**File:** `homeassistant-dev/scripts/eg4-switch-mode.sh`
+**verified-against-code** — script lines 20–74
+
+What it actually does:
+
+1. Maps `cloud|local|hybrid|local-nomidbox` → config directory.
+2. `sed -i.bak` rewrites the `*:/config` volume line in `docker-compose.yaml` for all known variants (leaves `docker-compose.yaml.bak` beside compose).
+3. Verifies the new path appears in compose.
+4. `docker-compose down` then `docker-compose up -d` (full stack restart, not soft reload).
+5. Prints access URL and log hint.
+
+```bash
+cd homeassistant-dev/   # parent of eg4_web_monitor
+./scripts/eg4-switch-mode.sh cloud            # or local | hybrid | local-nomidbox
+
+# Check current mode
+grep ":/config" docker-compose.yaml | head -1
+```
+
+**sed order hazard:** `config-local-nomidbox` must be rewritten **before** `config-local` or a partial match can leave the wrong directory. The script already orders the expressions correctly — **verified-against-code** — `eg4-switch-mode.sh:49-54`.
+
+## Operational hazards (do not skip)
+
+| Hazard | Rule | Grade |
+|--------|------|-------|
+| One mode at a time | Only one of cloud/local/hybrid/local-nomidbox may run — API rate limits + Modbus collisions | verified-against-code — `CLAUDE.md` |
+| Prod owns the gateway | Production runs **HYBRID** and holds the single Modbus/dongle gateway. Stop `homeassistant-dev` before local Modbus/dongle probing or production silently degrades to cloud-fallback | verified-against-code — `docs/reference/firmware/HYBRID_EPS_REGISTERS.md` (~303–304) |
+| Dongle single-client | Scripts that talk to the dongle (e.g. `scripts/probe_gridboss_nbu_regs.py`) require HA stopped or cloud-only mode | verified-against-code — probe script header / research dossier |
+| pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after EVERY switch if that happens | asserted-unverified in-repo (recorded in CLAUDE.md beta.21 narrative + beads memory); treat as operational fact |
+| Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | verified-against-code — `eg4-switch-mode.sh:67-68` |
+| `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` | verified-against-code — `eg4-switch-mode.sh:49` |
+
+Cross-check helper (parent): `homeassistant-dev/scripts/compare_ha_vs_cloud.py` (HA WebSocket vs cloud API) — **verified-against-code** — file exists in parent `scripts/`.
+
+## Agent copy-paste: live validation
+
+```bash
+cd homeassistant-dev/
+./scripts/eg4-switch-mode.sh cloud    # or local | hybrid | local-nomidbox
+docker logs -f homeassistant-dev
+# UI: http://localhost:8123
+```
+
+**This wiki page does not authorize starting/stopping docker during docs-only work.** Use these commands only when an operator has asked for live validation.

--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -2,7 +2,7 @@
 canonical-for: local development setup, HA docker bind mounts, four-mode testing, mode switch hazards
 sources:
   - docs/DEVELOPMENT.md
-  - CLAUDE.md
+  - CHANGELOG.md
   - prek.toml
   - tests/requirements-test.txt
   - scripts/probe_gridboss_nbu_regs.py
@@ -85,11 +85,13 @@ The same container also mounts two unrelated integrations — `intellicenter` (`
 `brilliant_mqtt` (`:26`) — so restarting it restarts those too — `verified-against-code` —
 `docker-compose.yaml:25-26`.
 
-Code is bind-mounted, so edits are visible immediately, but **Python import changes still require a
-container restart** — `asserted-unverified` — `CLAUDE.md` "Common Issues" ("Changes not reflecting:
-Container restart required for Python imports"). The bind mount itself is
-`verified-against-code` (`docker-compose.yaml:24`, `:27`); the restart requirement is the doc's
-claim about interpreter behavior, not something this tree proves.
+Code is bind-mounted, so an edit lands inside the container immediately — `verified-against-code` —
+`docker-compose.yaml:24`, `:27`. **But a running Python process does not re-import a changed
+module**, so the edit is live on disk and inert in the running integration until the container
+restarts. That gap is the trap: the file is visibly correct, the behavior is visibly old, and it
+reads as though the edit failed. Restart before concluding anything about a code change —
+`inferred` from the bind mount plus CPython's `sys.modules` caching; nothing in this tree enforces
+or asserts it.
 
 ```bash
 # Soft restart after import changes (integration or pylxpweb)
@@ -105,9 +107,13 @@ End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker
 
 ## Four test modes
 
-`CLAUDE.md` "Multi-Mode Testing" documents three modes. Compose and the switch script both support a
-fourth, `local-nomidbox` — `verified-against-code` — `homeassistant-dev/docker-compose.yaml:5-11`
-(mode comment block), `homeassistant-dev/scripts/eg4-switch-mode.sh:20-43` (the `case` statement).
+There are **four** modes — `verified-against-code` — `homeassistant-dev/docker-compose.yaml:5-11`
+(mode comment block) and `homeassistant-dev/scripts/eg4-switch-mode.sh:20-43`.
+
+**Take the mode list from the script's `case` statement, never from prose.** A mode exists if and
+only if it has a `case` arm; the arm is what maps the name to a config directory and what rejects an
+unknown name. `local-nomidbox` went undocumented for its entire existence while being fully
+supported there, so a prose list that omits a mode is the expected failure, not a surprising one.
 
 | Mode | Config dir (from `homeassistant-dev/`) | Purpose |
 |------|------------------------------------------|---------|
@@ -118,8 +124,10 @@ fourth, `local-nomidbox` — `verified-against-code` — `homeassistant-dev/dock
 
 ### Validation expectations
 
-These are project acceptance criteria, not properties of any file — nothing in the tree enforces
-them. `asserted-unverified` — `CLAUDE.md` "Validation requirements":
+Project acceptance criteria for a mode sweep, not properties of any file — no test or CI job
+enforces them, so a sweep is evidence only if its result was written down. The most recent one that
+was covers the three modes below — `asserted-unverified` — `CHANGELOG.md` 3.4.0-rc.1 ("three-mode
+entity-parity sweep passed (cloud/local/hybrid, registry-level)"):
 
 | Mode | Expectation |
 |------|-------------|
@@ -128,9 +136,9 @@ them. `asserted-unverified` — `CLAUDE.md` "Validation requirements":
 | Hybrid | Polls locally with cloud supplemental data |
 | All | Small margin OK for live readings (cloud lag) |
 
-Configs share HA user accounts/UI (copied from `./config`); each config has the EG4 entry removed for
-fresh configuration — `asserted-unverified` — `CLAUDE.md` "Setup details". The config directories are
-not in this repo, so the claim cannot be checked from the tree.
+Each mode is a **separate HA instance** with its own config directory, so entity registries, options
+and integration entries do not carry across a switch. None of it is in this repo, so nothing about
+those directories is checkable from the tree.
 
 ## Mode switch script
 
@@ -196,10 +204,10 @@ dev-environment consequence.
 
 | Hazard | Rule | Grade |
 |--------|------|-------|
-| One mode at a time | Compose declares exactly one `/config` bind and the script rewrites that single line, so the four modes are structurally mutually exclusive — `verified-against-code` — `docker-compose.yaml:23`, `eg4-switch-mode.sh:49-54`. The stated reasons (API rate limits, Modbus collisions) are `asserted-unverified` — `CLAUDE.md` "Setup details" | mixed, as noted |
+| One mode at a time | Compose declares exactly one `/config` bind and the script rewrites that single line, so the modes are structurally mutually exclusive — you cannot run two by accident. Running a *second* HA against the same hardware is a different problem, constrained by the single-client gateway ([above](#prod-owns-the-gateway)) | `verified-against-code` — `docker-compose.yaml:23`, `eg4-switch-mode.sh:49-54` |
 | Dongle single-client | Scripts that talk to the dongle require HA stopped or in cloud-only mode; `scripts/probe_gridboss_nbu_regs.py` states this in its module docstring under **Requirements** ("No other client connected to the dongle (single-client limitation)", "HA container should be stopped or in cloud-only mode") | `verified-against-code` for the script's stated requirement — `scripts/probe_gridboss_nbu_regs.py:15-19` |
-| pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after a switch if that happens | `asserted-unverified` — `memory/dev-container-pylxpweb-pin-bump-gotcha.md`; narrated in `CLAUDE.md` v3.4.0-beta.21 |
-| Bind-mounted pylxpweb source can be wiped | A `docker restart` has been observed deleting bind-mounted `src/pylxpweb/`; commit before restarting, recover with `git restore src/pylxpweb/` | `asserted-unverified` — `memory/dev-container-deletes-pylxpweb-src.md`; recovery command in `CLAUDE.md` "Common Issues" |
+| pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after a switch if that happens | `asserted-unverified` — `memory/dev-container-pylxpweb-pin-bump-gotcha.md` |
+| Bind-mounted pylxpweb source can be wiped | A `docker restart` has been observed deleting bind-mounted `src/pylxpweb/`; commit before restarting, recover with `git restore src/pylxpweb/` | `asserted-unverified` — `memory/dev-container-deletes-pylxpweb-src.md` |
 | Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | `verified-against-code` — `eg4-switch-mode.sh:66-68` |
 | `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` on every run | `verified-against-code` — `eg4-switch-mode.sh:49` |
 

--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -7,13 +7,13 @@ sources:
   - tests/requirements-test.txt
   - scripts/probe_gridboss_nbu_regs.py
   - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
-  - ../docker-compose.yaml (parent homeassistant-dev)
-  - ../scripts/eg4-switch-mode.sh (parent homeassistant-dev)
+  - the parent workspace containing this repo — its docker-compose.yaml and
+    scripts/ (unversioned; see "The parent workspace cannot be pinned")
   - memory/prod-is-hybrid-dev-contends-modbus.md
   - memory/dev-container-pylxpweb-pin-bump-gotcha.md
   - memory/dev-container-deletes-pylxpweb-src.md
 verified-against: 9f6d6e2
-last-verified: 2026-08-08
+last-verified: 2026-08-09
 ---
 
 # Dev environment
@@ -59,21 +59,51 @@ uv run ruff format
 uv run mypy
 ```
 
+## The parent workspace cannot be pinned
+
+The docker setup does not live in this repository. It lives in the **parent directory that contains
+this clone** — the compose file and the `scripts/` helpers sit one level above `eg4_web_monitor/`.
+
+**That parent directory is not under version control.** It has no `.git`, and no ancestor of it is a
+repository either, so there is no commit, tag or version that anyone could cite. Verified by running
+`git rev-parse --show-toplevel` from it: it fails with *"not a git repository (or any of the parent
+directories)"*.
+
+The consequence is unavoidable and this chapter states it rather than working around it:
+
+> **Every claim on this page sourced from the parent workspace is `asserted-unverified`** — sourced
+> from an unversioned local working directory; no durable revision exists to pin, so it cannot be
+> code-verified. This holds however precisely the claim is cited.
+
+Line numbers are still given below, because they are genuinely useful to anyone sitting at that
+machine. **They are not evidence.** They are offsets into a file that may already differ on any other
+machine, that no revision identifies, and that cannot be recovered as it was if it changes. A reader
+who cannot open that directory has no way to check any of it.
+
+**This is a real gap, not a formality.** A substantial part of the operations knowledge below — the
+container topology, the four modes, the whole mode-switch hazard set — rests on a source only the
+maintainer can audit. The knowledge is accurate and worth keeping; it simply is not verifiable by the
+standard the rest of this wiki is held to. Treat it as reliable operational lore, and re-read the
+actual files before depending on a detail.
+
+Everything else on this page — `prek.toml`, `tests/requirements-test.txt`, `scripts/probe_gridboss_nbu_regs.py`,
+`.github/workflows/quality-validation.yml` — is in **this** repo and keeps its grade at `9f6d6e2`.
+
 ## Home Assistant docker container
 
-Lives in the **parent** repo `homeassistant-dev/` (sibling of this clone), not inside eg4_web_monitor.
+Parent-workspace sourced — `asserted-unverified` throughout, per the section above.
 
-| Fact | Value | Grade |
-|------|-------|-------|
-| Compose file | `homeassistant-dev/docker-compose.yaml`, service block `:14-32` | `verified-against-code` |
-| Service / container | `homeassistant` / `homeassistant-dev` | `verified-against-code` — `docker-compose.yaml:14-16` |
-| Image | `homeassistant/home-assistant:latest` | `verified-against-code` — `docker-compose.yaml:15` |
-| UI port | `8123` → http://localhost:8123 | `verified-against-code` — `docker-compose.yaml:29-30` |
-| Container Python | 3.13 | `inferred` — the pylxpweb mount targets `/usr/local/lib/python3.13/site-packages/` (`docker-compose.yaml:27`); the image tag itself pins no version |
+| Fact | Value | Cited at (not evidence) |
+|------|-------|-------------------------|
+| Compose file | `docker-compose.yaml` in the parent workspace, service block `:14-32` | — |
+| Service / container | `homeassistant` / `homeassistant-dev` | `docker-compose.yaml:14-16` |
+| Image | `homeassistant/home-assistant:latest` | `docker-compose.yaml:15` |
+| UI port | `8123` → http://localhost:8123 | `docker-compose.yaml:29-30` |
+| Container Python | 3.13 — `inferred` from the pylxpweb mount targeting `/usr/local/lib/python3.13/site-packages/`; the image tag itself pins no version | `docker-compose.yaml:27` |
 
 ### Bind mounts (host → container)
 
-`verified-against-code` — `homeassistant-dev/docker-compose.yaml:21-28`
+`asserted-unverified` — parent workspace `docker-compose.yaml:21-28`
 
 | Host path (from `homeassistant-dev/`) | Container path | Purpose |
 |---------------------------------------|----------------|---------|
@@ -82,11 +112,11 @@ Lives in the **parent** repo `homeassistant-dev/` (sibling of this clone), not i
 | `../python/pylxpweb/src/pylxpweb` (`:27`) | `/usr/local/lib/python3.13/site-packages/pylxpweb` | Live library source over site-packages |
 
 The same container also mounts two unrelated integrations — `intellicenter` (`:25`) and
-`brilliant_mqtt` (`:26`) — so restarting it restarts those too — `verified-against-code` —
-`docker-compose.yaml:25-26`.
+`brilliant_mqtt` (`:26`) — so restarting it restarts those too — `asserted-unverified` — parent
+workspace `docker-compose.yaml:25-26`.
 
-Code is bind-mounted, so an edit lands inside the container immediately — `verified-against-code` —
-`docker-compose.yaml:24`, `:27`. **But a running Python process does not re-import a changed
+Code is bind-mounted, so an edit lands inside the container immediately — `asserted-unverified` —
+parent workspace `docker-compose.yaml:24`, `:27`. **But a running Python process does not re-import a changed
 module**, so the edit is live on disk and inert in the running integration until the container
 restarts. That gap is the trap: the file is visibly correct, the behavior is visibly old, and it
 reads as though the edit failed. Restart before concluding anything about a code change —
@@ -107,8 +137,9 @@ End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker
 
 ## Four test modes
 
-There are **four** modes — `verified-against-code` — `homeassistant-dev/docker-compose.yaml:5-11`
-(mode comment block) and `homeassistant-dev/scripts/eg4-switch-mode.sh:20-43`.
+There are **four** modes — `asserted-unverified` — parent workspace `docker-compose.yaml:5-11`
+(mode comment block) and `scripts/eg4-switch-mode.sh:20-43`. The four modes are real and the list is
+correct; it is the *grade* that the unversioned source caps, not the knowledge.
 
 **Take the mode list from the script's `case` statement, never from prose.** A mode exists if and
 only if it has a `case` arm; the arm is what maps the name to a config directory and what rejects an
@@ -142,8 +173,9 @@ those directories is checkable from the tree.
 
 ## Mode switch script
 
-**File:** `homeassistant-dev/scripts/eg4-switch-mode.sh`
-`verified-against-code` — `eg4-switch-mode.sh:12-74`
+**File:** `scripts/eg4-switch-mode.sh` in the parent workspace
+`asserted-unverified` — `eg4-switch-mode.sh:12-74` (unversioned source; see
+[above](#the-parent-workspace-cannot-be-pinned))
 
 What it actually does:
 
@@ -166,7 +198,7 @@ grep ":/config" docker-compose.yaml | head -1
 `config-local-nomidbox`. Every pattern ends `:/config`, so `- ./config-local:/config` cannot match
 inside `- ./config-local-nomidbox:/config` (the next character there is `-`, not `:`). Chained
 rewrites within the one `sed` invocation are idempotent for all four modes, so reordering the
-expressions would change nothing — `verified-against-code` — `eg4-switch-mode.sh:49-54`.
+expressions would change nothing — `asserted-unverified` — `eg4-switch-mode.sh:49-54`.
 
 **Real hazard — missing config directory.** The script never checks that the target directory
 exists; it edits compose and runs `docker-compose up -d` regardless (`:49-68`,
@@ -204,15 +236,17 @@ dev-environment consequence.
 
 | Hazard | Rule | Grade |
 |--------|------|-------|
-| One mode at a time | Compose declares exactly one `/config` bind and the script rewrites that single line, so the modes are structurally mutually exclusive — you cannot run two by accident. Running a *second* HA against the same hardware is a different problem, constrained by the single-client gateway ([above](#prod-owns-the-gateway)) | `verified-against-code` — `docker-compose.yaml:23`, `eg4-switch-mode.sh:49-54` |
+| One mode at a time | Compose declares exactly one `/config` bind and the script rewrites that single line, so the modes are structurally mutually exclusive — you cannot run two by accident. Running a *second* HA against the same hardware is a different problem, constrained by the single-client gateway ([above](#prod-owns-the-gateway)) | `asserted-unverified` — parent workspace `docker-compose.yaml:23`, `eg4-switch-mode.sh:49-54` |
 | Dongle single-client | Scripts that talk to the dongle require HA stopped or in cloud-only mode; `scripts/probe_gridboss_nbu_regs.py` states this in its module docstring under **Requirements** ("No other client connected to the dongle (single-client limitation)", "HA container should be stopped or in cloud-only mode") | `verified-against-code` for the script's stated requirement — `scripts/probe_gridboss_nbu_regs.py:15-19` |
 | pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after a switch if that happens | `asserted-unverified` — `memory/dev-container-pylxpweb-pin-bump-gotcha.md` |
 | Bind-mounted pylxpweb source can be wiped | A `docker restart` has been observed deleting bind-mounted `src/pylxpweb/`; commit before restarting, recover with `git restore src/pylxpweb/` | `asserted-unverified` — `memory/dev-container-deletes-pylxpweb-src.md` |
-| Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | `verified-against-code` — `eg4-switch-mode.sh:66-68` |
-| `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` on every run | `verified-against-code` — `eg4-switch-mode.sh:49` |
+| Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | `asserted-unverified` — `eg4-switch-mode.sh:66-68` |
+| `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` on every run | `asserted-unverified` — `eg4-switch-mode.sh:49` |
 
-Cross-check helper (parent): `homeassistant-dev/scripts/compare_ha_vs_cloud.py` compares HA state
-against the cloud API — `verified-against-code` — the file is present in the parent repo's `scripts/`.
+Cross-check helper: `scripts/compare_ha_vs_cloud.py` in the parent workspace compares HA state
+against the cloud API — `asserted-unverified`; it is **not** in this repo (`git cat-file -e
+9f6d6e2:scripts/compare_ha_vs_cloud.py` fails), so it carries the same unversioned-source cap.
+Not to be confused with `scripts/probe_gridboss_nbu_regs.py`, which **is** tracked here.
 
 ## Agent copy-paste: live validation
 

--- a/llmwiki/50-operations/dev-environment.md
+++ b/llmwiki/50-operations/dev-environment.md
@@ -1,11 +1,17 @@
 ---
 canonical-for: local development setup, HA docker bind mounts, four-mode testing, mode switch hazards
 sources:
-  - /tmp/llmwiki-research/repo-operations.md
   - docs/DEVELOPMENT.md
   - CLAUDE.md
+  - prek.toml
+  - tests/requirements-test.txt
+  - scripts/probe_gridboss_nbu_regs.py
+  - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
   - ../docker-compose.yaml (parent homeassistant-dev)
   - ../scripts/eg4-switch-mode.sh (parent homeassistant-dev)
+  - memory/prod-is-hybrid-dev-contends-modbus.md
+  - memory/dev-container-pylxpweb-pin-bump-gotcha.md
+  - memory/dev-container-deletes-pylxpweb-src.md
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
@@ -16,7 +22,10 @@ How an agent develops against this two-repo stack: **eg4_web_monitor** (this rep
 
 ## Python tooling (`uv`)
 
-**verified-against-code** — `docs/DEVELOPMENT.md:11-18`
+The documented setup procedure — `asserted-unverified` — `docs/DEVELOPMENT.md:11-19`. Nothing in the
+tree enforces it; the Python floor it states (3.13) is corroborated by CI, which runs the Gold and
+Platinum jobs on 3.13 (`verified-against-code` — `.github/workflows/quality-validation.yml`,
+`platinum-strict-typing` step **Set up Python 3.13**).
 
 ```bash
 git clone https://github.com/joyfulhouse/eg4_web_monitor.git
@@ -26,9 +35,10 @@ source .venv/bin/activate
 uv pip install -r tests/requirements-test.txt
 ```
 
-Agent day-to-day commands prefer `uv run` (no activate required) — **verified-against-code** — `CLAUDE.md` Testing section / `prek.toml` mypy hook.
+Agent day-to-day commands prefer `uv run` (no activate required) — `verified-against-code` —
+`prek.toml:22`, whose mypy hook runs `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/`.
 
-Pinned quality tools — **verified-against-code** — `tests/requirements-test.txt:19-21`:
+Pinned quality tools — `verified-against-code` — `tests/requirements-test.txt:20-21`:
 
 | Package | Pin | Why |
 |---------|-----|-----|
@@ -37,7 +47,8 @@ Pinned quality tools — **verified-against-code** — `tests/requirements-test.
 
 ### pylxpweb sibling setup
 
-**verified-against-code** — pylxpweb `docs/DEVELOPMENT.md` (sibling repo):
+`asserted-unverified` — pylxpweb `docs/DEVELOPMENT.md` (sibling repo); a documented procedure, not a
+tree-enforced one:
 
 ```bash
 cd ../python/pylxpweb   # relative to homeassistant-dev/
@@ -54,22 +65,31 @@ Lives in the **parent** repo `homeassistant-dev/` (sibling of this clone), not i
 
 | Fact | Value | Grade |
 |------|-------|-------|
-| Compose file | `homeassistant-dev/docker-compose.yaml` | verified-against-code — compose L14–36 |
-| Service / container | `homeassistant` / `homeassistant-dev` | verified-against-code |
-| Image | `homeassistant/home-assistant:latest` | verified-against-code |
-| UI port | `8123` → http://localhost:8123 | verified-against-code |
+| Compose file | `homeassistant-dev/docker-compose.yaml`, service block `:14-32` | `verified-against-code` |
+| Service / container | `homeassistant` / `homeassistant-dev` | `verified-against-code` — `docker-compose.yaml:14-16` |
+| Image | `homeassistant/home-assistant:latest` | `verified-against-code` — `docker-compose.yaml:15` |
+| UI port | `8123` → http://localhost:8123 | `verified-against-code` — `docker-compose.yaml:29-30` |
+| Container Python | 3.13 | `inferred` — the pylxpweb mount targets `/usr/local/lib/python3.13/site-packages/` (`docker-compose.yaml:27`); the image tag itself pins no version |
 
 ### Bind mounts (host → container)
 
-**verified-against-code** — `homeassistant-dev/docker-compose.yaml:24-28`
+`verified-against-code` — `homeassistant-dev/docker-compose.yaml:21-28`
 
 | Host path (from `homeassistant-dev/`) | Container path | Purpose |
 |---------------------------------------|----------------|---------|
-| `./eg4_web_monitor/custom_components/eg4_web_monitor` | `/config/custom_components/eg4_web_monitor` | Live integration code |
-| `../python/pylxpweb/src/pylxpweb` | `/usr/local/lib/python3.13/site-packages/pylxpweb` | Live library source over site-packages |
-| Mode-selected `./config*` | `/config` | HA config directory (see modes below) |
+| Mode-selected `./config*` (`:23`) | `/config` | HA config directory (see modes below) |
+| `./eg4_web_monitor/custom_components/eg4_web_monitor` (`:24`) | `/config/custom_components/eg4_web_monitor` | Live integration code |
+| `../python/pylxpweb/src/pylxpweb` (`:27`) | `/usr/local/lib/python3.13/site-packages/pylxpweb` | Live library source over site-packages |
 
-Code is bind-mounted; **Python import changes still require a container restart** because the interpreter already loaded modules — **verified-against-code** — `CLAUDE.md` Docker section.
+The same container also mounts two unrelated integrations — `intellicenter` (`:25`) and
+`brilliant_mqtt` (`:26`) — so restarting it restarts those too — `verified-against-code` —
+`docker-compose.yaml:25-26`.
+
+Code is bind-mounted, so edits are visible immediately, but **Python import changes still require a
+container restart** — `asserted-unverified` — `CLAUDE.md` "Common Issues" ("Changes not reflecting:
+Container restart required for Python imports"). The bind mount itself is
+`verified-against-code` (`docker-compose.yaml:24`, `:27`); the restart requirement is the doc's
+claim about interpreter behavior, not something this tree proves.
 
 ```bash
 # Soft restart after import changes (integration or pylxpweb)
@@ -81,11 +101,13 @@ cd ../   # homeassistant-dev/
 docker-compose down && docker-compose up -d
 ```
 
-End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker mounts above, not HACS — **inferred** from `docs/DEVELOPMENT.md` + `hacs.json`.
+End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker mounts above, not HACS — `inferred` from `docs/DEVELOPMENT.md` + `hacs.json`.
 
 ## Four test modes
 
-`CLAUDE.md` documents three modes. Compose and the switch script also support a fourth — **verified-against-code** — `homeassistant-dev/docker-compose.yaml:4-12`, `homeassistant-dev/scripts/eg4-switch-mode.sh:20-41`.
+`CLAUDE.md` "Multi-Mode Testing" documents three modes. Compose and the switch script both support a
+fourth, `local-nomidbox` — `verified-against-code` — `homeassistant-dev/docker-compose.yaml:5-11`
+(mode comment block), `homeassistant-dev/scripts/eg4-switch-mode.sh:20-43` (the `case` statement).
 
 | Mode | Config dir (from `homeassistant-dev/`) | Purpose |
 |------|------------------------------------------|---------|
@@ -96,7 +118,8 @@ End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker
 
 ### Validation expectations
 
-**verified-against-code** — `CLAUDE.md` Multi-Mode Testing section:
+These are project acceptance criteria, not properties of any file — nothing in the tree enforces
+them. `asserted-unverified` — `CLAUDE.md` "Validation requirements":
 
 | Mode | Expectation |
 |------|-------------|
@@ -105,20 +128,23 @@ End-user install is HACS zip (`INSTALL.md` / `hacs.json`); agents use the docker
 | Hybrid | Polls locally with cloud supplemental data |
 | All | Small margin OK for live readings (cloud lag) |
 
-Configs share HA user accounts/UI (copied from `./config`); each config has the EG4 entry removed for fresh configuration — **verified-against-code** — `CLAUDE.md`.
+Configs share HA user accounts/UI (copied from `./config`); each config has the EG4 entry removed for
+fresh configuration — `asserted-unverified` — `CLAUDE.md` "Setup details". The config directories are
+not in this repo, so the claim cannot be checked from the tree.
 
 ## Mode switch script
 
 **File:** `homeassistant-dev/scripts/eg4-switch-mode.sh`
-**verified-against-code** — script lines 20–74
+`verified-against-code` — `eg4-switch-mode.sh:12-74`
 
 What it actually does:
 
-1. Maps `cloud|local|hybrid|local-nomidbox` → config directory.
-2. `sed -i.bak` rewrites the `*:/config` volume line in `docker-compose.yaml` for all known variants (leaves `docker-compose.yaml.bak` beside compose).
-3. Verifies the new path appears in compose.
-4. `docker-compose down` then `docker-compose up -d` (full stack restart, not soft reload).
-5. Prints access URL and log hint.
+1. `set -e` at the top: any failing command aborts the switch (`:12`).
+2. Maps `cloud|local|hybrid|local-nomidbox` → config directory; anything else prints usage and `exit 1` (`:20-43`).
+3. `sed -i.bak` rewrites the `*:/config` volume line in `docker-compose.yaml` for all four variants, leaving `docker-compose.yaml.bak` beside compose (`:49-54`).
+4. Greps compose for the new path; `exit 1` if absent (`:57-62`).
+5. `docker-compose down` then `docker-compose up -d` — full stack restart, not a soft reload, and it takes the other two integrations down with it (`:66-68`).
+6. Prints access URL and log hint (`:70-74`).
 
 ```bash
 cd homeassistant-dev/   # parent of eg4_web_monitor
@@ -128,20 +154,57 @@ cd homeassistant-dev/   # parent of eg4_web_monitor
 grep ":/config" docker-compose.yaml | head -1
 ```
 
-**sed order hazard:** `config-local-nomidbox` must be rewritten **before** `config-local` or a partial match can leave the wrong directory. The script already orders the expressions correctly — **verified-against-code** — `eg4-switch-mode.sh:49-54`.
+**The sed expression order does not matter** — a natural worry, since `config-local` is a prefix of
+`config-local-nomidbox`. Every pattern ends `:/config`, so `- ./config-local:/config` cannot match
+inside `- ./config-local-nomidbox:/config` (the next character there is `-`, not `:`). Chained
+rewrites within the one `sed` invocation are idempotent for all four modes, so reordering the
+expressions would change nothing — `verified-against-code` — `eg4-switch-mode.sh:49-54`.
+
+**Real hazard — missing config directory.** The script never checks that the target directory
+exists; it edits compose and runs `docker-compose up -d` regardless (`:49-68`,
+`verified-against-code`). Docker creates a missing bind-mount source as an empty directory, so a
+typo or an un-provisioned mode yields a **fresh, empty Home Assistant** — onboarding screen, no
+integration, no entities — rather than an error. Confirm the directory exists before switching —
+`inferred` from the absent check plus Docker's bind-mount auto-create behavior.
 
 ## Operational hazards (do not skip)
 
+<a id="prod-owns-the-gateway"></a>
+
+### Production owns the Modbus gateway
+
+**Production Home Assistant runs in HYBRID mode and holds the gateway's single allowed connection.
+Stop the `homeassistant-dev` container before any local Modbus or dongle probing.** If both clients
+compete, production does not error — it silently degrades to cloud-fallback, and the sensors that
+only exist on the local transport go stale or unavailable with no alarm.
+
+`asserted-unverified` — `docs/reference/firmware/HYBRID_EPS_REGISTERS.md:303-304` (§8 "Reproducing
+this"), corroborated by `memory/prod-is-hybrid-dev-contends-modbus.md`. Both are prose records of an
+operational deployment; the production topology is not represented anywhere in this repo, so no code
+citation is possible. Treat it as a hard operating rule regardless — the failure mode is silent.
+
+```bash
+docker stop homeassistant-dev     # before any local Modbus/dongle probe
+docker start homeassistant-dev    # after
+```
+
+The bus-level fact that the gateway admits one client is owned by
+[`40-hardware/probing-playbook.md`](../40-hardware/probing-playbook.md); this page owns the
+dev-environment consequence.
+
+### Remaining hazards
+
 | Hazard | Rule | Grade |
 |--------|------|-------|
-| One mode at a time | Only one of cloud/local/hybrid/local-nomidbox may run — API rate limits + Modbus collisions | verified-against-code — `CLAUDE.md` |
-| Prod owns the gateway | Production runs **HYBRID** and holds the single Modbus/dongle gateway. Stop `homeassistant-dev` before local Modbus/dongle probing or production silently degrades to cloud-fallback | verified-against-code — `docs/reference/firmware/HYBRID_EPS_REGISTERS.md` (~303–304) |
-| Dongle single-client | Scripts that talk to the dongle (e.g. `scripts/probe_gridboss_nbu_regs.py`) require HA stopped or cloud-only mode | verified-against-code — probe script header / research dossier |
-| pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after EVERY switch if that happens | asserted-unverified in-repo (recorded in CLAUDE.md beta.21 narrative + beads memory); treat as operational fact |
-| Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | verified-against-code — `eg4-switch-mode.sh:67-68` |
-| `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` | verified-against-code — `eg4-switch-mode.sh:49` |
+| One mode at a time | Compose declares exactly one `/config` bind and the script rewrites that single line, so the four modes are structurally mutually exclusive — `verified-against-code` — `docker-compose.yaml:23`, `eg4-switch-mode.sh:49-54`. The stated reasons (API rate limits, Modbus collisions) are `asserted-unverified` — `CLAUDE.md` "Setup details" | mixed, as noted |
+| Dongle single-client | Scripts that talk to the dongle require HA stopped or in cloud-only mode; `scripts/probe_gridboss_nbu_regs.py` states this in its module docstring under **Requirements** ("No other client connected to the dongle (single-client limitation)", "HA container should be stopped or in cloud-only mode") | `verified-against-code` for the script's stated requirement — `scripts/probe_gridboss_nbu_regs.py:15-19` |
+| pylxpweb dist-info loss | After a mode switch, a fresh container layer can lack pylxpweb dist-info → HA pip-installs over the bind mount and breaks the integration. Recreate minimal dist-info after a switch if that happens | `asserted-unverified` — `memory/dev-container-pylxpweb-pin-bump-gotcha.md`; narrated in `CLAUDE.md` v3.4.0-beta.21 |
+| Bind-mounted pylxpweb source can be wiped | A `docker restart` has been observed deleting bind-mounted `src/pylxpweb/`; commit before restarting, recover with `git restore src/pylxpweb/` | `asserted-unverified` — `memory/dev-container-deletes-pylxpweb-src.md`; recovery command in `CLAUDE.md` "Common Issues" |
+| Mode switch restarts whole stack | Script uses `down`/`up`, not `restart` | `verified-against-code` — `eg4-switch-mode.sh:66-68` |
+| `.bak` left behind | `sed -i.bak` creates `docker-compose.yaml.bak` on every run | `verified-against-code` — `eg4-switch-mode.sh:49` |
 
-Cross-check helper (parent): `homeassistant-dev/scripts/compare_ha_vs_cloud.py` (HA WebSocket vs cloud API) — **verified-against-code** — file exists in parent `scripts/`.
+Cross-check helper (parent): `homeassistant-dev/scripts/compare_ha_vs_cloud.py` compares HA state
+against the cloud API — `verified-against-code` — the file is present in the parent repo's `scripts/`.
 
 ## Agent copy-paste: live validation
 

--- a/llmwiki/50-operations/issue-pipeline.md
+++ b/llmwiki/50-operations/issue-pipeline.md
@@ -91,7 +91,7 @@ Form emptiness alone is not enough — phone logcat or screenshots pass the form
 | Topic | Fact | Grade |
 |-------|------|-------|
 | In-repo PR template | **None** under `.github/` | `verified-against-code` — no `PULL_REQUEST_TEMPLATE` file exists |
-| Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | `asserted-unverified` — `docs/DEVELOPMENT.md:39-41` points there; the linked file lives in another repo and is not checked here |
+| Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | `asserted-unverified` — `docs/DEVELOPMENT.md` "Quality Checks" points there; the linked file lives in another repo and is not checked here |
 | CODEOWNERS | `* @btli` | `verified-against-code` — `.github/CODEOWNERS` |
 | Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | `inferred` — `CHANGELOG.md` release narratives |
 | Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | `verified-against-code` — `.github/ISSUE_TEMPLATE/*.yml`, `.github/workflows/issue-triage.yml`, `.github/workflows/issue-log-validation.yml` |

--- a/llmwiki/50-operations/issue-pipeline.md
+++ b/llmwiki/50-operations/issue-pipeline.md
@@ -9,10 +9,13 @@ sources:
   - AGENTS.md
   - scripts/bd_seed_maintainability.sh
   - .github/CODEOWNERS
+  - pylxpweb .github/workflows/dependabot-auto-merge.yml
   - memory/sprint-2026-07-16-issue-zeroing.md
   - memory/issue-pipeline-log-enforcement.md
-verified-against: 9f6d6e2
-last-verified: 2026-08-08
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
+last-verified: 2026-08-09
 ---
 
 # Issue and PR pipeline
@@ -95,7 +98,31 @@ Form emptiness alone is not enough — phone logcat or screenshots pass the form
 | CODEOWNERS | `* @btli` | `verified-against-code` — `.github/CODEOWNERS` |
 | Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | `inferred` — `CHANGELOG.md` release narratives |
 | Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | `verified-against-code` — `.github/ISSUE_TEMPLATE/*.yml`, `.github/workflows/issue-triage.yml`, `.github/workflows/issue-log-validation.yml` |
-| Auto-merge | **Not** enabled here — eg4_web_monitor has no auto-merge workflow. pylxpweb auto-merges Dependabot PRs for non-major bumps only | `verified-against-code` — no auto-merge workflow under eg4 `.github/workflows/`; pylxpweb `.github/workflows/dependabot-auto-merge.yml` (`if: steps.metadata.outputs.update-type != 'version-update:semver-major'`) |
+| Auto-merge (this repo) | **None.** No workflow in eg4_web_monitor approves or merges anything; nothing here uses `pull_request_target` either | `verified-against-code` — eg4_web_monitor@`9f6d6e2`: the eight files under `.github/workflows/` contain no `--auto`, `auto-merge` or `pull_request_target` |
+| Auto-merge (pylxpweb) | pylxpweb **approves and enables auto-merge** on Dependabot PRs for non-major bumps; major bumps get a comment demanding manual review and are not approved | `verified-against-code` — pylxpweb@`204b95d` `.github/workflows/dependabot-auto-merge.yml:27-39` (both the `gh pr review --approve` and `gh pr merge --auto --squash` steps carry `if: steps.metadata.outputs.update-type != 'version-update:semver-major'`), `:41-47` (major → comment only) |
+
+### What the pylxpweb auto-merge actually exposes
+
+Read the surface before changing anything there, because it is the one workflow in either repo that
+merges code without a human — `verified-against-code` — pylxpweb@`204b95d` `dependabot-auto-merge.yml`:
+
+| Property | Value | Line |
+|---|---|---|
+| Trigger | `pull_request_target` on `opened`, `synchronize`, `reopened` | `:9-10` |
+| Token permissions | `contents: write`, `pull-requests: write` | `:12-14` |
+| Only gate | `if: github.actor == 'dependabot[bot]'` on the single job | `:19` |
+| Update classification | `dependabot/fetch-metadata@v3` — the bot's own metadata decides major vs non-major | `:21-25` |
+
+`pull_request_target` runs in the **base** repo context with those write permissions, which is why it
+is normally dangerous. The mitigating property here is that the job **never checks out the PR head** —
+its four steps only run `gh pr` commands against the PR URL, and the URL is passed via `env:` rather
+than interpolated into the shell — `verified-against-code` — `:20-47` (the job's complete step list).
+The file states this reasoning itself at `:1-5`.
+
+Two limits worth stating precisely. `gh pr merge --auto` **enables** GitHub's auto-merge; it does not
+force a merge, so required status checks still apply — but *which* checks are required is branch
+protection, a repository setting, and therefore **not determinable from the tree**. And the
+major/non-major split is only as trustworthy as `fetch-metadata`'s classification of the bot's own PR.
 
 ## Work tracking (beads / `bd`)
 

--- a/llmwiki/50-operations/issue-pipeline.md
+++ b/llmwiki/50-operations/issue-pipeline.md
@@ -91,7 +91,7 @@ Form emptiness alone is not enough — phone logcat or screenshots pass the form
 |-------|------|-------|
 | In-repo PR template | **None** under `.github/` | verified-against-code — absent |
 | Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | verified-against-code — `docs/DEVELOPMENT.md:39-41` |
-| CODEOWNERS | `* @btli` | verified-against-code — `.github/CODEOWNERS` (if present; confirm before relying) |
+| CODEOWNERS | `* @btli` | verified-against-code — `.github/CODEOWNERS` |
 | Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | inferred |
 | Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | verified-against-code |
 | Auto-merge | **Not** enabled for eg4_web_monitor workflows. pylxpweb has Dependabot auto-merge for non-major only | verified-against-code — dossier §4.4 |

--- a/llmwiki/50-operations/issue-pipeline.md
+++ b/llmwiki/50-operations/issue-pipeline.md
@@ -1,8 +1,6 @@
 ---
 canonical-for: GitHub issue templates, debug-log auto-close, PR conventions, beads work tracking prohibitions
 sources:
-  - /tmp/llmwiki-research/repo-operations.md
-  - /tmp/llmwiki-research/knowledge-corpus-index.VERIFIED-claude_code.md
   - .github/ISSUE_TEMPLATE/bug_report.yml
   - .github/ISSUE_TEMPLATE/feature_request.yml
   - .github/ISSUE_TEMPLATE/config.yml
@@ -10,6 +8,9 @@ sources:
   - .github/workflows/issue-triage.yml
   - AGENTS.md
   - scripts/bd_seed_maintainability.sh
+  - .github/CODEOWNERS
+  - memory/sprint-2026-07-16-issue-zeroing.md
+  - memory/issue-pipeline-log-enforcement.md
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
@@ -20,14 +21,14 @@ How bugs, features, PRs, and agent work tracking flow in this repo.
 
 ## Issue templates
 
-**verified-against-code** — `.github/ISSUE_TEMPLATE/config.yml`
+`verified-against-code` — `.github/ISSUE_TEMPLATE/config.yml`
 
 - `blank_issues_enabled: false` — free-form issues are disabled.
 - Contact links: Home Assistant Community, DIY Solar Forum, Discord.
 
 ### Bug report (required fields)
 
-**verified-against-code** — `.github/ISSUE_TEMPLATE/bug_report.yml`
+`verified-against-code` — `.github/ISSUE_TEMPLATE/bug_report.yml`
 
 | Field | Required |
 |-------|----------|
@@ -45,11 +46,11 @@ How bugs, features, PRs, and agent work tracking flow in this repo.
 
 Auto-label: `bug`.
 
-Template warns: companion-app “share logs” / phone logcat is **rejected** — must be HA debug logging from a browser for this integration — **verified-against-code** — `bug_report.yml:17-21`.
+Template warns: companion-app “share logs” / phone logcat is **rejected** — must be HA debug logging from a browser for this integration — `verified-against-code` — `bug_report.yml:17-21`.
 
 ### Feature request (required fields)
 
-**verified-against-code** — `.github/ISSUE_TEMPLATE/feature_request.yml`
+`verified-against-code` — `.github/ISSUE_TEMPLATE/feature_request.yml`
 
 | Field | Required |
 |-------|----------|
@@ -62,7 +63,7 @@ Auto-label: `enhancement`.
 
 ## Debug-log validation automation
 
-**verified-against-code** — `.github/workflows/issue-log-validation.yml:1-12`, marker at L45
+`verified-against-code` — `.github/workflows/issue-log-validation.yml:1-12`, marker at L45
 
 | Behavior | Detail |
 |----------|--------|
@@ -76,7 +77,7 @@ Form emptiness alone is not enough — phone logcat or screenshots pass the form
 
 ## Issue triage automation
 
-**verified-against-code** — `.github/workflows/issue-triage.yml` (dossier §4.3)
+`verified-against-code` — `.github/workflows/issue-triage.yml`
 
 | Behavior | Detail |
 |----------|--------|
@@ -89,18 +90,22 @@ Form emptiness alone is not enough — phone logcat or screenshots pass the form
 
 | Topic | Fact | Grade |
 |-------|------|-------|
-| In-repo PR template | **None** under `.github/` | verified-against-code — absent |
-| Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | verified-against-code — `docs/DEVELOPMENT.md:39-41` |
-| CODEOWNERS | `* @btli` | verified-against-code — `.github/CODEOWNERS` |
-| Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | inferred |
-| Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | verified-against-code |
-| Auto-merge | **Not** enabled for eg4_web_monitor workflows. pylxpweb has Dependabot auto-merge for non-major only | verified-against-code — dossier §4.4 |
+| In-repo PR template | **None** under `.github/` | `verified-against-code` — no `PULL_REQUEST_TEMPLATE` file exists |
+| Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | `asserted-unverified` — `docs/DEVELOPMENT.md:39-41` points there; the linked file lives in another repo and is not checked here |
+| CODEOWNERS | `* @btli` | `verified-against-code` — `.github/CODEOWNERS` |
+| Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | `inferred` — `CHANGELOG.md` release narratives |
+| Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | `verified-against-code` — `.github/ISSUE_TEMPLATE/*.yml`, `.github/workflows/issue-triage.yml`, `.github/workflows/issue-log-validation.yml` |
+| Auto-merge | **Not** enabled here — eg4_web_monitor has no auto-merge workflow. pylxpweb auto-merges Dependabot PRs for non-major bumps only | `verified-against-code` — no auto-merge workflow under eg4 `.github/workflows/`; pylxpweb `.github/workflows/dependabot-auto-merge.yml` (`if: steps.metadata.outputs.update-type != 'version-update:semver-major'`) |
 
 ## Work tracking (beads / `bd`)
 
-**verified-against-code** — `AGENTS.md`
+Work state lives under `.beads/`. The tracked files at `9f6d6e2` are `config.yaml`,
+`interactions.jsonl`, `metadata.json`, `README.md`, and `.gitignore`. **There is no
+`.beads/issues.jsonl`** in this repo — do not go looking for one; the issue store is not a tracked
+JSONL here — `verified-against-code` — `git ls-files .beads/`.
 
-Source of truth under `.beads/` (`issues.jsonl`, `interactions.jsonl`, `config.yaml`, …).
+The `bd` command set below is the workflow `AGENTS.md` prescribes, not something the tree enforces —
+`asserted-unverified` — `AGENTS.md`.
 
 ```bash
 bd ready
@@ -114,19 +119,20 @@ bd sync
 
 | Prohibition | Why | Grade |
 |-------------|-----|-------|
-| **Never run `bd github sync` in this repo** | Historically mass-pushed ~90 internal beads records as GitHub issues (#381–#470). Close beads with `bd close`; manage GitHub with `gh` | asserted-unverified in current tree (recorded in verified knowledge-corpus index / research); treat as hard policy |
-| **Never re-run `scripts/bd_seed_maintainability.sh`** | **NOT idempotent** — running twice creates duplicate epics | verified-against-code — script header L13–14 |
-| Do not use `bd edit` | Opens `$EDITOR`, blocks agents | asserted-unverified in AGENTS/hooks; prefer `bd update` flags |
-| Do not use TodoWrite / markdown files for task tracking when beads is the project tracker | Session policy | asserted-unverified (hooks / AGENTS) |
+| **Never run `bd github sync` in this repo** | Mass-pushed 90 internal beads records as GitHub issues #381–#470. Close beads with `bd close`; manage GitHub with `gh` | `asserted-unverified` — `memory/sprint-2026-07-16-issue-zeroing.md`; the issue range #381–#470 is independently visible on the GitHub repo |
+| **Never re-run `scripts/bd_seed_maintainability.sh`** | **NOT idempotent** — running twice creates duplicate epics | `verified-against-code` — `scripts/bd_seed_maintainability.sh:13-14` |
+| Do not use `bd edit` | Opens `$EDITOR`, blocks non-interactive agents | `asserted-unverified` — `AGENTS.md` |
+| Do not use TodoWrite / markdown files for task tracking when beads is the project tracker | Session policy, not enforced by anything in the tree | `asserted-unverified` — `AGENTS.md` |
 
-Seed script dry-run only if needed: `./scripts/bd_seed_maintainability.sh --dry-run` — **verified-against-code** — script L14.
+Seed script dry-run only if needed: `./scripts/bd_seed_maintainability.sh --dry-run` — `verified-against-code` — `scripts/bd_seed_maintainability.sh:14`.
 
 ### Authority conflict (push)
 
 - `AGENTS.md` “Landing the Plane” says work is incomplete until `git push` succeeds.
 - Session hooks / user rules default to **conservative**: commit/push only with explicit authority.
 
-**Agents must treat user/orchestrator instructions as highest precedence** when those conflict — **inferred** from dossier §8.2.
+**Agents must treat user/orchestrator instructions as highest precedence** when those conflict —
+`asserted-unverified` — `AGENTS.md` "Landing the Plane" versus the session-level commit/push policy.
 
 ## Agent checklist when filing or answering bugs
 

--- a/llmwiki/50-operations/issue-pipeline.md
+++ b/llmwiki/50-operations/issue-pipeline.md
@@ -1,0 +1,136 @@
+---
+canonical-for: GitHub issue templates, debug-log auto-close, PR conventions, beads work tracking prohibitions
+sources:
+  - /tmp/llmwiki-research/repo-operations.md
+  - /tmp/llmwiki-research/knowledge-corpus-index.VERIFIED-claude_code.md
+  - .github/ISSUE_TEMPLATE/bug_report.yml
+  - .github/ISSUE_TEMPLATE/feature_request.yml
+  - .github/ISSUE_TEMPLATE/config.yml
+  - .github/workflows/issue-log-validation.yml
+  - .github/workflows/issue-triage.yml
+  - AGENTS.md
+  - scripts/bd_seed_maintainability.sh
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Issue and PR pipeline
+
+How bugs, features, PRs, and agent work tracking flow in this repo.
+
+## Issue templates
+
+**verified-against-code** — `.github/ISSUE_TEMPLATE/config.yml`
+
+- `blank_issues_enabled: false` — free-form issues are disabled.
+- Contact links: Home Assistant Community, DIY Solar Forum, Discord.
+
+### Bug report (required fields)
+
+**verified-against-code** — `.github/ISSUE_TEMPLATE/bug_report.yml`
+
+| Field | Required |
+|-------|----------|
+| Integration Version | yes |
+| Home Assistant Version | yes |
+| Connection Mode | yes |
+| Device Model(s) | yes |
+| Describe the Bug | yes |
+| Steps to Reproduce | yes |
+| Debug Logs | yes |
+| Diagnostics Download | yes |
+| Confirmation checkboxes (debug logs + diagnostics) | yes |
+| Affected Entity ID(s) | no |
+| Screenshots | no |
+
+Auto-label: `bug`.
+
+Template warns: companion-app “share logs” / phone logcat is **rejected** — must be HA debug logging from a browser for this integration — **verified-against-code** — `bug_report.yml:17-21`.
+
+### Feature request (required fields)
+
+**verified-against-code** — `.github/ISSUE_TEMPLATE/feature_request.yml`
+
+| Field | Required |
+|-------|----------|
+| Problem or Use Case | yes |
+| Proposed Solution | yes |
+| Affected Device Model(s) | yes (dropdown) |
+| Alternatives Considered | no |
+
+Auto-label: `enhancement`.
+
+## Debug-log validation automation
+
+**verified-against-code** — `.github/workflows/issue-log-validation.yml:1-12`, marker at L45
+
+| Behavior | Detail |
+|----------|--------|
+| Triggers | Issue opened/edited; issue comments |
+| Check | Downloads Debug Logs attachments; greps for `custom_components.eg4_web_monitor\|pylxpweb\|eg4_web_monitor` |
+| Invalid | Label `needs-logs`, explanatory comment, **close as not planned** |
+| Later valid edit/comment | Reopen + remove `needs-logs` |
+| Exempt | OWNER / MEMBER / COLLABORATOR |
+
+Form emptiness alone is not enough — phone logcat or screenshots pass the form but fail this workflow.
+
+## Issue triage automation
+
+**verified-against-code** — `.github/workflows/issue-triage.yml` (dossier §4.3)
+
+| Behavior | Detail |
+|----------|--------|
+| Rate limit | >2 issues / 24h by same user → comment, skip triage |
+| Classification | Labels `bug` / `enhancement` / `support` / `duplicate` / `needs-info` |
+| Assignment | `@btli` for actionable bugs/enhancements |
+| Closing | Must **not** close issues (log-validation workflow is the closer) |
+
+## PR conventions
+
+| Topic | Fact | Grade |
+|-------|------|-------|
+| In-repo PR template | **None** under `.github/` | verified-against-code — absent |
+| Contribution guide | Org `CONTRIBUTING.md`: https://github.com/joyfulhouse/.github/blob/main/CONTRIBUTING.md | verified-against-code — `docs/DEVELOPMENT.md:39-41` |
+| CODEOWNERS | `* @btli` | verified-against-code — `.github/CODEOWNERS` (if present; confirm before relying) |
+| Branch naming | Not formally documented in-repo. Observed: `integration/3.4.0`, `integration/3.5.0`, `feat/…` (pylxpweb). Follow the current release-line style | inferred |
+| Labels | From templates (`bug`, `enhancement`) + triage (`support`, `duplicate`, `needs-info`, `needs-logs`) | verified-against-code |
+| Auto-merge | **Not** enabled for eg4_web_monitor workflows. pylxpweb has Dependabot auto-merge for non-major only | verified-against-code — dossier §4.4 |
+
+## Work tracking (beads / `bd`)
+
+**verified-against-code** — `AGENTS.md`
+
+Source of truth under `.beads/` (`issues.jsonl`, `interactions.jsonl`, `config.yaml`, …).
+
+```bash
+bd ready
+bd show <id>
+bd update <id> --claim   # or --status in_progress
+bd close <id>
+bd sync
+```
+
+### Standing prohibitions
+
+| Prohibition | Why | Grade |
+|-------------|-----|-------|
+| **Never run `bd github sync` in this repo** | Historically mass-pushed ~90 internal beads records as GitHub issues (#381–#470). Close beads with `bd close`; manage GitHub with `gh` | asserted-unverified in current tree (recorded in verified knowledge-corpus index / research); treat as hard policy |
+| **Never re-run `scripts/bd_seed_maintainability.sh`** | **NOT idempotent** — running twice creates duplicate epics | verified-against-code — script header L13–14 |
+| Do not use `bd edit` | Opens `$EDITOR`, blocks agents | asserted-unverified in AGENTS/hooks; prefer `bd update` flags |
+| Do not use TodoWrite / markdown files for task tracking when beads is the project tracker | Session policy | asserted-unverified (hooks / AGENTS) |
+
+Seed script dry-run only if needed: `./scripts/bd_seed_maintainability.sh --dry-run` — **verified-against-code** — script L14.
+
+### Authority conflict (push)
+
+- `AGENTS.md` “Landing the Plane” says work is incomplete until `git push` succeeds.
+- Session hooks / user rules default to **conservative**: commit/push only with explicit authority.
+
+**Agents must treat user/orchestrator instructions as highest precedence** when those conflict — **inferred** from dossier §8.2.
+
+## Agent checklist when filing or answering bugs
+
+1. Require real integration debug logs (not companion logcat).
+2. Prefer diagnostics JSON from HA (credentials redacted; serials aliased on recent versions).
+3. Do not fight the auto-closer — attach a valid log and let reopen automation run.
+4. Track agent work in beads; never `bd github sync`; never re-seed maintainability.

--- a/llmwiki/50-operations/quality-gates.md
+++ b/llmwiki/50-operations/quality-gates.md
@@ -1,0 +1,145 @@
+---
+canonical-for: lint, format, typecheck, tests, coverage, quality-scale tier validators, CI blocking vs advisory
+sources:
+  - /tmp/llmwiki-research/repo-operations.md
+  - docs/DEVELOPMENT.md
+  - CLAUDE.md
+  - tests/requirements-test.txt
+  - prek.toml
+  - .github/workflows/quality-validation.yml
+  - .github/workflows/home-assistant-validation.yml
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Quality gates
+
+Canonical local and CI gates for eg4_web_monitor. Prefer `uv run` for agents.
+
+## Local command set
+
+**verified-against-code** — `CLAUDE.md` Pre-Commit Validation; `docs/DEVELOPMENT.md:21-52`; `prek.toml`
+
+```bash
+# Lint + format (fix) — agent-preferred form
+uv run ruff check custom_components/ --fix && uv run ruff format custom_components/
+
+# Full-tree check (matches CI / docs/DEVELOPMENT.md)
+uv run ruff check .
+uv run ruff format --check .
+
+# Typecheck — must pass with ZERO errors (strict config via tests/mypy.ini)
+uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/
+
+# Tests
+uv run pytest tests/ -x --tb=short
+
+# Coverage
+uv run pytest tests/ --cov=custom_components/eg4_web_monitor --cov-report=term-missing
+
+# Combined helper
+python tests/run_tests.py --all
+
+# Tier validators (Silver / Gold / Platinum — no standalone Bronze script)
+uv run python tests/validate_silver_tier.py
+uv run python tests/validate_gold_tier.py
+uv run python tests/validate_platinum_tier.py
+```
+
+**Divergence:** `docs/DEVELOPMENT.md` shows bare `ruff`/`mypy`/`pytest` after `source .venv/bin/activate`; `CLAUDE.md` and `prek.toml` use `uv run`. Both work if the venv is provisioned; agents should prefer `uv run` — **verified-against-code**.
+
+### Pre-commit / prek hooks
+
+**verified-against-code** — `prek.toml:1-23`
+
+| Hook | Behavior |
+|------|----------|
+| check-yaml, end-of-file-fixer, trailing-whitespace, check-added-large-files | Standard hygiene |
+| ruff `--fix` + ruff-format | Rev `v0.15.5` |
+| mypy | `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` |
+
+## Pins that must stay in lockstep
+
+**verified-against-code** — `tests/requirements-test.txt:19-21`
+
+| Tool | Pin | Failure mode if floated |
+|------|-----|-------------------------|
+| `ruff` | **0.15.5** | Unpinned CI floated to 0.16 and failed repo-wide (#482) |
+| `mypy` | **2.3.0** | Keep in sync with `quality-validation.yml` |
+
+Sync surfaces: `tests/requirements-test.txt`, `prek.toml`, `.github/workflows/quality-validation.yml`.
+
+**Strict typing gate:** Platinum CI and local mypy must exit 0 with zero errors — **verified-against-code** — `quality-validation.yml` `platinum-strict-typing` job (`exit 1` on failure).
+
+## Quality scale tiers
+
+| Tier | How enforced | Local script |
+|------|--------------|--------------|
+| Bronze | Directly in `quality-validation.yml` | None (no standalone validator) — **verified-against-code** — `docs/DEVELOPMENT.md:54-55` |
+| Silver | CI job + script | `tests/validate_silver_tier.py` |
+| Gold | CI job + script | `tests/validate_gold_tier.py` |
+| Platinum | CI job + script | `tests/validate_platinum_tier.py` |
+
+Tier sequencing in CI: Silver `needs: bronze-summary` → Gold `needs: silver-summary` → Platinum `needs: gold-summary` (fail-fast across tiers) — **verified-against-code** — `quality-validation.yml`.
+
+## CI workflows
+
+**verified-against-code** — workflow `on:` blocks
+
+| Workflow | File | Triggers | Role |
+|----------|------|----------|------|
+| Quality Tier Validation | `.github/workflows/quality-validation.yml` | **push → `develop` only**; PR → `main`,`develop`; `workflow_dispatch` | Bronze→Silver→Gold→Platinum |
+| Home Assistant Validation | `.github/workflows/home-assistant-validation.yml` | push → `develop`; PR → `main`,`develop`; daily cron; dispatch | hassfest + HACS |
+| Release | `.github/workflows/release.yml` | `release: published` | Zip + attach `eg4_web_monitor.zip` |
+| Issue Log Validation | `.github/workflows/issue-log-validation.yml` | issues opened/edited; comments | Auto-close bad debug logs |
+| Issue Triage | `.github/workflows/issue-triage.yml` | issues opened (+ dispatch) | Claude triage + rate limit |
+| Claude Code | `.github/workflows/claude.yml` | @claude on comments/reviews (collaborators) | Interactive assist |
+
+**Push quality gate is develop-only.** Pushing to `main` does **not** run `quality-validation.yml` — **verified-against-code** — `quality-validation.yml:3-7`. Note: `.github/WORKFLOWS.md` is stale if it claims push to `main` or `develop` — prefer the YAML.
+
+### Python version split
+
+**verified-against-code** — `quality-validation.yml`
+
+| Jobs | Python |
+|------|--------|
+| Bronze ruff/syntax | 3.12 |
+| Gold coverage + Platinum mypy/tests | 3.13 |
+
+## Blocking vs advisory (quality-validation.yml)
+
+### Blocking (job fails / `exit 1`)
+
+Majority of Bronze/Silver/Gold/Platinum steps, including:
+
+- Ruff lint + format check (`bronze-code-quality`)
+- Bandit (`bronze-security-scan`)
+- `pytest` with coverage in `gold-test-coverage` (ignores `tests/test_plant_api.py`)
+- Strict mypy in `platinum-strict-typing`
+- Tier scripts: `validate_silver_tier.py`, `validate_gold_tier.py`, `validate_platinum_tier.py`
+- Translation completeness via `tests/validate_translations.py`
+
+### Advisory / soft (warn only)
+
+**verified-against-code** — `quality-validation.yml` cited lines:
+
+| Check | Behavior |
+|-------|----------|
+| `bronze-entity-naming` | Prints `⚠️` if `has_entity_name` missing — **does not `exit 1`** (~152–156) |
+| `silver-entity-availability` | `⚠️` if no `def available` found — **no exit 1** (~358–360) |
+| `platinum-comprehensive-tests` | API client / coordinator platinum tests use `\|\| echo "⚠️ … (non-blocking)"` (~864–875) |
+| Codecov upload | `fail_ci_if_error: false` (~678) |
+
+## Agent pre-PR gate (integration)
+
+```bash
+cd eg4_web_monitor/   # repo root
+uv run ruff check . --fix && uv run ruff format .
+uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/
+uv run pytest tests/ -x --tb=short
+uv run python tests/validate_silver_tier.py
+uv run python tests/validate_gold_tier.py
+uv run python tests/validate_platinum_tier.py
+```
+
+**Test-count drift:** `CLAUDE.md` still says “692 tests”; recent CHANGELOG/CI narratives cite 2000+. Do not treat the CLAUDE.md count as authoritative — **inferred** from dossier §9.

--- a/llmwiki/50-operations/quality-gates.md
+++ b/llmwiki/50-operations/quality-gates.md
@@ -1,10 +1,10 @@
 ---
 canonical-for: lint, format, typecheck, tests, coverage, quality-scale tier validators, CI blocking vs advisory
 sources:
-  - /tmp/llmwiki-research/repo-operations.md
   - docs/DEVELOPMENT.md
   - CLAUDE.md
   - tests/requirements-test.txt
+  - tests/mypy.ini
   - prek.toml
   - .github/workflows/quality-validation.yml
   - .github/workflows/home-assistant-validation.yml
@@ -18,7 +18,10 @@ Canonical local and CI gates for eg4_web_monitor. Prefer `uv run` for agents.
 
 ## Local command set
 
-**verified-against-code** — `CLAUDE.md` Pre-Commit Validation; `docs/DEVELOPMENT.md:21-52`; `prek.toml`
+The tool invocations are `verified-against-code` — `prek.toml` (ruff `rev`, mypy hook `entry`) and
+`.github/workflows/quality-validation.yml` (jobs `bronze-code-quality`, `gold-test-coverage`,
+`platinum-strict-typing`). The command *listing* below also appears in `docs/DEVELOPMENT.md:21-52`,
+which is prose and is cited as corroboration only.
 
 ```bash
 # Lint + format (fix) — agent-preferred form
@@ -46,11 +49,15 @@ uv run python tests/validate_gold_tier.py
 uv run python tests/validate_platinum_tier.py
 ```
 
-**Divergence:** `docs/DEVELOPMENT.md` shows bare `ruff`/`mypy`/`pytest` after `source .venv/bin/activate`; `CLAUDE.md` and `prek.toml` use `uv run`. Both work if the venv is provisioned; agents should prefer `uv run` — **verified-against-code**.
+**Divergence:** `docs/DEVELOPMENT.md:23-37` shows bare `ruff`/`mypy`/`pytest`, which assume the
+activated venv from its own setup block (`:13-19`); `prek.toml`'s mypy hook invokes `uv run`. Both
+work once the venv is provisioned; agents should prefer `uv run` because it needs no activation. The
+`uv run` form is `verified-against-code` — `prek.toml:22`; the bare form is what
+`docs/DEVELOPMENT.md:23-37` prints, quoted here as the text being compared, not as authority.
 
 ### Pre-commit / prek hooks
 
-**verified-against-code** — `prek.toml:1-23`
+`verified-against-code` — `prek.toml:1-23`
 
 | Hook | Behavior |
 |------|----------|
@@ -60,31 +67,37 @@ uv run python tests/validate_platinum_tier.py
 
 ## Pins that must stay in lockstep
 
-**verified-against-code** — `tests/requirements-test.txt:19-21`
+`verified-against-code` — `tests/requirements-test.txt:20-21`
 
 | Tool | Pin | Failure mode if floated |
 |------|-----|-------------------------|
 | `ruff` | **0.15.5** | Unpinned CI floated to 0.16 and failed repo-wide (#482) |
-| `mypy` | **2.3.0** | Keep in sync with `quality-validation.yml` |
+| `mypy` | **2.3.0** | Pinned per #528 review; keep in sync with `quality-validation.yml` |
 
-Sync surfaces: `tests/requirements-test.txt`, `prek.toml`, `.github/workflows/quality-validation.yml`.
+Sync surfaces: `tests/requirements-test.txt:20-21`, `prek.toml:13` (ruff `rev`),
+`.github/workflows/quality-validation.yml` (job `platinum-strict-typing` installs `mypy==2.3.0`).
 
-**Strict typing gate:** Platinum CI and local mypy must exit 0 with zero errors — **verified-against-code** — `quality-validation.yml` `platinum-strict-typing` job (`exit 1` on failure).
+**Strict typing gate:** Platinum CI and local mypy must exit 0 with zero errors — `verified-against-code`
+— `quality-validation.yml`, job `platinum-strict-typing`, steps **Verify strict typing configuration**
+(asserts `tests/mypy.ini` exists, contains `strict = True`, and `py.typed` is present) and **Run mypy
+type checking** (`exit 1` on type errors).
 
 ## Quality scale tiers
 
 | Tier | How enforced | Local script |
 |------|--------------|--------------|
-| Bronze | Directly in `quality-validation.yml` | None (no standalone validator) — **verified-against-code** — `docs/DEVELOPMENT.md:54-55` |
+| Bronze | Directly in `quality-validation.yml` (the `bronze-*` jobs) | None — `tests/` contains `validate_silver_tier.py`, `validate_gold_tier.py`, `validate_platinum_tier.py`, `validate_translations.py` and **no** `validate_bronze_tier.py` — `verified-against-code` — `tests/` listing; stated the same way in `docs/DEVELOPMENT.md:54-55` |
 | Silver | CI job + script | `tests/validate_silver_tier.py` |
 | Gold | CI job + script | `tests/validate_gold_tier.py` |
 | Platinum | CI job + script | `tests/validate_platinum_tier.py` |
 
-Tier sequencing in CI: Silver `needs: bronze-summary` → Gold `needs: silver-summary` → Platinum `needs: gold-summary` (fail-fast across tiers) — **verified-against-code** — `quality-validation.yml`.
+Tier sequencing in CI: every Silver job declares `needs: bronze-summary`, Gold `needs: silver-summary`,
+Platinum `needs: gold-summary` (fail-fast across tiers) — `verified-against-code` — `quality-validation.yml`,
+jobs `bronze-summary`, `silver-summary`, `gold-summary` and their dependents.
 
 ## CI workflows
 
-**verified-against-code** — workflow `on:` blocks
+`verified-against-code` — workflow `on:` blocks
 
 | Workflow | File | Triggers | Role |
 |----------|------|----------|------|
@@ -95,11 +108,13 @@ Tier sequencing in CI: Silver `needs: bronze-summary` → Gold `needs: silver-su
 | Issue Triage | `.github/workflows/issue-triage.yml` | issues opened (+ dispatch) | Claude triage + rate limit |
 | Claude Code | `.github/workflows/claude.yml` | @claude on comments/reviews (collaborators) | Interactive assist |
 
-**Push quality gate is develop-only.** Pushing to `main` does **not** run `quality-validation.yml` — **verified-against-code** — `quality-validation.yml:3-7`. Note: `.github/WORKFLOWS.md` is stale if it claims push to `main` or `develop` — prefer the YAML.
+**Push quality gate is develop-only.** Pushing to `main` does **not** run `quality-validation.yml`;
+`main` is covered only via pull request — `verified-against-code` — `quality-validation.yml`, `on:`
+(`push.branches: [develop]`, `pull_request.branches: [main, develop]`, `workflow_dispatch`).
 
 ### Python version split
 
-**verified-against-code** — `quality-validation.yml`
+`verified-against-code` — `quality-validation.yml`
 
 | Jobs | Python |
 |------|--------|
@@ -121,14 +136,16 @@ Majority of Bronze/Silver/Gold/Platinum steps, including:
 
 ### Advisory / soft (warn only)
 
-**verified-against-code** — `quality-validation.yml` cited lines:
+These four look like gates and are not. A green run does **not** mean they passed.
 
-| Check | Behavior |
-|-------|----------|
-| `bronze-entity-naming` | Prints `⚠️` if `has_entity_name` missing — **does not `exit 1`** (~152–156) |
-| `silver-entity-availability` | `⚠️` if no `def available` found — **no exit 1** (~358–360) |
-| `platinum-comprehensive-tests` | API client / coordinator platinum tests use `\|\| echo "⚠️ … (non-blocking)"` (~864–875) |
-| Codecov upload | `fail_ci_if_error: false` (~678) |
+`verified-against-code` — `.github/workflows/quality-validation.yml`, by job and step name:
+
+| Job | Step | Why it is advisory |
+|-----|------|--------------------|
+| `bronze-entity-naming` | **Check has_entity_name** | Loops the five platform files and `echo`s `⚠️  $file may not use has_entity_name = True`; the branch has no `exit 1`, so the job succeeds either way |
+| `silver-entity-availability` | **Check entity availability** | Sets `found=1` on the first file containing `def available` and `break`s; if none match it `echo`s `⚠️  Entity availability property not found` and still exits 0. One match across all platforms satisfies it |
+| `platinum-comprehensive-tests` | **(test invocations)** | `pytest tests/test_api_client.py … \|\| echo "⚠️  API client tests failed (non-blocking)"` and the same pattern for `tests/test_coordinator_platinum.py` — the `\|\|` swallows a non-zero exit |
+| `gold-test-coverage` | **(codecov upload)** | `codecov/codecov-action@v4` with `fail_ci_if_error: false` — upload failure never fails the job |
 
 ## Agent pre-PR gate (integration)
 
@@ -142,4 +159,7 @@ uv run python tests/validate_gold_tier.py
 uv run python tests/validate_platinum_tier.py
 ```
 
-**Test-count drift:** `CLAUDE.md` still says “692 tests”; recent CHANGELOG/CI narratives cite 2000+. Do not treat the CLAUDE.md count as authoritative — **inferred** from dossier §9.
+**Test-count drift:** `CLAUDE.md` "Local Testing" says “692 tests”; `CHANGELOG.md` release entries
+from the same period cite 2000+. Neither is authoritative — count it yourself with
+`uv run pytest tests/ --collect-only -q | tail -1` — `asserted-unverified` (the two docs disagree;
+`CLAUDE.md` "Local Testing" vs `CHANGELOG.md` v3.5.1-beta.1).

--- a/llmwiki/50-operations/quality-gates.md
+++ b/llmwiki/50-operations/quality-gates.md
@@ -2,7 +2,6 @@
 canonical-for: lint, format, typecheck, tests, coverage, quality-scale tier validators, CI blocking vs advisory
 sources:
   - docs/DEVELOPMENT.md
-  - CLAUDE.md
   - tests/requirements-test.txt
   - tests/mypy.ini
   - prek.toml
@@ -20,8 +19,8 @@ Canonical local and CI gates for eg4_web_monitor. Prefer `uv run` for agents.
 
 The tool invocations are `verified-against-code` — `prek.toml` (ruff `rev`, mypy hook `entry`) and
 `.github/workflows/quality-validation.yml` (jobs `bronze-code-quality`, `gold-test-coverage`,
-`platinum-strict-typing`). The command *listing* below also appears in `docs/DEVELOPMENT.md:21-52`,
-which is prose and is cited as corroboration only.
+`platinum-strict-typing`). The command *listing* below also appears in `docs/DEVELOPMENT.md`
+"Quality Checks", which is prose and is cited as corroboration only.
 
 ```bash
 # Lint + format (fix) — agent-preferred form
@@ -86,7 +85,7 @@ type checking** (`exit 1` on type errors).
 
 | Tier | How enforced | Local script |
 |------|--------------|--------------|
-| Bronze | Directly in `quality-validation.yml` (the `bronze-*` jobs) | None — `tests/` contains `validate_silver_tier.py`, `validate_gold_tier.py`, `validate_platinum_tier.py`, `validate_translations.py` and **no** `validate_bronze_tier.py` — `verified-against-code` — `tests/` listing; stated the same way in `docs/DEVELOPMENT.md:54-55` |
+| Bronze | Directly in `quality-validation.yml` (the `bronze-*` jobs) | None — `tests/` contains `validate_silver_tier.py`, `validate_gold_tier.py`, `validate_platinum_tier.py`, `validate_translations.py` and **no** `validate_bronze_tier.py` — `verified-against-code` — `tests/` listing; stated the same way in `docs/DEVELOPMENT.md` "Quality Scale" |
 | Silver | CI job + script | `tests/validate_silver_tier.py` |
 | Gold | CI job + script | `tests/validate_gold_tier.py` |
 | Platinum | CI job + script | `tests/validate_platinum_tier.py` |
@@ -159,7 +158,10 @@ uv run python tests/validate_gold_tier.py
 uv run python tests/validate_platinum_tier.py
 ```
 
-**Test-count drift:** `CLAUDE.md` "Local Testing" says “692 tests”; `CHANGELOG.md` release entries
-from the same period cite 2000+. Neither is authoritative — count it yourself with
-`uv run pytest tests/ --collect-only -q | tail -1` — `asserted-unverified` (the two docs disagree;
-`CLAUDE.md` "Local Testing" vs `CHANGELOG.md` v3.5.1-beta.1).
+**Never cite a written test count.** The suite total has been copied into prose repeatedly and every
+copy rots within a release or two — docs and release notes have disagreed by a factor of three. No
+document is authoritative for it, including this one. Collect it:
+
+```bash
+uv run pytest tests/ --collect-only -q | tail -1
+```

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -1,0 +1,114 @@
+---
+canonical-for: two-repo release ordering, version scheme, manifest pin coupling, HACS zip publish
+sources:
+  - /tmp/llmwiki-research/repo-operations.md
+  - docs/DEVELOPMENT.md
+  - CHANGELOG.md
+  - custom_components/eg4_web_monitor/manifest.json
+  - tests/requirements-test.txt
+  - hacs.json
+  - .github/workflows/release.yml
+  - ../python/pylxpweb/docs/DEVELOPMENT.md
+  - ../python/pylxpweb/.github/workflows/release.yml
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Release process
+
+Highest-risk operational rule in this project: **publish pylxpweb to PyPI before bumping the integration pin.** Getting the order wrong breaks CI and Home Assistant installs.
+
+## Two-repo ordering constraint (hard)
+
+**verified-against-code** / operational record — pin locations + CHANGELOG “Requires pylxpweb>=…” coupling; dossier §5.4.
+
+| Step | Repo | Action |
+|------|------|--------|
+| 1 | **pylxpweb** | Bump `pyproject.toml` version, update CHANGELOG, tag, publish GitHub Release → workflow publishes TestPyPI then PyPI |
+| 2 | **wait** | Confirm the wheel is installable (`pip install pylxpweb==…` / PyPI page) |
+| 3 | **eg4_web_monitor** | Bump **both** `manifest.json` `requirements` and `tests/requirements-test.txt` in lockstep; add CHANGELOG “Requires pylxpweb>=…” note |
+| 4 | **eg4_web_monitor** | Bump `manifest.json` `version`, move Unreleased CHANGELOG entries, tag `vX.Y.Z` / `vX.Y.Z-beta.N`, publish GitHub Release |
+
+**Do not bump the integration pin before the library is on PyPI.** Dev docker bind-mounts bypass PyPI for local validation, but **CI and end users require the published wheel**.
+
+```bash
+# 1) pylxpweb: bump pyproject version, changelog, tag, publish GitHub release → PyPI
+# 2) Wait until pip can install the new version
+# 3) eg4: bump manifest.json requirements + tests/requirements-test.txt + CHANGELOG Requires line
+# 4) Tag/publish integration release
+```
+
+## Where versions live
+
+| Project | Source of truth | Scheme |
+|---------|-----------------|--------|
+| eg4_web_monitor | `custom_components/eg4_web_monitor/manifest.json` → `"version"` | SemVer + prerelease: `X.Y.Z`, `X.Y.Z-beta.N`, `X.Y.Z-rc.N`; Git tags `vX.Y.Z` / `vX.Y.Z-beta.N` |
+| pylxpweb | `pyproject.toml` `[project].version` | PEP 440 (e.g. `0.9.39b10`); Git tags `v0.9.39b10` |
+
+**verified-against-code** — `docs/DEVELOPMENT.md:57-64`; manifest `version` field; pylxpweb `pyproject.toml`.
+
+Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
+
+| Field | Value at verify |
+|-------|-----------------|
+| Integration version | `3.5.1-beta.10` |
+| Integration pin | `pylxpweb>=0.9.39b10` |
+| `tests/requirements-test.txt` | `pylxpweb>=0.9.39b10  # keep in sync with manifest.json` |
+
+**Note:** `CLAUDE.md` Current Version may lag the manifest — prefer `manifest.json` — **verified-against-code** vs dossier §9 contradiction table.
+
+## Integration pin locations (must stay equal)
+
+**verified-against-code**
+
+1. `custom_components/eg4_web_monitor/manifest.json` → `"requirements": ["pylxpweb>=…", …]`
+2. `tests/requirements-test.txt` → `pylxpweb>=…  # keep in sync with manifest.json`
+3. CI Platinum mypy job reads the pin from `tests/requirements-test.txt` dynamically (`quality-validation.yml` ~793–801) so typecheck matches tests.
+
+CHANGELOG convention: each beta/stable header states **Requires pylxpweb>=…** with a GitHub release link — first-class release note, not optional commentary.
+
+## Integration release steps
+
+**verified-against-code** — `docs/DEVELOPMENT.md:57-64`, `.github/workflows/release.yml`
+
+1. Bump `version` in `manifest.json`.
+2. Move `Unreleased` CHANGELOG entries under the new version heading (Keep a Changelog).
+3. Ensure pylxpweb pin already published (ordering constraint above).
+4. Tag `vX.Y.Z` (or `vX.Y.Z-beta.N` / `vX.Y.Z-rc.N`).
+5. Publish GitHub Release → `release.yml` builds a zip of `custom_components/eg4_web_monitor` and attaches `eg4_web_monitor.zip`.
+6. HACS consumes the tagged release.
+
+Zip exclusions (secrets must never ship) — **verified-against-code** — `release.yml:20-29`:
+
+- `*.env`, `.env`, `secrets.py`
+- `*.pyc`, `__pycache__/*`, caches, `.git/*`
+
+## How HACS consumes releases
+
+**verified-against-code** — `hacs.json`
+
+| Key | Value |
+|-----|-------|
+| `zip_release` | `true` |
+| `filename` | `eg4_web_monitor.zip` |
+| `homeassistant` | `>=2026.1.0` (minimum HA version) |
+| `content_in_root` | `false` |
+
+HACS installs from the GitHub Release asset produced by `release.yml`, not from raw tree contents.
+
+## pylxpweb release / PyPI publish
+
+**verified-against-code** — pylxpweb `docs/DEVELOPMENT.md`, pylxpweb `.github/workflows/release.yml`
+
+1. Bump version in `pyproject.toml`.
+2. Update pylxpweb `CHANGELOG.md`.
+3. Tag and publish a GitHub Release (e.g. `gh release create v0.9.39b10 …`).
+4. Workflow **Publish to PyPI** on `release: published`:
+   - Build with `uv build`
+   - Publish to **TestPyPI** (OIDC environment `testpypi`)
+   - Then publish to **PyPI** (OIDC environment `pypi`)
+5. Manual `workflow_dispatch` may allow `skip-publish` / target selection — check the workflow file before relying on it.
+
+## SemVer / prerelease ordering reminder
+
+Observed line: `…-beta.N` < `…-rc.N` < final `X.Y.Z` (e.g. beta.27 < rc.1 < 3.4.0) — **inferred** from CHANGELOG release narrative; treat as project convention when cutting candidates.

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -220,34 +220,43 @@ tree**, so confirm them on GitHub each time rather than inheriting a belief abou
 |---|---|---|---|
 | 1 | The `pypi` environment restricts **which refs may deploy** to protected release tags — GitHub evaluates its deployment branch/tag policy against the run's `github.ref`, and it is the only automatic control that constrains *which ref* may publish | Repo → Settings → Environments → `pypi` → deployment branches and tags | **Unverified — settings not in the tree** |
 | 2 | The `pypi` environment requires **review by someone other than the dispatcher** | Same screen → required reviewers | **Unverified — settings not in the tree** |
-| 3 | An **immutable, protected release tag** exists, and the version in `pyproject.toml` at that tag equals the version being published | `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit; a tag protection rule or ruleset to stop the tag being moved afterwards | **Unverified — tag protection is a repo setting.** And see below: the release tags carry no immutability of their own |
+| 3 | An **immutable, protected release tag** exists, and the version in `pyproject.toml` at that tag equals the version being published | `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit; a tag protection rule or ruleset to stop the tag being moved afterwards | **Unverified — tag protection is a repo setting.** Re-check the tag itself too: when last observed the release tags were lightweight and so supplied no immutability of their own ([below](#a-lightweight-tag-carries-no-evidence-of-its-own)) |
 
 If any is unconfirmed, **publish through a published GitHub Release instead of a manual dispatch**,
 and treat the manual `pypi` path as unavailable. The release path at least binds the checkout to
 `github.event.release.tag_name`; note that this still assumes the tag is protected, since an
 unprotected git tag can be moved after review (precondition 3 covers both paths).
 
-**The release tags are lightweight, so they carry no evidence of their own.** Checked at the pin:
-`git cat-file -t refs/tags/v0.9.39b10` returns `commit`, not `tag` — the ref points straight at the
-commit with no tag object behind it. The same holds for `v0.9.39b9`. A lightweight tag has **no
-tagger identity, no timestamp and no signature**, and it is an ordinary ref that anyone with push
-access can move with `git push --force origin v0.9.39b10`. So a tag matching the artifact proves only
-where the ref points *right now*; it is not evidence of who cut the release or that it has not been
-repointed since. Precondition 3's immutability therefore rests **entirely** on GitHub tag protection
-rules — there is no fallback in the git data — `verified-against-code` — pylxpweb@`204b95d`:
-`git cat-file -t` on both release tag refs.
+#### A lightweight tag carries no evidence of its own
 
-Worked example at the pin, which resolves gate checks 1 and 2 concretely:
+A lightweight tag is an ordinary ref pointing straight at a commit, with no tag object behind it, so
+it has **no tagger identity, no timestamp and no signature**, and anyone with push access can move it
+with `git push --force origin <tag>`. A tag
+matching the artifact therefore proves only where the ref points at the moment you look; it is not
+evidence of who cut the release, nor that the ref has not been repointed since. That is a property
+of git's data model, not of this project — `inferred`.
 
-| Step | Result |
-|---|---|
-| `git rev-parse 'v0.9.39b10^{commit}'` | `204b95d…` |
-| `git ls-remote --tags origin refs/tags/v0.9.39b10` | `204b95d…` — local and origin agree, so the ref has not been repointed on one side only |
-| `git show 204b95d:pyproject.toml` → `[project].version` | `0.9.39b10` — matches the tag name and the floor `manifest.json:13` pins |
+**pylxpweb's release tags are of that kind.** Observed **2026-08-09**: `git cat-file -t
+refs/tags/v0.9.39b10` returns `commit` rather than `tag`, and the same holds for `v0.9.39b9`.
+`asserted-unverified` — and deliberately not graded higher, because **a tag ref is not pinnable**.
+`204b95d` identifies a commit; nothing identifies the state of a ref that points at it, so this
+observation has an expiry a reader cannot see and must be re-run rather than trusted. Consequence
+while it holds: precondition 3's immutability rests **entirely** on GitHub tag protection rules,
+with no fallback in the git data.
 
-That is a clean tag → commit → version chain, and it is what checks 1 and 2 look like when they pass.
-It still says nothing about *who* published or whether the tag moved before you looked, which is the
-gap the paragraph above describes.
+Worked example — what gate checks 1 and 2 look like when they pass. The first two rows read **mutable
+refs** and are an observation of **2026-08-09**, not a durable fact; re-run them rather than citing
+this table. Only the third row is pinned, and therefore reproducible by anyone at any time:
+
+| Step | Result | Durable? |
+|---|---|---|
+| `git rev-parse 'v0.9.39b10^{commit}'` | `204b95d…` | No — local tag ref, movable |
+| `git ls-remote --tags origin refs/tags/v0.9.39b10` | `204b95d…` — origin agreed with local, so the ref had not been repointed on one side only | No — remote ref, movable |
+| `git show 204b95d:pyproject.toml` → `[project].version` | `0.9.39b10` — matches the tag name and the floor `manifest.json:13` pins | **Yes** — addressed by commit |
+
+That is a clean tag → commit → version chain. It still says nothing about *who* published, or whether
+the tag moved before you looked — which is exactly the gap above, and the reason the first two rows
+carry a date instead of a grade.
 
 **Who can trigger it.** The workflow declares no actor restriction — `verified-against-code` for the
 absence of one (pylxpweb@`204b95d` `release.yml`: the only job-level `if:` conditions are `:76` and

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -46,7 +46,7 @@ not provenance. Check all five before moving the pin:
 
 | # | Check | How | Grade |
 |---|-------|-----|-------|
-| 1 | **Tag → commit** | The tag you released points at the reviewed merge commit: `git rev-parse 'v0.9.39b10^{commit}'`. The build job checks out `github.event.release.tag_name \|\| github.ref`, so the tag alone determines what is built | `verified-against-code` — pylxpweb `release.yml`, `build` job, `actions/checkout` `ref:` |
+| 1 | **Ref → commit** | Confirm what was actually built. The build job checks out `github.event.release.tag_name \|\| github.ref` — a **published release** builds its tag; a **manual dispatch** builds whatever ref the dispatcher picked. Check the run's ref, then `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit, and confirm the tag is protected against being moved | `verified-against-code` — pylxpweb `release.yml`, `build` job, `actions/checkout` `ref:`. See [Sequencing is not provenance](#sequencing-is-not-provenance) |
 | 2 | **Commit → version** | `pyproject.toml` `[project].version` **at that tag** equals the version now on PyPI. A tag on the wrong commit ships the wrong version silently | `verified-against-code` — pylxpweb `release.yml`, `build` job, `uv build` |
 | 3 | **Trusted Publisher provenance** | Publication is OIDC, not a stored API token: the workflow declares `permissions: id-token: write` and both publish jobs use `pypa/gh-action-pypi-publish` against GitHub Environments `testpypi` / `pypi`. On PyPI, confirm the release shows the Trusted Publisher and the originating workflow run | `verified-against-code` — pylxpweb `release.yml` `permissions:`, jobs `publish-testpypi` / `publish-pypi` (`environment:`) |
 | 4 | **Artifact hashes** | Both publish steps set `print-hash: true`. Take the wheel/sdist hashes from the run log and compare them to the hashes PyPI lists for the release. Equal hashes on the TestPyPI and PyPI steps prove the same file reached both indexes | `verified-against-code` — pylxpweb `release.yml`, `publish-testpypi` / `publish-pypi` steps (`print-hash: true`) |
@@ -64,10 +64,17 @@ it is a resolvability check, not a trust check.
 # 4) Tag/publish integration release
 ```
 
-**What the gate does not cover:** the workflow never installs or imports the TestPyPI artifact before
-promoting it. TestPyPI success means "upload accepted", not "the package works". Step 2's clean-env
-install is the only import check in the chain, and it runs after PyPI publication — `verified-against-code`
-— pylxpweb `release.yml` (no install/smoke step between `publish-testpypi` and `publish-pypi`).
+**What the gate does not cover.** Two limits, both structural:
+
+1. **No smoke test.** The workflow never installs or imports the TestPyPI artifact before promoting
+   it. TestPyPI success means "upload accepted", not "the package works". The clean-env install above
+   is the only import check in the chain, and it runs after PyPI publication — `verified-against-code`
+   — pylxpweb `release.yml` (no install or import step between `publish-testpypi` and `publish-pypi`).
+2. **No enforced provenance.** Checks 1–5 are things a human performs *after* the fact; the workflow
+   itself never verifies that what it built came from a reviewed, immutable ref. On a manual dispatch
+   it builds whatever ref the dispatcher selected. See
+   [Sequencing is not provenance](#sequencing-is-not-provenance) and the preconditions that follow it
+   before using the manual `pypi` path at all.
 
 ## Where versions live
 
@@ -171,13 +178,52 @@ skipped `publish-testpypi` skips `publish-pypi` too. Every input value is covere
 
 There is no input combination that reaches PyPI without publishing to TestPyPI first.
 
-**Who can trigger it.** The workflow declares no actor restriction, so this reduces to GitHub's own
-rule that `workflow_dispatch` requires write access to the repository — `verified-against-code` for
-the absence of a restriction (pylxpweb `release.yml`, no `if: github.actor` guard on any job);
-`asserted-unverified` for the platform rule itself (GitHub Actions documented behavior, not a fact in
-this tree). The `testpypi` and `pypi` GitHub Environments **may** carry required-reviewer or branch
-protection rules, which would gate dispatch further — those live in repository settings and are **not
-determinable from the tree**; check the environment settings on GitHub before assuming either way.
+### Sequencing is not provenance
+
+**TestPyPI-first is an ordering property, not a trust boundary.** It proves the same artifact reached
+TestPyPI before PyPI. It proves nothing about *which source* that artifact was built from.
+
+The build job resolves its checkout as
+`ref: ${{ github.event.release.tag_name || github.ref }}`. On `workflow_dispatch` there is no release
+payload, so it falls through to `github.ref` — **the ref the dispatcher chose**. Any branch, any tag,
+reviewed or not. The version published is whatever `pyproject.toml` declares on that ref; nothing
+compares it to a tag, a release, or a merged commit — `verified-against-code` — pylxpweb
+`release.yml`, `build` job, `actions/checkout` `ref:`.
+
+Three properties that look protective and are not:
+
+| Looks like a control | What it actually constrains |
+|---|---|
+| TestPyPI runs first | Order only. Both jobs consume the same artifact, so they agree with each other — including when that artifact was built from an unreviewed ref |
+| OIDC / Trusted Publisher | Binds publication to *this repo, this workflow file, this environment*. It attests **who published**, never **what was reviewed**. A dispatch from an arbitrary branch is signed just as legitimately |
+| Environment gating on the publish jobs | Only the publish jobs declare `environment:`; `build` declares none, so protection rules never gate the checkout or the build — an unreviewed ref is fetched and built regardless, and the rules can only stop it at upload — `verified-against-code` — pylxpweb `release.yml`, `build` (no `environment:`) vs `publish-testpypi` / `publish-pypi` |
+
+Absent environment restrictions, this means: **any repository writer can have OIDC publish an
+arbitrary ref to PyPI as the real package.** Downstream, `manifest.json` resolves `pylxpweb>=…` from
+PyPI, so that artifact lands in Home Assistant installs.
+
+### Preconditions for a production `pypi` dispatch
+
+**Do not dispatch `environment: pypi` unless all three hold.** These are preconditions to *verify*,
+not assumptions — the first two live in repository settings and are **not determinable from this
+tree**, so confirm them on GitHub each time rather than inheriting a belief about them:
+
+| # | Precondition | How to confirm | Status here |
+|---|---|---|---|
+| 1 | The `pypi` environment restricts **which refs may deploy** to protected release tags — GitHub evaluates its deployment branch/tag policy against the run's `github.ref`, and it is the only automatic control that constrains *which ref* may publish | Repo → Settings → Environments → `pypi` → deployment branches and tags | **Unverified — settings not in the tree** |
+| 2 | The `pypi` environment requires **review by someone other than the dispatcher** | Same screen → required reviewers | **Unverified — settings not in the tree** |
+| 3 | An **immutable, protected release tag** exists, and the version in `pyproject.toml` at that tag equals the version being published | `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit; a tag protection rule or ruleset to stop the tag being moved afterwards | **Unverified — tag protection is a repo setting** |
+
+If any is unconfirmed, **publish through a published GitHub Release instead of a manual dispatch**,
+and treat the manual `pypi` path as unavailable. The release path at least binds the checkout to
+`github.event.release.tag_name`; note that this still assumes the tag is protected, since an
+unprotected git tag can be moved after review (precondition 3 covers both paths).
+
+**Who can trigger it.** The workflow declares no actor restriction — `verified-against-code` for the
+absence of one (pylxpweb `release.yml`, no `if: github.actor` guard on any job). It therefore reduces
+to GitHub's rule that `workflow_dispatch` requires write access — `asserted-unverified` (GitHub
+Actions documented behavior, not a fact in this tree). Repository write access is a much larger set
+than release authority, which is what makes preconditions 1 and 2 load-bearing rather than optional.
 
 `concurrency: release-publish` with `cancel-in-progress: false` serializes releases — a second
 dispatch queues rather than cancelling the first — `verified-against-code` — pylxpweb `release.yml`, `concurrency:`.

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -7,10 +7,12 @@ sources:
   - tests/requirements-test.txt
   - hacs.json
   - .github/workflows/release.yml
-  - ../python/pylxpweb/docs/DEVELOPMENT.md
-  - ../python/pylxpweb/.github/workflows/release.yml
-verified-against: 9f6d6e2
-last-verified: 2026-08-08
+  - pylxpweb docs/DEVELOPMENT.md
+  - pylxpweb .github/workflows/release.yml
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
+last-verified: 2026-08-09
 ---
 
 # Release process
@@ -44,13 +46,16 @@ exists at that version. It does not prove that the artifact came from the review
 was built by the release workflow, or that TestPyPI and PyPI received the same file. Availability is
 not provenance. Check all five before moving the pin:
 
+All five re-verified against pylxpweb `.github/workflows/release.yml` at **`204b95d`**; line numbers below
+are that revision's.
+
 | # | Check | How | Grade |
 |---|-------|-----|-------|
-| 1 | **Ref → commit** | Confirm what was actually built. The build job checks out `github.event.release.tag_name \|\| github.ref` — a **published release** builds its tag; a **manual dispatch** builds whatever ref the dispatcher picked. Check the run's ref, then `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit, and confirm the tag is protected against being moved | `verified-against-code` — pylxpweb `release.yml`, `build` job, `actions/checkout` `ref:`. See [Sequencing is not provenance](#sequencing-is-not-provenance) |
-| 2 | **Commit → version** | `pyproject.toml` `[project].version` **at that tag** equals the version now on PyPI. A tag on the wrong commit ships the wrong version silently | `verified-against-code` — pylxpweb `release.yml`, `build` job, `uv build` |
-| 3 | **Trusted Publisher provenance** | Publication is OIDC, not a stored API token: the workflow declares `permissions: id-token: write` and both publish jobs use `pypa/gh-action-pypi-publish` against GitHub Environments `testpypi` / `pypi`. On PyPI, confirm the release shows the Trusted Publisher and the originating workflow run | `verified-against-code` — pylxpweb `release.yml` `permissions:`, jobs `publish-testpypi` / `publish-pypi` (`environment:`) |
-| 4 | **Artifact hashes** | Both publish steps set `print-hash: true`. Take the wheel/sdist hashes from the run log and compare them to the hashes PyPI lists for the release. Equal hashes on the TestPyPI and PyPI steps prove the same file reached both indexes | `verified-against-code` — pylxpweb `release.yml`, `publish-testpypi` / `publish-pypi` steps (`print-hash: true`) |
-| 5 | **Same-artifact promotion** | Nothing is rebuilt between indexes. `build` uploads one artifact (`python-package-distributions`); both publish jobs download **that** artifact rather than rebuilding, so the file `twine check` validated is the file promoted | `verified-against-code` — pylxpweb `release.yml`: `build` → `actions/upload-artifact`; `publish-testpypi` / `publish-pypi` → `actions/download-artifact` |
+| 1 | **Ref → commit** | Confirm what was actually built. The build job checks out `github.event.release.tag_name \|\| github.ref` — a **published release** builds its tag; a **manual dispatch** builds whatever ref the dispatcher picked. Check the run's ref, then `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit, and confirm the tag is protected against being moved | `verified-against-code` — pylxpweb@`204b95d` `release.yml:35-37` (`build` → `actions/checkout` `ref:`). See [Sequencing is not provenance](#sequencing-is-not-provenance) |
+| 2 | **Commit → version** | `pyproject.toml` `[project].version` **at that tag** equals the version now on PyPI. Nothing overrides it: the job runs a bare `uv build` against the checked-out tree, so the version is whatever that ref declares. A tag on the wrong commit ships the wrong version silently | `verified-against-code` — pylxpweb@`204b95d` `release.yml:52` (`uv build`), `:37` (checkout ref) |
+| 3 | **Trusted Publisher provenance** | Publication is OIDC, not a stored API token: the workflow sets `id-token: write` at workflow level and again on each publish job, and both use `pypa/gh-action-pypi-publish@release/v1` against GitHub Environments `testpypi` / `pypi`. On PyPI, confirm the release shows the Trusted Publisher and the originating workflow run | `verified-against-code` — pylxpweb@`204b95d` `release.yml:25-27` (workflow `permissions:`), `:77-79` / `:99-101` (job `environment:` + `permissions:`), `:88` / `:110` (publish action) |
+| 4 | **Artifact hashes** | Both publish steps set `print-hash: true`. Take the wheel/sdist hashes from the run log and compare them to the hashes PyPI lists for the release. Equal hashes on the TestPyPI and PyPI steps prove the same file reached both indexes | `verified-against-code` — pylxpweb@`204b95d` `release.yml:91`, `:112` |
+| 5 | **Same-artifact promotion** | Nothing is rebuilt between indexes. `build` uploads one artifact (`python-package-distributions`); both publish jobs download **that** artifact rather than rebuilding, so the file `twine check` validated is the file promoted | `verified-against-code` — pylxpweb@`204b95d` `release.yml:57-61` (upload), `:81-85` / `:103-107` (download), `:55` (`twine check`) |
 
 Only after those pass does `pip install pylxpweb==X` in a clean environment mean anything — and then
 it is a resolvability check, not a trust check.
@@ -67,9 +72,11 @@ it is a resolvability check, not a trust check.
 **What the gate does not cover.** Two limits, both structural:
 
 1. **No smoke test.** The workflow never installs or imports the TestPyPI artifact before promoting
-   it. TestPyPI success means "upload accepted", not "the package works". The clean-env install above
-   is the only import check in the chain, and it runs after PyPI publication — `verified-against-code`
-   — pylxpweb `release.yml` (no install or import step between `publish-testpypi` and `publish-pypi`).
+   it. TestPyPI success means "upload accepted", not "the package works". `publish-testpypi` has
+   exactly two steps — download the artifact, publish it — and nothing between it and `publish-pypi`.
+   The clean-env install above is the only import check in the chain, and it runs after PyPI
+   publication — `verified-against-code` — pylxpweb@`204b95d` `release.yml:80-91` (the job's complete
+   step list), `:93-112`.
 2. **No enforced provenance.** Checks 1–5 are things a human performs *after* the fact; the workflow
    itself never verifies that what it built came from a reviewed, immutable ref. On a manual dispatch
    it builds whatever ref the dispatcher selected. See
@@ -83,9 +90,9 @@ it is a resolvability check, not a trust check.
 | eg4_web_monitor | `custom_components/eg4_web_monitor/manifest.json` → `"version"` | SemVer + prerelease: `X.Y.Z`, `X.Y.Z-beta.N`, `X.Y.Z-rc.N`; Git tags `vX.Y.Z` / `vX.Y.Z-beta.N` |
 | pylxpweb | `pyproject.toml` `[project].version` | PEP 440 (e.g. `0.9.39b10`); Git tags `v0.9.39b10` |
 
-`verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:14` (`version`); pylxpweb
-`pyproject.toml` `[project].version`. The SemVer/Keep-a-Changelog convention around them is
-`asserted-unverified` — `docs/DEVELOPMENT.md` "Releasing".
+`verified-against-code` — eg4_web_monitor@`9f6d6e2` `custom_components/eg4_web_monitor/manifest.json:14`
+(`version`); pylxpweb@`204b95d` `pyproject.toml:1-3` (`[project]` … `version = "0.9.39b10"`). The
+SemVer/Keep-a-Changelog convention around them is `asserted-unverified` — `docs/DEVELOPMENT.md` "Releasing".
 
 Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
 
@@ -149,7 +156,7 @@ HACS installs from the GitHub Release asset produced by `release.yml`, not from 
 ## pylxpweb release / PyPI publish
 
 Steps 1–3 are the documented procedure — `asserted-unverified` — pylxpweb `docs/DEVELOPMENT.md`.
-Step 4 and everything below it are `verified-against-code` — pylxpweb `.github/workflows/release.yml`.
+Step 4 and everything below it are `verified-against-code` — pylxpweb@`204b95d` `.github/workflows/release.yml:1-121`.
 
 1. Bump version in `pyproject.toml`.
 2. Update pylxpweb `CHANGELOG.md`.
@@ -163,12 +170,12 @@ Step 4 and everything below it are `verified-against-code` — pylxpweb `.github
 
 `workflow_dispatch` takes exactly **one** input — `environment`, required, `type: choice` — with
 three options: `skip-publish`, `testpypi`, `pypi`. There is no `skip-publish` *flag*; it is one of the
-three values of that single input — `verified-against-code` — pylxpweb `release.yml`, `on.workflow_dispatch.inputs.environment`.
+three values of that single input — `verified-against-code` — pylxpweb@`204b95d` `release.yml:9-18`.
 
 **Dispatch cannot bypass the TestPyPI → PyPI gate.** The gate is structural, not conditional:
 `publish-pypi` declares `needs: [build, publish-testpypi]`, and no job uses `if: always()`, so a
 skipped `publish-testpypi` skips `publish-pypi` too. Every input value is covered —
-`verified-against-code` — pylxpweb `release.yml`, jobs `publish-testpypi` / `publish-pypi` (`needs:` and `if:`):
+`verified-against-code` — pylxpweb@`204b95d` `release.yml:75-76` / `:97-98` (`needs:` and `if:` on both publish jobs):
 
 | `environment` input | `publish-testpypi` | `publish-pypi` | Net effect |
 |---|---|---|---|
@@ -188,8 +195,8 @@ The build job resolves its checkout as
 `ref: ${{ github.event.release.tag_name || github.ref }}`. On `workflow_dispatch` there is no release
 payload, so it falls through to `github.ref` — **the ref the dispatcher chose**. Any branch, any tag,
 reviewed or not. The version published is whatever `pyproject.toml` declares on that ref; nothing
-compares it to a tag, a release, or a merged commit — `verified-against-code` — pylxpweb
-`release.yml`, `build` job, `actions/checkout` `ref:`.
+compares it to a tag, a release, or a merged commit — `verified-against-code` — pylxpweb@`204b95d`
+`release.yml:35-37`.
 
 Three properties that look protective and are not:
 
@@ -197,7 +204,7 @@ Three properties that look protective and are not:
 |---|---|
 | TestPyPI runs first | Order only. Both jobs consume the same artifact, so they agree with each other — including when that artifact was built from an unreviewed ref |
 | OIDC / Trusted Publisher | Binds publication to *this repo, this workflow file, this environment*. It attests **who published**, never **what was reviewed**. A dispatch from an arbitrary branch is signed just as legitimately |
-| Environment gating on the publish jobs | Only the publish jobs declare `environment:`; `build` declares none, so protection rules never gate the checkout or the build — an unreviewed ref is fetched and built regardless, and the rules can only stop it at upload — `verified-against-code` — pylxpweb `release.yml`, `build` (no `environment:`) vs `publish-testpypi` / `publish-pypi` |
+| Environment gating on the publish jobs | **`build` declares no `environment:` at all.** Only the two publish jobs do, so environment protection rules never gate the checkout or the build — an unreviewed ref is fetched and built regardless, and the rules can only stop it at upload — `verified-against-code` — pylxpweb@`204b95d`: `build` spans `release.yml:30-69` with no `environment:` key, against `:77` (`environment: testpypi`) and `:99` (`environment: pypi`) |
 
 Absent environment restrictions, this means: **any repository writer can have OIDC publish an
 arbitrary ref to PyPI as the real package.** Downstream, `manifest.json` resolves `pylxpweb>=…` from
@@ -213,21 +220,44 @@ tree**, so confirm them on GitHub each time rather than inheriting a belief abou
 |---|---|---|---|
 | 1 | The `pypi` environment restricts **which refs may deploy** to protected release tags — GitHub evaluates its deployment branch/tag policy against the run's `github.ref`, and it is the only automatic control that constrains *which ref* may publish | Repo → Settings → Environments → `pypi` → deployment branches and tags | **Unverified — settings not in the tree** |
 | 2 | The `pypi` environment requires **review by someone other than the dispatcher** | Same screen → required reviewers | **Unverified — settings not in the tree** |
-| 3 | An **immutable, protected release tag** exists, and the version in `pyproject.toml` at that tag equals the version being published | `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit; a tag protection rule or ruleset to stop the tag being moved afterwards | **Unverified — tag protection is a repo setting** |
+| 3 | An **immutable, protected release tag** exists, and the version in `pyproject.toml` at that tag equals the version being published | `git rev-parse 'v0.9.39b10^{commit}'` against the reviewed merge commit; a tag protection rule or ruleset to stop the tag being moved afterwards | **Unverified — tag protection is a repo setting.** And see below: the release tags carry no immutability of their own |
 
 If any is unconfirmed, **publish through a published GitHub Release instead of a manual dispatch**,
 and treat the manual `pypi` path as unavailable. The release path at least binds the checkout to
 `github.event.release.tag_name`; note that this still assumes the tag is protected, since an
 unprotected git tag can be moved after review (precondition 3 covers both paths).
 
+**The release tags are lightweight, so they carry no evidence of their own.** Checked at the pin:
+`git cat-file -t refs/tags/v0.9.39b10` returns `commit`, not `tag` — the ref points straight at the
+commit with no tag object behind it. The same holds for `v0.9.39b9`. A lightweight tag has **no
+tagger identity, no timestamp and no signature**, and it is an ordinary ref that anyone with push
+access can move with `git push --force origin v0.9.39b10`. So a tag matching the artifact proves only
+where the ref points *right now*; it is not evidence of who cut the release or that it has not been
+repointed since. Precondition 3's immutability therefore rests **entirely** on GitHub tag protection
+rules — there is no fallback in the git data — `verified-against-code` — pylxpweb@`204b95d`:
+`git cat-file -t` on both release tag refs.
+
+Worked example at the pin, which resolves gate checks 1 and 2 concretely:
+
+| Step | Result |
+|---|---|
+| `git rev-parse 'v0.9.39b10^{commit}'` | `204b95d…` |
+| `git ls-remote --tags origin refs/tags/v0.9.39b10` | `204b95d…` — local and origin agree, so the ref has not been repointed on one side only |
+| `git show 204b95d:pyproject.toml` → `[project].version` | `0.9.39b10` — matches the tag name and the floor `manifest.json:13` pins |
+
+That is a clean tag → commit → version chain, and it is what checks 1 and 2 look like when they pass.
+It still says nothing about *who* published or whether the tag moved before you looked, which is the
+gap the paragraph above describes.
+
 **Who can trigger it.** The workflow declares no actor restriction — `verified-against-code` for the
-absence of one (pylxpweb `release.yml`, no `if: github.actor` guard on any job). It therefore reduces
+absence of one (pylxpweb@`204b95d` `release.yml`: the only job-level `if:` conditions are `:76` and
+`:98`, both on the publish-target input, and no job tests `github.actor`). It therefore reduces
 to GitHub's rule that `workflow_dispatch` requires write access — `asserted-unverified` (GitHub
 Actions documented behavior, not a fact in this tree). Repository write access is a much larger set
 than release authority, which is what makes preconditions 1 and 2 load-bearing rather than optional.
 
 `concurrency: release-publish` with `cancel-in-progress: false` serializes releases — a second
-dispatch queues rather than cancelling the first — `verified-against-code` — pylxpweb `release.yml`, `concurrency:`.
+dispatch queues rather than cancelling the first — `verified-against-code` — pylxpweb@`204b95d` `release.yml:21-23`.
 
 ## SemVer / prerelease ordering reminder
 

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -1,7 +1,6 @@
 ---
-canonical-for: two-repo release ordering, version scheme, manifest pin coupling, HACS zip publish
+canonical-for: two-repo release ordering, artifact-trust gate before a pin move, version scheme, manifest pin coupling, HACS zip publish
 sources:
-  - /tmp/llmwiki-research/repo-operations.md
   - docs/DEVELOPMENT.md
   - CHANGELOG.md
   - custom_components/eg4_web_monitor/manifest.json
@@ -20,23 +19,55 @@ Highest-risk operational rule in this project: **publish pylxpweb to PyPI before
 
 ## Two-repo ordering constraint (hard)
 
-**verified-against-code** / operational record — pin locations + CHANGELOG “Requires pylxpweb>=…” coupling; dossier §5.4.
+This page owns the full ordering procedure. `20-pylxpweb/release-and-pinning.md` owns pin
+mechanics (where the floor lives, how `__version__` resolves) and links here for ordering.
 
 | Step | Repo | Action |
 |------|------|--------|
-| 1 | **pylxpweb** | Bump `pyproject.toml` version, update CHANGELOG, tag, publish GitHub Release → workflow publishes TestPyPI then PyPI |
-| 2 | **wait** | Confirm the wheel is installable (`pip install pylxpweb==…` / PyPI page) |
+| 1 | **pylxpweb** | Bump `pyproject.toml` version, update CHANGELOG, tag, publish GitHub Release → `release.yml` builds once, publishes TestPyPI, then PyPI |
+| 2 | **gate** | **Verify the published artifact** — provenance, not availability. See the gate below; it is the step this project has historically shortcut |
 | 3 | **eg4_web_monitor** | Bump **both** `manifest.json` `requirements` and `tests/requirements-test.txt` in lockstep; add CHANGELOG “Requires pylxpweb>=…” note |
 | 4 | **eg4_web_monitor** | Bump `manifest.json` `version`, move Unreleased CHANGELOG entries, tag `vX.Y.Z` / `vX.Y.Z-beta.N`, publish GitHub Release |
 
-**Do not bump the integration pin before the library is on PyPI.** Dev docker bind-mounts bypass PyPI for local validation, but **CI and end users require the published wheel**.
+Pin locations and the CHANGELOG “Requires pylxpweb>=…” coupling are `verified-against-code` —
+`custom_components/eg4_web_monitor/manifest.json:13`, `tests/requirements-test.txt:17`, `CHANGELOG.md`.
+
+**Do not bump the integration pin before the library is on PyPI.** Dev docker bind-mounts bypass
+PyPI for local validation, but **CI and end users require the published wheel** — `inferred` from
+`manifest.json:13` (`requirements`) plus the `platinum-strict-typing` job installing the pin from
+`tests/requirements-test.txt`.
+
+### Step 2: the artifact-trust gate
+
+`pip install pylxpweb==X` succeeding, or the PyPI page rendering, proves only that **something**
+exists at that version. It does not prove that the artifact came from the reviewed commit, that it
+was built by the release workflow, or that TestPyPI and PyPI received the same file. Availability is
+not provenance. Check all five before moving the pin:
+
+| # | Check | How | Grade |
+|---|-------|-----|-------|
+| 1 | **Tag → commit** | The tag you released points at the reviewed merge commit: `git rev-parse 'v0.9.39b10^{commit}'`. The build job checks out `github.event.release.tag_name \|\| github.ref`, so the tag alone determines what is built | `verified-against-code` — pylxpweb `release.yml`, `build` job, `actions/checkout` `ref:` |
+| 2 | **Commit → version** | `pyproject.toml` `[project].version` **at that tag** equals the version now on PyPI. A tag on the wrong commit ships the wrong version silently | `verified-against-code` — pylxpweb `release.yml`, `build` job, `uv build` |
+| 3 | **Trusted Publisher provenance** | Publication is OIDC, not a stored API token: the workflow declares `permissions: id-token: write` and both publish jobs use `pypa/gh-action-pypi-publish` against GitHub Environments `testpypi` / `pypi`. On PyPI, confirm the release shows the Trusted Publisher and the originating workflow run | `verified-against-code` — pylxpweb `release.yml` `permissions:`, jobs `publish-testpypi` / `publish-pypi` (`environment:`) |
+| 4 | **Artifact hashes** | Both publish steps set `print-hash: true`. Take the wheel/sdist hashes from the run log and compare them to the hashes PyPI lists for the release. Equal hashes on the TestPyPI and PyPI steps prove the same file reached both indexes | `verified-against-code` — pylxpweb `release.yml`, `publish-testpypi` / `publish-pypi` steps (`print-hash: true`) |
+| 5 | **Same-artifact promotion** | Nothing is rebuilt between indexes. `build` uploads one artifact (`python-package-distributions`); both publish jobs download **that** artifact rather than rebuilding, so the file `twine check` validated is the file promoted | `verified-against-code` — pylxpweb `release.yml`: `build` → `actions/upload-artifact`; `publish-testpypi` / `publish-pypi` → `actions/download-artifact` |
+
+Only after those pass does `pip install pylxpweb==X` in a clean environment mean anything — and then
+it is a resolvability check, not a trust check.
 
 ```bash
-# 1) pylxpweb: bump pyproject version, changelog, tag, publish GitHub release → PyPI
-# 2) Wait until pip can install the new version
+# 1) pylxpweb: bump pyproject version, changelog, tag, publish GitHub release
+# 2) GATE: tag→commit, commit→version, Trusted Publisher, hashes, same-artifact promotion
+#          then confirm resolvability in a clean env:
+#          uv run --isolated --with 'pylxpweb==X' python -c 'import pylxpweb'
 # 3) eg4: bump manifest.json requirements + tests/requirements-test.txt + CHANGELOG Requires line
 # 4) Tag/publish integration release
 ```
+
+**What the gate does not cover:** the workflow never installs or imports the TestPyPI artifact before
+promoting it. TestPyPI success means "upload accepted", not "the package works". Step 2's clean-env
+install is the only import check in the chain, and it runs after PyPI publication — `verified-against-code`
+— pylxpweb `release.yml` (no install/smoke step between `publish-testpypi` and `publish-pypi`).
 
 ## Where versions live
 
@@ -45,7 +76,9 @@ Highest-risk operational rule in this project: **publish pylxpweb to PyPI before
 | eg4_web_monitor | `custom_components/eg4_web_monitor/manifest.json` → `"version"` | SemVer + prerelease: `X.Y.Z`, `X.Y.Z-beta.N`, `X.Y.Z-rc.N`; Git tags `vX.Y.Z` / `vX.Y.Z-beta.N` |
 | pylxpweb | `pyproject.toml` `[project].version` | PEP 440 (e.g. `0.9.39b10`); Git tags `v0.9.39b10` |
 
-**verified-against-code** — `docs/DEVELOPMENT.md:57-64`; manifest `version` field; pylxpweb `pyproject.toml`.
+`verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:14` (`version`); pylxpweb
+`pyproject.toml` `[project].version`. The SemVer/Keep-a-Changelog convention around them is
+`asserted-unverified` — `docs/DEVELOPMENT.md:57-64`.
 
 Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
 
@@ -55,21 +88,27 @@ Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
 | Integration pin | `pylxpweb>=0.9.39b10` |
 | `tests/requirements-test.txt` | `pylxpweb>=0.9.39b10  # keep in sync with manifest.json` |
 
-**Note:** `CLAUDE.md` Current Version may lag the manifest — prefer `manifest.json` — **verified-against-code** vs dossier §9 contradiction table.
+**Note:** the shipped version is `3.5.1-beta.10` — `verified-against-code` —
+`custom_components/eg4_web_monitor/manifest.json:14`, which is what HA and HACS read. `CLAUDE.md`
+"Current Version" lags it (naming `v3.5.1-beta.1` at `9f6d6e2`) and must not be used as the version
+source.
 
 ## Integration pin locations (must stay equal)
 
-**verified-against-code**
+1. `custom_components/eg4_web_monitor/manifest.json` → `"requirements": ["pylxpweb>=…", …]` — `verified-against-code` — `manifest.json:13`
+2. `tests/requirements-test.txt` → `pylxpweb>=…  # keep in sync with manifest.json` — `verified-against-code` — `tests/requirements-test.txt:17`
+3. CI reads the pin from `tests/requirements-test.txt` dynamically so typecheck resolves the same pylxpweb the tests do — `verified-against-code` — `.github/workflows/quality-validation.yml`, job `platinum-strict-typing`, step **Install mypy and dependencies with uv** (`PYLXPWEB_PIN=$(grep -oE '^pylxpweb[><=!~]+[0-9a-zA-Z.]+' tests/requirements-test.txt)`).
 
-1. `custom_components/eg4_web_monitor/manifest.json` → `"requirements": ["pylxpweb>=…", …]`
-2. `tests/requirements-test.txt` → `pylxpweb>=…  # keep in sync with manifest.json`
-3. CI Platinum mypy job reads the pin from `tests/requirements-test.txt` dynamically (`quality-validation.yml` ~793–801) so typecheck matches tests.
+The dynamic read exists because a hardcoded `>=`-stable specifier resolved the latest **stable** and
+hid prerelease-only APIs from mypy (`0.9.37` → `0.9.38b1`: `run_firmware_update_to_completion` was
+invisible) — `verified-against-code` — same step's inline comment.
 
 CHANGELOG convention: each beta/stable header states **Requires pylxpweb>=…** with a GitHub release link — first-class release note, not optional commentary.
 
 ## Integration release steps
 
-**verified-against-code** — `docs/DEVELOPMENT.md:57-64`, `.github/workflows/release.yml`
+Steps 1–4 are the documented procedure — `asserted-unverified` — `docs/DEVELOPMENT.md:57-64`. Steps
+5–6 (what publishing actually triggers) are `verified-against-code` — `.github/workflows/release.yml`.
 
 1. Bump `version` in `manifest.json`.
 2. Move `Unreleased` CHANGELOG entries under the new version heading (Keep a Changelog).
@@ -78,14 +117,17 @@ CHANGELOG convention: each beta/stable header states **Requires pylxpweb>=…** 
 5. Publish GitHub Release → `release.yml` builds a zip of `custom_components/eg4_web_monitor` and attaches `eg4_web_monitor.zip`.
 6. HACS consumes the tagged release.
 
-Zip exclusions (secrets must never ship) — **verified-against-code** — `release.yml:20-29`:
+Zip exclusions (secrets must never ship) — `verified-against-code` — `.github/workflows/release.yml`, step **Create release asset** (`zip -x` list):
 
 - `*.env`, `.env`, `secrets.py`
-- `*.pyc`, `__pycache__/*`, caches, `.git/*`
+- `*.pyc`, `*.pyo`, `__pycache__/*`, `.mypy_cache/*`, `.ruff_cache/*`, `.git/*`
+
+The integration's `release.yml` has **no** `workflow_dispatch` — `release: published` is its only
+trigger, so there is no manual path that attaches a zip — `verified-against-code` — `.github/workflows/release.yml`, `on:`.
 
 ## How HACS consumes releases
 
-**verified-against-code** — `hacs.json`
+`verified-against-code` — `hacs.json`
 
 | Key | Value |
 |-----|-------|
@@ -98,17 +140,49 @@ HACS installs from the GitHub Release asset produced by `release.yml`, not from 
 
 ## pylxpweb release / PyPI publish
 
-**verified-against-code** — pylxpweb `docs/DEVELOPMENT.md`, pylxpweb `.github/workflows/release.yml`
+Steps 1–3 are the documented procedure — `asserted-unverified` — pylxpweb `docs/DEVELOPMENT.md`.
+Step 4 and everything below it are `verified-against-code` — pylxpweb `.github/workflows/release.yml`.
 
 1. Bump version in `pyproject.toml`.
 2. Update pylxpweb `CHANGELOG.md`.
 3. Tag and publish a GitHub Release (e.g. `gh release create v0.9.39b10 …`).
 4. Workflow **Publish to PyPI** on `release: published`:
-   - Build with `uv build`
+   - Build with `uv build`, then `uv run twine check dist/*`
    - Publish to **TestPyPI** (OIDC environment `testpypi`)
    - Then publish to **PyPI** (OIDC environment `pypi`)
-5. Manual `workflow_dispatch` may allow `skip-publish` / target selection — check the workflow file before relying on it.
+
+### Manual dispatch: inputs, triggers, and the TestPyPI gate
+
+`workflow_dispatch` takes exactly **one** input — `environment`, required, `type: choice` — with
+three options: `skip-publish`, `testpypi`, `pypi`. There is no `skip-publish` *flag*; it is one of the
+three values of that single input — `verified-against-code` — pylxpweb `release.yml`, `on.workflow_dispatch.inputs.environment`.
+
+**Dispatch cannot bypass the TestPyPI → PyPI gate.** The gate is structural, not conditional:
+`publish-pypi` declares `needs: [build, publish-testpypi]`, and no job uses `if: always()`, so a
+skipped `publish-testpypi` skips `publish-pypi` too. Every input value is covered —
+`verified-against-code` — pylxpweb `release.yml`, jobs `publish-testpypi` / `publish-pypi` (`needs:` and `if:`):
+
+| `environment` input | `publish-testpypi` | `publish-pypi` | Net effect |
+|---|---|---|---|
+| `skip-publish` | skipped (`if` excludes it) | skipped (`if` requires `pypi`; dependency also skipped) | build + `twine check` only |
+| `testpypi` | runs | skipped (`if` requires `pypi`) | TestPyPI only |
+| `pypi` | **runs** (`if` is `!= 'skip-publish'`) | runs after it succeeds | TestPyPI **then** PyPI |
+| (release published) | runs | runs after it succeeds | TestPyPI then PyPI |
+
+There is no input combination that reaches PyPI without publishing to TestPyPI first.
+
+**Who can trigger it.** The workflow declares no actor restriction, so this reduces to GitHub's own
+rule that `workflow_dispatch` requires write access to the repository — `verified-against-code` for
+the absence of a restriction (pylxpweb `release.yml`, no `if: github.actor` guard on any job);
+`asserted-unverified` for the platform rule itself (GitHub Actions documented behavior, not a fact in
+this tree). The `testpypi` and `pypi` GitHub Environments **may** carry required-reviewer or branch
+protection rules, which would gate dispatch further — those live in repository settings and are **not
+determinable from the tree**; check the environment settings on GitHub before assuming either way.
+
+`concurrency: release-publish` with `cancel-in-progress: false` serializes releases — a second
+dispatch queues rather than cancelling the first — `verified-against-code` — pylxpweb `release.yml`, `concurrency:`.
 
 ## SemVer / prerelease ordering reminder
 
-Observed line: `…-beta.N` < `…-rc.N` < final `X.Y.Z` (e.g. beta.27 < rc.1 < 3.4.0) — **inferred** from CHANGELOG release narrative; treat as project convention when cutting candidates.
+Observed line: `…-beta.N` < `…-rc.N` < final `X.Y.Z` (e.g. beta.27 < rc.1 < 3.4.0) — `inferred` from
+the `CHANGELOG.md` 3.4.0 release sequence; treat as project convention when cutting candidates.

--- a/llmwiki/50-operations/release-process.md
+++ b/llmwiki/50-operations/release-process.md
@@ -85,7 +85,7 @@ it is a resolvability check, not a trust check.
 
 `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:14` (`version`); pylxpweb
 `pyproject.toml` `[project].version`. The SemVer/Keep-a-Changelog convention around them is
-`asserted-unverified` — `docs/DEVELOPMENT.md:57-64`.
+`asserted-unverified` — `docs/DEVELOPMENT.md` "Releasing".
 
 Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
 
@@ -95,10 +95,11 @@ Snapshot at `9f6d6e2` (will drift — re-read files, do not hard-code forever):
 | Integration pin | `pylxpweb>=0.9.39b10` |
 | `tests/requirements-test.txt` | `pylxpweb>=0.9.39b10  # keep in sync with manifest.json` |
 
-**Note:** the shipped version is `3.5.1-beta.10` — `verified-against-code` —
-`custom_components/eg4_web_monitor/manifest.json:14`, which is what HA and HACS read. `CLAUDE.md`
-"Current Version" lags it (naming `v3.5.1-beta.1` at `9f6d6e2`) and must not be used as the version
-source.
+**`manifest.json` is the only version authority** — it is what HA and HACS actually read —
+`verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:14` (`3.5.1-beta.10` at
+`9f6d6e2`). A version copied into prose is a snapshot that stops being true at the next release
+unless someone remembers to update it, and that has already gone wrong here by nine betas. Read the
+manifest; do not trust a version you find written in a document, including this one.
 
 ## Integration pin locations (must stay equal)
 
@@ -114,8 +115,8 @@ CHANGELOG convention: each beta/stable header states **Requires pylxpweb>=…** 
 
 ## Integration release steps
 
-Steps 1–4 are the documented procedure — `asserted-unverified` — `docs/DEVELOPMENT.md:57-64`. Steps
-5–6 (what publishing actually triggers) are `verified-against-code` — `.github/workflows/release.yml`.
+Steps 1–4 are the documented procedure — `asserted-unverified` — `docs/DEVELOPMENT.md` "Releasing".
+Steps 5–6 (what publishing actually triggers) are `verified-against-code` — `.github/workflows/release.yml`.
 
 1. Bump `version` in `manifest.json`.
 2. Move `Unreleased` CHANGELOG entries under the new version heading (Keep a Changelog).


### PR DESCRIPTION
## Summary
- Adds `llmwiki/50-operations/` operations chapter for coding agents: dev environment (incl. four-mode docker switching), quality gates, two-repo release ordering, and issue/PR/beads pipeline.
- Sourced from `/tmp/llmwiki-research/repo-operations.md` and verified against tree at `9f6d6e2`.
- Scope is docs-only under `llmwiki/50-operations/`; no product code changes.

## Test plan
- [ ] Spot-check front matter (`verified-against: 9f6d6e2`) on all four pages
- [ ] Confirm `git diff --name-only origin/main...HEAD` lists only `llmwiki/50-operations/*`
- [ ] Cross-read commands against `docs/DEVELOPMENT.md`, `prek.toml`, and `quality-validation.yml` push triggers (`develop` only)
- [ ] Confirm release ordering page states PyPI-first before integration pin bump
- [ ] Confirm issue-pipeline documents `bd github sync` ban and non-idempotent seed script ban


Made with [Cursor](https://cursor.com)