### PR TITLE
docs(llmwiki): portal API chapter

### DIFF
--- a/llmwiki/30-portal-api/auth-and-session.md
+++ b/llmwiki/30-portal-api/auth-and-session.md
@@ -1,0 +1,135 @@
+---
+canonical-for:
+  - EG4 portal authentication
+  - JSESSIONID session lifecycle
+  - pylxpweb reauthentication and request encoding
+sources:
+  - docs/api/openapi.yaml
+  - docs/api/README.md
+  - custom_components/eg4_web_monitor/__init__.py
+  - custom_components/eg4_web_monitor/_config_flow/__init__.py
+  - custom_components/eg4_web_monitor/cloud_requests.py
+  - custom_components/eg4_web_monitor/cloud_session.py
+  - custom_components/eg4_web_monitor/coordinator.py
+  - custom_components/eg4_web_monitor/coordinator_http.py
+  - custom_components/eg4_web_monitor/diagnostics.py
+  - joyfulhouse/pylxpweb/.gitignore
+  - joyfulhouse/pylxpweb/src/pylxpweb/client.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/constants/api.py
+  - joyfulhouse/pylxpweb/tests/integration/conftest.py
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Authentication and session lifecycle
+
+## Non-negotiable wire contract
+
+| Rule | Evidence |
+|---|---|
+| Authentication is an HTTP session cookie named `JSESSIONID`. It is **not** a bearer token, API key, or token returned in the login JSON. | `verified-against-code` `docs/api/openapi.yaml:29-35`; `pylxpweb/src/pylxpweb/client.py:818-835` |
+| Login is `POST /WManage/api/login`. | `verified-against-code` OpenAPI path `/WManage/api/login`; `pylxpweb/src/pylxpweb/client.py:825` |
+| The login body is `account=<username>&password=<password>&language=ENGLISH`. The password is sent as a normal form value over HTTPS; pylxpweb does not hash it first. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:818-825`; OpenAPI path `/WManage/api/login` |
+| `aiohttp.ClientSession` owns the effective cookie jar and attaches the cookie to subsequent calls. `LuxpowerClient._session_id` is declared but never assigned and is not authentication state. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:107-119,818-835` |
+| All JSON API operations are form-encoded POSTs. The sole method/response exception in the 44-path spec is the history export: GET returning binary `.xls`. | `verified-against-code` `docs/api/openapi.yaml:23-30`; `pylxpweb/src/pylxpweb/client.py:603-624`; `pylxpweb/src/pylxpweb/endpoints/export.py:183-202` |
+
+Do not invent an `Authorization` header and do not serialize request parameters as JSON. `verified-against-code` `docs/api/openapi.yaml:23-35`; `pylxpweb/src/pylxpweb/client.py:603-624`
+
+## Login costs three HTTP requests
+
+One successful `LuxpowerClient.login()` normally performs the following request sequence. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:818-839,935-989`
+
+| Order | Request | Why | Evidence |
+|---:|---|---|---|
+| 1 | `POST /WManage/api/login` | Establish `JSESSIONID`; parse `userId`, `role`, and the eager plant/inverter tree. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:818-835`; OpenAPI path `/WManage/api/login` |
+| 2 | Role-selected plant list (`/plant/list` or `/plant/list/viewer`) | `_detect_account_level()` obtains plants immediately inside `login()`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:839,935-962`; `pylxpweb/src/pylxpweb/endpoints/plants.py:29-30,50-52` |
+| 3 | `POST /WManage/api/inverterOverview/list` for the first plant | `_detect_account_level()` inspects `endUser` plus the login role to infer `guest`, `viewer`, `installer`, or `owner`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:962-979` |
+
+Therefore, request-budget calculations must count a normal login or renewal as three portal requests, not one. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:839,956,962`
+
+`INSTALLER` and `I_ASSISTANT` use `/WManage/web/config/plant/list`; other roles use `/WManage/web/config/plant/list/viewer`. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/plants.py:29-30,50-52`; `pylxpweb/src/pylxpweb/client.py:933`
+
+The account-level probe is deliberately best-effort: failures are caught and logged rather than invalidating an otherwise successful login. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:951-989`
+
+## The “two-hour session” is not a server fact
+
+| Statement | Grade and source |
+|---|---|
+| After login, pylxpweb locally sets `_session_expires = now + 2 hours`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:829` |
+| No inspected response field communicates a server expiry time, and no repository-visible expiry negotiation exists. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:818-841`; OpenAPI schema `LoginResponse` |
+| “Sessions last two hours” is therefore a **client-side guess**, useful only as a proactive refresh threshold. It must not be treated as the portal's authoritative TTL. | `inferred` from the preceding two code facts |
+| The operational expiry signal is usually an HTML login page where JSON was expected; HTTP 401 is the other explicit signal. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:664-732` |
+
+An expired-cookie response can still have HTTP 200. JSON parsing then raises `aiohttp.ContentTypeError`, which pylxpweb interprets as authentication expiry and routes through renewal. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:664-696`
+
+## Renewal state machine
+
+| Condition | Client action | Loop bound | Evidence |
+|---|---|---:|---|
+| Local two-hour timestamp has passed | `_ensure_authenticated()` renews before the request. | One shared login task | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:874-878` |
+| Response body is HTML/wrong content type | Treat as expired session, renew, replay. | One renewal and one replay | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:664-696,746-774` |
+| HTTP status is 401 | Renew, replay. | One renewal and one replay | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:698-732,746-774` |
+| Replayed request is still unauthorized | Raise `LuxpowerAuthError("Session remained unauthorized after re-authentication")`. | No second replay | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:746-759` |
+
+### Why concurrent expiry produces only one login
+
+| Mechanism | Required interpretation | Evidence |
+|---|---|---|
+| Authentication generation counter | Each failed caller records the generation it observed. If another caller has already completed renewal and incremented the generation, the stale caller does not log in again. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:124,880-906` |
+| Shared authentication task | Concurrent renewers await the same in-flight login task. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:880-921` |
+| `asyncio.shield` | Cancelling one waiter cannot cancel the shared authentication task needed by other requests. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:880-921` |
+| Context-local replay guard | `_reactive_authentication_replay` records that the current request chain already replayed, preventing an authentication loop. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:127-130,746-774` |
+
+This is single-flight renewal: N concurrent expired requests may all observe failure, but they converge on one login generation and each original operation is replayed at most once. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:874-921`; concurrency coverage `pylxpweb/tests/unit/test_client_aioresponses.py:781-900,945-1058`
+
+## Session ownership and isolation
+
+| Client construction | Close behavior | Evidence |
+|---|---|---|
+| pylxpweb creates the `aiohttp.ClientSession` | `close()` drains/cancels in-flight authentication and closes the owned session, dropping its cookie jar. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:195-236` |
+| Caller injects the session | `close()` does not close or clear the caller-owned session or cookie jar. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:211-236` |
+
+Cookie-authenticated accounts on the same portal host must not share a domain-level cookie jar: each cloud-capable Home Assistant config entry creates its own private `ClientSession`/cookie jar, even when several entries reuse one account, and drains it before detach/close. `verified-against-code` `custom_components/eg4_web_monitor/coordinator.py:299-325,1048-1066`; `cloud_session.py` → `async_close_client_session`
+
+There is no implemented portal logout, explicit cookie revocation, or password/token rotation operation in pylxpweb. Closing an owned session is the only repository-visible cookie-discard path. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:211-236,818-914`
+
+## Credential-compromise incident procedure
+
+Trigger this procedure when a portal password, `JSESSIONID`, credential-bearing configuration file, command line, log, screenshot, support bundle, or public commit is exposed or suspected exposed. Record the discovery time and source without copying the secret into another ticket or log, remove public access to the artifact, and assume it was copied before removal. `inferred` from the cookie/password authentication boundary above and the durable storage paths below
+
+| Inventory target | What to inspect without echoing the secret | Evidence |
+|---|---|---|
+| Home Assistant configuration entries | Identify every HTTP or HYBRID entry whose `entry.data` uses the affected username and base URL. Home Assistant persists config-entry data under `.storage/core.config_entries`; use the UI/API rather than editing that file. | `verified-against-code` `custom_components/eg4_web_monitor/coordinator.py:299-315`; `_config_flow/__init__.py:824-841,1451-1452`; persistence filename `asserted-unverified` from the Home Assistant storage convention, with this repo's config-entry access as the durable artifact |
+| pylxpweb development credentials | Inventory the pylxpweb repository root `.env`, `.env.local`, `.env.*.local`, process environment variables `LUXPOWER_USERNAME`/`LUXPOWER_PASSWORD`, and any private copies or backups of those files. Do not read values into logs. | `verified-against-code` `pylxpweb/tests/integration/conftest.py` (`env_path`, `LUXPOWER_USERNAME`, `LUXPOWER_PASSWORD`); `pylxpweb/.gitignore:60-62` |
+| Automation and copies | Inventory CI/secret-manager entries, shell history, Home Assistant backups, browser password stores, and exported support artifacts that could contain the same password or cookie. Diagnostics currently redact username/password, but that does not prove every external artifact is clean. | Redaction `verified-against-code` `custom_components/eg4_web_monitor/diagnostics.py:31-45`; broader-copy inventory `inferred` from the two persisted credential locations above |
+| Active sessions | Enumerate Home Assistant entries, browser profiles, scripts, and other clients logged into the affected portal account; each can hold a separate cookie. Entries sharing credentials have the same account blast radius even though each coordinator creates a separate private `ClientSession`/cookie jar. | `verified-against-code` `custom_components/eg4_web_monitor/coordinator.py:299-315,765-785`; `cloud_requests.py` → `CloudRequestLimiter` |
+
+| Order | Required action | Verification and evidence |
+|---:|---|---|
+| 1 | **Contain:** disable or unload every affected Home Assistant config entry and stop affected scripts before rotation so they cannot create fresh sessions with the exposed password. Preserve one controlled pre-rotation browser session only if it is needed for the read-only invalidation check in step 5. | Entry unload closes the client and disposes its private cookie-bearing session. `verified-against-code` `custom_components/eg4_web_monitor/__init__.py` → `async_unload_entry`; `cloud_session.py` → `async_close_client_session` |
+| 2 | **Rotate manually:** from a trusted device, sign in directly to the portal, open its account/profile password control, and set a new unique password. The repository does not document the UI route or expose a password-change API; if the control is unavailable, contact the portal account administrator or EG4 support instead of inventing an endpoint. | UI path and support workflow `asserted-unverified` (`docs/api/openapi.yaml` contains no account-password path; `pylxpweb/src/pylxpweb/client.py:818-914` contains no rotation call) |
+| 3 | **Dispose local sessions and force reauthentication:** reload or re-enable every affected Home Assistant entry after the password change. After its private old cookie jar is disposed, setup uses the stored old password; a completed rotation makes that login fail and enter the integration's reauthentication flow. Enter the new password there: the flow validates it, updates `entry.data`, and reloads the entry. Close affected browser sessions and restart each script/client so no controlled old cookie jar remains. | `verified-against-code` `custom_components/eg4_web_monitor/coordinator_http.py:540-565`; `_config_flow/__init__.py:807-847`; `cloud_session.py` → `async_close_client_session`; rotation consequence `inferred` |
+| 4 | **Verify credential revocation:** in a fresh private browser/client with no cookies, confirm the old password can no longer log in, then confirm the new password can. Do not test with a control write. | This proves password replacement, not cookie revocation. `inferred` from `/WManage/api/login` and the cookie boundary |
+| 5 | **Test server-session invalidation separately:** use the one controlled pre-rotation session, if retained, for a read-only page/request after rotation. Whether password rotation invalidates existing server-side `JSESSIONID` sessions is **UNKNOWN until tested**; the two-hour client timestamp is not proof. | `asserted-unverified` (`pylxpweb/src/pylxpweb/client.py:829`; no logout/revocation path in `client.py:211-236,818-914`) |
+| 6 | **Escalate if an old cookie still works:** keep affected integrations/scripts unloaded, delete controlled local cookies, and request account-wide session revocation from the portal administrator or EG4 support. Do not claim containment from password rotation alone. | Server-side manual revocation capability and response time `asserted-unverified` (`docs/api/openapi.yaml` has no revocation endpoint; no repository issue records a tested support flow) |
+
+**Manual target:** the incident owner is the operator who controls both the portal account and the Home Assistant host. Begin immediately and target password rotation, controlled-session disposal, and the old-password negative test within **15 minutes** of confirmed disclosure; start vendor/admin escalation immediately if the controlled old-cookie test remains authorized. This is a local response target, not a server guarantee. `asserted-unverified` (operational policy recorded in `llmwiki/30-portal-api/auth-and-session.md`)
+
+## Encoding details agents routinely get wrong
+
+| Detail | Correct behavior | Evidence |
+|---|---|---|
+| Content type | `application/x-www-form-urlencoded; charset=UTF-8`; `Accept: application/json`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:603-609` |
+| aiohttp call | Pass a flat mapping as `data=...`; do not pass `json=...`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:622` |
+| Most booleans | Explicit lower-case strings, for example `"true"` and `"false"`. | `verified-against-code` `docs/api/openapi.yaml:23-28` and endpoint call sites |
+| `autoRetry`, `daylightSavingTime` | Passed as Python booleans, so aiohttp form-encodes `True`/`False`; the documented client behavior relies on the portal accepting that capitalization. | `verified-against-code` `docs/api/openapi.yaml:23-28`; `pylxpweb/src/pylxpweb/endpoints/control.py:145-150`; `pylxpweb/src/pylxpweb/endpoints/plants.py:310-364` |
+| Nested mappings | Never put a mapping inside a form value. The historical raw-write body encoded the inner mapping opaquely and silently dropped the intended values. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:292-305` |
+| Export | Use `GET /WManage/web/analyze/data/export/{serialNum}/{startDate}` with optional `endDateText` query parameter and parse the binary workbook separately. | `verified-against-code` OpenAPI export path; `pylxpweb/src/pylxpweb/endpoints/export.py:183-231` |
+
+## Login failure boundaries
+
+`login()` retries only `LuxpowerConnectionError`, with exponential delay and `MAX_LOGIN_RETRIES = 3`; authentication rejection and application errors are surfaced immediately. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:843-872`; `pylxpweb/src/pylxpweb/constants/api.py:38`
+
+This separation matters to Home Assistant: a temporary network failure must not be converted into a bad-credentials repair flow. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:686-687,843-872`
+
+For application-error retry rules and the absence of HTTP 429 handling, see `errors.md`. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:626-655,698-744`

--- a/llmwiki/30-portal-api/auth-and-session.md
+++ b/llmwiki/30-portal-api/auth-and-session.md
@@ -17,7 +17,9 @@ sources:
   - joyfulhouse/pylxpweb/src/pylxpweb/client.py
   - joyfulhouse/pylxpweb/src/pylxpweb/constants/api.py
   - joyfulhouse/pylxpweb/tests/integration/conftest.py
-verified-against: 9f6d6e2
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 
@@ -113,7 +115,7 @@ Trigger this procedure when a portal password, `JSESSIONID`, credential-bearing 
 | 5 | **Test server-session invalidation separately:** use the one controlled pre-rotation session, if retained, for a read-only page/request after rotation. Whether password rotation invalidates existing server-side `JSESSIONID` sessions is **UNKNOWN until tested**; the two-hour client timestamp is not proof. | `asserted-unverified` (`pylxpweb/src/pylxpweb/client.py:829`; no logout/revocation path in `client.py:211-236,818-914`) |
 | 6 | **Escalate if an old cookie still works:** keep affected integrations/scripts unloaded, delete controlled local cookies, and request account-wide session revocation from the portal administrator or EG4 support. Do not claim containment from password rotation alone. | Server-side manual revocation capability and response time `asserted-unverified` (`docs/api/openapi.yaml` has no revocation endpoint; no repository issue records a tested support flow) |
 
-**Manual target:** the incident owner is the operator who controls both the portal account and the Home Assistant host. Begin immediately and target password rotation, controlled-session disposal, and the old-password negative test within **15 minutes** of confirmed disclosure; start vendor/admin escalation immediately if the controlled old-cookie test remains authorized. This is a local response target, not a server guarantee. `asserted-unverified` (operational policy recorded in `llmwiki/30-portal-api/auth-and-session.md`)
+**Manual target:** the incident owner is the operator who controls both the portal account and the Home Assistant host. Begin immediately and target password rotation, controlled-session disposal, and the old-password negative test within **15 minutes** of confirmed disclosure; start vendor/admin escalation immediately if the controlled old-cookie test remains authorized. This is a proposed local response target, not a server guarantee; no repository issue, vendor SLA, or tested support record establishes the 15-minute value. `asserted-unverified`
 
 ## Encoding details agents routinely get wrong
 

--- a/llmwiki/30-portal-api/endpoints.md
+++ b/llmwiki/30-portal-api/endpoints.md
@@ -11,7 +11,9 @@ sources:
   - scripts/download_inverter_firmware.py
   - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/
   - joyfulhouse/pylxpweb/src/pylxpweb/models.py
-verified-against: 9f6d6e2
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 

--- a/llmwiki/30-portal-api/endpoints.md
+++ b/llmwiki/30-portal-api/endpoints.md
@@ -1,0 +1,158 @@
+---
+canonical-for:
+  - EG4 portal endpoint inventory
+  - EG4 portal object and identifier model
+  - OpenAPI coverage boundaries
+sources:
+  - docs/api/openapi.yaml
+  - docs/api/README.md
+  - docs/api/PORTAL_ENDPOINTS.md
+  - docs/reference/firmware/FIRMWARE_ACQUISITION.md
+  - scripts/download_inverter_firmware.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/
+  - joyfulhouse/pylxpweb/src/pylxpweb/models.py
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Portal endpoint reference
+
+## Coverage boundary
+
+| Inventory | Count | Meaning | Evidence |
+|---|---:|---|---|
+| `docs/api/openapi.yaml` paths | **44** | Deliberate pylxpweb-called subset, not the complete portal. | `verified-against-code` `docs/api/openapi.yaml:7-13`; machine count of `paths` |
+| OpenAPI component schemas | **64** | Reusable request/response definitions in the current spec. | `verified-against-code` `docs/api/openapi.yaml` `components.schemas`; machine count |
+| Spec paths with live pylxpweb call sites | **44** | Every specified path is used; there are **zero unused spec paths**. | `verified-against-code` exhaustive comparison of OpenAPI `paths` with `pylxpweb/src/pylxpweb/endpoints/*.py` |
+| Routes referenced elsewhere but absent from the spec | **7** | Two script-used API routes, two documented but uncalled API routes, two HTML pages, and one API route on another host. | `verified-against-code` repository string inventory summarized below |
+| `PORTAL_ENDPOINTS.md` catalog | **251** | Broader authenticated-frontend discovery map; the OpenAPI subset is intentionally much smaller. | `asserted-unverified` `docs/api/PORTAL_ENDPOINTS.md:9-12,429`; deliberate OpenAPI scope `verified-against-code` `docs/api/openapi.yaml:7-13` |
+
+Unless a row says otherwise, paths are relative to `https://monitor.eg4electronics.com`, use form-encoded POST, and return JSON. `verified-against-code` `docs/api/openapi.yaml:23-30,48-50`; `pylxpweb/src/pylxpweb/client.py:603-624`
+
+## The 44 specified paths
+
+### Authentication and plants
+
+| # | Path | Request → result | pylxpweb call site | Evidence |
+|---:|---|---|---|---|
+| 1 | `POST /WManage/api/login` | `account`, `password`, `language=ENGLISH` → session cookie plus `LoginResponse` with `userId`, `role`, and eager topology | `LuxpowerClient.login()` | `verified-against-code` OpenAPI path; `client.py:818-839` |
+| 2 | `POST /WManage/web/config/plant/list/viewer` | paging/search, optionally `targetPlantId` → viewer/admin plant rows | `PlantsEndpoints.get_plants()`, `get_plant_details()` | `verified-against-code` OpenAPI path; `endpoints/plants.py:30,90,133` |
+| 3 | `POST /WManage/web/config/plant/list` | same shape → installer/I-assistant plant rows | role-selected variants of the same methods | `verified-against-code` OpenAPI path; `endpoints/plants.py:29,50-52` |
+| 4 | `POST /WManage/web/config/plant/edit` | full plant record including `plantId`, timezone/country enums and `daylightSavingTime` → success envelope | `update_plant_config()`, `set_daylight_saving_time()` | `verified-against-code` OpenAPI path; `endpoints/plants.py:310-396` |
+| 5 | `POST /WManage/locale/region` | `continent` enum → `[{value,text}]` regions | `_fetch_country_location_from_api()` | `verified-against-code` OpenAPI path; `endpoints/plants.py:181` |
+| 6 | `POST /WManage/locale/country` | `region` enum → `[{value,text}]` countries | `_fetch_country_location_from_api()` | `verified-against-code` OpenAPI path; `endpoints/plants.py:195` |
+| 7 | `POST /WManage/api/plantOverview/list/viewer` | `searchText` → aggregate plant metrics and nested inverters | `get_plant_overview()` | `verified-against-code` OpenAPI path; `endpoints/plants.py:423` |
+
+The locale calls are real call sites but bypass the normal request helper: they have no shared caching, backoff, reauthentication, or `success:false` handling, and they silently continue on non-200. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/plants.py:150-221`
+
+### Discovery, hierarchy, runtime, energy and batteries
+
+| # | Path | Request → result | pylxpweb call site | Evidence |
+|---:|---|---|---|---|
+| 8 | `POST /WManage/api/inverterOverview/list` | `plantId`, paging/search/status → devices in the plant | `devices.get_devices()`; `plants.get_inverter_overview()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:145`; `endpoints/plants.py:476` |
+| 9 | `POST /WManage/api/inverterOverview/getParallelGroupDetails` | device `serialNum` → group devices and roles | `get_parallel_group_details()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:47-69` |
+| 10 | `POST /WManage/api/inverter/autoParallel` | `plantId` → request group re-detection | `sync_parallel_groups()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:110` |
+| 11 | `POST /WManage/api/inverter/getInverterInfo` | inverter `serialNum` → static config, firmware, datalog SN and ratings | `devices.get_inverter_info()`; `analytics.get_inverter_info()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:178`; `endpoints/analytics.py:561` |
+| 12 | `POST /WManage/api/inverter/getInverterRuntime` | inverter `serialNum` → raw realtime inverter metrics | `get_inverter_runtime()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:213` |
+| 13 | `POST /WManage/api/inverter/getInverterEnergyInfo` | inverter `serialNum` → raw daily/lifetime energy totals | `get_inverter_energy()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:243` |
+| 14 | `POST /WManage/api/inverter/getInverterEnergyInfoParallel` | any group member `serialNum` → group-aggregate energy | `get_parallel_energy()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:270` |
+| 15 | `POST /WManage/api/battery/getBatteryInfo` | inverter `serialNum` → bank aggregate and `batteryArray[]` module data | `get_battery_info()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:302` |
+| 16 | `POST /WManage/api/battery/getBatteryInfoForSet` | inverter `serialNum` → lightweight battery identities/status | `devices.get_battery_list()`; `analytics.get_battery_list()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:335`; `endpoints/analytics.py:514` |
+| 17 | `POST /WManage/api/midbox/getMidboxRuntime` | GridBOSS/MID `serialNum` → `MidboxRuntime` with `midboxData` and primary `deviceData` | `get_midbox_runtime()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:366`; `models.py:1023-1035` |
+| 18 | `POST /WManage/api/system/cluster/search/findOnlineDatalog` | **datalog** `serialNum` → derived online state | `get_dongle_status()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:407-411` |
+| 19 | `POST /WManage/web/config/datalog/list` | `plantId` (`-1` for all), paging/search → dongles, `lost`, update time | `get_datalog_list()` | `verified-against-code` OpenAPI path; `endpoints/devices.py:431-461` |
+
+Three paths intentionally have duplicate wrappers: inverter overview, inverter info, and battery-list-for-set. The duplication is in Python access paths, not on the wire. `verified-against-code` call sites in rows 8, 11 and 16
+
+### Parameter and immediate controls
+
+| # | Path | Request → result | pylxpweb call site | Evidence |
+|---:|---|---|---|---|
+| 20 | `POST /WManage/web/maintain/remoteRead/read` | `inverterSn`, `startRegister`, `pointNumber`, `autoRetry` → flat root-level `HOLD_*`/`FUNC_*` values | `read_parameters()` | `verified-against-code` OpenAPI path; `endpoints/control.py:145-157`; `models.py:1041-1057` |
+| 21 | `POST /WManage/web/maintain/remoteSet/write` | `inverterSn`, `holdParam`, pre-scaled `valueText`, client/type fields → success envelope | `write_parameter()` | `verified-against-code` OpenAPI path; `endpoints/control.py:200-217` |
+| 22 | `POST /WManage/web/maintain/remoteSet/writeTime` | `inverterSn`, `timeParam`, `hour`, `minute`, client/type fields → one atomic boundary write | `write_time_parameter()` | `verified-against-code` OpenAPI path; `endpoints/control.py:230-280` |
+| 23 | `POST /WManage/web/maintain/remoteSet/functionControl` | `functionParam`, lower-case `enable` → one boolean function bit | `control_function()` | `verified-against-code` OpenAPI path; `endpoints/control.py:441-502` |
+| 24 | `POST /WManage/web/maintain/remoteSet/bitParamControl` | `bitParam`, multi-valued `value` → GridBOSS smart-port mode | `control_bit_param()` | `verified-against-code` OpenAPI path; `endpoints/control.py:504-562` |
+| 25 | `POST /WManage/web/config/quickCharge/start` | inverter SN, client type, optional positive `minute` → start | `start_quick_charge()` | `verified-against-code` OpenAPI path; `endpoints/control.py:564-615` |
+| 26 | `POST /WManage/web/config/quickCharge/stop` | inverter SN and client type → stop | `stop_quick_charge()` | `verified-against-code` OpenAPI path; `endpoints/control.py:617-648` |
+| 27 | `POST /WManage/web/config/quickCharge/getStatusInfo` | inverter SN → task flags/status; `quickChargeMinute` represents raw holding register 234 | `get_quick_charge_status()` | `verified-against-code` OpenAPI path; `endpoints/control.py:650-681`; `models.py:1079-1114` |
+| 28 | `POST /WManage/web/config/quickDischarge/start` | inverter SN and client type → start | `start_quick_discharge()` | `verified-against-code` OpenAPI path; `endpoints/control.py:683-709` |
+| 29 | `POST /WManage/web/config/quickDischarge/stop` | inverter SN and client type → stop | `stop_quick_discharge()` | `verified-against-code` OpenAPI path; `endpoints/control.py:711-733` |
+
+### Firmware
+
+| # | Path | Request → result | pylxpweb call site | Evidence |
+|---:|---|---|---|---|
+| 30 | `POST /WManage/web/maintain/standardUpdate/checkUpdates` | `serialNum` → component/version/update-chain details | `check_firmware_updates()` | `verified-against-code` OpenAPI path; `endpoints/firmware.py:91` |
+| 31 | `POST /WManage/web/maintain/standardUpdate/check12KParallelStatus` | `userId`, `serialNum` → eligibility | `check_update_eligibility()` | `verified-against-code` OpenAPI path; `endpoints/firmware.py:154-193` |
+| 32 | `POST /WManage/web/maintain/standardUpdate/run` | `userId`, `serialNum`, lower-case `tryFastMode` → begin update | `start_firmware_update()` | `verified-against-code` OpenAPI path; `endpoints/firmware.py:252-264` |
+| 33 | `POST /WManage/web/maintain/remoteUpdate/info` | account `userId` → status rows for all account devices | `get_firmware_update_status()` | `verified-against-code` OpenAPI path; `endpoints/firmware.py:140-148` |
+
+`check12KParallelStatus` is used for all device families despite its name, and `remoteUpdate/info` is account-scoped rather than serial-scoped. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/firmware.py:140-159`
+
+Firmware start is a destructive, long-running operation; this knowledge-base work did not invoke it. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/firmware.py:202-214`
+
+### Analytics, forecasting and export
+
+| # | Path | Request → result | pylxpweb call site | Evidence |
+|---:|---|---|---|---|
+| 34 | `POST /WManage/api/analyze/chart/dayLine` | `serialNum`, free-form `attr`, date → raw hourly points | `get_chart_data()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:99` |
+| 35 | `POST /WManage/api/analyze/energy/dayColumn` | SN, parallel flag, date, free-form `energyType` → hourly energy series | `get_energy_day_breakdown()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:162` |
+| 36 | `POST /WManage/api/analyze/energy/monthColumn` | SN, parallel flag, year/month, energy type → monthly series | `get_energy_month_breakdown()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:214` |
+| 37 | `POST /WManage/api/analyze/energy/yearColumn` | SN, parallel flag, year, energy type → yearly series | `get_energy_year_breakdown()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:339` |
+| 38 | `POST /WManage/api/analyze/energy/totalColumn` | SN, parallel flag, energy type → lifetime series | `get_energy_total_breakdown()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:383` |
+| 39 | `POST /WManage/api/inverterChart/monthColumn` | SN, year, month → typed daily-energy history for one inverter | `get_month_daily_energy(parallel=False)` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:260-262` |
+| 40 | `POST /WManage/api/inverterChart/monthColumnParallel` | SN, year, month → typed daily-energy history for its group | `get_month_daily_energy(parallel=True)` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:260-262` |
+| 41 | `POST /WManage/api/analyze/event/list` | paging, `plantId=-1` for all, optional SN, `_all` or event code → event rows | `get_event_list()` | `verified-against-code` OpenAPI path; `endpoints/analytics.py:456-475` |
+| 42 | `POST /WManage/api/predict/solar/dayPredictColumnParallel` | `serialNum` → solar forecast | `get_solar_forecast()` | `verified-against-code` OpenAPI path; `endpoints/forecasting.py:61` |
+| 43 | `POST /WManage/api/weather/forecast` | `serialNum` → weather plus plant latitude/longitude | `get_weather_forecast()` | `verified-against-code` OpenAPI path; `endpoints/forecasting.py:105` |
+| 44 | `GET /WManage/web/analyze/data/export/{serialNum}/{startDate}` | optional `endDateText` query → binary `.xls` | `export_data()` | `verified-against-code` OpenAPI path; `endpoints/export.py:183-231` |
+
+The forecasting shapes are intentionally provisional in the schema even though repository records say their bodies were live-validated on 2026-07-15. `portal-correlated` `docs/api/README.md:414-422`; OpenAPI forecasting paths
+
+The export workbook is capped at ten day sheets and has firmware-dependent columns, so pylxpweb parses it by header rather than fixed column number. `portal-correlated` `docs/api/README.md:484-486`; `pylxpweb/src/pylxpweb/endpoints/export.py:186-231`
+
+## Seven referenced routes outside the OpenAPI spec
+
+“Absent” means absent from `docs/api/openapi.yaml`; it does not mean safe, stable, or publicly supported. `verified-against-code` comparison against OpenAPI `paths`
+
+| Path | Category and known contract | Evidence grade |
+|---|---|---|
+| `POST /WManage/web/maintain/appLocalUpdate/listForAppByType` | Used by a repository firmware-download script. Form field: `firmwareDeviceType`; documented rows include `recordId`, filename/version fields, and `encryptedFirmware`. | Reference/call site `verified-against-code` `scripts/download_inverter_firmware.py:58`; response behavior `portal-correlated` `docs/reference/firmware/FIRMWARE_ACQUISITION.md:40-43` |
+| `POST /WManage/web/maintain/appLocalUpdate/getUploadFileAnalyzeInfo` | Used by the same script. Form fields: `recordId`, **1-based** `startIndex`; documented result contains paged base64 chunks and metadata. | Reference/call site `verified-against-code` `scripts/download_inverter_firmware.py:59`; paging behavior `portal-correlated` `docs/reference/firmware/FIRMWARE_ACQUISITION.md:44-66` |
+| `POST /WManage/web/maintain/remoteWeeklyOperation/readValues` | Documented future weekly-schedule read for registers 500-723; no pylxpweb call site. | String/reference `verified-against-code` `pylxpweb/src/pylxpweb/registers/scheduling.py:1-29`; portal availability `asserted-unverified` |
+| `POST /WManage/web/maintain/remoteWeeklyOperation/setValues` | Documented future weekly-schedule write; no pylxpweb call site. | String/reference `verified-against-code` `pylxpweb/src/pylxpweb/registers/scheduling.py:1-29`; portal availability `asserted-unverified` |
+| `/WManage/web/maintain/workingMode/sna` | Portal HTML page, not a JSON API; used as provenance for some `HOLD_AC_FIRST_*` names. | Reference `verified-against-code` `pylxpweb/src/pylxpweb/constants/registers.py:97`; page behavior `asserted-unverified` |
+| `/WManage/web/config/plant/edit/{plant_id}` | Portal HTML edit page linked by a Home Assistant Repair for manual DST work; distinct from the form POST path without the ID suffix. | Reference `verified-against-code` `pylxpweb/src/pylxpweb/constants/locations.py:8`; `custom_components/eg4_web_monitor/coordinator_mixins.py:4091`; page behavior `asserted-unverified` |
+| `POST https://res.solarcloudsystem.com:8443/resource/findAllTypeInfo` | Different host; documented firmware release-note lookup by `firmwareDeviceType`. | Documentation `asserted-unverified` `docs/reference/firmware/FIRMWARE_ACQUISITION.md:83-85` |
+
+The broader catalog states that it contains 251 paths observed in portal frontend assets; that discovery claim is not re-proven here. `asserted-unverified` (`docs/api/PORTAL_ENDPOINTS.md:9-12,429-441`) Do not promote a catalog entry into client code without request/response evidence. `inferred` from the OpenAPI call-site scope
+
+## Object model
+
+| Parent | Child | Cardinality represented by the API | Identity | Evidence |
+|---|---|---:|---|---|
+| Plant / station | Parallel group | `0..n` | `plantId` identifies the plant; groups carry a name such as `Parallel_A`. | `verified-against-code` login/OpenAPI schemas; `pylxpweb/src/pylxpweb/models.py:184-195` |
+| Parallel group | MID / GridBOSS | `0..1` | `serialNum`; portal `deviceType=9`. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:371-381`; `constants/api.py:20-21` |
+| Parallel group | Inverter | `1..n` | `serialNum`; portal `deviceType=6`. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:371-381`; `constants/api.py:20-21` |
+| Inverter | Battery module | `0..n` | `batteryKey`, `batIndex`, and usually a positional `batterySn`. | `verified-against-code` OpenAPI schemas `BatteryInfo`, `BatteryModule`; `pylxpweb/src/pylxpweb/models.py:638-755` |
+
+Login eagerly returns `plants[] -> inverters[]`, including `parallelGroups[]` when the device family supplies them, so topology is partially known before explicit discovery. `verified-against-code` OpenAPI schema `LoginResponse`; `pylxpweb/src/pylxpweb/models.py:184-238`
+
+`parallelGroups` may be absent and defaults to an empty list, including on some 12000XP payloads. `portal-correlated` `pylxpweb/src/pylxpweb/models.py:187-195` and captured-login rationale in `docs/api/README.md`
+
+## Identifier rules and traps
+
+| Identifier | Wire type / meaning | Agent rule | Evidence |
+|---|---|---|---|
+| `plantId` | Integer in cloud JSON. | Home Assistant's selector submits a **string**; normalize at the UI/storage boundary. Do not assume matching Python types. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:123,190,277,399,1682`; `portal-correlated` `CHANGELOG.md:556` |
+| `plantId=-1` | Sentinel meaning “all plants” for datalog and event list queries. | Preserve the sentinel; do not validate it as a real station ID. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/devices.py:431`; `endpoints/analytics.py:470` |
+| `serialNum` | String. It may be alphanumeric, not just digits. | Do not apply a numeric-only regex. Synthetic format examples: numeric `1234567890`; alphanumeric `ABCDE12345` and `EXAMPLE001`. Each is exactly 10 characters; none identifies real hardware. | `portal-correlated` captured payload shapes documented in `docs/api/README.md`; `verified-against-code` `pylxpweb/src/pylxpweb/models.py` serial fields and absence of numeric-format validation |
+| `getParallelGroupDetails.serialNum` | An inverter/MID device serial. | **Do not pass `plantId`** even though neighboring discovery calls use it. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/devices.py:47-69` |
+| `findOnlineDatalog.serialNum` | Datalog/dongle serial, not inverter serial. | Obtain it from `getInverterInfo.datalogSn`. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/devices.py:407-411`; OpenAPI schema `InverterInfo` |
+| `batteryKey` | Composite string `{inverterSerial}_{batterySn}`. | Use the returned key as identity; synthetic example: `ABCDE12345_Battery_ID_01`. | `portal-correlated` battery payload shape documented in `docs/api/README.md`; `verified-against-code` schema field at `docs/api/openapi.yaml:2574` |
+| `batterySn` | Often a position label such as `Battery_ID_01`. | Do not assume it is a manufacturer-unique hardware serial. | `portal-correlated` `pylxpweb/samples/battery.json` |
+| `deviceType` | Portal topology discriminator: 6 inverter, 9 MID/GridBOSS. | Do not confuse it with local Modbus register-19 `deviceTypeCode`; they are separate namespaces. | `verified-against-code` `pylxpweb/src/pylxpweb/constants/api.py:20-21`; `devices/discovery.py:52,87,121` |
+| `userId` | Integer from login. | Required by firmware eligibility, start, and account-wide status calls. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/firmware.py:140-142,185-187,252-254` |
+
+`MidboxRuntime` contains both a 108-field `midboxData` structure and `deviceData` for the primary inverter summary. The typed `MidboxDeviceData` model retains only `isOffGrid`; other wire keys in that nested object are discarded unless raw JSON is retained. `verified-against-code` `pylxpweb/src/pylxpweb/models.py:1012-1035`; `portal-correlated` `pylxpweb/samples/midbox_runtime.json`

--- a/llmwiki/30-portal-api/errors.md
+++ b/llmwiki/30-portal-api/errors.md
@@ -1,0 +1,146 @@
+---
+canonical-for:
+  - EG4 portal error envelopes
+  - pylxpweb retry and backoff behavior
+  - EG4 cloud request throttling and cache policy
+sources:
+  - docs/api/openapi.yaml
+  - docs/api/README.md
+  - CHANGELOG.md
+  - custom_components/eg4_web_monitor/cloud_requests.py
+  - custom_components/eg4_web_monitor/coordinator.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/client.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/constants/api.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/exceptions.py
+  - joyfulhouse/pylxpweb/tests/integration/test_control_operations.py
+  - joyfulhouse/pylxpweb/tests/integration/test_get_operations.py
+  - joyfulhouse/pylxpweb/tests/unit/test_transient_error_retry.py
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Errors, retries, rate control and readback limits
+
+## HTTP 200 can be failure
+
+Portal application errors normally arrive as an HTTP 200 JSON envelope with `success:false`; HTTP status alone does not identify success. `verified-against-code` `docs/api/openapi.yaml:34-39`; `pylxpweb/src/pylxpweb/client.py:626-655`
+
+```json
+{"success": false, "message": "REMOTE_SET_ERROR"}
+```
+
+The example is a known envelope shape and known firmware-rejection message. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:626-655`; `portal-correlated` `CHANGELOG.md` issues #316/#331
+
+| Parsing rule | Behavior | Evidence |
+|---|---|---|
+| `success` is explicitly `false` | Treat as application failure even when status is 200. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:626-655` |
+| `success` is absent | Default to **true** via `json_data.get("success", True)`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:627` |
+| Error text | Select `message`, then `msg`, then a diagnostic containing the full response. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:628-631` |
+| Terminal application error | Raise `LuxpowerAPIError("API error (HTTP <status>): <message>")`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:655` |
+
+Do not “tighten” the absent-`success` default without endpoint-by-endpoint evidence: several portal responses are legitimate data structures rather than a uniform success envelope. `inferred` from the verified default and raw-dictionary endpoint behavior in `pylxpweb/src/pylxpweb/endpoints/analytics.py`, `forecasting.py`, and `plants.py`
+
+## Retry classification
+
+Only five portal-message fragments are transient. Matching is substring-based. `verified-against-code` `pylxpweb/src/pylxpweb/constants/api.py:42-48`; `client.py:634-652`
+
+| Transient fragment | Interpretation | Retry behavior | Evidence |
+|---|---|---|---|
+| `DATAFRAME_TIMEOUT` | Device dataframe communication timed out. | Retry with exponential backoff. | `verified-against-code` `constants/api.py:42-48`; `client.py:634-652` |
+| `TIMEOUT` | Generic timeout message. | Retry with exponential backoff. | `verified-against-code` same |
+| `BUSY` | Busy message, also matching busy-like prose by substring. | Retry with exponential backoff. | `verified-against-code` same |
+| `COMMUNICATION_ERROR` | Portal-to-device communication failure. | Retry with exponential backoff. | `verified-against-code` same |
+| `DEVICE_BUSY` | Device is processing another request. | Retry with exponential backoff. | `verified-against-code` same |
+
+The client allows `MAX_TRANSIENT_ERROR_RETRIES = 3`, meaning one initial request plus as many as three retries for a matching portal-message error. `verified-against-code` `pylxpweb/src/pylxpweb/constants/api.py:32-48`; `pylxpweb/tests/unit/test_transient_error_retry.py:103-125`
+
+### `apiBlocked`
+
+`apiBlocked` is a portal application message carried as HTTP 200 JSON with `success:false`; the locked unit-test shape is `{"success":false,"msg":"apiBlocked"}`. pylxpweb classifies it as non-transient, raises `LuxpowerAPIError` immediately, and makes exactly one request. `verified-against-code` `pylxpweb/tests/unit/test_transient_error_retry.py` → `test_is_not_transient_error_api_blocked`, `test_non_transient_error_not_retried`
+
+Live-test handling associates `apiBlocked` with an account that lacks permission for remote parameter reads or writes. The repository does **not** establish that it is an HTTP-rate quota signal, so do not treat it as equivalent to 429. `portal-correlated` `pylxpweb/tests/integration/test_get_operations.py:103-113`; `test_control_operations.py:153-163`
+
+A caller should stop retrying the operation, surface a permission/account-level error, and require the operator to use an account authorized for that parameter action. Reauthentication with the same account is not a demonstrated remedy. `inferred` from the terminal classification and permission-correlated integration handling above
+
+## `REMOTE_SET_ERROR` is terminal firmware rejection
+
+| Wire outcome | Meaning | Client action | Evidence |
+|---|---|---|---|
+| HTTP 200, `success:false`, `message` or `msg` contains `REMOTE_SET_ERROR` | Firmware rejected or does not support the named write for that device/family. | Raise `LuxpowerAPIError`; **do not retry** because the message is not transient. | `portal-correlated` issues #316/#331 in `CHANGELOG.md`; `verified-against-code` transient set in `constants/api.py:42-48` |
+| HTTP 200, `success:false`, one of the five transient fragments | Temporary busy/communication failure. | Retry up to the configured bound. | `verified-against-code` `client.py:634-652` |
+| Successful write envelope | Portal accepted the named operation. | Invalidate relevant cache; no automatic cloud hardware readback follows. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:210-219,271-280` |
+
+Repeatedly retrying `REMOTE_SET_ERROR` cannot turn a family-incompatible parameter into a supported one and adds portal load. `inferred` from the verified terminal classification and portal-correlated family rejection evidence
+
+## ACK is not semantic proof
+
+A write aimed at the wrong function bit can still be acknowledged. In the documented off-grid green-mode incident, the server/firmware accepted the write even though the inferred bit identity was wrong; reading through the same interpreted path could not expose that semantic mismatch. `portal-correlated` `CHANGELOG.md:166` and issue #476
+
+Therefore, an ACK or success envelope proves request acceptance, not that the intended physical feature changed. A name-to-register or bit mapping requires an independent delta test against the intended behavior: capture baseline, write, observe the target state through an independent source, and restore. `inferred` from the portal-correlated wrong-bit incident and verified absence of automatic cloud readback
+
+Cloud cache invalidation is likewise not verification. It merely forces a later fetch. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:210-219,271-280`
+
+## Authentication and transport errors are different classes
+
+| Situation | Wire symptom | Result | Retry/repair boundary | Evidence |
+|---|---|---|---|---|
+| Expired session | HTTP 200 HTML login page causes `aiohttp.ContentTypeError` | Authentication renewal and once-only replay | A second unauthorized result raises `LuxpowerAuthError`. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:664-696,746-774` |
+| Unauthorized session | HTTP 401 | Same renewal/replay path | Once only. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:698-732,746-774` |
+| Forbidden | HTTP 403 | `LuxpowerAPIError("HTTP 403: ...")` | No reauthentication branch and no immediate retry. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:698-744` |
+| Too many requests | HTTP 429 | `LuxpowerAPIError("HTTP 429: ...")` | No `Retry-After` handling and no immediate retry. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:698-744` |
+| Network failure | `aiohttp.ClientError` | `LuxpowerConnectionError` | Login retries only connection failures; HA should not treat them as bad credentials. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:680-687,843-872` |
+| Other non-success HTTP status | `ClientResponseError` | `LuxpowerAPIError` with HTTP status/message | Not an auth replay unless status is 401. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:698-744` |
+| Response validates at HTTP/request layer but fails endpoint model validation | Pydantic schema error after `_request()` returns | `pydantic.ValidationError` can escape | Not translated to a portal exception. | `verified-against-code` endpoint `model_validate` calls, for example `endpoints/control.py:210-213` |
+
+The exception hierarchy is `LuxpowerError` with API, authentication, connection, and device branches; `LuxpowerDeviceOfflineError` derives from the device branch. `verified-against-code` `pylxpweb/src/pylxpweb/exceptions.py:6-27`
+
+`LuxpowerAPIError` has no structured `status`, response, or headers attribute. HTTP 403 and 429 therefore have the same public exception type and are **not robustly distinguishable through pylxpweb's structured API**; the numeric status survives only in the exception text and in the chained private `aiohttp.ClientResponseError`. Parsing `str(error)` or inspecting `error.__cause__` is possible but is not a stable typed contract. The request telemetry counts both requests without status-specific counters. `verified-against-code` `pylxpweb/src/pylxpweb/exceptions.py` → `LuxpowerAPIError`; `client.py:342-394,698-744`
+
+## There is no HTTP 429 handling
+
+No HTTP 429 constant, `Retry-After` parser, or rate-limit-specific branch exists in the inspected pylxpweb request path. `verified-against-code` exhaustive `429`/`TOO_MANY` search; `pylxpweb/src/pylxpweb/client.py:698-744`; `constants/api.py:32-48`
+
+No observed server-side 429 behavior is established by the durable repository evidence. Treat any claim about the portal's actual quota or reset window as unverified. `asserted-unverified` (`docs/api/README.md:471-486`; no 429 fixture or branch in `pylxpweb/src/pylxpweb/client.py`)
+
+The implemented rate strategy is client-side self-restraint; `apiBlocked` is a separate terminal application message whose relationship to rate quotas is not established. `inferred` from the absence of 429 logic and the verified mechanisms below
+
+### Client-side controls
+
+| Control | Value / behavior | Evidence |
+|---|---|---|
+| Cloud poll floor | `min_poll_interval_seconds = 30.0`; local Modbus is 1.0 seconds. | `verified-against-code` `pylxpweb/src/pylxpweb/transports/capabilities.py:74-75,95` |
+| Error backoff | Base 1.0 second, factor 2.0, maximum 60.0 seconds, jitter 0.1. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:145-150`; `constants/api.py:27-30` |
+| Backoff scope | Applies before the next request after any recorded request error, not only rate-limit-like failures; resets after success. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:396-435,601` |
+| Device discovery cache | 15 minutes. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:135` |
+| Battery info cache | **60 seconds**; the stale prose conflict is owned by the [divergence ledger](./schemas-and-scaling.md#verified-divergence-ledger). | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:136` |
+| Parameter read cache | 2 minutes. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:137` |
+| Quick-charge status cache | 1 minute. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:138` |
+| Runtime, energy and MID caches | 20 seconds each. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:139-141` |
+| Unlisted cache-key default | 30 seconds. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:452` |
+| Hour-boundary flush | The first request after the local hour changes clears the whole response cache, protecting date-bucketed energy from stale rollover values. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:580-591`; purpose `inferred` |
+| Request telemetry | Tracks per-minute, last-hour, densest 60-second rate and today's calls; it observes but does not enforce a quota. Cache hits are not counted. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:342-394,159-162` |
+
+### Hour-boundary thundering-herd exposure and bound
+
+The hour change clears every response-cache key in each pylxpweb client. The cache has no per-key single-flight and the flush adds no jitter, so concurrent coordinator work immediately after the boundary can turn many formerly cached operations into queued calls against a vendor portal the integration treats as rate-sensitive. Multiple config entries using the same account can synchronize on the same boundary; the actual vendor quota remains unknown. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:440-532,580-598`; herd consequence and rate-risk classification `inferred`
+
+The Home Assistant integration bounds that exposure with a semaphore of **3 request chains**, shared per normalized `(username, base_url, verify_ssl)` key; see [Intervals, throttles and caches](../10-integration/data-flow-by-mode.md#intervals-throttles-and-caches). The limiter is re-entrant for pylxpweb's recursive retry/reauthentication calls, so one admitted chain keeps one slot instead of deadlocking on reacquisition. `verified-against-code` `custom_components/eg4_web_monitor/cloud_requests.py` → `SharedCloudRequestBudget`, `CloudRequestLimiter`, `acquire_shared_cloud_request_budget`; `coordinator.py:765-785`
+
+For one Home Assistant process and one exact account key, the instantaneous admitted-chain bound is `C <= 3`. This caps concurrency, **not total post-flush calls**: every distinct cache miss may still queue, each normal login costs three sequential portal requests, and separate Home Assistant processes or direct pylxpweb clients do not share this semaphore. The limiter therefore contains the herd but does not prove compliance with an unknown vendor quota. `verified-against-code` limiter sources above and `pylxpweb/src/pylxpweb/client.py:818-839,935-989`; conclusion `inferred`
+
+The 30-second transport floor and 20-second runtime cache are separate layers: the transport capability prevents the cloud polling cadence from being set below 30 seconds even though an individual cached response has a shorter TTL. `verified-against-code` `pylxpweb/src/pylxpweb/transports/capabilities.py:74-75`; `client.py:139-141`; `inferred` interaction statement
+
+Login amplifies traffic because account-level detection adds plant and device requests; budget three calls per normal login/renewal. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:839,935-989`
+
+## Decision table for callers
+
+| Observed result | Safe classification | Caller behavior | Evidence |
+|---|---|---|---|
+| `success:false`, `REMOTE_SET_ERROR` | Terminal parameter/firmware rejection | Surface and family-gate; no automatic retry. | `portal-correlated` issues #316/#331; `inferred` caller rule |
+| `success:false`, one of five transient fragments | Temporary portal/device communication problem | Let pylxpweb perform its bounded retries; do not add an unbounded outer retry. | `verified-against-code` `client.py:634-652`; `inferred` outer-loop rule |
+| `success:false`, `apiBlocked` | Terminal permission-correlated application block | Stop; surface account-level/permission remediation. Do not retry or map it to 429. | `verified-against-code` `test_transient_error_retry.py` → `test_non_transient_error_not_retried`; interpretation `portal-correlated` integration tests cited above |
+| HTTP 200 HTML or 401 | Expired/invalid session | Let the single-flight renewal path perform one replay. | `verified-against-code` `client.py:664-732,746-774` |
+| HTTP 403 | Forbidden, non-auth-replay HTTP failure | Surface `LuxpowerAPIError`; no automatic retry. It is not structurally distinguishable from 429 by exception type. | `verified-against-code` `client.py:698-744`; `exceptions.py` → `LuxpowerAPIError` |
+| HTTP 429 | Too-many-requests, but unsupported as a special case | Surface `LuxpowerAPIError`; no `Retry-After` semantics. It is not structurally distinguishable from 403 by exception type. | `verified-against-code` `client.py:698-744`; `exceptions.py` → `LuxpowerAPIError` |
+| Success ACK after control write | Accepted request only | Do not claim the intended feature changed without independent evidence. | `portal-correlated` wrong-bit incident #476; `inferred` caller rule |
+| Partial offline JSON | Valid degraded data | Preserve the object and mark missing metrics unavailable; do not turn it into an all-entity failure. | `portal-correlated` issues #256/#479; `verified-against-code` optional fields in `models.py:458-465,706-755,1023-1035` |

--- a/llmwiki/30-portal-api/errors.md
+++ b/llmwiki/30-portal-api/errors.md
@@ -15,7 +15,9 @@ sources:
   - joyfulhouse/pylxpweb/tests/integration/test_control_operations.py
   - joyfulhouse/pylxpweb/tests/integration/test_get_operations.py
   - joyfulhouse/pylxpweb/tests/unit/test_transient_error_retry.py
-verified-against: 9f6d6e2
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 
@@ -124,7 +126,7 @@ The implemented rate strategy is client-side self-restraint; `apiBlocked` is a s
 
 The hour change clears every response-cache key in each pylxpweb client. The cache has no per-key single-flight and the flush adds no jitter, so concurrent coordinator work immediately after the boundary can turn many formerly cached operations into queued calls against a vendor portal the integration treats as rate-sensitive. Multiple config entries using the same account can synchronize on the same boundary; the actual vendor quota remains unknown. `verified-against-code` `pylxpweb/src/pylxpweb/client.py:440-532,580-598`; herd consequence and rate-risk classification `inferred`
 
-The Home Assistant integration bounds that exposure with a semaphore of **3 request chains**, shared per normalized `(username, base_url, verify_ssl)` key; see [Intervals, throttles and caches](../10-integration/data-flow-by-mode.md#intervals-throttles-and-caches). The limiter is re-entrant for pylxpweb's recursive retry/reauthentication calls, so one admitted chain keeps one slot instead of deadlocking on reacquisition. `verified-against-code` `custom_components/eg4_web_monitor/cloud_requests.py` → `SharedCloudRequestBudget`, `CloudRequestLimiter`, `acquire_shared_cloud_request_budget`; `coordinator.py:765-785`
+The Home Assistant integration bounds that exposure with a semaphore of **3 request chains**, shared per normalized `(username, base_url, verify_ssl)` key; see [Intervals, throttles and caches](../10-integration/data-flow-by-mode.md#6-intervals-throttles-and-caches). The limiter is re-entrant for pylxpweb's recursive retry/reauthentication calls, so one admitted chain keeps one slot instead of deadlocking on reacquisition. `verified-against-code` `custom_components/eg4_web_monitor/cloud_requests.py` → `SharedCloudRequestBudget`, `CloudRequestLimiter`, `acquire_shared_cloud_request_budget`; `coordinator.py:765-785`
 
 For one Home Assistant process and one exact account key, the instantaneous admitted-chain bound is `C <= 3`. This caps concurrency, **not total post-flush calls**: every distinct cache miss may still queue, each normal login costs three sequential portal requests, and separate Home Assistant processes or direct pylxpweb clients do not share this semaphore. The limiter therefore contains the herd but does not prove compliance with an unknown vendor quota. `verified-against-code` limiter sources above and `pylxpweb/src/pylxpweb/client.py:818-839,935-989`; conclusion `inferred`
 

--- a/llmwiki/30-portal-api/schemas-and-scaling.md
+++ b/llmwiki/30-portal-api/schemas-and-scaling.md
@@ -1,0 +1,162 @@
+---
+canonical-for:
+  - EG4 portal response shapes
+  - EG4 cloud value scaling
+  - EG4 parameter read and write representation
+  - spec, documentation, sample, and pylxpweb schema divergences
+sources:
+  - CLAUDE.md
+  - CHANGELOG.md
+  - docs/api/openapi.yaml
+  - docs/api/PORTAL_ENDPOINTS.md
+  - docs/api/README.md
+  - joyfulhouse/pylxpweb/samples/battery.json
+  - joyfulhouse/pylxpweb/samples/energy.json
+  - joyfulhouse/pylxpweb/samples/midbox_runtime.json
+  - joyfulhouse/pylxpweb/src/pylxpweb/client.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/constants/registers.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/models.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/constants/scaling.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/control.py
+  - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/devices.py
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Schemas and scaling
+
+## Governing asymmetry
+
+> **Cloud reads deliver raw integers that still need scaling. Named cloud writes accept pre-scaled engineering units.** `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py:49-192`; `pylxpweb/src/pylxpweb/endpoints/control.py:420-439`
+
+The read and write paths are intentionally asymmetric. Applying a read divisor again before `remoteSet/write` corrupts a setpoint; sending a local raw register integer as `valueText` can be wrong by the same factor in the opposite direction. `inferred` from the verified read/write contracts above
+
+| Direction | Wire representation | Required client behavior | Evidence |
+|---|---|---|---|
+| Runtime, energy, battery, MID and parameter **read** | Raw integer fields | Apply the field's divisor while constructing engineering-unit values. Preserve `None` and documented sentinels. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:448-755,827-1035`; `constants/scaling.py:49-192` |
+| Named parameter **write** via `remoteSet/write` | Engineering value in string field `valueText` | Convert the local/canonical raw value to its engineering value first; for example raw 595 with divisor 10 becomes `"59.5"`. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:200-217,420-439` |
+| Boolean function write | Named `functionParam` plus lower-case `enable` | Use `functionControl`; do not write the containing register as a scalar. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:441-502` |
+| Multi-valued bit field | Named `bitParam` plus `value` | Use `bitParamControl`; do not coerce it to boolean. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:504-562` |
+
+## Authoritative scaling table
+
+| Field family | Raw → engineering conversion | Evidence |
+|---|---:|---|
+| `vpv1..6`, `vacr/s/t`, `vepsr/s/t`, bank `vBat`, `genVolt`, GridBOSS grid/UPS/gen RMS voltages | divide by **10** | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py:49-59`; OpenAPI `x-scaling`; `portal-correlated` battery capture `vBat=531` and `totalVoltageText="53.1"` |
+| `vBus1`, `vBus2` | divide by 100 | `verified-against-code` OpenAPI schema `InverterRuntime` `vBus1`/`vBus2` scaling |
+| `fac`, `feps`, `genFreq`, `gridFreq`, `phaseLockFreq` | divide by 100 | `verified-against-code` OpenAPI `x-scaling` and `pylxpweb/src/pylxpweb/constants/scaling.py` |
+| `maxChgCurr`, `maxDischgCurr` | divide by 100 | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py` → `INVERTER_RUNTIME_SCALING` |
+| GridBOSS/MID grid, UPS and generator RMS currents | divide by 100 | `verified-against-code` OpenAPI schema `MidboxData` |
+| GridBOSS/MID **smart-load** RMS currents | divide by **10** | `verified-against-code` OpenAPI schema `MidboxData` |
+| Battery-module `totalVoltage` | divide by 100 | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:638-704`; `portal-correlated` capture `5324 -> 53.24 V` |
+| Battery-module `current` | divide by **10**, not 100 | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py:190-192`; `models.py:645` |
+| Battery-module `batMaxCellVoltage`, `batMinCellVoltage` | divide by 1000 | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:638-704`; `portal-correlated` capture `3332 -> 3.332 V` |
+| Battery-module `batMaxCellTemp`, `batMinCellTemp` | divide by 10 | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:638-704`; `portal-correlated` capture `250 -> 25.0 C` |
+| Active-power fields beginning with `p` | multiply by 1; values are watts | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py:100-114` |
+| `tinner`, `tradiator*`, valid `tBat` | multiply by 1; values are degrees Celsius | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py` → `INVERTER_RUNTIME_SCALING` |
+| `soc`, `seps`, `capacityPercent` | multiply by 1; values are percentage points | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py` → runtime/battery scaling maps; Pydantic model types |
+| **All energy totals** in `EnergyInfo`, `MidboxData`, and history | divide by **10**; raw unit is 0.1 kWh | `verified-against-code` `pylxpweb/src/pylxpweb/constants/scaling.py:121-166`; OpenAPI energy schemas |
+
+### Captured proof for energy
+
+`pylxpweb/samples/energy.json` contains `todayYielding=5` beside a rendered value of `"0.5"`, and `totalYielding=13597` beside `"1359.7"`. This establishes 0.1 kWh wire units and a divisor of 10; it contradicts the stale “Wh, divide by 1000” endpoint docstring. `portal-correlated` `pylxpweb/samples/energy.json`; `verified-against-code` `pylxpweb/src/pylxpweb/models.py:609-627`; `constants/scaling.py:121-166`
+
+Many payloads provide raw values together with `*Text`, `*TextUnitLess`, or `*Data`/`*Unit` siblings. Use these captured display fields to test a suspected divisor, but use canonical scaling metadata in implementation. `portal-correlated` `pylxpweb/samples/energy.json`, `pylxpweb/samples/battery.json`; `inferred` implementation rule
+
+## `remoteRead/read` is flat and name-keyed
+
+The response from `POST /WManage/web/maintain/remoteRead/read` places parameters directly at the JSON root under descriptive names such as `HOLD_*` and `FUNC_*`. It is **not** nested under `parameters`, and it is **not** keyed by numeric register address. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:92-95,145-157`; `pylxpweb/src/pylxpweb/models.py:1041-1057`
+
+```json
+{
+  "success": true,
+  "inverterSn": "...",
+  "deviceType": 6,
+  "startRegister": 0,
+  "pointNumber": 127,
+  "HOLD_DEVICE_TYPE_CODE": 54,
+  "FUNC_EPS_EN": true
+}
+```
+
+The example shows the documented OpenAPI shape only; its illustrative values are not a captured response. `asserted-unverified` (`docs/api/openapi.yaml` path `/WManage/web/maintain/remoteRead/read`)
+
+`ReadParametersResponse` therefore allows extra fields and exposes a computed `.parameters` view over those extras while typing the fixed envelope fields. `verified-against-code` `pylxpweb/src/pylxpweb/models.py:1048-1057`
+
+| Prefix | Meaning | Correct write endpoint | Evidence |
+|---|---|---|---|
+| `HOLD_*` | Scalar holding value | `remoteSet/write` with `holdParam` and pre-scaled `valueText` | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:164-217`; `constants/registers.py:661-693` |
+| `FUNC_*` | One named boolean bit from a bit-field register | `remoteSet/functionControl` with `functionParam` and `enable` | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:441-502` |
+| `BIT_*` | Named multi-valued bit field | `remoteSet/bitParamControl` with `bitParam` and `value` | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:504-562` |
+| `_12K_HOLD_*` | Off-grid-family named scalar variant | Same scalar endpoint; family-specific name | `verified-against-code` `pylxpweb/src/pylxpweb/constants/registers.py:1138-1152` |
+| `LSP_HOLD_*` | Server-side read interpretation used by peak-shaving schedules | Read-only mapping; do not derive a write name from it | `verified-against-code` `pylxpweb/src/pylxpweb/constants/registers.py:121-126`; `endpoints/control.py:1689-1768` |
+
+The server synthesizes `FUNC_LSP_*` interpretations for register 22; they are not proven local Modbus bit fields. Register 22 is locally a scalar PV-start-voltage register, so never port those cloud names into local bit writes. `verified-against-code` `pylxpweb/src/pylxpweb/constants/registers.py:688-693`
+
+## Named-write conversion and rejection rules
+
+The historical cloud raw-write implementation placed a dictionary inside one form field. aiohttp serialized it as an opaque representation, the intended inner values did not reach the portal as parameters, and success-shaped responses could accompany a no-op. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:292-305`
+
+Current `write_parameters()` resolves an address/value mapping into sequential, flat, named writes. `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:292-351`
+
+| Stage | Contract | Evidence |
+|---|---|---|
+| Preflight | Resolve every requested address before the first write so an unsupported member cannot cause an avoidable partial update. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:337-342` |
+| Reject | Reject packed-time registers, unmapped addresses, bit-field/multi-name registers, and signed values whose negative portal representation is unverified. Never guess. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:377-418` |
+| Scale | Prefer canonical `ScaleFactor`; then explicit name/address divide-by-ten fallbacks; otherwise divisor 1. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:420-439`; `constants/registers.py:1138-1152` |
+| Send | Issue one `remoteSet/write` per resolved name, sequentially. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:344-351` |
+| Failure | Stop at the first failed write. Earlier successful writes remain applied. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:344-351` |
+| Success | Invalidate cached values for that device. Cache invalidation is not hardware readback proof. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:210-219` |
+
+Cloud multi-write is therefore not atomic. `inferred` from the verified sequential stop-on-first-failure behavior
+
+## Partial, unreliable and sentinel-valued fields
+
+Absence and `None` are domain states, not schema noise. A model that requires every online field will reject valid offline payloads and can blank the entire device in Home Assistant. `portal-correlated` issues #256/#479 recorded in `CHANGELOG.md`; `verified-against-code` optional fields in `pylxpweb/src/pylxpweb/models.py`
+
+| Payload / field | Observed behavior | Required handling | Evidence |
+|---|---|---|---|
+| Offline `getInverterRuntime`: `status`, `ppv`, `soc`, `vBat`, `pCharge`, `pDisCharge`, `batPower`, `batteryColor`, `pinv`, `prec`, `peps` | Fields can be omitted while identity, `statusText="offline"`, some PV/voltage/temperature fields remain. | Make live metrics optional and preserve the partial object; do not reject the whole payload. | `portal-correlated` issue #256; `verified-against-code` `pylxpweb/src/pylxpweb/models.py:458-465` |
+| Offline `getBatteryInfo`: `batStatus`, `soc`, `vBat`, `pCharge`, `pDisCharge` | Fields can be omitted. | Keep the response/bank identity and treat metrics as unavailable. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:706-755` |
+| Inverter runtime `tBat` sentinel | Apply the canonical value and handling from [the inverter input-register ledger](../40-hardware/registers.md#inverter-input-register-ledger); this page does not duplicate that hardware fact. | Normalize the sentinel to null/unavailable before plausibility checks. | `verified-against-code` `pylxpweb/src/pylxpweb/devices/inverters/_runtime_properties.py` → `battery_temperature`; hardware evidence remains with the linked keeper |
+| Battery `capacityPercent=0` | Can be a fake value on 12000XP payloads with no cloud module array while the BMS charge/capacity pair remains live. | Keep raw value primary; only use the proven BMS-pair fallback under the library's guarded condition. | `portal-correlated` issue #514; `CHANGELOG.md:30` |
+| MID `lost` | When true, the dongle is offline and cloud data can be a frozen last-register mirror. | Retain and surface the offline signal; do not present frozen metrics as current. | `portal-correlated` issue #479; `verified-against-code` `pylxpweb/src/pylxpweb/models.py:1029-1033` |
+| Battery strings `ambientTemp`, `mosTemp`, `chgCapacity`, `disChgCapacity`, `noticeInfo` | Captures use empty string `""` as well as null-like absence. | Model as optional strings; do not parse blindly as numbers. | `portal-correlated` `pylxpweb/samples/battery.json`; `verified-against-code` `models.py:698-703` |
+| `batteryArray` | May be absent when no batteries are reported. | Default to an empty list. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:753-754` |
+| Parallel energy `serialNum`, `soc` | May be absent from group responses. | Keep optional. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:613,617-618` |
+| Viewer `endUser`, `deviceTypeText4APP` | May be absent. | Do not make account/device discovery depend on presence. | `portal-correlated` `docs/api/README.md:468-470` |
+| Analytics `attr` and `energyType` | Unknown strings can return success with empty or zero-filled series. | Validate against a proven vocabulary; zero data alone cannot prove the selector was valid. | `portal-correlated` `docs/api/README.md:430-434,475-480`; `inferred` validation rule |
+| `chart/dayLine.data[].month` versus `energy/yearColumn.data[].month` | Day-line month is zero-indexed; year-column month is one-indexed. | Normalize per endpoint, never globally. | `portal-correlated` `docs/api/README.md:428-429` |
+
+The failure mode is whole-object amplification: one required-but-omitted live field causes Pydantic validation failure, and downstream consumers lose every otherwise-valid entity from that response. This previously happened for offline inverters until the affected runtime fields became optional. `portal-correlated` issue #256; `inferred` failure-chain description from `models.py:458-465`
+
+## `MidboxData` completeness
+
+The OpenAPI `MidboxData` schema enumerates **108 fields**, and the pylxpweb Pydantic `MidboxData` model has exactly the same 108-field set. `verified-against-code` `docs/api/openapi.yaml:2699-3078`; `pylxpweb/src/pylxpweb/models.py:827-1010`; machine field-set comparison
+
+A captured `midbox_runtime.json` contains **101** of those fields. The schema/model are a superset because inactive or unsupported smart-load, AC-couple, current, and energy families can be omitted. `portal-correlated` `pylxpweb/samples/midbox_runtime.json`; `verified-against-code` OpenAPI `MidboxData` optional properties
+
+All `MidboxData` numeric properties are nullable. For optional port families, zero or null can mean inactive/unavailable rather than a measured physical zero; `null` specifically documents a register-read failure. `verified-against-code` `docs/api/openapi.yaml:2702-2708`; `inferred` do-not-conflate rule
+
+## Verified divergence ledger
+
+This table records source conflicts so an agent does not trust whichever prose it happens to find first. `verified-against-code` each row cites its adjudicating source
+
+| Severity | Conflicting source | Incorrect claim | Adjudicated truth | Evidence |
+|---|---|---|---|---|
+| **HIGH** | `pylxpweb/endpoints/devices.py:222,233-234` | Energy is Wh divided by 1000; examples use `eInvDay`/`eInvAll`. | Raw energy is **0.1 kWh divided by 10**; actual fields are `todayYielding` and `totalYielding`. | `verified-against-code` `models.py:609-627`; `constants/scaling.py:121-166`; `portal-correlated` `samples/energy.json` |
+| **HIGH** | `pylxpweb/endpoints/devices.py:188-192,204` | Runtime voltage is divided by 100; example uses `vacr / 100`. | Runtime PV/AC voltage is divided by **10**; the stale docstring is a 10x error. | `verified-against-code` `constants/scaling.py:49-59`; `models.py:449-450`; OpenAPI runtime `x-scaling` |
+| MEDIUM | `CLAUDE.md` API architecture (`asserted-unverified` source claim) | Serial numbers are 10-digit numeric strings. | Values are 10-character strings and may be alphanumeric; code does not validate numeric form. The sanitized format examples are owned by [Identifier rules and traps](./endpoints.md#identifier-rules-and-traps). | `portal-correlated` captured payload shapes documented in `docs/api/README.md`; `verified-against-code` `models.py` serial fields |
+| MEDIUM | `CLAUDE.md:155` (`asserted-unverified` source claim) | Battery-info cache is five minutes. | `client.py` uses 60 seconds. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:136` |
+| MEDIUM | `PORTAL_ENDPOINTS.md:11` (`asserted-unverified` source claim) | 41 catalog routes map to the validated spec. | The spec has 44 paths; the difference is login, installer-only plant list, and an export placeholder-name mismatch. | `verified-against-code` machine comparison of `docs/api/openapi.yaml` paths with pylxpweb endpoint call sites |
+| INFO | `PORTAL_ENDPOINTS.md` versus OpenAPI | Catalog claims 251 discovered portal routes; the spec deliberately covers only the 44 pylxpweb-called paths. | Treat the catalog as a discovery map and the OpenAPI as the call-site contract. | Catalog count `asserted-unverified` `docs/api/PORTAL_ENDPOINTS.md:9-12`; spec scope `verified-against-code` `docs/api/openapi.yaml:7-13` |
+| LOW | Sample versus schema/model | `MidboxData` “has 108 fields” could imply every response has all 108. | Spec and model match at 108, but one capture has 101 because optional families can be absent. | `verified-against-code` OpenAPI/model field comparison; `portal-correlated` `samples/midbox_runtime.json` |
+| LOW | `pylxpweb/endpoints/devices.py:345,355-357` | MID voltage/current/frequency uniformly divide by 100; examples use `gridPower`, `loadPower`, `genPower`. | Voltage divides by 10, most current/frequency by 100, and real names are per-leg fields such as `gridL1ActivePower`. | `verified-against-code` OpenAPI schema `MidboxData` |
+| LOW | `pylxpweb/endpoints/devices.py:280,293` | Battery example uses `module.vBat / 100`. | `BatteryModule` has `totalVoltage / 100`; it has no `vBat` field. | `verified-against-code` `pylxpweb/src/pylxpweb/models.py:638-704` |
+| LOW | Client state declaration | `_session_id` appears to hold session identity. | It is never assigned; authentication lives in the aiohttp cookie jar. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:107-119,818-835` |
+| LOW | OpenAPI-only view | Every relevant repository route appears in the 44 paths. | Four routes are referenced but never called (two weekly APIs, two HTML pages), two script-used firmware-download APIs are omitted, and one documented route uses another host. | `verified-against-code` repository string inventory; operational availability `asserted-unverified` with durable sources in [Seven referenced routes outside the OpenAPI spec](./endpoints.md#seven-referenced-routes-outside-the-openapi-spec) |
+| LOW | `locale/region` and `locale/country` placement | Presence in endpoint modules suggests normal client behavior. | They bypass `_request()`, hence lack its cache, backoff, reauth and application-error behavior. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/plants.py:150-221` |
+| LOW | Quick charge/discharge symmetry | Start/stop cache behavior appears parallel. | Quick-charge start/stop invalidates its cache; quick-discharge start/stop does not. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:612-648,702-733` |
+| LOW | `CLAUDE.md` cache-boundary wording (`asserted-unverified` source claim) | Cache is cleared before the hour boundary. | The first request **after** the local hour changes clears it. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:580-591` |
+
+When scaling sources disagree, prefer canonical constants, Pydantic field names, OpenAPI `x-scaling`, locked tests, and captured raw/display pairs over endpoint docstrings. `inferred` priority derived from the HIGH divergences and their adjudicating evidence

--- a/llmwiki/30-portal-api/schemas-and-scaling.md
+++ b/llmwiki/30-portal-api/schemas-and-scaling.md
@@ -19,7 +19,9 @@ sources:
   - joyfulhouse/pylxpweb/src/pylxpweb/constants/scaling.py
   - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/control.py
   - joyfulhouse/pylxpweb/src/pylxpweb/endpoints/devices.py
-verified-against: 9f6d6e2
+verified-against:
+  eg4_web_monitor: 9f6d6e2
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 

--- a/llmwiki/30-portal-api/schemas-and-scaling.md
+++ b/llmwiki/30-portal-api/schemas-and-scaling.md
@@ -5,7 +5,6 @@ canonical-for:
   - EG4 parameter read and write representation
   - spec, documentation, sample, and pylxpweb schema divergences
 sources:
-  - CLAUDE.md
   - CHANGELOG.md
   - docs/api/openapi.yaml
   - docs/api/PORTAL_ENDPOINTS.md
@@ -142,14 +141,14 @@ All `MidboxData` numeric properties are nullable. For optional port families, ze
 
 ## Verified divergence ledger
 
-This table records source conflicts so an agent does not trust whichever prose it happens to find first. `verified-against-code` each row cites its adjudicating source
+This table records source conflicts and durable traps so an agent does not trust whichever assumption or prose it happens to find first. `verified-against-code` each row cites its adjudicating source
 
-| Severity | Conflicting source | Incorrect claim | Adjudicated truth | Evidence |
+| Severity | Conflict or trap | Incorrect claim | Adjudicated truth | Evidence |
 |---|---|---|---|---|
 | **HIGH** | `pylxpweb/endpoints/devices.py:222,233-234` | Energy is Wh divided by 1000; examples use `eInvDay`/`eInvAll`. | Raw energy is **0.1 kWh divided by 10**; actual fields are `todayYielding` and `totalYielding`. | `verified-against-code` `models.py:609-627`; `constants/scaling.py:121-166`; `portal-correlated` `samples/energy.json` |
 | **HIGH** | `pylxpweb/endpoints/devices.py:188-192,204` | Runtime voltage is divided by 100; example uses `vacr / 100`. | Runtime PV/AC voltage is divided by **10**; the stale docstring is a 10x error. | `verified-against-code` `constants/scaling.py:49-59`; `models.py:449-450`; OpenAPI runtime `x-scaling` |
-| MEDIUM | `CLAUDE.md` API architecture (`asserted-unverified` source claim) | Serial numbers are 10-digit numeric strings. | Values are 10-character strings and may be alphanumeric; code does not validate numeric form. The sanitized format examples are owned by [Identifier rules and traps](./endpoints.md#identifier-rules-and-traps). | `portal-correlated` captured payload shapes documented in `docs/api/README.md`; `verified-against-code` `models.py` serial fields |
-| MEDIUM | `CLAUDE.md:155` (`asserted-unverified` source claim) | Battery-info cache is five minutes. | `client.py` uses 60 seconds. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:136` |
+| MEDIUM | Numeric-only identifier assumption | Treat a 10-character device serial as ten decimal digits and enforce numeric-only validation. | Portal serials are 10-character alphanumeric strings; code models them as strings and does not validate a digit-only form. The sanitized format examples are owned by [Identifier rules and traps](./endpoints.md#identifier-rules-and-traps). | `portal-correlated` captured payload shapes documented in `docs/api/README.md`; `verified-against-code` `models.py` serial fields |
+| MEDIUM | Stale battery-cache duration | Treat battery information as cached for five minutes. | The battery-information cache TTL is **60 seconds**. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:136` |
 | MEDIUM | `PORTAL_ENDPOINTS.md:11` (`asserted-unverified` source claim) | 41 catalog routes map to the validated spec. | The spec has 44 paths; the difference is login, installer-only plant list, and an export placeholder-name mismatch. | `verified-against-code` machine comparison of `docs/api/openapi.yaml` paths with pylxpweb endpoint call sites |
 | INFO | `PORTAL_ENDPOINTS.md` versus OpenAPI | Catalog claims 251 discovered portal routes; the spec deliberately covers only the 44 pylxpweb-called paths. | Treat the catalog as a discovery map and the OpenAPI as the call-site contract. | Catalog count `asserted-unverified` `docs/api/PORTAL_ENDPOINTS.md:9-12`; spec scope `verified-against-code` `docs/api/openapi.yaml:7-13` |
 | LOW | Sample versus schema/model | `MidboxData` “has 108 fields” could imply every response has all 108. | Spec and model match at 108, but one capture has 101 because optional families can be absent. | `verified-against-code` OpenAPI/model field comparison; `portal-correlated` `samples/midbox_runtime.json` |
@@ -159,6 +158,6 @@ This table records source conflicts so an agent does not trust whichever prose i
 | LOW | OpenAPI-only view | Every relevant repository route appears in the 44 paths. | Four routes are referenced but never called (two weekly APIs, two HTML pages), two script-used firmware-download APIs are omitted, and one documented route uses another host. | `verified-against-code` repository string inventory; operational availability `asserted-unverified` with durable sources in [Seven referenced routes outside the OpenAPI spec](./endpoints.md#seven-referenced-routes-outside-the-openapi-spec) |
 | LOW | `locale/region` and `locale/country` placement | Presence in endpoint modules suggests normal client behavior. | They bypass `_request()`, hence lack its cache, backoff, reauth and application-error behavior. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/plants.py:150-221` |
 | LOW | Quick charge/discharge symmetry | Start/stop cache behavior appears parallel. | Quick-charge start/stop invalidates its cache; quick-discharge start/stop does not. | `verified-against-code` `pylxpweb/src/pylxpweb/endpoints/control.py:612-648,702-733` |
-| LOW | `CLAUDE.md` cache-boundary wording (`asserted-unverified` source claim) | Cache is cleared before the hour boundary. | The first request **after** the local hour changes clears it. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:580-591` |
+| LOW | Hour-boundary timing ambiguity | Treat the response cache as cleared before the hour boundary. | The first request **after** the local hour changes clears the response cache. | `verified-against-code` `pylxpweb/src/pylxpweb/client.py:580-591` |
 
 When scaling sources disagree, prefer canonical constants, Pydantic field names, OpenAPI `x-scaling`, locked tests, and captured raw/display pairs over endpoint docstrings. `inferred` priority derived from the HIGH divergences and their adjudicating evidence


### PR DESCRIPTION
## Summary

- document cookie/JSESSIONID authentication, three-request login, single-flight renewal, and credential-compromise recovery
- catalog all 44 specified paths, 64 schemas, seven out-of-spec references, and sanitized identifier rules
- document raw-read versus engineering-unit write scaling, partial payloads, sentinel ownership, and the full A6 divergence ledger
- document HTTP-200 application errors, `apiBlocked`, 403/429 exception limits, readback limits, and the hour-boundary herd bound

## Verification

- documentation contract check: 4 pages, 44/44 paths, 64 schemas, 7/7 outside routes, graded prose and table claims
- cross-repository citation pins: `eg4_web_monitor: 9f6d6e2`, `pylxpweb: 204b95d` on all four pages
- A35/G8 fact-preservation and mutable-source gates: clean
- `git diff --check` / staged scope gate: clean
- repository commit hooks: EOF and trailing-whitespace checks passed; code-only checks skipped
- history grep for disclosed serials: 0; deterministic tree grep: `CLEAN-NO-SERIALS`
- tests not run by explicit request (docs-only change)
- no EG4 portal calls and no credentials used

## Scope

Only `llmwiki/30-portal-api/` is changed.

## Tribunal

### Round 1

- Codex + security lens: 2 BLOCKER, 2 HIGH, 1 MEDIUM — fixed.
- Claude Code cross-chapter: 3 MEDIUM, 1 LOW — fixed.
- Binding ownership decisions A4/A6 and global rules G1-G6 applied.
- Dismissed: none.

### Round 2

- Codex + security lens: 1 MEDIUM — fixed.
- Claude Code cross-chapter: 1 LOW — fixed.
- A16 cross-repository citation pins applied; G7 durable-page narration audit clean.
- Dismissed: none.

### Round 3

- Codex and Claude Code: clean.

### Round 4

- Codex and Claude Code independently flagged the same HIGH/MEDIUM A35/G8 finding — fixed.
- Three mutable sibling-content comparisons were converted to durable traps while retaining the serial-format, cache-TTL, and hour-boundary truths.
- Dismissed: none.