### PR TITLE
docs(llmwiki): pylxpweb library chapter

### DIFF
--- a/llmwiki/20-pylxpweb/api-surface.md
+++ b/llmwiki/20-pylxpweb/api-surface.md
@@ -5,7 +5,8 @@ sources:
   - pylxpweb@204b95d:src/pylxpweb/api_namespace.py
   - pylxpweb@204b95d:src/pylxpweb/devices/
   - pylxpweb@204b95d:src/pylxpweb/transports/
-verified-against: 9f6d6e2
+verified-against:
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 

--- a/llmwiki/20-pylxpweb/api-surface.md
+++ b/llmwiki/20-pylxpweb/api-surface.md
@@ -1,23 +1,17 @@
 ---
 canonical-for: pylxpweb public client, device-factory, and transport-factory seams
 sources:
-  - /tmp/llmwiki-research/pylxpweb-library.md
-  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+  - pylxpweb@204b95d:src/pylxpweb/client.py
+  - pylxpweb@204b95d:src/pylxpweb/api_namespace.py
+  - pylxpweb@204b95d:src/pylxpweb/devices/
+  - pylxpweb@204b95d:src/pylxpweb/transports/
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
 
 # API surface
 
-## Evidence grades
-
-| Grade | Meaning |
-|---|---|
-| `verified-against-code` | The cited source implements or locks the claim. |
-| `hardware-proven` | A cited source records a live-device result. |
-| `portal-correlated` | A cited source correlates a portal payload or behavior. |
-| `inferred` | The conclusion follows from cited evidence but is not enforced directly. |
-| `asserted-unverified` | No code, portal capture, or hardware capture in the cited source proves it. |
+Evidence grades follow the [canonical llmwiki legend](../README.md); this chapter does not redefine them.
 
 ## Recommended entry point
 

--- a/llmwiki/20-pylxpweb/api-surface.md
+++ b/llmwiki/20-pylxpweb/api-surface.md
@@ -1,0 +1,217 @@
+---
+canonical-for: pylxpweb public client, device-factory, and transport-factory seams
+sources:
+  - /tmp/llmwiki-research/pylxpweb-library.md
+  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# API surface
+
+## Evidence grades
+
+| Grade | Meaning |
+|---|---|
+| `verified-against-code` | The cited source implements or locks the claim. |
+| `hardware-proven` | A cited source records a live-device result. |
+| `portal-correlated` | A cited source correlates a portal payload or behavior. |
+| `inferred` | The conclusion follows from cited evidence but is not enforced directly. |
+| `asserted-unverified` | No code, portal capture, or hardware capture in the cited source proves it. |
+
+## Recommended entry point
+
+| Rule | Evidence |
+|---|---|
+| Construct `LuxpowerClient`, enter it asynchronously or close it explicitly, then use `client.api.<namespace>`. | `verified-against-code` — `src/pylxpweb/client.py:181-236`, `src/pylxpweb/client.py:238-267` |
+| `client.api.plants`, `.devices`, `.control`, `.analytics`, `.forecasting`, `.export`, and `.firmware` are lazy endpoint namespaces. | `verified-against-code` — `src/pylxpweb/api_namespace.py:51-240` |
+| New code should use `client.api.*`. Bare `client.plants`, `.devices`, `.control`, `.analytics`, `.forecasting`, `.export`, and `.firmware` remain compatibility aliases; they are labeled deprecated in comments but emit no runtime warning. | `verified-against-code` — `src/pylxpweb/client.py:238-318` |
+| Do not infer an endpoint method from namespace examples or prose. Some examples are stale; inspect the endpoint implementation before calling a method not listed here. | `verified-against-code` — `src/pylxpweb/api_namespace.py:133-138`, `src/pylxpweb/api_namespace.py:159-163`, `src/pylxpweb/api_namespace.py:207-211`, `src/pylxpweb/api_namespace.py:231-235` |
+
+## `LuxpowerClient`
+
+Exact constructor signature: `verified-against-code` — `src/pylxpweb/client.py:82-106`.
+
+```python
+LuxpowerClient(
+    username: str,
+    password: str,
+    *,
+    base_url: str = "https://monitor.eg4electronics.com",
+    verify_ssl: bool = True,
+    timeout: int = 30,
+    session: aiohttp.ClientSession | None = None,
+    iana_timezone: str | None = None,
+) -> None
+```
+
+| Namespace | Endpoint class | Intended seam | Evidence |
+|---|---|---|---|
+| `client.api.plants` | `PlantEndpoints` | Plant list/detail/configuration, DST, and overviews | `verified-against-code` — `src/pylxpweb/api_namespace.py:68-90`, `src/pylxpweb/endpoints/plants.py:54-436` |
+| `client.api.devices` | `DeviceEndpoints` | Device discovery, runtime, energy, batteries, MID/GridBOSS, dongles, and datalogs | `verified-against-code` — `src/pylxpweb/api_namespace.py:92-117`, `src/pylxpweb/endpoints/devices.py:44-532` |
+| `client.api.control` | `ControlEndpoints` | Parameter, function, bitfield, schedule, quick-action, inverter, battery, and MID controls | `verified-against-code` — `src/pylxpweb/api_namespace.py:119-144`, `src/pylxpweb/endpoints/control.py:83-3581` |
+| `client.api.analytics` | `AnalyticsEndpoints` | Charts, histories, events, and analytical reads | `verified-against-code` — `src/pylxpweb/api_namespace.py:146-169`, `src/pylxpweb/endpoints/analytics.py:54-522` |
+| `client.api.forecasting` | `ForecastingEndpoints` | Solar and weather forecasts | `verified-against-code` — `src/pylxpweb/api_namespace.py:171-193`, `src/pylxpweb/endpoints/forecasting.py:29-67` |
+| `client.api.export` | `ExportEndpoints` | Binary spreadsheet export and parsing | `verified-against-code` — `src/pylxpweb/api_namespace.py:195-217`, `src/pylxpweb/endpoints/export.py:25-231` |
+| `client.api.firmware` | `FirmwareEndpoints` | Firmware check, status, eligibility, and start calls | `verified-against-code` — `src/pylxpweb/api_namespace.py:219-240`, `src/pylxpweb/endpoints/firmware.py:36-268` |
+
+## High-level device factories
+
+The signatures below are the supported construction seam; retain the keyword-only markers and async boundaries. `verified-against-code` — `src/pylxpweb/devices/station.py:553-665`, `src/pylxpweb/devices/station.py:1286-1300`, `src/pylxpweb/devices/inverters/base.py:335-409`, `src/pylxpweb/devices/inverters/base.py:586-620`, `src/pylxpweb/devices/mid_device.py:115-120`.
+
+```python
+async Station.load(
+    client: LuxpowerClient,
+    plant_id: int,
+) -> Station
+
+async Station.load_all(
+    client: LuxpowerClient,
+) -> list[Station]
+
+async Station.from_local_discovery(
+    configs: list[TransportConfig],
+    *,
+    station_name: str = "Local Station",
+    plant_id: int = 0,
+    timezone_str: str = "UTC",
+) -> Station
+
+async station.attach_local_transports(
+    configs: list[TransportConfig],
+) -> AttachResult
+
+async BaseInverter.from_transport(
+    transport_or_type: InverterTransport | str,
+    *,
+    model: str | None = None,
+    **config: Any,
+) -> BaseInverter
+
+async BaseInverter.from_modbus_transport(
+    transport: InverterTransport,
+    model: str | None = None,
+) -> BaseInverter
+
+async BaseInverter.from_dongle_transport(
+    transport: InverterTransport,
+    model: str | None = None,
+) -> BaseInverter
+
+async MIDDevice.from_transport(
+    transport: InverterTransport,
+    model: str = "GridBOSS",
+) -> MIDDevice
+```
+
+| Factory behavior | Evidence |
+|---|---|
+| `Station.load` builds the cloud hierarchy; `load_all` loads all returned plants concurrently. | `verified-against-code` — `src/pylxpweb/devices/station.py:553-632` |
+| `Station.from_local_discovery` is asynchronous even though some older summaries omit `async`; it accepts transport configs and constructs a clientless local station. | `verified-against-code` — `src/pylxpweb/devices/station.py:634-665` |
+| `attach_local_transports` attaches local transports to cloud-discovered devices and returns match/failure counts in `AttachResult`. | `verified-against-code` — `src/pylxpweb/devices/station.py:1286-1300`, `src/pylxpweb/transports/config.py:284-317` |
+| `BaseInverter.from_transport` accepts an existing transport or one of the strings `"modbus"`, `"serial"`, `"dongle"`, or `"hybrid"`; it rejects other strings. | `verified-against-code` — `src/pylxpweb/devices/inverters/base.py:335-402` |
+| `from_dongle_transport` is a compatibility alias that delegates to `from_modbus_transport`; both accept any `InverterTransport`. | `verified-against-code` — `src/pylxpweb/devices/inverters/base.py:586-620` |
+| A transport-created `MIDDevice` has no cloud client. Do not call cloud-only firmware or MID controls on it. | `verified-against-code` — `src/pylxpweb/devices/mid_device.py:115-188`, `src/pylxpweb/devices/mid_device.py:356-490` |
+
+## Transport factories
+
+`ConnectionType` is `Literal["http", "modbus", "serial", "dongle", "hybrid"]`. The unified factory is recommended; the named convenience factories remain public and supported. `verified-against-code` — `src/pylxpweb/transports/factory.py:54-137`, `src/pylxpweb/transports/__init__.py:80-121`.
+
+```python
+create_transport(
+    connection_type: ConnectionType,
+    **config: Any,
+) -> InverterTransport
+
+create_http_transport(
+    client: LuxpowerClient,
+    serial: str,
+) -> HTTPTransport
+
+create_modbus_transport(
+    host: str,
+    serial: str,
+    *,
+    port: int = 502,
+    unit_id: int = 1,
+    timeout: float = 10.0,
+    inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = 40,
+) -> ModbusTransport
+
+create_dongle_transport(
+    host: str,
+    dongle_serial: str,
+    inverter_serial: str,
+    *,
+    port: int = 8000,
+    timeout: float = 10.0,
+    inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = 40,
+) -> DongleTransport
+
+create_serial_transport(
+    port: str,
+    serial: str,
+    *,
+    baudrate: int = 19200,
+    parity: str = "N",
+    stopbits: int = 1,
+    unit_id: int = 1,
+    timeout: float = 10.0,
+    inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = 40,
+) -> ModbusSerialTransport
+
+create_transport_from_config(
+    config: TransportConfig,
+) -> BaseTransport
+```
+
+Exact convenience-factory definitions: `verified-against-code` — `src/pylxpweb/transports/factory.py:329-581`; the default block size is `40`: `verified-against-code` — `src/pylxpweb/transports/_register_data.py:136-145`.
+
+The `create_transport` overloads require these keys. `verified-against-code` — `src/pylxpweb/transports/factory.py:63-137`.
+
+| `connection_type` | Required configuration | Optional configuration | Evidence |
+|---|---|---|---|
+| `http` | `client`, `serial` | none | `verified-against-code` — `src/pylxpweb/transports/factory.py:63-69` |
+| `modbus` | `host`, `serial` | `port`, `unit_id`, `timeout`, `inverter_family`, `max_input_block_size` | `verified-against-code` — `src/pylxpweb/transports/factory.py:72-83` |
+| `serial` | `port`, `serial` | `baudrate`, `parity`, `stopbits`, `unit_id`, `timeout`, `inverter_family`, `max_input_block_size` | `verified-against-code` — `src/pylxpweb/transports/factory.py:86-99` |
+| `dongle` | `host`, `dongle_serial`, `inverter_serial` | `port`, `timeout`, `inverter_family`, `max_input_block_size` | `verified-against-code` — `src/pylxpweb/transports/factory.py:102-113` |
+| `hybrid` | `client`, `serial`, `local_host` | `local_type`, `local_port`, `dongle_serial`, `unit_id`, `timeout`, `inverter_family`, `local_retry_interval`, `max_input_block_size` | `verified-against-code` — `src/pylxpweb/transports/factory.py:116-131` |
+
+## Common transport contract
+
+`InverterTransport` is runtime-checkable. Implementations must provide the following exact protocol surface. `verified-against-code` — `src/pylxpweb/transports/protocol.py:70-238`.
+
+```python
+serial: str                       # read-only property
+is_connected: bool                # read-only property
+capabilities: TransportCapabilities  # read-only property
+
+async connect() -> None
+async disconnect() -> None
+async read_runtime() -> InverterRuntimeData
+async read_energy() -> InverterEnergyData
+async read_battery() -> BatteryBankData | None
+async read_parameters(
+    start_address: int,
+    count: int,
+) -> dict[int, int]
+async write_parameters(
+    parameters: dict[int, int],
+) -> bool
+async read_named_parameters(
+    start_address: int,
+    count: int,
+) -> dict[str, Any]
+async write_named_parameters(
+    parameters: dict[str, Any],
+) -> bool
+```
+
+| Contract boundary | Evidence |
+|---|---|
+| `BaseTransport` adds async context management: `__aenter__()` connects and `__aexit__(...)` disconnects. Context management is a base-class facility, not a declared `InverterTransport` protocol member. | `verified-against-code` — `src/pylxpweb/transports/protocol.py:241-288` |
+| Specialist methods such as `read_all_input_data()` and `read_midbox_runtime()` are concrete extensions, not guaranteed by `InverterTransport`. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1398-1536`, `src/pylxpweb/devices/inverters/base.py:1110-1116` |
+| Use normalized return dataclasses and typed transport exceptions; do not depend on leading-underscore framing, reader, or coalescing helpers. | `verified-against-code` — `src/pylxpweb/transports/__init__.py:112-165`, `src/pylxpweb/transports/exceptions.py:1-80` |

--- a/llmwiki/20-pylxpweb/models-and-scaling.md
+++ b/llmwiki/20-pylxpweb/models-and-scaling.md
@@ -6,7 +6,8 @@ sources:
   - pylxpweb@204b95d:src/pylxpweb/registers/
   - pylxpweb@204b95d:src/pylxpweb/transports/
   - pylxpweb@204b95d:tests/unit/test_models.py
-verified-against: 9f6d6e2
+verified-against:
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 
@@ -23,9 +24,11 @@ Evidence grades follow the [canonical llmwiki legend](../README.md).
 | Register absent | `None` | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:54-70` |
 | Either half of a 32-bit pair absent | `None` for the whole value | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:54-70` |
 | Scaling receives `None` | Preserve `None`; do not create zero | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:130-148` |
-| Temperature raw value exactly `127` / `0x7F` | `None` meaning sensor absent | `verified-against-code` — `src/pylxpweb/transports/data.py:62-70`, `src/pylxpweb/transports/data.py:318-321` |
+| Battery-temperature value exactly `127.0` | Normalize it to `None` on every construction path | `verified-against-code` — `src/pylxpweb/transports/data.py:62-70`, `src/pylxpweb/transports/data.py:318-321` |
 | Other extreme temperature | Preserve it so corruption validation can inspect it | `verified-against-code` — `src/pylxpweb/transports/data.py:62-70`, `src/pylxpweb/transports/data.py:1417-1428` |
 | Present individual battery block | `BatteryData` is a documented exception: several child fields use zero/empty defaults | `verified-against-code` — `src/pylxpweb/transports/data.py:973-1035`, `src/pylxpweb/transports/data.py:1250-1339` |
+
+The physical meaning of I67 raw `0x007f` / 127 is `portal-correlated` and owned by the [hardware register keeper](../40-hardware/registers.md#i67-0x7f-sentinel); this page establishes only pylxpweb's normalization.
 
 Do not generalize the `BatteryData` exception to inverter runtime, aggregate energy, battery-bank, or MID/GridBOSS telemetry. `verified-against-code` — `src/pylxpweb/transports/data.py:144-790`, `src/pylxpweb/transports/data.py:1343-1385`, `src/pylxpweb/transports/data.py:1773-1829`.
 

--- a/llmwiki/20-pylxpweb/models-and-scaling.md
+++ b/llmwiki/20-pylxpweb/models-and-scaling.md
@@ -1,15 +1,18 @@
 ---
 canonical-for: pylxpweb portal models, local normalized data, missing values, enums, and scaling
 sources:
-  - /tmp/llmwiki-research/pylxpweb-library.md
-  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+  - pylxpweb@204b95d:src/pylxpweb/models.py
+  - pylxpweb@204b95d:src/pylxpweb/endpoints/devices.py
+  - pylxpweb@204b95d:src/pylxpweb/registers/
+  - pylxpweb@204b95d:src/pylxpweb/transports/
+  - pylxpweb@204b95d:tests/unit/test_models.py
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
 
 # Models and scaling
 
-Use the evidence-grade meanings defined in [api-surface.md](api-surface.md).
+Evidence grades follow the [canonical llmwiki legend](../README.md).
 
 ## Non-negotiable missing-data rule
 
@@ -41,9 +44,9 @@ Portal responses are Pydantic models that preserve portal field spelling. Compat
 | `MidboxRuntime` | Success, serial, firmware, and `midbox` data are required; `lost` and primary-inverter `deviceData` are optional. | `verified-against-code` — `src/pylxpweb/models.py:1023-1035` |
 | Dynamic parameter reads | This is the sole general `extra="allow"` response because parameter names arrive dynamically. | `verified-against-code` — `src/pylxpweb/models.py:1041-1076` |
 
-Offline portal responses are intentionally partial across inverter runtime, battery, and MID/GridBOSS models; omitted telemetry must remain optional rather than being synthesized. `portal-correlated` — `src/pylxpweb/models.py:458-465`, `src/pylxpweb/models.py:706-755`, `src/pylxpweb/models.py:827-1035`.
+The portal models deliberately accept partial inverter-runtime, battery, and MID/GridBOSS payloads; omitted telemetry must remain optional rather than being synthesized. `verified-against-code` — `src/pylxpweb/models.py:458-465`, `src/pylxpweb/models.py:706-755`, `src/pylxpweb/models.py:827-1035`.
 
-Making observed-optional fields required previously caused whole-response validation to fail and blanked every related Home Assistant entity in production. `verified-against-code` — `src/pylxpweb/models.py:458-465`, `tests/unit/test_models.py:226-266`, `tests/unit/test_models.py:304-322`.
+The offline-tolerance fix commit records that making these fields required caused whole-response validation to fail and blanked every related Home Assistant entity in production; it does not include a production trace. `asserted-unverified` — `pylxpweb commit 36a3e298f0590447a7c58f3b422b953e39f1395d`.
 
 ## Enums
 
@@ -74,13 +77,8 @@ Changing one table does **not** change the other. A new canonical holding row al
 
 Never infer local bit order from portal list order. Ordinary operational bitfields use list index as bit number, while explicit compound layouts override that rule. `verified-against-code` — `src/pylxpweb/constants/registers.py:1049-1119`, `src/pylxpweb/transports/protocol.py:591-626`.
 
-## Known-wrong upstream endpoint docstrings
+## Schema-divergence ownership
 
-The task brief names `src/pylxpweb/api/devices.py`; the current source path is `src/pylxpweb/endpoints/devices.py`. The defect is documentation only and must not be copied into integration logic. `verified-against-code` — `src/pylxpweb/endpoints/devices.py:185-248`.
+`src/pylxpweb/endpoints/devices.py` is the current device-endpoint module. `verified-against-code` — `src/pylxpweb/endpoints/devices.py:1-532`.
 
-| Wrong upstream prose/example | Correct contract | Evidence |
-|---|---|---|
-| Energy is “Wh; divide by 1000,” using `energy.eInvDay` / `energy.eInvAll`. | `EnergyInfo` exposes `todayYielding` / `totalYielding`; raw portal energy is in 0.1 kWh units and divides by 10 for kWh. `eInvDay` and `eInvAll` are not `EnergyInfo` fields. | `portal-correlated` — wrong text at `src/pylxpweb/endpoints/devices.py:220-235`; model/scaling at `src/pylxpweb/models.py:606-630`, `src/pylxpweb/constants/scaling.py:123-162` |
-| Runtime voltage divides by 100, including example `runtime.vacr / 100`. | Normal AC/PV/EPS/battery runtime voltages divide by 10; e.g. raw `vacr=2411` means `241.1 V`, not `24.11 V`. | `portal-correlated` — wrong text at `src/pylxpweb/endpoints/devices.py:185-205`; operational scale at `src/pylxpweb/constants/scaling.py:47-68`, `src/pylxpweb/models.py:443-453` |
-
-Treat the endpoint docstrings as known-wrong by a factor of 100 for energy (`1000` versus `10`) and by 10 for runtime voltage (`100` versus `10`). Prefer the canonical scaling tables and normalized high-level properties. `portal-correlated` — `src/pylxpweb/constants/scaling.py:47-68`, `src/pylxpweb/constants/scaling.py:123-162`, `src/pylxpweb/transports/data.py:513-513`, `src/pylxpweb/transports/data.py:875-883`.
+Known endpoint-docstring, model-field, and scaling divergences are canonical in the [portal schema-and-scaling ledger](../30-portal-api/schemas-and-scaling.md); do not duplicate that ledger here.

--- a/llmwiki/20-pylxpweb/models-and-scaling.md
+++ b/llmwiki/20-pylxpweb/models-and-scaling.md
@@ -1,0 +1,86 @@
+---
+canonical-for: pylxpweb portal models, local normalized data, missing values, enums, and scaling
+sources:
+  - /tmp/llmwiki-research/pylxpweb-library.md
+  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Models and scaling
+
+Use the evidence-grade meanings defined in [api-surface.md](api-surface.md).
+
+## Non-negotiable missing-data rule
+
+> Missing telemetry is `None`, **not zero**. Never manufacture `0` from an absent register, an absent half of a 32-bit value, or an optional offline portal field. `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:54-70`, `src/pylxpweb/transports/_canonical_reader.py:130-148`, `src/pylxpweb/transports/data.py:125-142`.
+
+| Input condition | Correct representation | Evidence |
+|---|---|---|
+| Register absent | `None` | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:54-70` |
+| Either half of a 32-bit pair absent | `None` for the whole value | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:54-70` |
+| Scaling receives `None` | Preserve `None`; do not create zero | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:130-148` |
+| Temperature raw value exactly `127` / `0x7F` | `None` meaning sensor absent | `verified-against-code` — `src/pylxpweb/transports/data.py:62-70`, `src/pylxpweb/transports/data.py:318-321` |
+| Other extreme temperature | Preserve it so corruption validation can inspect it | `verified-against-code` — `src/pylxpweb/transports/data.py:62-70`, `src/pylxpweb/transports/data.py:1417-1428` |
+| Present individual battery block | `BatteryData` is a documented exception: several child fields use zero/empty defaults | `verified-against-code` — `src/pylxpweb/transports/data.py:973-1035`, `src/pylxpweb/transports/data.py:1250-1339` |
+
+Do not generalize the `BatteryData` exception to inverter runtime, aggregate energy, battery-bank, or MID/GridBOSS telemetry. `verified-against-code` — `src/pylxpweb/transports/data.py:144-790`, `src/pylxpweb/transports/data.py:1343-1385`, `src/pylxpweb/transports/data.py:1773-1829`.
+
+## Portal Pydantic models and optionality
+
+Portal responses are Pydantic models that preserve portal field spelling. Compatibility is targeted: known partial fields are optional/defaulted, while core identity/schema errors remain strict. `verified-against-code` — `src/pylxpweb/models.py:1-5`, `src/pylxpweb/models.py:1041-1076`.
+
+| Model/family | Optionality contract | Evidence |
+|---|---|---|
+| `UserVisitRecord` | Only `plantId` and `serialNum` are required; device-specific values may be absent for parallel-group visits. | `verified-against-code` — `src/pylxpweb/models.py:112-139`, `tests/unit/test_models.py:120-161` |
+| Parallel overview rows | Normal inverter metrics are optional because GridBOSS rows do not carry them. | `verified-against-code` — `src/pylxpweb/models.py:339-381` |
+| `InverterRuntime` | Offline responses may omit status, aggregate PV, SOC, battery voltage/power/color, and inverter/rectifier/EPS power; those fields default to `None`. | `verified-against-code` — `src/pylxpweb/models.py:443-465`, `src/pylxpweb/models.py:501-543`, `tests/samples/runtime_offline.json:1-74` |
+| `EnergyInfo` | Daily/lifetime energy and success remain required; `serialNum` and `soc` are optional because parallel-group responses omit them. | `verified-against-code` — `src/pylxpweb/models.py:606-632` |
+| `BatteryInfo` | Only success and inverter serial are required; aggregate runtime values are optional/defaulted and `batteryArray` defaults empty. | `verified-against-code` — `src/pylxpweb/models.py:706-755`, `tests/unit/test_models.py:304-322` |
+| `MidboxData` | Original core keys may be required-but-null; newer smart-load, AC-couple, current, and energy families default to `None`. | `verified-against-code` — `src/pylxpweb/models.py:827-1009` |
+| `MidboxRuntime` | Success, serial, firmware, and `midbox` data are required; `lost` and primary-inverter `deviceData` are optional. | `verified-against-code` — `src/pylxpweb/models.py:1023-1035` |
+| Dynamic parameter reads | This is the sole general `extra="allow"` response because parameter names arrive dynamically. | `verified-against-code` — `src/pylxpweb/models.py:1041-1076` |
+
+Offline portal responses are intentionally partial across inverter runtime, battery, and MID/GridBOSS models; omitted telemetry must remain optional rather than being synthesized. `portal-correlated` — `src/pylxpweb/models.py:458-465`, `src/pylxpweb/models.py:706-755`, `src/pylxpweb/models.py:827-1035`.
+
+Making observed-optional fields required previously caused whole-response validation to fail and blanked every related Home Assistant entity in production. `verified-against-code` — `src/pylxpweb/models.py:458-465`, `tests/unit/test_models.py:226-266`, `tests/unit/test_models.py:304-322`.
+
+## Enums
+
+| Rule | Evidence |
+|---|---|
+| `UpdateStatus._missing_` maps unknown values to `UpdateStatus.UNKNOWN`. | `verified-against-code` — `src/pylxpweb/models.py:1167-1182` |
+| `UpdateEligibilityMessage._missing_` maps unknown values to `UNKNOWN`, and that value is not allowed. | `verified-against-code` — `src/pylxpweb/models.py:1185-1201` |
+| These are the only source enums with `_missing_`; all other enums are strict. Never assume a universal unknown fallback. | `verified-against-code` — `src/pylxpweb/models.py:16-1880` |
+
+## Canonical decoding and scaling
+
+| Rule | Evidence |
+|---|---|
+| Canonical input scale divisors are 1, 10, 100, and 1000. | `verified-against-code` — `src/pylxpweb/registers/inverter_input.py:77-84` |
+| 32-bit inverter values are low-word first: `(high << 16) | low`. | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:34-70` |
+| Packed bytes are extracted before signed conversion; signed 16/32-bit values use two's-complement subtraction. | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:34-86` |
+| Canonical names are stable register identities and may differ from normalized dataclass field names; explicit mappings bridge them. | `verified-against-code` — `src/pylxpweb/transports/_field_mappings.py:1-8`, `src/pylxpweb/transports/_field_mappings.py:17-340` |
+| Raw SOC/SOH is retained before public clamping so corruption checks still see out-of-range hardware values. | `verified-against-code` — `src/pylxpweb/transports/_canonical_reader.py:196-206`, `src/pylxpweb/transports/data.py:339-358` |
+
+## Separate register tables: a real maintenance trap
+
+| Table | Used for | Does **not** update | Evidence |
+|---|---|---|---|
+| Canonical `INVERTER_HOLDING_REGISTERS` and indexes in `registers/inverter_holding.py` | Stable canonical/API/entity identity, width, scale, signedness, bounds, writability, family, and bit metadata | Operational local named reads/writes | `verified-against-code` — `src/pylxpweb/registers/inverter_holding.py:50-106`, `src/pylxpweb/registers/inverter_holding.py:1818-1881` |
+| Operational `REGISTER_TO_PARAM_KEYS`, aliases, compound layouts, and scale sets in `constants/registers.py` | `BaseTransport.read_named_parameters` and `write_named_parameters` resolution/RMW | Canonical register definitions and indexes | `verified-against-code` — `src/pylxpweb/transports/protocol.py:376-420`, `src/pylxpweb/constants/registers.py:661-693` |
+
+Changing one table does **not** change the other. A new canonical holding row alone does not make a name locally readable or writable; an operational mapping alone does not create canonical metadata. Update both deliberately when both seams are intended. `verified-against-code` — `src/pylxpweb/transports/protocol.py:376-420`, `src/pylxpweb/registers/inverter_holding.py:1818-1881`.
+
+Never infer local bit order from portal list order. Ordinary operational bitfields use list index as bit number, while explicit compound layouts override that rule. `verified-against-code` — `src/pylxpweb/constants/registers.py:1049-1119`, `src/pylxpweb/transports/protocol.py:591-626`.
+
+## Known-wrong upstream endpoint docstrings
+
+The task brief names `src/pylxpweb/api/devices.py`; the current source path is `src/pylxpweb/endpoints/devices.py`. The defect is documentation only and must not be copied into integration logic. `verified-against-code` — `src/pylxpweb/endpoints/devices.py:185-248`.
+
+| Wrong upstream prose/example | Correct contract | Evidence |
+|---|---|---|
+| Energy is “Wh; divide by 1000,” using `energy.eInvDay` / `energy.eInvAll`. | `EnergyInfo` exposes `todayYielding` / `totalYielding`; raw portal energy is in 0.1 kWh units and divides by 10 for kWh. `eInvDay` and `eInvAll` are not `EnergyInfo` fields. | `portal-correlated` — wrong text at `src/pylxpweb/endpoints/devices.py:220-235`; model/scaling at `src/pylxpweb/models.py:606-630`, `src/pylxpweb/constants/scaling.py:123-162` |
+| Runtime voltage divides by 100, including example `runtime.vacr / 100`. | Normal AC/PV/EPS/battery runtime voltages divide by 10; e.g. raw `vacr=2411` means `241.1 V`, not `24.11 V`. | `portal-correlated` — wrong text at `src/pylxpweb/endpoints/devices.py:185-205`; operational scale at `src/pylxpweb/constants/scaling.py:47-68`, `src/pylxpweb/models.py:443-453` |
+
+Treat the endpoint docstrings as known-wrong by a factor of 100 for energy (`1000` versus `10`) and by 10 for runtime voltage (`100` versus `10`). Prefer the canonical scaling tables and normalized high-level properties. `portal-correlated` — `src/pylxpweb/constants/scaling.py:47-68`, `src/pylxpweb/constants/scaling.py:123-162`, `src/pylxpweb/transports/data.py:513-513`, `src/pylxpweb/transports/data.py:875-883`.

--- a/llmwiki/20-pylxpweb/release-and-pinning.md
+++ b/llmwiki/20-pylxpweb/release-and-pinning.md
@@ -1,0 +1,64 @@
+---
+canonical-for: pylxpweb version derivation, publication workflow, and eg4_web_monitor dependency ordering
+sources:
+  - /tmp/llmwiki-research/pylxpweb-library.md
+  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+  - eg4_web_monitor@9f6d6e2
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Release and pinning
+
+Use the evidence-grade meanings defined in [api-surface.md](api-surface.md).
+
+## Version authority
+
+| Context | Authority | Evidence |
+|---|---|---|
+| Build metadata | `pyproject.toml` declares `version = "0.9.39b10"`. | `verified-against-code` — `pyproject.toml:1-4` in the pylxpweb repository |
+| Installed runtime | `pylxpweb.__version__` comes from `importlib.metadata.version("pylxpweb")`. | `verified-against-code` — `src/pylxpweb/__init__.py:42-42`, `src/pylxpweb/__init__.py:97-100` |
+| Uninstalled source checkout | Missing distribution metadata falls back to `"0.0.0-dev"`. | `verified-against-code` — `src/pylxpweb/__init__.py:97-100` |
+
+Do not edit a hard-coded package `__version__`; there is none. The installed distribution metadata is runtime-authoritative. `verified-against-code` — `src/pylxpweb/__init__.py:97-100`.
+
+## pylxpweb release workflow
+
+| Order | Action | Evidence |
+|---:|---|---|
+| 1 | Bump `pyproject.toml` and update `CHANGELOG.md`. | `verified-against-code` — `docs/DEVELOPMENT.md:30-34` in the pylxpweb repository |
+| 2 | Tag the version and publish a GitHub Release, or invoke the workflow manually with the intended environment. | `verified-against-code` — `.github/workflows/release.yml:3-18` in the pylxpweb repository |
+| 3 | The workflow checks out the selected tag/ref, installs Python with uv, builds, and runs `twine check`. | `verified-against-code` — `.github/workflows/release.yml:29-62` in the pylxpweb repository |
+| 4 | Publish the same build artifact to TestPyPI. | `verified-against-code` — `.github/workflows/release.yml:71-91` in the pylxpweb repository |
+| 5 | Publish to PyPI only after the TestPyPI job succeeds; authentication uses OIDC. | `verified-against-code` — `.github/workflows/release.yml:25-27`, `.github/workflows/release.yml:93-112` in the pylxpweb repository |
+
+The active trigger is a **published GitHub Release** or manual dispatch, not merely a pushed tag. Follow the active `release.yml` when older workflow prose disagrees. `verified-against-code` — `.github/workflows/release.yml:1-18` in the pylxpweb repository.
+
+## Two-repository ordering constraint
+
+| Phase | pylxpweb repository | eg4_web_monitor repository | Evidence |
+|---:|---|---|---|
+| 1 | Merge, version, tag/release, and publish the required pylxpweb wheel to **PyPI first**. | Do not raise the integration minimum yet. | `inferred` — pylxpweb `.github/workflows/release.yml:93-112`; integration `custom_components/eg4_web_monitor/manifest.json:13-14` |
+| 2 | Confirm the published version is resolvable from PyPI. | Then bump both dependency declarations in the same integration change. | `inferred` — integration `.github/workflows/quality-validation.yml:791-801` |
+| 3 | No further library action is required for the pin. | Keep `custom_components/eg4_web_monitor/manifest.json` and `tests/requirements-test.txt` identical for pylxpweb. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `tests/requirements-test.txt:17-17` |
+
+Publishing pylxpweb to PyPI **after** raising the integration requirement reverses the dependency order. Until that wheel exists, CI's installer and Home Assistant cannot resolve the new floor, so CI and installs break. `inferred` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `.github/workflows/quality-validation.yml:791-801`.
+
+## Current integration floor
+
+| File | Required value | Evidence |
+|---|---|---|
+| `custom_components/eg4_web_monitor/manifest.json` | `pylxpweb>=0.9.39b10` | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14` |
+| `tests/requirements-test.txt` | `pylxpweb>=0.9.39b10` | `verified-against-code` — `tests/requirements-test.txt:17-17` |
+
+The requirement is a minimum, not an exact lock; a later compatible release may resolve. During beta development the floor must still name the matching beta because a stable-only specifier can hide prerelease-only APIs from type checking. `verified-against-code` — `.github/workflows/quality-validation.yml:791-801`.
+
+## Release checklist for an integration-facing pylxpweb change
+
+| Check | Stop condition | Evidence |
+|---|---|---|
+| pylxpweb version | `pyproject.toml` contains the intended new version. | `verified-against-code` — pylxpweb `pyproject.toml:1-4` |
+| pylxpweb artifact | TestPyPI succeeds before the PyPI job runs. | `verified-against-code` — pylxpweb `.github/workflows/release.yml:71-112` |
+| Publication order | The required wheel is resolvable from PyPI before the integration pin changes. | `inferred` — pylxpweb `.github/workflows/release.yml:93-112`; integration `.github/workflows/quality-validation.yml:791-801` |
+| Pin lockstep | Manifest and test requirements carry exactly the same `pylxpweb>=...` floor. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `tests/requirements-test.txt:17-17` |
+| Runtime version reporting | Validate an installed wheel when checking `__version__`; a source checkout may report `0.0.0-dev`. | `verified-against-code` — pylxpweb `src/pylxpweb/__init__.py:97-100` |

--- a/llmwiki/20-pylxpweb/release-and-pinning.md
+++ b/llmwiki/20-pylxpweb/release-and-pinning.md
@@ -6,7 +6,9 @@ sources:
   - eg4_web_monitor@9f6d6e2:custom_components/eg4_web_monitor/manifest.json
   - eg4_web_monitor@9f6d6e2:tests/requirements-test.txt
   - eg4_web_monitor@9f6d6e2:.github/workflows/quality-validation.yml
-verified-against: 9f6d6e2
+verified-against:
+  pylxpweb: 204b95d
+  eg4_web_monitor: 9f6d6e2
 last-verified: 2026-08-08
 ---
 

--- a/llmwiki/20-pylxpweb/release-and-pinning.md
+++ b/llmwiki/20-pylxpweb/release-and-pinning.md
@@ -1,16 +1,18 @@
 ---
-canonical-for: pylxpweb version derivation, publication workflow, and eg4_web_monitor dependency ordering
+canonical-for: pylxpweb version derivation and eg4_web_monitor dependency pin mechanics
 sources:
-  - /tmp/llmwiki-research/pylxpweb-library.md
-  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
-  - eg4_web_monitor@9f6d6e2
+  - pylxpweb@204b95d:pyproject.toml
+  - pylxpweb@204b95d:src/pylxpweb/__init__.py
+  - eg4_web_monitor@9f6d6e2:custom_components/eg4_web_monitor/manifest.json
+  - eg4_web_monitor@9f6d6e2:tests/requirements-test.txt
+  - eg4_web_monitor@9f6d6e2:.github/workflows/quality-validation.yml
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
 
 # Release and pinning
 
-Use the evidence-grade meanings defined in [api-surface.md](api-surface.md).
+Evidence grades follow the [canonical llmwiki legend](../README.md).
 
 ## Version authority
 
@@ -22,27 +24,9 @@ Use the evidence-grade meanings defined in [api-surface.md](api-surface.md).
 
 Do not edit a hard-coded package `__version__`; there is none. The installed distribution metadata is runtime-authoritative. `verified-against-code` — `src/pylxpweb/__init__.py:97-100`.
 
-## pylxpweb release workflow
+## Canonical release process
 
-| Order | Action | Evidence |
-|---:|---|---|
-| 1 | Bump `pyproject.toml` and update `CHANGELOG.md`. | `verified-against-code` — `docs/DEVELOPMENT.md:30-34` in the pylxpweb repository |
-| 2 | Tag the version and publish a GitHub Release, or invoke the workflow manually with the intended environment. | `verified-against-code` — `.github/workflows/release.yml:3-18` in the pylxpweb repository |
-| 3 | The workflow checks out the selected tag/ref, installs Python with uv, builds, and runs `twine check`. | `verified-against-code` — `.github/workflows/release.yml:29-62` in the pylxpweb repository |
-| 4 | Publish the same build artifact to TestPyPI. | `verified-against-code` — `.github/workflows/release.yml:71-91` in the pylxpweb repository |
-| 5 | Publish to PyPI only after the TestPyPI job succeeds; authentication uses OIDC. | `verified-against-code` — `.github/workflows/release.yml:25-27`, `.github/workflows/release.yml:93-112` in the pylxpweb repository |
-
-The active trigger is a **published GitHub Release** or manual dispatch, not merely a pushed tag. Follow the active `release.yml` when older workflow prose disagrees. `verified-against-code` — `.github/workflows/release.yml:1-18` in the pylxpweb repository.
-
-## Two-repository ordering constraint
-
-| Phase | pylxpweb repository | eg4_web_monitor repository | Evidence |
-|---:|---|---|---|
-| 1 | Merge, version, tag/release, and publish the required pylxpweb wheel to **PyPI first**. | Do not raise the integration minimum yet. | `inferred` — pylxpweb `.github/workflows/release.yml:93-112`; integration `custom_components/eg4_web_monitor/manifest.json:13-14` |
-| 2 | Confirm the published version is resolvable from PyPI. | Then bump both dependency declarations in the same integration change. | `inferred` — integration `.github/workflows/quality-validation.yml:791-801` |
-| 3 | No further library action is required for the pin. | Keep `custom_components/eg4_web_monitor/manifest.json` and `tests/requirements-test.txt` identical for pylxpweb. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `tests/requirements-test.txt:17-17` |
-
-Publishing pylxpweb to PyPI **after** raising the integration requirement reverses the dependency order. Until that wheel exists, CI's installer and Home Assistant cannot resolve the new floor, so CI and installs break. `inferred` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `.github/workflows/quality-validation.yml:791-801`.
+Two-repository ordering and publication trust are owned by the [canonical release process](../50-operations/release-process.md); this page keeps only dependency-pin mechanics.
 
 ## Current integration floor
 
@@ -53,12 +37,12 @@ Publishing pylxpweb to PyPI **after** raising the integration requirement revers
 
 The requirement is a minimum, not an exact lock; a later compatible release may resolve. During beta development the floor must still name the matching beta because a stable-only specifier can hide prerelease-only APIs from type checking. `verified-against-code` — `.github/workflows/quality-validation.yml:791-801`.
 
-## Release checklist for an integration-facing pylxpweb change
+## Pin mechanics
 
-| Check | Stop condition | Evidence |
+| Mechanic | Required action | Evidence |
 |---|---|---|
-| pylxpweb version | `pyproject.toml` contains the intended new version. | `verified-against-code` — pylxpweb `pyproject.toml:1-4` |
-| pylxpweb artifact | TestPyPI succeeds before the PyPI job runs. | `verified-against-code` — pylxpweb `.github/workflows/release.yml:71-112` |
-| Publication order | The required wheel is resolvable from PyPI before the integration pin changes. | `inferred` — pylxpweb `.github/workflows/release.yml:93-112`; integration `.github/workflows/quality-validation.yml:791-801` |
-| Pin lockstep | Manifest and test requirements carry exactly the same `pylxpweb>=...` floor. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `tests/requirements-test.txt:17-17` |
-| Runtime version reporting | Validate an installed wheel when checking `__version__`; a source checkout may report `0.0.0-dev`. | `verified-against-code` — pylxpweb `src/pylxpweb/__init__.py:97-100` |
+| Select the floor | Use the version approved by the canonical release process; do not derive it from source-checkout `__version__`, which may be `0.0.0-dev`. | `verified-against-code` — pylxpweb `src/pylxpweb/__init__.py:97-100` |
+| Update runtime dependency | Change the `pylxpweb>=...` entry in `custom_components/eg4_web_monitor/manifest.json`. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14` |
+| Update test dependency | Apply the identical minimum in `tests/requirements-test.txt`; its inline comment requires lockstep with the manifest. | `verified-against-code` — `tests/requirements-test.txt:17-17` |
+| Preserve beta visibility | When the integration consumes prerelease-only APIs, keep the prerelease minimum explicit so the type-check job installs the intended surface. | `verified-against-code` — `.github/workflows/quality-validation.yml:791-801` |
+| Verify the pair | Compare both requirement strings in the same integration change; a one-file pin update is incomplete. | `verified-against-code` — `custom_components/eg4_web_monitor/manifest.json:13-14`, `tests/requirements-test.txt:17-17` |

--- a/llmwiki/20-pylxpweb/transports.md
+++ b/llmwiki/20-pylxpweb/transports.md
@@ -1,15 +1,16 @@
 ---
 canonical-for: pylxpweb local Modbus TCP and WiFi dongle transport behavior
 sources:
-  - /tmp/llmwiki-research/pylxpweb-library.md
-  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+  - pylxpweb@204b95d:src/pylxpweb/transports/
+  - pylxpweb@204b95d:src/pylxpweb/registers/battery.py
+  - pylxpweb@204b95d:tests/unit/transports/
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
 
 # Local transports
 
-Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Do not generalize one transport's wire behavior to another.
+Evidence grades follow the [canonical llmwiki legend](../README.md). Do not generalize one transport's wire behavior to another.
 
 ## Transport comparison
 
@@ -19,9 +20,9 @@ Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Do 
 | Default port | `502` | `8000` | `verified-against-code` — `src/pylxpweb/transports/factory.py:357-366`, `src/pylxpweb/transports/factory.py:436-445` |
 | Reads | FC03 holding, FC04 input | Embedded FC03/FC04 | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:167-220`, `src/pylxpweb/transports/dongle.py:56-77`, `src/pylxpweb/transports/dongle.py:1293-1367` |
 | Writes | FC06 single, FC16 multiple | Embedded FC06/FC16 | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:316-367`, `src/pylxpweb/transports/dongle.py:56-77`, `src/pylxpweb/transports/dongle.py:1380-1461` |
-| Concurrency | Operations are guarded; competing gateway clients can desynchronize transaction IDs | One serialized request/response workflow over the dongle's single TCP slot | `hardware-proven` — `src/pylxpweb/transports/modbus.py:7-16`, `src/pylxpweb/transports/modbus.py:46-55`, `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
+| Concurrency | Operations are guarded inside this process; external gateway clients are outside those locks | One serialized request/response workflow over the dongle's transaction lock | `verified-against-code` — `src/pylxpweb/transports/modbus.py:46-55`, `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
 
-**Operational rule:** run one active application/client per gateway or dongle. `hardware-proven` — `README.md:67-69`, `src/pylxpweb/transports/modbus.py:7-16`.
+The upstream README instructs operators to run one active application/client per gateway or dongle, but the cited artifact contains no qualifying raw before/after observation. `asserted-unverified` — `pylxpweb@204b95d:README.md:67-69`.
 
 ## Modbus TCP
 
@@ -35,9 +36,9 @@ Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Do 
 
 ### Intentional Waveshare transaction-ID workaround
 
-Waveshare TCP-to-RTU gateways can replace the MBAP transaction ID instead of echoing it. The transport therefore parses with `exp_tid=0`, rewrites the returned PDU transaction ID to the currently expected value, and ignores a response if the current future is already complete. `hardware-proven` — `src/pylxpweb/transports/modbus.py:207-254`.
+The upstream source states that Waveshare TCP-to-RTU gateways can replace the MBAP transaction ID instead of echoing it, but it does not cite a qualifying raw before/after capture. `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/transports/modbus.py:207-254`.
 
-Do **not** remove this as “lax validation” without new hardware proof. It is deliberate compatibility for a gateway that violates normal MBAP echo behavior. `hardware-proven` — `src/pylxpweb/transports/modbus.py:207-254`.
+The compatibility code parses with `exp_tid=0`, rewrites the returned PDU transaction ID to the currently expected value, and ignores a response if the current future is already complete. Do not remove that behavior as “lax validation” without replacement evidence. `verified-against-code` — `src/pylxpweb/transports/modbus.py:207-254`.
 
 ## WiFi dongle protocol
 
@@ -69,10 +70,12 @@ Do **not** remove this as “lax validation” without new hardware proof. It is
 | Merge eligibility | Merge only contiguous or overlapping spans whose union fits `max_input_block_size`. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:203-238` |
 | Gaps | Never bridge an unmapped gap, even when the numeric start-to-end span would fit. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:207-217` |
 | Oversized logical group | Never split it; preserve the original one-read group. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:216-238` |
-| Configuration | Accepted `max_input_block_size` is 40 through 125; default 40 is conservative, and 120 is field-proven. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:123-175` |
-| GridBOSS/MID | Keep every group at 40 registers or fewer and never coalesce it. Reads larger than 40 failed on real GridBOSS hardware. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:111-134` |
+| Configuration | Accepted `max_input_block_size` is 40 through 125; the default is 40. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:136-175` |
+| Claimed fast setting | A source comment describes 120 as field-proven, but no qualifying raw before/after artifact is cited here. | `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/transports/_register_data.py:123-142` |
+| GridBOSS/MID | Keep every group at 40 registers or fewer and never coalesce it. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:111-134` |
+| GridBOSS hardware rationale | A source comment reports that reads above 40 failed on real GridBOSS hardware, but it supplies no qualifying raw before/after capture. | `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/transports/_register_data.py:130-134` |
 | Batteries | Always read the four 30-register physical slots as one atomic 120-register FC04 block starting at 5002, independent of the configured normal block size. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:322-374` |
-| Battery rationale | One 120-register read prevents firmware page rotation between per-slot reads. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:322-374` |
+| Battery rationale | One 120-register read places all four physical slots in the same transaction, eliminating inter-read page rotation by construction. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:322-374` |
 
 At configured size 120, the inverter plan is `(0,113)`, `(113,41)`, `(170,4)`, `(193,12)`; gaps 154–169 and 174–192 remain unread. `verified-against-code` — `tests/unit/transports/test_input_block_coalescing.py:50-59`, `tests/unit/transports/test_input_block_coalescing.py:98-148`.
 

--- a/llmwiki/20-pylxpweb/transports.md
+++ b/llmwiki/20-pylxpweb/transports.md
@@ -1,0 +1,87 @@
+---
+canonical-for: pylxpweb local Modbus TCP and WiFi dongle transport behavior
+sources:
+  - /tmp/llmwiki-research/pylxpweb-library.md
+  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Local transports
+
+Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Do not generalize one transport's wire behavior to another.
+
+## Transport comparison
+
+| Property | Modbus TCP | WiFi dongle | Evidence |
+|---|---|---|---|
+| Wire protocol | Standard Modbus TCP MBAP/PDU through `pymodbus` | Proprietary LuxPower `A1 1A` TCP envelope around an embedded Modbus data frame | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:167-209`, `src/pylxpweb/transports/dongle.py:1-10`, `src/pylxpweb/transports/dongle.py:545-624` |
+| Default port | `502` | `8000` | `verified-against-code` — `src/pylxpweb/transports/factory.py:357-366`, `src/pylxpweb/transports/factory.py:436-445` |
+| Reads | FC03 holding, FC04 input | Embedded FC03/FC04 | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:167-220`, `src/pylxpweb/transports/dongle.py:56-77`, `src/pylxpweb/transports/dongle.py:1293-1367` |
+| Writes | FC06 single, FC16 multiple | Embedded FC06/FC16 | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:316-367`, `src/pylxpweb/transports/dongle.py:56-77`, `src/pylxpweb/transports/dongle.py:1380-1461` |
+| Concurrency | Operations are guarded; competing gateway clients can desynchronize transaction IDs | One serialized request/response workflow over the dongle's single TCP slot | `hardware-proven` — `src/pylxpweb/transports/modbus.py:7-16`, `src/pylxpweb/transports/modbus.py:46-55`, `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
+
+**Operational rule:** run one active application/client per gateway or dongle. `hardware-proven` — `README.md:67-69`, `src/pylxpweb/transports/modbus.py:7-16`.
+
+## Modbus TCP
+
+| Behavior | Agent constraint | Evidence |
+|---|---|---|
+| `connect()` constructs `AsyncModbusTcpClient(host, port, timeout, retries=pymodbus_retries)`, connects, installs the transaction-ID compatibility hook, and resets error state. | Do not rely on the stale docstring's claimed synchronization read; no synchronization read occurs. | `verified-against-code` — `src/pylxpweb/transports/modbus.py:145-180` |
+| FC03/FC04 calls use `device_id=unit_id`. | Preserve the unit ID and distinguish holding from input reads. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:167-220` |
+| FC06 is used for one value; FC16 is used for a contiguous list. | Do not replace schedule FC06 behavior with FC16; schedule firmware rejects FC16. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:339-352`, `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
+| Short holding reads fail inside the retry loop; short input reads pass upward for coalescing/BMS fallback policy. | Do not make both paths uniformly strict or uniformly permissive. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:222-237` |
+| Modbus writes validate the response but do not read the register back. | An accepted response is not independent readback proof. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:341-367` |
+
+### Intentional Waveshare transaction-ID workaround
+
+Waveshare TCP-to-RTU gateways can replace the MBAP transaction ID instead of echoing it. The transport therefore parses with `exp_tid=0`, rewrites the returned PDU transaction ID to the currently expected value, and ignores a response if the current future is already complete. `hardware-proven` — `src/pylxpweb/transports/modbus.py:207-254`.
+
+Do **not** remove this as “lax validation” without new hardware proof. It is deliberate compatibility for a gateway that violates normal MBAP echo behavior. `hardware-proven` — `src/pylxpweb/transports/modbus.py:207-254`.
+
+## WiFi dongle protocol
+
+### A11A envelope
+
+| Field/order | Encoding | Evidence |
+|---|---|---|
+| Prefix | `A1 1A` | `verified-against-code` — `src/pylxpweb/transports/dongle.py:545-575` |
+| Outer metadata | version LE16, frame length LE16, address `01`, outer function, ten-byte dongle serial, data length LE16 | `verified-against-code` — `src/pylxpweb/transports/dongle.py:545-624` |
+| Embedded request | action byte `0`, Modbus function, ten-byte inverter serial, register LE16, then count/value fields | `verified-against-code` — `src/pylxpweb/transports/dongle.py:576-604` |
+| Integrity | CRC-16/Modbus over the embedded data frame; CRC stored LE16 | `verified-against-code` — `src/pylxpweb/transports/dongle.py:101-118`, `src/pylxpweb/transports/dongle.py:606-624` |
+| Outer functions | C1 heartbeat, C2 translated Modbus, C3 read parameter, C4 write parameter | `verified-against-code` — `src/pylxpweb/transports/dongle.py:56-77` |
+
+### Single serialized TCP workflow
+
+| Rule | Why | Evidence |
+|---|---|---|
+| `_connect_lock` serializes dial/close, the transaction lock serializes request/response, and the reentrant operation lock covers multi-request operations. | The dongle exposes one TCP slot and processes one request at a time. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
+| One timeout bounds the whole prefix/header/body receive. | Fragment arrival does not restart the timeout. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:898-904` |
+| A write request is not replayed at request level after missing ACK/EOF/socket error. | The inverter may already have applied it; replay could overwrite a concurrent bitfield change with stale state. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1401-1418` |
+| Response identity validation checks outer function before inner parsing, then CRC, serial, Modbus function, and start register. | A heartbeat/proxied frame must become `TransportResponseMismatchError`, not false evidence that fast reads are unsupported. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1080-1268` |
+
+## Input-read planning
+
+### Coalescing invariants
+
+| Invariant | Required behavior | Evidence |
+|---|---|---|
+| Merge eligibility | Merge only contiguous or overlapping spans whose union fits `max_input_block_size`. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:203-238` |
+| Gaps | Never bridge an unmapped gap, even when the numeric start-to-end span would fit. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:207-217` |
+| Oversized logical group | Never split it; preserve the original one-read group. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:216-238` |
+| Configuration | Accepted `max_input_block_size` is 40 through 125; default 40 is conservative, and 120 is field-proven. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:123-175` |
+| GridBOSS/MID | Keep every group at 40 registers or fewer and never coalesce it. Reads larger than 40 failed on real GridBOSS hardware. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:111-134` |
+| Batteries | Always read the four 30-register physical slots as one atomic 120-register FC04 block starting at 5002, independent of the configured normal block size. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:322-374` |
+| Battery rationale | One 120-register read prevents firmware page rotation between per-slot reads. | `hardware-proven` — `src/pylxpweb/transports/_register_data.py:322-374` |
+
+At configured size 120, the inverter plan is `(0,113)`, `(113,41)`, `(170,4)`, `(193,12)`; gaps 154–169 and 174–192 remain unread. `verified-against-code` — `tests/unit/transports/test_input_block_coalescing.py:50-59`, `tests/unit/transports/test_input_block_coalescing.py:98-148`.
+
+### Fast-read latch state machine
+
+| Prior evidence / failure | Immediate action | Future mode | Evidence |
+|---|---|---|---|
+| No successful read above 40; a genuine coalesced request raises or short-reads | Rerun the current cycle using the plain plan | **Permanently latch conservative mode for that transport instance**; recreation/reload re-arms it | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:888-918`, `src/pylxpweb/transports/_register_data.py:1007-1024`, `src/pylxpweb/transports/_register_data.py:1058-1066` |
+| Any response mismatch, whether support was proven or not | Rerun the current cycle using the plain plan | Plain reads for 300 monotonic seconds, then probe fast mode again | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:920-939`, `src/pylxpweb/transports/_register_data.py:1000-1006` |
+| At least one successful coalesced read above 40; any later exception or short read | Rerun the current cycle using the plain plan | Plain reads for 300 monotonic seconds, then probe fast mode again | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:941-970`, `src/pylxpweb/transports/_register_data.py:1007-1032` |
+
+Do not collapse the last two rows into the permanent latch. A mismatch is evidence of a misrouted frame, and a failure after proven support cannot prove an old-firmware 40-register cap. `verified-against-code` — `src/pylxpweb/transports/_register_data.py:920-1032`.

--- a/llmwiki/20-pylxpweb/transports.md
+++ b/llmwiki/20-pylxpweb/transports.md
@@ -4,7 +4,8 @@ sources:
   - pylxpweb@204b95d:src/pylxpweb/transports/
   - pylxpweb@204b95d:src/pylxpweb/registers/battery.py
   - pylxpweb@204b95d:tests/unit/transports/
-verified-against: 9f6d6e2
+verified-against:
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 
@@ -30,9 +31,11 @@ The upstream README instructs operators to run one active application/client per
 |---|---|---|
 | `connect()` constructs `AsyncModbusTcpClient(host, port, timeout, retries=pymodbus_retries)`, connects, installs the transaction-ID compatibility hook, and resets error state. | Do not rely on the stale docstring's claimed synchronization read; no synchronization read occurs. | `verified-against-code` — `src/pylxpweb/transports/modbus.py:145-180` |
 | FC03/FC04 calls use `device_id=unit_id`. | Preserve the unit ID and distinguish holding from input reads. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:167-220` |
-| FC06 is used for one value; FC16 is used for a contiguous list. | Do not replace schedule FC06 behavior with FC16; schedule firmware rejects FC16. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:339-352`, `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
+| FC06 is used for one value; FC16 is used for a contiguous list. | Schedule code sends start and end as separate one-register calls, so local Modbus and dongle transports issue two FC06 writes. | `verified-against-code` — `src/pylxpweb/devices/inverters/hybrid.py:352-363`, `src/pylxpweb/transports/_register_data.py:1589-1611`, `src/pylxpweb/transports/_modbus_base.py:339-352`, `src/pylxpweb/transports/dongle.py:1387-1393` |
 | Short holding reads fail inside the retry loop; short input reads pass upward for coalescing/BMS fallback policy. | Do not make both paths uniformly strict or uniformly permissive. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:222-237` |
 | Modbus writes validate the response but do not read the register back. | An accepted response is not independent readback proof. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:341-367` |
+
+The schedule implementation comment attributes those separate writes to firmware rejection of FC16, but no raw rejection capture establishes that hardware behavior. `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/devices/inverters/hybrid.py:352-363`. See the [hardware evidence boundary](../40-hardware/registers.md#schedule-write-evidence-boundary).
 
 ### Intentional Waveshare transaction-ID workaround
 
@@ -56,7 +59,8 @@ The compatibility code parses with `exp_tid=0`, rewrites the returned PDU transa
 
 | Rule | Why | Evidence |
 |---|---|---|
-| `_connect_lock` serializes dial/close, the transaction lock serializes request/response, and the reentrant operation lock covers multi-request operations. | The dongle exposes one TCP slot and processes one request at a time. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
+| `_connect_lock` serializes dial/close, the transaction lock serializes request/response, and the reentrant operation lock covers multi-request operations. | pylxpweb serializes its own transactions and multi-step operations within this transport instance. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:247-254`, `src/pylxpweb/transports/dongle.py:1467-1481` |
+| Gateway capacity | Source comments describe the dongle as having one TCP slot and processing one request at a time. | `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/transports/dongle.py:247-254`, `pylxpweb@204b95d:src/pylxpweb/transports/dongle.py:1467-1481`; no external-client connection capture is cited |
 | One timeout bounds the whole prefix/header/body receive. | Fragment arrival does not restart the timeout. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:898-904` |
 | A write request is not replayed at request level after missing ACK/EOF/socket error. | The inverter may already have applied it; replay could overwrite a concurrent bitfield change with stale state. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1401-1418` |
 | Response identity validation checks outer function before inner parsing, then CRC, serial, Modbus function, and start register. | A heartbeat/proxied frame must become `TransportResponseMismatchError`, not false evidence that fast reads are unsupported. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1080-1268` |

--- a/llmwiki/20-pylxpweb/write-paths.md
+++ b/llmwiki/20-pylxpweb/write-paths.md
@@ -4,7 +4,8 @@ sources:
   - pylxpweb@204b95d:src/pylxpweb/endpoints/control.py
   - pylxpweb@204b95d:src/pylxpweb/transports/
   - pylxpweb@e53b16b:tests/unit/endpoints/test_control_helpers.py
-verified-against: 9f6d6e2
+verified-against:
+  pylxpweb: 204b95d
 last-verified: 2026-08-08
 ---
 
@@ -78,6 +79,8 @@ Dongle readback is **diagnostic, not corrective**. A mismatch is not authorizati
 | Contiguous local raw write | No partiality within pylxpweb's requested run | One FC16 frame, except a one-register run uses FC06 | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1591-1612`, `src/pylxpweb/transports/_modbus_base.py:339-352` |
 | Cloud classic schedule window | Yes | Four named writes: start hour/minute, end hour/minute | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1656-1687` |
 | Cloud `writeTime` schedule window | Yes | Each boundary is atomic, but start and end are two requests | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1635-1654` |
-| Local schedule window | Yes | Code sends start and end as separate FC06 requests and documents firmware rejection of FC16 for these registers | `verified-against-code` — `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
+| Local schedule window | Yes | Code sends start and end as separate one-register calls; local Modbus and dongle transports produce two FC06 requests | `verified-against-code` — `src/pylxpweb/devices/inverters/hybrid.py:352-363`, `src/pylxpweb/transports/_register_data.py:1589-1611`, `src/pylxpweb/transports/_modbus_base.py:339-352`, `src/pylxpweb/transports/dongle.py:1387-1393` |
+
+The implementation comment attributes the separate schedule writes to firmware rejection of FC16, but no raw rejection capture establishes that hardware behavior. `asserted-unverified` — `pylxpweb@204b95d:src/pylxpweb/devices/inverters/hybrid.py:352-363`. See the [hardware evidence boundary](../40-hardware/registers.md#schedule-write-evidence-boundary).
 
 Cache invalidation is not verification. Cloud writes trust `SuccessResponse`; Modbus trusts its response; only the dongle adds strict ACK echo validation plus optional non-fatal diagnostic readback. `verified-against-code` — `src/pylxpweb/endpoints/control.py:210-219`, `src/pylxpweb/transports/_modbus_base.py:341-367`, `src/pylxpweb/transports/dongle.py:1420-1461`, `src/pylxpweb/transports/dongle.py:1640-1675`.

--- a/llmwiki/20-pylxpweb/write-paths.md
+++ b/llmwiki/20-pylxpweb/write-paths.md
@@ -1,15 +1,16 @@
 ---
 canonical-for: pylxpweb cloud, local, hybrid, and schedule write routing and verification
 sources:
-  - /tmp/llmwiki-research/pylxpweb-library.md
-  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+  - pylxpweb@204b95d:src/pylxpweb/endpoints/control.py
+  - pylxpweb@204b95d:src/pylxpweb/transports/
+  - pylxpweb@e53b16b:tests/unit/endpoints/test_control_helpers.py
 verified-against: 9f6d6e2
 last-verified: 2026-08-08
 ---
 
 # Write paths
 
-Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Assume partial application unless a cited row proves one contiguous local frame.
+Evidence grades follow the [canonical llmwiki legend](../README.md). Assume partial application unless a cited row proves one contiguous local frame.
 
 ## Routing matrix
 
@@ -25,9 +26,11 @@ Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Ass
 
 ## Historical cloud raw-register defect
 
-The original cloud raw-register batch nested `{register: value}` under a form field named `data`. `aiohttp` serialized the nested mapping as repeated `data=<register>` fields and discarded the values; the portal silently treated the malformed request as a no-op. Cloud raw-register writes therefore never worked from inception until the named-write rewrite. `verified-against-code` — `src/pylxpweb/endpoints/control.py:292-305`; historical release record: `CLAUDE.md:177`.
+Before the named-write rewrite, `write_parameters` put `{register: value}` under a form field named `data`. `verified-against-code` — `pylxpweb@e53b16b^:src/pylxpweb/endpoints/control.py:259-269`.
 
-Do not resurrect a supposed portal “batch raw register” endpoint. The working cloud format is flat named fields. `hardware-proven` — `src/pylxpweb/endpoints/control.py:164-219`, live write/readback record at `src/pylxpweb/endpoints/control.py:320-328`.
+The fix commit records that `aiohttp` serialized the nested mapping as repeated `data=<register>` fields with values dropped, that the portal silently no-op'd, and that cloud raw-register writes had never worked; the durable artifact does not include the captured HTTP body or portal response. `asserted-unverified` — `pylxpweb commit e53b16be26f86c5c614f8ed4370ff5cc38cc9187`.
+
+Do not resurrect a supposed portal “batch raw register” endpoint. The current code sends flat named `holdParam` / `valueText` fields. `verified-against-code` — `src/pylxpweb/endpoints/control.py:164-219`, `src/pylxpweb/endpoints/control.py:282-351`.
 
 ## Current cloud raw-address compatibility adapter
 
@@ -75,6 +78,6 @@ Dongle readback is **diagnostic, not corrective**. A mismatch is not authorizati
 | Contiguous local raw write | No partiality within pylxpweb's requested run | One FC16 frame, except a one-register run uses FC06 | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1591-1612`, `src/pylxpweb/transports/_modbus_base.py:339-352` |
 | Cloud classic schedule window | Yes | Four named writes: start hour/minute, end hour/minute | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1656-1687` |
 | Cloud `writeTime` schedule window | Yes | Each boundary is atomic, but start and end are two requests | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1635-1654` |
-| Local schedule window | Yes | Start and end are separate FC06 requests because firmware rejects FC16 for these registers | `hardware-proven` — `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
+| Local schedule window | Yes | Code sends start and end as separate FC06 requests and documents firmware rejection of FC16 for these registers | `verified-against-code` — `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
 
 Cache invalidation is not verification. Cloud writes trust `SuccessResponse`; Modbus trusts its response; only the dongle adds strict ACK echo validation plus optional non-fatal diagnostic readback. `verified-against-code` — `src/pylxpweb/endpoints/control.py:210-219`, `src/pylxpweb/transports/_modbus_base.py:341-367`, `src/pylxpweb/transports/dongle.py:1420-1461`, `src/pylxpweb/transports/dongle.py:1640-1675`.

--- a/llmwiki/20-pylxpweb/write-paths.md
+++ b/llmwiki/20-pylxpweb/write-paths.md
@@ -1,0 +1,80 @@
+---
+canonical-for: pylxpweb cloud, local, hybrid, and schedule write routing and verification
+sources:
+  - /tmp/llmwiki-research/pylxpweb-library.md
+  - /Users/bryanli/Projects/joyfulhouse/python/pylxpweb@204b95d
+verified-against: 9f6d6e2
+last-verified: 2026-08-08
+---
+
+# Write paths
+
+Use the evidence-grade meanings defined in [api-surface.md](api-surface.md). Assume partial application unless a cited row proves one contiguous local frame.
+
+## Routing matrix
+
+| Caller/path | Route | Atomicity / verification | Evidence |
+|---|---|---|---|
+| `client.api.control.write_parameter(...)` | Cloud named `holdParam` / `valueText` form | One portal request; success invalidates cache but does not read back | `verified-against-code` — `src/pylxpweb/endpoints/control.py:164-219` |
+| `client.api.control.write_time_parameter(...)` | Cloud named schedule boundary with hour/minute in one `writeTime` request | Atomic for one boundary, not for the whole start/end window | `verified-against-code` — `src/pylxpweb/endpoints/control.py:221-280`, `src/pylxpweb/endpoints/control.py:1635-1654` |
+| `client.api.control.write_parameters(dict[int, int])` | Resolve raw addresses to flat named cloud writes, then send sequentially | Resolve-all-before-write prevents an unsafe mapping from causing initial side effects; later network/portal failure can leave earlier values applied | `verified-against-code` — `src/pylxpweb/endpoints/control.py:282-351` |
+| `HTTPTransport.write_named_parameters(dict[str, Any])` | Booleans use `control_function`; other values use `write_parameter(str(value))`, one name per request | Multi-key call is non-atomic and can partially apply | `verified-against-code` — `src/pylxpweb/transports/http.py:423-494` |
+| Local `write_named_parameters` | Resolve family names, then lock-held read-modify-write for shared bitfield registers | Same-register bit changes combine into one raw register write | `verified-against-code` — `src/pylxpweb/transports/protocol.py:551-630` |
+| Local `write_parameters(dict[int, int])` | Sort addresses; FC06 for one register, FC16 for a contiguous run | Each contiguous run is one frame; separate noncontiguous runs can partially apply | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1572-1618`, `src/pylxpweb/transports/_modbus_base.py:339-352` |
+| `HybridTransport` writes | Try local while its local-failure latch permits; on typed local failure, fall back to HTTP | A failed local multi-run operation may already have applied an earlier run before cloud fallback | `inferred` — `src/pylxpweb/transports/hybrid.py:102-173`, `src/pylxpweb/transports/hybrid.py:315-380`, `src/pylxpweb/transports/_register_data.py:1610-1618` |
+
+## Historical cloud raw-register defect
+
+The original cloud raw-register batch nested `{register: value}` under a form field named `data`. `aiohttp` serialized the nested mapping as repeated `data=<register>` fields and discarded the values; the portal silently treated the malformed request as a no-op. Cloud raw-register writes therefore never worked from inception until the named-write rewrite. `verified-against-code` — `src/pylxpweb/endpoints/control.py:292-305`; historical release record: `CLAUDE.md:177`.
+
+Do not resurrect a supposed portal “batch raw register” endpoint. The working cloud format is flat named fields. `hardware-proven` — `src/pylxpweb/endpoints/control.py:164-219`, live write/readback record at `src/pylxpweb/endpoints/control.py:320-328`.
+
+## Current cloud raw-address compatibility adapter
+
+`write_parameters(inverter_sn, parameters)` is a compatibility adapter, not a raw batch write. `verified-against-code` — `src/pylxpweb/endpoints/control.py:282-351`.
+
+| Stage | Required behavior | Failure behavior | Evidence |
+|---|---|---|---|
+| 1. Resolve | Resolve every address into exactly one `(holdParam, valueText)` before the first request. | Any unsafe address raises before any write. | `verified-against-code` — `src/pylxpweb/endpoints/control.py:334-342` |
+| 2. Reject ambiguity | Reject packed schedule addresses, unmapped addresses, multi-name/bitfield registers, canonical bit rows, and signed registers whose negative portal encoding is not proven. | Reject rather than guess. | `verified-against-code` — `src/pylxpweb/endpoints/control.py:353-418` |
+| 3. Scale | Prefer canonical holding scale; otherwise use only the explicit divide-by-ten fallback sets. | Do not apply a universal scale. | `verified-against-code` — `src/pylxpweb/endpoints/control.py:420-439` |
+| 4. Write | Call the singular named `write_parameter` in input iteration order. | Stop on first `success=False`; earlier successes remain applied. | `verified-against-code` — `src/pylxpweb/endpoints/control.py:344-351` |
+
+Examples: raw `595` for a divisor-10 register becomes portal string `"59.5"`; a signed negative raw register is refused because the portal may want either `"-1"` or `"65535"` and that encoding is unverified. `verified-against-code` — `src/pylxpweb/endpoints/control.py:409-438`.
+
+## Local named and raw writes
+
+| Concern | Behavior | Evidence |
+|---|---|---|
+| Unknown name | Raise `ValueError`. | `verified-against-code` — `src/pylxpweb/transports/protocol.py:558-560` |
+| Placeholder `FUNC_<reg>_BIT<n>` | Decode-only; refuse writes because the function is not hardware-verified. | `verified-against-code` — `src/pylxpweb/transports/protocol.py:562-567` |
+| Disputed mapping | Refuse the write rather than risk changing a different setting that firmware would still ACK. | `verified-against-code` — `src/pylxpweb/transports/protocol.py:569-575` |
+| Ordinary/compound bitfield | Read current value, mask/update only requested bits, validate multi-bit width, then write one combined register value. | `verified-against-code` — `src/pylxpweb/transports/protocol.py:591-629` |
+| Raw address runs | Sort and group only consecutive addresses. | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1589-1612` |
+| Modbus response | Validate response object; do not perform independent readback. | `verified-against-code` — `src/pylxpweb/transports/_modbus_base.py:341-367` |
+| Dongle ACK | Validate serial/function/start address and exact echoed FC06 value or FC16 register count. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1420-1461` |
+
+## Dongle retry and diagnostic readback
+
+| Rule | Consequence | Evidence |
+|---|---|---|
+| Never replay the same raw write packet merely because its ACK was lost. | The inverter may already have applied it; stale replay could overwrite a concurrent bitfield change. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1401-1418` |
+| Named-write retries reconnect and rerun the whole sequence, including a fresh register read before recomputing the RMW. | Retry does not reuse stale bitfield state. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1565-1638` |
+| Optional readback is skipped when more than three distinct registers would be read. | Absence of readback does not change the ACK result. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1682-1714` |
+| Readback failure or mismatch is diagnostic only. | Accept the ACKed write; do not rewrite to fight firmware clamping/rounding or a concurrent portal/group writer. | `verified-against-code` — `src/pylxpweb/transports/dongle.py:1640-1675` |
+
+Dongle readback is **diagnostic, not corrective**. A mismatch is not authorization to write repeatedly until the observed value matches. `verified-against-code` — `src/pylxpweb/transports/dongle.py:1662-1675`.
+
+## Partial-application matrix
+
+| Operation | Can partially apply? | Boundary | Evidence |
+|---|---:|---|---|
+| Cloud multi-parameter write | Yes | One named portal request per value; earlier success survives later failure | `verified-against-code` — `src/pylxpweb/endpoints/control.py:344-351` |
+| HTTP named multi-write | Yes | One function/value request per dictionary entry | `verified-against-code` — `src/pylxpweb/transports/http.py:423-494` |
+| Noncontiguous local raw write | Yes | One FC06/FC16 operation per contiguous run | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1591-1618` |
+| Contiguous local raw write | No partiality within pylxpweb's requested run | One FC16 frame, except a one-register run uses FC06 | `verified-against-code` — `src/pylxpweb/transports/_register_data.py:1591-1612`, `src/pylxpweb/transports/_modbus_base.py:339-352` |
+| Cloud classic schedule window | Yes | Four named writes: start hour/minute, end hour/minute | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1656-1687` |
+| Cloud `writeTime` schedule window | Yes | Each boundary is atomic, but start and end are two requests | `verified-against-code` — `src/pylxpweb/endpoints/control.py:1635-1654` |
+| Local schedule window | Yes | Start and end are separate FC06 requests because firmware rejects FC16 for these registers | `hardware-proven` — `src/pylxpweb/devices/inverters/hybrid.py:352-363` |
+
+Cache invalidation is not verification. Cloud writes trust `SuccessResponse`; Modbus trusts its response; only the dongle adds strict ACK echo validation plus optional non-fatal diagnostic readback. `verified-against-code` — `src/pylxpweb/endpoints/control.py:210-219`, `src/pylxpweb/transports/_modbus_base.py:341-367`, `src/pylxpweb/transports/dongle.py:1420-1461`, `src/pylxpweb/transports/dongle.py:1640-1675`.


### PR DESCRIPTION
## Summary
- document the supported pylxpweb client, high-level device, and transport API seams
- document Modbus TCP and WiFi dongle framing, coalescing, latch, model/scaling, and write-path invariants
- document release derivation and the PyPI-before-integration pin ordering constraint

## Verification
- docs-only static audit: 5 expected pages, 534 lines, 243 valid source citations
- git diff --check passed
- commit hooks passed (YAML/EOF/whitespace/large-file checks; code-only hooks skipped)
- tests not run per task instruction

## Evidence downgrades
- cross-repository publication-order failure mechanics are graded inferred because no single workflow enforces both repositories
- hybrid fallback partiality is graded inferred from local grouping plus fallback control flow