### PR TITLE
ci: fix quality-validation compileall target and dead exit-code guards (#549)

### DIFF
--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Validate Python syntax
         run: |
           # Compile the whole tree: compileall exits 0 on a nonexistent file
-          # argument, so an explicit file list can silently skip files (#549).
+          # OR directory argument ("Can't list", success), so an explicit file
+          # list can silently skip files (#549) — and the tree path itself
+          # needs the test -d guard against the same failure class one level
+          # up (rename/typo). Under bash -e both guards fail the step
+          # directly, so no exit-code check is needed.
+          test -d custom_components/eg4_web_monitor
           python -m compileall -q custom_components/eg4_web_monitor
           echo "✅ All Python files have valid syntax"
 

--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -27,11 +27,8 @@ jobs:
       - name: Validate Python syntax
         run: |
           # Compile the whole tree: compileall exits 0 on a nonexistent file
-          # OR directory argument ("Can't list", success), so an explicit file
-          # list can silently skip files (#549) — and the tree path itself
-          # needs the test -d guard against the same failure class one level
-          # up (rename/typo). Under bash -e both guards fail the step
-          # directly, so no exit-code check is needed.
+          # or directory argument ("Can't list"), so an explicit file list can
+          # silently skip files (#549) and the tree path needs the test -d guard.
           test -d custom_components/eg4_web_monitor
           python -m compileall -q custom_components/eg4_web_monitor
           echo "✅ All Python files have valid syntax"

--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -26,13 +26,12 @@ jobs:
 
       - name: Validate Python syntax
         run: |
-          python -m compileall -q custom_components/eg4_web_monitor/__init__.py custom_components/eg4_web_monitor/_config_flow/__init__.py custom_components/eg4_web_monitor/coordinator.py custom_components/eg4_web_monitor/sensor.py custom_components/eg4_web_monitor/number.py custom_components/eg4_web_monitor/switch.py custom_components/eg4_web_monitor/button.py custom_components/eg4_web_monitor/select.py custom_components/eg4_web_monitor/utils.py custom_components/eg4_web_monitor/const.py
-          if [ $? -eq 0 ]; then
-            echo "✅ All Python files have valid syntax"
-          else
-            echo "❌ Python syntax errors found"
-            exit 1
-          fi
+          # Compile the whole integration tree: const.py and utils.py do not
+          # exist (const/ is a package), so the old explicit file list always
+          # failed (#549). Under the default bash -e shell a compileall
+          # failure aborts the step directly, so no exit-code guard is needed.
+          python -m compileall -q custom_components/eg4_web_monitor
+          echo "✅ All Python files have valid syntax"
 
   bronze-config-flow-tests:
     name: Bronze - Config Flow Tests
@@ -204,20 +203,16 @@ jobs:
 
       - name: Run ruff linter
         run: |
+          # Under the default bash -e shell a non-zero ruff exit aborts the
+          # step directly; the old `if [ $? -ne 0 ]` guard was unreachable.
           ruff check . --output-format=github
-          if [ $? -ne 0 ]; then
-            echo "❌ Ruff linter found issues"
-            exit 1
-          fi
           echo "✅ Ruff linter passed"
 
       - name: Run ruff formatter check
         run: |
+          # Same bash -e reasoning as the ruff linter step above: a non-zero
+          # exit fails the step before any exit-code guard could run.
           ruff format --check .
-          if [ $? -ne 0 ]; then
-            echo "❌ Ruff formatter check failed - code needs formatting"
-            exit 1
-          fi
           echo "✅ Ruff formatter check passed"
 
   bronze-security-scan:
@@ -828,11 +823,9 @@ jobs:
       - name: Run mypy type checking
         run: |
           echo "Running mypy type checking with Home Assistant 2025.11.0+..."
+          # Under the default bash -e shell a non-zero mypy exit aborts the
+          # step directly; the old `if [ $? -ne 0 ]` guard was unreachable.
           mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/
-          if [ $? -ne 0 ]; then
-            echo "❌ Type errors found - must be fixed for Platinum tier"
-            exit 1
-          fi
           echo "✅ Mypy type checking passed with zero errors"
 
   platinum-comprehensive-tests:

--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -26,10 +26,13 @@ jobs:
 
       - name: Validate Python syntax
         run: |
-          # Compile the whole integration tree: const.py and utils.py do not
-          # exist (const/ is a package), so the old explicit file list always
-          # failed (#549). Under the default bash -e shell a compileall
-          # failure aborts the step directly, so no exit-code guard is needed.
+          # Compile the whole integration tree: compileall silently skips a
+          # nonexistent file argument (prints "Can't list" but exits 0), so
+          # the old explicit list quietly never compiled const.py — which is
+          # the const/ package, not a module — while still passing (#549).
+          # Compiling the tree removes the stale-list failure mode. Under the
+          # default bash -e shell a compileall failure aborts the step
+          # directly, so no exit-code guard is needed.
           python -m compileall -q custom_components/eg4_web_monitor
           echo "✅ All Python files have valid syntax"
 

--- a/.github/workflows/quality-validation.yml
+++ b/.github/workflows/quality-validation.yml
@@ -26,13 +26,8 @@ jobs:
 
       - name: Validate Python syntax
         run: |
-          # Compile the whole integration tree: compileall silently skips a
-          # nonexistent file argument (prints "Can't list" but exits 0), so
-          # the old explicit list quietly never compiled const.py — which is
-          # the const/ package, not a module — while still passing (#549).
-          # Compiling the tree removes the stale-list failure mode. Under the
-          # default bash -e shell a compileall failure aborts the step
-          # directly, so no exit-code guard is needed.
+          # Compile the whole tree: compileall exits 0 on a nonexistent file
+          # argument, so an explicit file list can silently skip files (#549).
           python -m compileall -q custom_components/eg4_web_monitor
           echo "✅ All Python files have valid syntax"
 
@@ -206,15 +201,11 @@ jobs:
 
       - name: Run ruff linter
         run: |
-          # Under the default bash -e shell a non-zero ruff exit aborts the
-          # step directly; the old `if [ $? -ne 0 ]` guard was unreachable.
           ruff check . --output-format=github
           echo "✅ Ruff linter passed"
 
       - name: Run ruff formatter check
         run: |
-          # Same bash -e reasoning as the ruff linter step above: a non-zero
-          # exit fails the step before any exit-code guard could run.
           ruff format --check .
           echo "✅ Ruff formatter check passed"
 
@@ -826,8 +817,6 @@ jobs:
       - name: Run mypy type checking
         run: |
           echo "Running mypy type checking with Home Assistant 2025.11.0+..."
-          # Under the default bash -e shell a non-zero mypy exit aborts the
-          # step directly; the old `if [ $? -ne 0 ]` guard was unreachable.
           mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/
           echo "✅ Mypy type checking passed with zero errors"
 


### PR DESCRIPTION
Fixes #549

## What was broken

**1. The `Validate Python syntax` step listed a file that does not exist — and silently passed anyway.**

The step passed an explicit file list to `python -m compileall`, ending in `.../const.py`. There is no `const.py`: `const/` is a package. Verified locally: `python -m compileall -q <missing file>` prints `Can't list '<path>'` but **exits 0**. So the old step never actually compiled `const.py`, yet passed every run — it under-gated the syntax check, and its file list could silently drift out of date again as modules are added or moved.

Fix: compile the whole tree — `python -m compileall -q custom_components/eg4_web_monitor`. Every target now exists by construction, and new files are picked up automatically instead of requiring the list to be maintained. The compileall is preceded by `test -d custom_components/eg4_web_monitor` because compileall also exits 0 on a nonexistent **directory** argument (same `Can't list`, exit 0) — without the guard, a path rename/typo would silently un-gate the step again, the #549 failure class one level up.

**2. The `if [ $? ... ]` guards were dead code.**

GitHub Actions runs `run:` steps with `bash -e` by default. Under `bash -e`, a command that exits non-zero aborts the script *immediately* — control never reaches the next line, so `if [ $? -eq 0 ]` / `if [ $? -ne 0 ]` after the command can never observe a failure. The guard bodies were unreachable; the step failed (or passed) purely via `bash -e` semantics, and the guards only added noise.

## Each guard fix

- **`Validate Python syntax` (was lines 29–35):** replaced the file list + `if [ $? -eq 0 ]` guard with a single `compileall -q custom_components/eg4_web_monitor` followed by the success echo. On a syntax error, `compileall` exits 1 and `bash -e` fails the step with compileall's own diagnostic; the success echo never runs.
- **`Run ruff linter` (was lines 207–212):** removed `if [ $? -ne 0 ]; ... exit 1; fi`. `ruff check` already prints its findings in GitHub format; under `bash -e` a non-zero exit fails the step directly.
- **`Run ruff formatter check` (same pattern):** same fix — removed the unreachable guard after `ruff format --check .`.
- **`Run mypy type checking` (was lines 831–835):** same fix — removed the unreachable guard after `mypy`. mypy prints each type error itself before exiting non-zero.

No other workflow behavior changed; the success echoes are kept so passing logs look the same.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/quality-validation.yml'))"` → parses clean.
- `python -m compileall -q custom_components/eg4_web_monitor` on the real tree → exit 0.
- `python3 -m compileall -q <missing file>` → prints `Can't list '<path>'`, exit 0 — confirming the old step silently passed while never compiling `const.py`. Same result for a missing **directory**, which is why the step now guards the tree path with `test -d` (verified: `bash -e -c 'test -d <missing dir>; echo should-not-print'` → exit 1, echo suppressed).
- Shell semantics, proven locally with a deliberately broken file (`def broken(:`) in a temp dir:
  - `python3 -m compileall -q <dir>` → exit 1 with a SyntaxError diagnostic.
  - `bash -e -c 'python3 -m compileall -q <dir>; echo OK'` → exit 1, success echo not printed: a broken `.py` fails the step directly.
  - `bash -e -c 'python3 -m compileall -q <dir>; if [ $? -eq 0 ]; then ...; else echo guard-ran; exit 1; fi'` → `guard-ran` **never printed**, demonstrating the old guard body was unreachable (the step's exit 1 came from `bash -e` aborting at `compileall`, not from the guard's `exit 1`).

