### PR TITLE
chore: remove orphaned generate_entity_id (#550 follow-up)

### DIFF
--- a/custom_components/eg4_web_monitor/utils.py
+++ b/custom_components/eg4_web_monitor/utils.py
@@ -652,25 +652,6 @@ def battery_row_is_absent(battery: Any) -> bool:
 # These functions eliminate code duplication across multiple platform files
 
 
-def clean_model_name(model: str, use_underscores: bool = False) -> str:
-    """Clean model name for consistent entity ID generation.
-
-    Args:
-        model: Raw model name from device
-        use_underscores: If True, replace spaces/hyphens with underscores instead of removing them
-
-    Returns:
-        Cleaned model name suitable for entity IDs
-    """
-    if not model:
-        return "unknown"
-
-    cleaned = model.lower()
-    if use_underscores:
-        return cleaned.replace(" ", "_").replace("-", "_")
-    return cleaned.replace(" ", "").replace("-", "")
-
-
 def create_device_info(serial: str, model: str) -> DeviceInfo:
     """Create standardized device info dictionary for Home Assistant entities.
 
@@ -689,34 +670,6 @@ def create_device_info(serial: str, model: str) -> DeviceInfo:
         serial_number=serial,
         sw_version="1.0.0",  # Default version, can be updated from API
     )
-
-
-def generate_entity_id(
-    platform: str,
-    model: str,
-    serial: str,
-    entity_type: str,
-    suffix: str | None = None,
-) -> str:
-    """Generate standardized entity IDs across all platforms.
-
-    Args:
-        platform: Platform name (sensor, switch, button, number)
-        model: Device model name
-        serial: Device serial number
-        entity_type: Type of entity (e.g., "refresh_data", "ac_charge")
-        suffix: Optional suffix for multi-part entities
-
-    Returns:
-        Standardized entity ID
-    """
-    clean_model = clean_model_name(model)
-    base_id = f"{platform}.{clean_model}_{serial}_{entity_type}"
-
-    if suffix:
-        base_id = f"{base_id}_{suffix}"
-
-    return base_id
 
 
 def generate_unique_id(serial: str, entity_type: str, suffix: str | None = None) -> str:

--- a/llmwiki/10-integration/entities-identity-availability.md
+++ b/llmwiki/10-integration/entities-identity-availability.md
@@ -17,8 +17,9 @@ sources:
   - memory/issue-262-operating-state-and-i18n-names.md
   - memory/queue-cleanup-2026-07-26.md
   - eg4_web_monitor issues #550, #253, #256, #261, #479
+  - eg4_web_monitor PRs #566, #571
 verified-against:
-  eg4_web_monitor: 7641b96
+  eg4_web_monitor: e42ed86
   homeassistant: 2025.11.2
 last-verified: 2026-08-12
 see-also:
@@ -28,7 +29,7 @@ see-also:
 
 # Entities: inheritance, identity, availability
 
-Line numbers are pinned per source by the `verified-against:` mapping above — `7641b96` for
+Line numbers are pinned per source by the `verified-against:` mapping above — `e42ed86` for
 `eg4_web_monitor`, package version `2025.11.2` for `homeassistant`. Each citation names its source
 where it is not this repo. Symbol names are the durable anchor.
 
@@ -39,31 +40,31 @@ reasoning about any entity-state bug.
 
 ```
 CoordinatorEntity
-├── EG4DeviceEntity                            base_entity.py:66
-│   ├── EG4BaseSensor                          base_entity.py:414
-│   │   └── EG4InverterSensor                  sensor.py:675
-│   │       ├── EG4LastEventSensor             sensor.py:688
-│   │       └── EG4QuickChargeRemainingSensor  sensor.py:723
-│   ├── EG4BatteryBankEntity                   base_entity.py:627
-│   │   └── EG4BatteryBankSensor               sensor.py:747
-│   ├── EG4OffGridBinarySensor                 binary_sensor.py:56
-│   └── EG4RefreshButton                       button.py:166
-├── EG4BatteryEntity                           base_entity.py:117
-│   ├── EG4BaseBatterySensor                   base_entity.py:522
-│   │   └── EG4BatterySensor                   sensor.py:759
-│   └── EG4BatteryRefreshButton                button.py:300
-├── EG4StationEntity                           base_entity.py:182
-│   ├── EG4StationSensor                       sensor.py:790
-│   └── EG4StationRefreshButton                button.py:379
-├── EG4OptimisticEntity                        base_entity.py:741
-│   ├── EG4BaseNumber                          base_entity.py:1029
-│   │   └── EG4BaseNumberEntity(+NumberEntity) number.py:177  → concrete number classes
-│   ├── EG4BaseTime                            base_entity.py:1117
+├── EG4DeviceEntity                            base_entity.py:63
+│   ├── EG4BaseSensor                          base_entity.py:411
+│   │   └── EG4InverterSensor                  sensor.py:683
+│   │       ├── EG4LastEventSensor             sensor.py:696
+│   │       └── EG4QuickChargeRemainingSensor  sensor.py:731
+│   ├── EG4BatteryBankEntity                   base_entity.py:600
+│   │   └── EG4BatteryBankSensor               sensor.py:755
+│   ├── EG4OffGridBinarySensor                 binary_sensor.py:55
+│   └── EG4RefreshButton                       button.py:165
+├── EG4BatteryEntity                           base_entity.py:114
+│   ├── EG4BaseBatterySensor                   base_entity.py:501
+│   │   └── EG4BatterySensor                   sensor.py:767
+│   └── EG4BatteryRefreshButton                button.py:288
+├── EG4StationEntity                           base_entity.py:179
+│   ├── EG4StationSensor                       sensor.py:798
+│   └── EG4StationRefreshButton                button.py:364
+├── EG4OptimisticEntity                        base_entity.py:707
+│   ├── EG4BaseNumber                          base_entity.py:995
+│   │   └── EG4BaseNumberEntity(+NumberEntity) number.py:178  → concrete number classes
+│   ├── EG4BaseTime                            base_entity.py:1083
 │   │   └── EG4ScheduleTimeEntity              time.py:185
-│   ├── EG4BaseSelect(+SelectEntity)           base_entity.py:1184  → concrete selects
-│   └── EG4BaseSwitch(+SwitchEntity)           base_entity.py:1246  → concrete switches
+│   ├── EG4BaseSelect(+SelectEntity)           base_entity.py:1150  → concrete selects
+│   └── EG4BaseSwitch(+SwitchEntity)           base_entity.py:1212  → concrete switches
 ├── EG4FirmwareUpdateEntity                    update.py:55
-└── EG4DSTSwitch                               switch.py:1540   (direct CoordinatorEntity)
+└── EG4DSTSwitch                               switch.py:1611   (direct CoordinatorEntity)
 ```
 
 Evidence: `verified-against-code` — class declarations at the cited lines.
@@ -78,7 +79,7 @@ This is the single most-cited non-obvious mechanic in this codebase. There is **
 availability rule.
 
 > **Scope of this section.** Everything in §2.1–§2.4 describes the **verified current
-> implementation** at `9f6d6e2` — what the code does. Whether that behaviour is the *intended*
+> implementation** at `e42ed86` — what the code does. Whether that behaviour is the *intended*
 > contract is an open question, recorded as **C10** in
 > [../60-history/open-contradictions.md](../60-history/open-contradictions.md#c10--availability-contract-the-audit-contests-a-base-entity-behaviour-the-bug-notes-rely-on):
 > the #261 notes treat "missing key → unknown, stays available" as deliberate, while the
@@ -89,38 +90,38 @@ availability rule.
 
 | Class | `available` returns | Checks `last_update_success`? | Checks `"error"` key? | Checks key presence? | Cite |
 |---|---|---|---|---|---|
-| `EG4DeviceEntity` | serial present in `data["devices"]` | **No** | No | No | `base_entity.py:101-114` |
-| `EG4BaseSensor` | `device_present_and_healthy()` | Yes | **Yes** | No | `base_entity.py:516-519`; helper `:282-299` |
-| `EG4BaseBatterySensor` | parent healthy **and** `battery_key in parent["batteries"]` | Yes | Yes (on parent) | Yes (battery key) | `base_entity.py:610-624` |
-| `EG4BatteryBankEntity` | device present, no `"error"`, **and `sensor_key in device["sensors"]`** | Yes | Yes | **Yes (sensor key)** | `base_entity.py:691-710` |
-| `EG4BatteryEntity` | parent device present **and** `battery_key in parent["batteries"]` — **does not check `last_update_success`** | **No** | No | Yes (battery key) | `base_entity.py:162-180` |
-| `EG4StationEntity` | `last_update_success` and `"station" in data` — **never reads `data["devices"]`** | Yes | n/a | No | `base_entity.py:212-228` |
-| `EG4OptimisticEntity._control_device_available()` — a **helper**, not an `available` property; called by `EG4BaseNumber` / `EG4BaseTime` / `EG4BaseSwitch` | success + `_control_discovery_supported` + device exists + `device["type"] == expected_type` (**defaults** to `"inverter"`; see §2.4) | Yes | **Deliberately No** | No | `base_entity.py:796-812` |
-| `EG4OffGridBinarySensor` | mirrors `EG4BaseSensor` on purpose (calls the same helper) | Yes | Yes | No | `binary_sensor.py:94-105` |
-| `EG4FirmwareUpdateEntity` | `last_update_success` + serial present | Yes | No | No | `update.py:203-211` |
+| `EG4DeviceEntity` | serial present in `data["devices"]` | **No** | No | No | `base_entity.py:99-111` |
+| `EG4BaseSensor` | `device_present_and_healthy()` | Yes | **Yes** | No | `base_entity.py:496-498`; helper `:279-296` |
+| `EG4BaseBatterySensor` | parent healthy **and** `battery_key in parent["batteries"]` | Yes | Yes (on parent) | Yes (battery key) | `base_entity.py:584-597` |
+| `EG4BatteryBankEntity` | device present, no `"error"`, **and `sensor_key in device["sensors"]`** | Yes | Yes | **Yes (sensor key)** | `base_entity.py:658-676` |
+| `EG4BatteryEntity` | parent device present **and** `battery_key in parent["batteries"]` — **does not check `last_update_success`** | **No** | No | Yes (battery key) | `base_entity.py:159-176` |
+| `EG4StationEntity` | `last_update_success` and `"station" in data` — **never reads `data["devices"]`** | Yes | n/a | No | `base_entity.py:210-225` |
+| `EG4OptimisticEntity._control_device_available()` — a **helper**, not an `available` property; called by `EG4BaseNumber` / `EG4BaseTime` / `EG4BaseSwitch` | success + `_control_discovery_supported` + device exists + `device["type"] == expected_type` (**defaults** to `"inverter"`; see §2.4) | Yes | **Deliberately No** | No | `base_entity.py:762-778` |
+| `EG4OffGridBinarySensor` | mirrors `EG4BaseSensor` on purpose (calls the same helper) | Yes | Yes | No | `binary_sensor.py:90-100` |
+| `EG4FirmwareUpdateEntity` | `last_update_success` + serial present | Yes | No | No | `update.py:184-190` |
 
 Every row: `verified-against-code`.
 
 > **Frame: this table is not the whole availability model.** A component-wide
-> `grep -rn 'def available'` at `9f6d6e2` returns **21** definitions, broken down as:
+> `grep -rn 'def available'` at `e42ed86` returns **22** definitions, broken down as:
 >
 > | Group | Count | Where |
 > |---|---|---|
-> | Listed above as `available` definitions | 8 | `base_entity.py` ×6 (`:102`, `:162`, `:213`, `:517`, `:611`, `:692`), `binary_sensor.py:96`, `update.py:204` |
-> | Control base classes that only delegate | 3 | `EG4BaseNumber` (`base_entity.py:1076`), `EG4BaseTime` (`:1162`), `EG4BaseSwitch` (`:1352`) — each `return self._control_device_available()` |
-> | Platform subclasses | 10 | **7 change the contract** (§2.4); 3 only delegate — `EG4OperatingModeSelect` (`select.py:238`), `EG4PVInputModeSelect` (`:345`), `EG4BatteryControlModeSelect` (`:607`) |
+> | Listed above as `available` definitions | 8 | `base_entity.py` ×6 (`:99`, `:159`, `:210`, `:496`, `:584`, `:658`), `binary_sensor.py:90`, `update.py:184` |
+> | Control base classes that only delegate | 3 | `EG4BaseNumber` (`base_entity.py:1042`), `EG4BaseTime` (`:1128`), `EG4BaseSwitch` (`:1315`) — each `return self._control_device_available()` |
+> | Platform subclasses | 11 | **8 change the contract** (§2.4 plus `EG4QuickChargeSwitch` at `switch.py:525`); 3 only delegate — `EG4OperatingModeSelect` (`select.py:234`), `EG4PVInputModeSelect` (`:338`), `EG4BatteryControlModeSelect` (`:594`) |
 >
-> 8 + 3 + 10 = 21. Per file: `base_entity.py` 9, `select.py` 4, `switch.py` 3, `number.py` 2,
+> 8 + 3 + 11 = 22. Per file: `base_entity.py` 9, `select.py` 4, `switch.py` 4, `number.py` 2,
 > `binary_sensor.py` / `update.py` / `time.py` 1 each.
 >
 > Note `EG4OptimisticEntity` defines **no** `available` at all — it defines the
-> `_control_device_available()` **helper** (`base_entity.py:796`) that the three control bases call.
+> `_control_device_available()` **helper** (`base_entity.py:762`) that the three control bases call.
 > The row above is the helper's contract, not an inherited property.
 >
 > Resolving an entity's real behaviour means finding its **concrete class** first. A base-class
 > table that reads as complete is the same defect this chapter documents for write paths — see
 > [controls-and-writes.md §0](controls-and-writes.md#0-the-write-surface-is-not-reliably-enumerable-from-documentation).
-> `verified-against-code` at `9f6d6e2`.
+> `verified-against-code` at `e42ed86`.
 
 ### 2.1 The asymmetry that causes flicker bugs
 
@@ -129,10 +130,10 @@ Every row: `verified-against-code`.
 
 | Class | Key absent from `device["sensors"]` | Mechanism |
 |---|---|---|
-| `EG4BaseSensor` | Entity stays **available**, `native_value` is `None` → HA renders **unknown** | `available` never consults key presence; `_get_raw_value()` returns `None` (`base_entity.py:484-497`) |
-| `EG4BatteryBankEntity` | Entity becomes **unavailable** | key presence is *part of* `available` (`base_entity.py:710`) |
+| `EG4BaseSensor` | Entity stays **available**, `native_value` is `None` → HA renders **unknown** | `available` never consults key presence; `_get_raw_value()` returns `None` (`base_entity.py:463-493`) |
+| `EG4BatteryBankEntity` | Entity becomes **unavailable** | key presence is *part of* `available` (`base_entity.py:676`) |
 
-Evidence: `verified-against-code` — both properties read at `9f6d6e2`.
+Evidence: `verified-against-code` — both properties read at `e42ed86`.
 
 This asymmetry is the root of the #261 HYBRID flicker. It compounds with a coordinator behaviour:
 **the coordinator writes a sensor key only when its value is non-None**, so a transient transport
@@ -192,14 +193,14 @@ the contract rather than simply delegating to the base:
 | Class | Site | What it adds |
 |---|---|---|
 | `EG4ScheduleTimeEntity` | `time.py:320` | `super().available and self.native_value is not None` — **key-presence semantics for a control**, the shape §2.1 attributes to `EG4BatteryBankEntity` |
-| `EG4CloudStoreSwitch` | `switch.py:689` | Unavailable while the cloud-store state is absent — first fetch pending, an older pylxpweb lacking the getter, or a family that genuinely lacks the feature |
-| `EG4WorkingModeSwitch` | `switch.py:1316` | Modes flagged `requires_known_state` go **unavailable** while their state key is absent, instead of publishing a fake OFF (#497) |
-| `ACCoupleSOCNumberBase` | `number.py:1647` | Unavailable on an absent value, same known-state rationale |
-| `SmartLoadNumber` | `number.py:1932` | `super().available`, then treats a held optimistic value as available |
-| `EG4SmartPortModeSelect` | `select.py:468` | `_control_device_available(DEVICE_TYPE_GRIDBOSS)` — the expected device type is a **parameter** (`base_entity.py` → `_control_device_available(expected_type="inverter")`), so the "device type is `inverter`" rule in §2 is the default, not a universal |
-| `EG4DSTSwitch` | `switch.py:1592` | Its own coordinator-health check; it descends from `CoordinatorEntity` directly, not from the base classes in §2 |
+| `EG4CloudStoreSwitch` | `switch.py:755` | Unavailable while the cloud-store state is absent — first fetch pending, an older pylxpweb lacking the getter, or a family that genuinely lacks the feature |
+| `EG4WorkingModeSwitch` | `switch.py:1387` | Modes flagged `requires_known_state` go **unavailable** while their state key is absent, instead of publishing a fake OFF (#497) |
+| `ACCoupleSOCNumberBase` | `number.py:1766` | Unavailable on an absent value, same known-state rationale |
+| `SmartLoadNumber` | `number.py:2051` | `super().available`, then treats a held optimistic value as available |
+| `EG4SmartPortModeSelect` | `select.py:458` | `_control_device_available(DEVICE_TYPE_GRIDBOSS)` — the expected device type is a **parameter** (`base_entity.py` → `_control_device_available(expected_type="inverter")`), so the "device type is `inverter`" rule in §2 is the default, not a universal |
+| `EG4DSTSwitch` | `switch.py:1663` | Its own coordinator-health check; it descends from `CoordinatorEntity` directly, not from the base classes in §2 |
 
-Whole table: `verified-against-code` at `9f6d6e2`. The remaining overrides delegate to
+Whole table: `verified-against-code` at `e42ed86`. The remaining overrides delegate to
 `_control_device_available()` or `super().available` and do not change the contract.
 
 **Derivation, so this does not need hand-maintaining:** `grep -rn 'def available'` over
@@ -211,26 +212,26 @@ in this table.
 
 | Stage | Behavior | Evidence |
 |---|---|---|
-| `native_value` runs `_guard_total_increasing()` | Pins downward dips **smaller than 10 %** for `total_increasing` sensors to the prior high-water mark; larger drops pass through as genuine resets | `verified-against-code` — `base_entity.py:312-345`, threshold `_RESET_DETECTION_THRESHOLD = 0.9` at `:309` |
-| Why 10 % | Matches HA recorder's own reset threshold; smaller dips trigger a "state is not strictly increasing" warning and are virtually always cloud rounding noise | `verified-against-code` — comment at `base_entity.py:302-308` |
-| Non-numeric / `None` / non-`total_increasing` | Returned untouched, cache not updated | `verified-against-code` — `base_entity.py:314-329` |
-| `_apply_sensor_config()` | Applies unit / device_class / state_class / icon / options / `translation_key` / precision / entity_category / `enabled_default` from `SENSOR_TYPES` | `verified-against-code` — `base_entity.py:348-411` |
+| `native_value` runs `_guard_total_increasing()` | Pins downward dips **smaller than 10 %** for `total_increasing` sensors to the prior high-water mark; larger drops pass through as genuine resets | `verified-against-code` — `base_entity.py:309-343`, threshold `_RESET_DETECTION_THRESHOLD = 0.9` at `:306` |
+| Why 10 % | Matches HA recorder's own reset threshold; smaller dips trigger a "state is not strictly increasing" warning and are virtually always cloud rounding noise | `verified-against-code` — comment at `base_entity.py:298-305` |
+| Non-numeric / `None` / non-`total_increasing` | Returned untouched, cache not updated | `verified-against-code` — `base_entity.py:320-333` |
+| `_apply_sensor_config()` | Applies unit / device_class / state_class / icon / options / `translation_key` / precision / entity_category / `enabled_default` from `SENSOR_TYPES` | `verified-against-code` — `base_entity.py:345-408` |
 
 Two typing gaps worth knowing (`verified-against-code`):
 
 - `SensorConfig` (`const/sensors/types.py:16-37`) **lacks** `options` and `translation_key`, even
-  though `_apply_sensor_config` reads both (`base_entity.py:374-384`).
+  though `_apply_sensor_config` reads both (`base_entity.py:371-381`).
 - `SENSOR_TYPES` is **not** annotated as `dict[str, SensorConfig]`; only `STATION_SENSOR_TYPES` is
-  (`const/sensors/station.py:13`). `base_entity.py:367-369` casts.
-- The `enabled_default` check uses truthiness, not `is False` (`base_entity.py:408`).
+  (`const/sensors/station.py:13`). `base_entity.py:365-367` casts.
+- The `enabled_default` check uses truthiness, not `is False` (`base_entity.py:405`).
 
 This guard is the sanctioned alternative to a coordinator-level energy clamp. See
 [data-semantics.md](data-semantics.md) §4 — that section is mandatory reading before touching any
 energy sensor.
 
-## 4. `_attr_entity_id` is NOT a Home Assistant attribute — all 17 assignments are inert
+## 4. `_attr_entity_id` was never a Home Assistant attribute — 17 assignments were inert
 
-### 4.1 The finding
+### 4.1 The finding (historical; remediated in #566)
 
 Home Assistant claims are verified at the pinned package version **2025.11.2**, not at whatever
 version happens to be installed. Three different Home Assistant versions exist in virtualenvs in
@@ -240,19 +241,23 @@ this working tree, so an unpinned grep is not reproducible evidence.
 |---|---|
 | The string `_attr_entity_id` appears **0 times in the entire `homeassistant` package** — not merely in `helpers/entity.py` | `verified-against-code` — recursive grep over the installed package at `homeassistant 2025.11.2` (8,521 `.py` files) returned 0 matches |
 | `Entity` declares a plain `entity_id: str = None  # type: ignore[assignment]` | `verified-against-code` — `homeassistant/helpers/entity.py:441` at 2025.11.2 |
-| This repo contains **17** `_attr_entity_id` assignments, across 5 files | `verified-against-code` — `grep -rn '_attr_entity_id' --include='*.py'` → 17: `base_entity.py` (6), `button.py` (4), `select.py` (4), `update.py` (2), `binary_sensor.py` (1) |
-| **All 17 are inert.** Nothing in Home Assistant reads that name | `verified-against-code` — the package-wide zero above |
-| Tracked as issue **#550** | `asserted-unverified` — an issue title and its open/closed state are tracker metadata, not code; they can change without any code changing. Cited as provenance, not as a verified fact |
+| This repo **had** **17** `_attr_entity_id` assignments across 5 files (`base_entity.py` 6, `button.py` 4, `select.py` 4, `update.py` 2, `binary_sensor.py` 1) | Historical count from the pre-#566 tree; **removed in #566**. At pin `e42ed86`, `rg '_attr_entity_id' custom_components/eg4_web_monitor/` returns **0** (`verified-against-code`) |
+| **All 17 were inert.** Nothing in Home Assistant reads that name | `verified-against-code` — the package-wide zero above (unchanged by the deletion) |
+| Tracked as issue **#550**; assignments deleted in PR **#566** | `asserted-unverified` — issue/PR metadata are tracker provenance, not code |
 
 `utils.generate_entity_id` (and its sole feeder `clean_model_name`) likewise only fed those
-dead attributes; both helpers were removed in #571 after the assignments themselves were
-deleted in #566 (`verified-against-code` — `rg generate_entity_id custom_components/eg4_web_monitor/`
-returns empty at pin `7641b96`).
+dead attributes. After #566 removed every assignment, both helpers remained as **uncalled
+orphans** at pin `e42ed86` (`verified-against-code` — definitions at `utils.py:655` /
+`:694`; `rg 'generate_entity_id|clean_model_name' custom_components/eg4_web_monitor/` finds
+only those definition sites plus the one internal call from `generate_entity_id` to
+`clean_model_name`). PR **#571** deletes both helpers — verified at the PR #571 head; that
+deletion lands when the #571 squash merges onto main.
 
-#### Why they are inert — it is the prefix, not the concept
+#### Why they were inert — it is the prefix, not the concept
 
-This is the part that makes #550 a **one-character** issue rather than a deletion, and it is easy
-to get backwards: **the bare `entity_id` attribute is very much alive.** Home Assistant reads it.
+This is the part that made #550 a **one-character** issue rather than a behaviour bug, and it is
+easy to get backwards: **the bare `entity_id` attribute is very much alive.** Home Assistant
+reads it.
 
 | Fact | Evidence |
 |---|---|
@@ -261,25 +266,22 @@ to get backwards: **the bare `entity_id` attribute is very much alive.** Home As
 | The `_attr_` prefix is only meaningful for names listed in `CACHED_PROPERTIES_WITH_ATTR_`, which the `ABCCachedProperties` metaclass turns into `_attr_`-backed cached properties | `verified-against-code` — `helpers/entity.py:407` (the set) and `:434` (the metaclass) |
 | `entity_id` is **not** in that set, so no `_attr_entity_id` → `entity_id` binding exists. Compare `_attr_name`, `_attr_icon`, `_attr_available`, `_attr_unique_id`, `_attr_device_info`, which are declared and do bind | `verified-against-code` — `helpers/entity.py:407-433`, declarations at `:532-550` |
 
-So each of the 17 assignments creates an unused instance attribute beside the live one. The strings
-are computed correctly and land one underscore-prefix away from working.
-
-> **This is not a recommendation to drop the prefix.** Assigning `entity_id` directly would make 17
-> currently-inert statements suddenly authoritative over registry object ids — a mass entity-id
-> change on every existing installation, with statistics and automations attached to the old ids
-> (§8). The narrowness of the defect is exactly what makes it dangerous to "fix" casually. What to
-> do about #550 is a product decision, not a mechanical one.
+Each of the 17 assignments created an unused instance attribute beside the live one. The strings
+were computed correctly and landed one underscore-prefix away from working. #566 deleted the
+assignments rather than dropping the `_attr_` prefix — assigning bare `entity_id` would have made
+those statements suddenly authoritative over registry object ids (a mass entity-id change on every
+existing installation, with statistics and automations attached to the old ids — §8).
 
 ### 4.2 What HA actually does
 
 Every entity in this integration sets `_attr_has_entity_name = True`
-(`verified-against-code` — `base_entity.py:462, 570, 665, 1045, 1131, 1300`, and the platform
+(`verified-against-code` — `base_entity.py:459, 549, 638, 1011, 1097, 1266`, and the platform
 classes). Under that flag, HA composes the display name as *device name + entity name* and derives
 the `entity_id` object_id by **slugifying that name** at first registration.
 
 | Consequence | Detail |
 |---|---|
-| Entity IDs come from **slugified names**, never from `entity_key` constants | `verified-against-code` — HA `Entity`/`EntityPlatform` naming path + the `_attr_entity_id` finding |
+| Entity IDs come from **slugified names**, never from `entity_key` constants | `verified-against-code` — HA `Entity`/`EntityPlatform` naming path + the historical `_attr_entity_id` finding |
 | Live registry examples | `switch.18kpv_<serial>_eps_battery_backup` (despite `entity_key='battery_backup'`); `sensor.battery_bank_<serial>_battery_bank_max_cell_temperature` — `asserted-unverified` — production entity-registry capture recorded in `memory/queue-cleanup-2026-07-26.md`; not re-captured here |
 | **HA freezes `entity_id` at first registration** | A device whose model string drifted across pylxpweb versions shows entities with two different model prefixes. That is one device, not two (`asserted-unverified` — `memory/queue-cleanup-2026-07-26.md`) |
 
@@ -289,19 +291,21 @@ the `entity_id` object_id by **slugifying that name** at first registration.
 
 ### 4.3 The documented format never took effect
 
-**The trap is in the code, and it is convincing.** `_setup_entity_id` and its siblings build
-correct-looking, fully-formed entity IDs — model cleaned, prefix applied, per-device-type branches
-— and assign each one to `_attr_entity_id`. Reading that function, the format below looks
-authoritative. It is never registered, because the attribute it lands in does not exist in Home
-Assistant (§4.1). Any document repeating these strings inherited them from this code.
+**The trap was in the code, and it was convincing.** Before #566, `_setup_entity_id` and its
+siblings built correct-looking, fully-formed entity IDs — model cleaned, prefix applied,
+per-device-type branches — and assigned each one to `_attr_entity_id`. Reading that function, the
+format below looked authoritative. It was never registered, because the attribute it landed in
+does not exist in Home Assistant (§4.1). Those builders were deleted with the inert assignments
+in #566; at pin `e42ed86` they are gone (`verified-against-code` — `rg '_setup_entity_id|_attr_entity_id' custom_components/eg4_web_monitor/` returns empty). Any document that still
+repeats these strings inherited them from that removed code.
 
-| Format the code appears to promise | Reality |
+| Format the old code appeared to promise | Reality |
 |---|---|
-| `eg4_{model}_{serial}_{sensor_name}` (inverter) | **Never registered by HA.** Built, then written to `_attr_entity_id`, which HA ignores (`verified-against-code` — `base_entity.py:470-482` + the §4.1 finding) |
-| `eg4_{model}_{serial}_battery_{batteryKey}_{sensor_name}` (battery) | Same — inert (`base_entity.py:578`) |
-| `eg4_gridboss_{serial}_{sensor_name}` (GridBOSS) | Same — inert (`base_entity.py:473-475`) |
+| `eg4_{model}_{serial}_{sensor_name}` (inverter) | **Never registered by HA.** Was built, then written to `_attr_entity_id`, which HA ignores (§4.1) |
+| `eg4_{model}_{serial}_battery_{batteryKey}_{sensor_name}` (battery) | Same — was inert |
+| `eg4_gridboss_{serial}_{sensor_name}` (GridBOSS) | Same — was inert |
 
-The strings are constructed correctly; they simply go nowhere. Do not use them to predict a live
+The strings were constructed correctly; they simply went nowhere. Do not use them to predict a live
 entity ID, to write a test assertion about registry contents, or to build a dashboard reference.
 
 ### 4.4 Two related naming rules
@@ -322,23 +326,23 @@ these strings are real and stable.
 
 | Entity kind | Format | Cite |
 |---|---|---|
-| Device sensor | `f"{serial}_{sensor_key}"` | `base_entity.py:457` |
-| Individual battery sensor | `f"{serial}_{battery_key}_{sensor_key}"` | `base_entity.py:565` |
-| Battery bank sensor | `f"{serial}_battery_bank_{sensor_key}"` | `base_entity.py:660` |
-| Station sensor | `f"station_{coordinator.plant_id}_{sensor_key}"` | `sensor.py:829` |
-| Off-grid binary sensor | `f"{serial}_off_grid"` | `binary_sensor.py:73` |
-| Firmware update | `f"{serial}_firmware_update"` | `update.py:80` |
-| Switch | `generate_unique_id(serial, entity_key)` | `base_entity.py:1306` |
-| Select | `generate_unique_id(serial, "operating_mode")` (etc.) | `select.py:180` |
-| Number / time (via `EG4OptimisticEntity`) | `generate_unique_id(self._retention_serial.lower(), entity_key)` | `base_entity.py:814-816` |
+| Device sensor | `f"{serial}_{sensor_key}"` | `base_entity.py:454` |
+| Individual battery sensor | `f"{serial}_{battery_key}_{sensor_key}"` | `base_entity.py:544` |
+| Battery bank sensor | `f"{serial}_battery_bank_{sensor_key}"` | `base_entity.py:633` |
+| Station sensor | `f"station_{coordinator.plant_id}_{sensor_key}"` | `sensor.py:837` |
+| Off-grid binary sensor | `f"{serial}_off_grid"` | `binary_sensor.py:72` |
+| Firmware update | `f"{serial}_firmware_update"` | `update.py:70` |
+| Switch | `generate_unique_id(serial, entity_key)` | `base_entity.py:1272` |
+| Select | `generate_unique_id(serial, "operating_mode")` (etc.) | `select.py:179` |
+| Number / time (via `EG4OptimisticEntity`) | `generate_unique_id(self._retention_serial.lower(), entity_key)` | `base_entity.py:780-782` |
 
-All rows: `verified-against-code`. `utils.generate_unique_id` (`utils.py:675-691`) is literally
+All rows: `verified-against-code`. `utils.generate_unique_id` (`utils.py:722-738`) is literally
 `f"{serial}_{entity_type}"` plus an optional `_{suffix}`.
 
 > ⚠️ **Case divergence.** `_stable_control_unique_id` lowercases the serial; switch and select
 > unique IDs do not. Lettered serials therefore differ in case **between platforms**. This is why
 > `flag_offgrid_control_suppression` matches case-insensitively (`verified-against-code` —
-> `utils.py:406`, `:421`). Any code matching unique-ID suffixes must be case-insensitive.
+> `utils.py:442`, `:451`, `:466`). Any code matching unique-ID suffixes must be case-insensitive.
 
 ### 5.1 The `{data_type}` format that never existed
 
@@ -362,16 +366,16 @@ also recorded as **S1** in
 
 | Device | `identifiers` | `via_device` | Cite |
 |---|---|---|---|
-| inverter / gridboss / parallel_group | `(DOMAIN, serial)` — PG serial is `parallel_group_<name>` | `(DOMAIN, parallel_group_serial)` when a group is found | `coordinator_mixins.py:3924`, `:3937-3940` |
-| individual battery | `(DOMAIN, battery_key)` | `(DOMAIN, f"{serial}_battery_bank")` | `coordinator_mixins.py:4000-4005` |
-| battery bank | `(DOMAIN, f"{serial}_battery_bank")` | `(DOMAIN, serial)` | `coordinator_mixins.py:4053-4057` |
-| station | `(DOMAIN, f"station_{plant_id}")` | — | `coordinator_mixins.py:4082` |
+| inverter / gridboss / parallel_group | `(DOMAIN, serial)` — PG serial is `parallel_group_<name>` | `(DOMAIN, parallel_group_serial)` when a group is found | `coordinator_mixins.py:3919`, `:3934-3936` |
+| individual battery | `(DOMAIN, battery_key)` | `(DOMAIN, f"{serial}_battery_bank")` | `coordinator_mixins.py:3993-4001` |
+| battery bank | `(DOMAIN, f"{serial}_battery_bank")` | `(DOMAIN, serial)` | `coordinator_mixins.py:4048-4053` |
+| station | `(DOMAIN, f"station_{plant_id}")` | — | `coordinator_mixins.py:4077-4078` |
 
 All rows: `verified-against-code`. Cloud PG naming is
-`f"parallel_group_{group.name.lower()}"` (`coordinator_mixins.py:3961`).
+`f"parallel_group_{group.name.lower()}"` (`coordinator_mixins.py:3957`).
 
 Because of the `via_device` chain, the `SENSOR` platform must be forwarded **before** every other
-platform — it is what creates the parent devices (`verified-against-code` — `__init__.py:80-93`).
+platform — it is what creates the parent devices (`verified-against-code` — `__init__.py:1360-1363`).
 
 **Battery identity is serial-first across all three modes**, with in-place registry migration
 (`battery_migration.py`), so switching modes no longer duplicates battery devices (#252). Identity
@@ -381,10 +385,10 @@ must stay transport-independent.
 
 | Category | Rule | Cite |
 |---|---|---|
-| `SENSOR_TYPES` / `STATION_SENSOR_TYPES` rows with `"enabled_default": False` | Honored by `_apply_sensor_config` (truthiness check) | `base_entity.py:408-409`, `sensor.py:825-826`; example `const/sensors/station.py:44-50` |
-| **All** schedule time entities | Disabled by default — explicit product decision | `time.py:225-226` |
-| Regime-gated numbers | Default to `is_control_active(control_key, configured_charge, configured_discharge)`; the non-selected SOC/Voltage set starts disabled | `number.py:200-204` |
-| Individually pinned | `GridPeakShavingPowerNumber` (`number.py:1203`), `SmartLoadNumber` (`number.py:1901`), `StartChargePowerNumber` (`number.py:2226`), `EG4SmartLoadSwitch` (`switch.py:1020`), some `EG4WorkingModeSwitch` rows (`switch.py:1302`) | as cited |
+| `SENSOR_TYPES` / `STATION_SENSOR_TYPES` rows with `"enabled_default": False` | Honored by `_apply_sensor_config` (truthiness check) | `base_entity.py:405-406`, `sensor.py:832-835`; example `const/sensors/station.py:44-50` |
+| **All** schedule time entities | Disabled by default — explicit product decision | `time.py:226` |
+| Regime-gated numbers | Default to `is_control_active(control_key, configured_charge, configured_discharge)`; the non-selected SOC/Voltage set starts disabled | `number.py:203-205` |
+| Individually pinned | `GridPeakShavingPowerNumber` (`number.py:1295`), `SmartLoadNumber` (`number.py:2020`), `StartChargePowerNumber` (`number.py:2345`), `EG4SmartLoadSwitch` (`switch.py:1086`), some `EG4WorkingModeSwitch` rows (`switch.py:1373`) | as cited |
 
 All rows: `verified-against-code`.
 

--- a/llmwiki/10-integration/entities-identity-availability.md
+++ b/llmwiki/10-integration/entities-identity-availability.md
@@ -63,7 +63,7 @@ CoordinatorEntity
 │   │   └── EG4ScheduleTimeEntity              time.py:185
 │   ├── EG4BaseSelect(+SelectEntity)           base_entity.py:1150  → concrete selects
 │   └── EG4BaseSwitch(+SwitchEntity)           base_entity.py:1212  → concrete switches
-├── EG4FirmwareUpdateEntity                    update.py:55
+├── EG4FirmwareUpdateEntity                    update.py:54
 └── EG4DSTSwitch                               switch.py:1611   (direct CoordinatorEntity)
 ```
 
@@ -109,7 +109,7 @@ Every row: `verified-against-code`.
 > |---|---|---|
 > | Listed above as `available` definitions | 8 | `base_entity.py` ×6 (`:99`, `:159`, `:210`, `:496`, `:584`, `:658`), `binary_sensor.py:90`, `update.py:184` |
 > | Control base classes that only delegate | 3 | `EG4BaseNumber` (`base_entity.py:1042`), `EG4BaseTime` (`:1128`), `EG4BaseSwitch` (`:1315`) — each `return self._control_device_available()` |
-> | Platform subclasses | 11 | **8 change the contract** (§2.4 plus `EG4QuickChargeSwitch` at `switch.py:525`); 3 only delegate — `EG4OperatingModeSelect` (`select.py:234`), `EG4PVInputModeSelect` (`:338`), `EG4BatteryControlModeSelect` (`:594`) |
+> | Platform subclasses | 11 | **8 change the contract** (§2.4); 3 only delegate — `EG4OperatingModeSelect` (`select.py:234`), `EG4PVInputModeSelect` (`:338`), `EG4BatteryControlModeSelect` (`:594`) |
 >
 > 8 + 3 + 11 = 22. Per file: `base_entity.py` 9, `select.py` 4, `switch.py` 4, `number.py` 2,
 > `binary_sensor.py` / `update.py` / `time.py` 1 each.
@@ -193,6 +193,7 @@ the contract rather than simply delegating to the base:
 | Class | Site | What it adds |
 |---|---|---|
 | `EG4ScheduleTimeEntity` | `time.py:320` | `super().available and self.native_value is not None` — **key-presence semantics for a control**, the shape §2.1 attributes to `EG4BatteryBankEntity` |
+| `EG4QuickChargeSwitch` | `switch.py:525` | Unavailable when `_offgrid_without_cloud()` — off-grid (or not positively identified as non-offgrid) with no cloud client, so a toggle would only hit an H233 write that is firmware-rejected or of unproven effect (#558 / #296) |
 | `EG4CloudStoreSwitch` | `switch.py:755` | Unavailable while the cloud-store state is absent — first fetch pending, an older pylxpweb lacking the getter, or a family that genuinely lacks the feature |
 | `EG4WorkingModeSwitch` | `switch.py:1387` | Modes flagged `requires_known_state` go **unavailable** while their state key is absent, instead of publishing a fake OFF (#497) |
 | `ACCoupleSOCNumberBase` | `number.py:1766` | Unavailable on an absent value, same known-state rationale |
@@ -201,7 +202,9 @@ the contract rather than simply delegating to the base:
 | `EG4DSTSwitch` | `switch.py:1663` | Its own coordinator-health check; it descends from `CoordinatorEntity` directly, not from the base classes in §2 |
 
 Whole table: `verified-against-code` at `e42ed86`. The remaining overrides delegate to
-`_control_device_available()` or `super().available` and do not change the contract.
+`_control_device_available()` or `super().available` and do not change the contract. The set
+above is derived — not hand-listed — by the rule in the next paragraph (8 contract-changers +
+3 pure delegates among the 11 platform `available` definitions in the §2 frame).
 
 **Derivation, so this does not need hand-maintaining:** `grep -rn 'def available'` over
 `custom_components/eg4_web_monitor/`, then for each hit read whether the body delegates to a base
@@ -212,8 +215,8 @@ in this table.
 
 | Stage | Behavior | Evidence |
 |---|---|---|
-| `native_value` runs `_guard_total_increasing()` | Pins downward dips **smaller than 10 %** for `total_increasing` sensors to the prior high-water mark; larger drops pass through as genuine resets | `verified-against-code` — `base_entity.py:309-343`, threshold `_RESET_DETECTION_THRESHOLD = 0.9` at `:306` |
-| Why 10 % | Matches HA recorder's own reset threshold; smaller dips trigger a "state is not strictly increasing" warning and are virtually always cloud rounding noise | `verified-against-code` — comment at `base_entity.py:298-305` |
+| `native_value` runs `_guard_total_increasing()` | Pins downward dips of **10 % or smaller** (≤10 %) for `total_increasing` sensors to the prior high-water mark; larger drops pass through as genuine resets | `verified-against-code` — `base_entity.py:334-342` (`new_val >= _RESET_DETECTION_THRESHOLD * last_reported`), threshold `_RESET_DETECTION_THRESHOLD = 0.9` at `:306`; boundary covered by `tests/test_base_entity.py` (`test_drop_exactly_at_10pct_is_suppressed`) |
+| Why 10 % | Matches HA recorder's own reset threshold; dips at or below that boundary trigger a "state is not strictly increasing" warning and are virtually always cloud rounding noise | `verified-against-code` — comment at `base_entity.py:298-305` |
 | Non-numeric / `None` / non-`total_increasing` | Returned untouched, cache not updated | `verified-against-code` — `base_entity.py:320-333` |
 | `_apply_sensor_config()` | Applies unit / device_class / state_class / icon / options / `translation_key` / precision / entity_category / `enabled_default` from `SENSOR_TYPES` | `verified-against-code` — `base_entity.py:345-408` |
 

--- a/llmwiki/10-integration/entities-identity-availability.md
+++ b/llmwiki/10-integration/entities-identity-availability.md
@@ -18,9 +18,9 @@ sources:
   - memory/queue-cleanup-2026-07-26.md
   - eg4_web_monitor issues #550, #253, #256, #261, #479
 verified-against:
-  eg4_web_monitor: 9f6d6e2
+  eg4_web_monitor: 7641b96
   homeassistant: 2025.11.2
-last-verified: 2026-08-09
+last-verified: 2026-08-12
 see-also:
   - ../60-history/open-contradictions.md
   - data-semantics.md
@@ -28,7 +28,7 @@ see-also:
 
 # Entities: inheritance, identity, availability
 
-Line numbers are pinned per source by the `verified-against:` mapping above — `9f6d6e2` for
+Line numbers are pinned per source by the `verified-against:` mapping above — `7641b96` for
 `eg4_web_monitor`, package version `2025.11.2` for `homeassistant`. Each citation names its source
 where it is not this repo. Symbol names are the durable anchor.
 
@@ -244,8 +244,10 @@ this working tree, so an unpinned grep is not reproducible evidence.
 | **All 17 are inert.** Nothing in Home Assistant reads that name | `verified-against-code` — the package-wide zero above |
 | Tracked as issue **#550** | `asserted-unverified` — an issue title and its open/closed state are tracker metadata, not code; they can change without any code changing. Cited as provenance, not as a verified fact |
 
-`utils.generate_entity_id` (`utils.py:649-674`) likewise only feeds these dead attributes
-(`verified-against-code`).
+`utils.generate_entity_id` (and its sole feeder `clean_model_name`) likewise only fed those
+dead attributes; both helpers were removed in #571 after the assignments themselves were
+deleted in #566 (`verified-against-code` — `rg generate_entity_id custom_components/eg4_web_monitor/`
+returns empty at pin `7641b96`).
 
 #### Why they are inert — it is the prefix, not the concept
 
@@ -330,7 +332,7 @@ these strings are real and stable.
 | Select | `generate_unique_id(serial, "operating_mode")` (etc.) | `select.py:180` |
 | Number / time (via `EG4OptimisticEntity`) | `generate_unique_id(self._retention_serial.lower(), entity_key)` | `base_entity.py:814-816` |
 
-All rows: `verified-against-code`. `utils.generate_unique_id` (`utils.py:677-693`) is literally
+All rows: `verified-against-code`. `utils.generate_unique_id` (`utils.py:675-691`) is literally
 `f"{serial}_{entity_type}"` plus an optional `_{suffix}`.
 
 > ⚠️ **Case divergence.** `_stable_control_unique_id` lowercases the serial; switch and select

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -357,3 +357,14 @@ whole page and re-numbered drifted cites (inheritance graph, availability
 table + 21→22 `def available` frame including `EG4QuickChargeSwitch`, §2.4
 overrides, §3 pipeline, §5 unique_id / `generate_unique_id` `:722-738`, §6
 DeviceInfo, §7 enabled_default). Rule paid: a pin move is never a local edit.
+
+## [2026-08-12] lint | §2.4 QuickCharge row + ≤10% guard + update.py:54
+
+Tribunal round 2 on #571 (codex MEDIUM/LOW, kimi LOW). (1) §2.4's completeness
+claim omitted `EG4QuickChargeSwitch` while the §2 frame already counted it as
+contract-changing — added the row at `switch.py:525` (`_offgrid_without_cloud`
+gate) and reconciled the frame's "§2.4 plus …" hedge so the table alone owns
+the 8 contract-changers. (2) `_guard_total_increasing` suppresses dips
+`new_val >= 0.9 * last` including exactly 10% — reworded "smaller than 10%" to
+"≤10%" with the boundary test cite. (3) Inheritance-tree `EG4FirmwareUpdateEntity`
+anchor `update.py:55` → `:54` (class keyword at pin `e42ed86`).

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -342,3 +342,18 @@ left from the #550/#566 `_attr_entity_id` cleanup. Reworded to past tense
 `generate_unique_id` cite (`utils.py:677-693` → `:675-691`). Grep across
 `llmwiki/` found no other references; left
 `docs/claude/DEVICE_OBJECTS_REFACTOR_PLAN.md` alone (historical).
+
+## [2026-08-12] lint | entities-identity pin e42ed86 — §4 past-tense + page-wide re-cite
+
+Tribunal round 1 on #571: bumping the page pin to a PR-branch SHA (`7641b96`)
+falsified §4's present-tense "17 `_attr_entity_id` assignments" claim (grep is
+0 since #566) and left in-body `verified-against-code` pins at `9f6d6e2` that
+the front matter no longer carried. Re-pinned `verified-against.eg4_web_monitor`
+to main-reachable `e42ed86` (`origin/main` at this correction). Rewrote §4 to
+past tense for the #566 removals; stated `generate_entity_id` /
+`clean_model_name` as **orphans still defined at `e42ed86`**, with deletion
+verified at the PR #571 head and landing as the #571 squash. Re-grepped the
+whole page and re-numbered drifted cites (inheritance graph, availability
+table + 21→22 `def available` frame including `EG4QuickChargeSwitch`, §2.4
+overrides, §3 pipeline, §5 unique_id / `generate_unique_id` `:722-738`, §6
+DeviceInfo, §7 enabled_default). Rule paid: a pin move is never a local edit.

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -330,3 +330,15 @@ H233 `_prefers_cloud_control` boundary) re-read against the files at
 corrected in the same commit (comment-only): `const/modbus.py`,
 `const/working_modes.py`, `switch.py` `_WORKING_MODE_PARAMETERS`, and the
 contract harness's `_CONTROL_REGISTER_CONTRACT` entry.
+
+## [2026-08-12] lint | generate_entity_id citation after #571 deletion
+
+`10-integration/entities-identity-availability.md` §4.1 still cited
+`utils.generate_entity_id` (`utils.py:649-674`) as `verified-against-code` after
+PR #571 removed that helper (and its sole feeder `clean_model_name`) as dead code
+left from the #550/#566 `_attr_entity_id` cleanup. Reworded to past tense
+(removed in #571), re-pinned `verified-against.eg4_web_monitor` `9f6d6e2` →
+`7641b96`, refreshed `last-verified` to 2026-08-12, and re-numbered the live
+`generate_unique_id` cite (`utils.py:677-693` → `:675-691`). Grep across
+`llmwiki/` found no other references; left
+`docs/claude/DEVICE_OBJECTS_REFACTOR_PLAN.md` alone (historical).

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -2219,7 +2219,7 @@ class TestOffgridGridTiedNumberSuppression:
 
         serial = "1234567890"
         registry = er.async_get(hass)
-        # 6000XP → slug "6000xp" in unique_id / entity object id.
+        # Legacy model-prefixed unique_id ("6000xp_..." era, #219/#222) — the suppression probe matches by suffix.
         registry.async_get_or_create(
             "number", DOMAIN, f"6000xp_{serial}_forced_discharge_power"
         )

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -2219,7 +2219,7 @@ class TestOffgridGridTiedNumberSuppression:
 
         serial = "1234567890"
         registry = er.async_get(hass)
-        # 6000XP → clean model "6000xp" (clean_model_name with underscores).
+        # 6000XP → slug "6000xp" in unique_id / entity object id.
         registry.async_get_or_create(
             "number", DOMAIN, f"6000xp_{serial}_forced_discharge_power"
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,7 @@ from custom_components.eg4_web_monitor.utils import (
     _resolve_chart_day_timezone,
     battery_row_is_absent,
     clean_battery_display_name,
-    clean_model_name,
     create_device_info,
-    generate_entity_id,
     generate_unique_id,
     is_supported_control_model,
 )
@@ -147,34 +145,6 @@ class TestCleanBatteryDisplayName:
         )
 
 
-class TestCleanModelName:
-    """Test clean_model_name function."""
-
-    def test_normal_model(self):
-        """Test normal model name."""
-        assert clean_model_name("FlexBOSS21") == "flexboss21"
-
-    def test_with_spaces(self):
-        """Test model with spaces."""
-        assert clean_model_name("Flex BOSS 21") == "flexboss21"
-
-    def test_with_hyphens(self):
-        """Test model with hyphens."""
-        assert clean_model_name("Flex-BOSS-21") == "flexboss21"
-
-    def test_empty_string(self):
-        """Test empty string."""
-        assert clean_model_name("") == "unknown"
-
-    def test_mixed_case(self):
-        """Test mixed case."""
-        assert clean_model_name("GridBOSS-MID") == "gridbossmid"
-
-    def test_with_underscores_option(self):
-        """Test with use_underscores option."""
-        assert clean_model_name("Flex BOSS 21", use_underscores=True) == "flex_boss_21"
-
-
 class TestCreateDeviceInfo:
     """Test create_device_info function."""
 
@@ -194,29 +164,6 @@ class TestCreateDeviceInfo:
 
         assert info["name"] == "GridBOSS 9876543210"
         assert info["model"] == "GridBOSS"
-
-
-class TestGenerateEntityId:
-    """Test generate_entity_id function."""
-
-    def test_basic_entity_id(self):
-        """Test basic entity ID generation."""
-        entity_id = generate_entity_id("sensor", "FlexBOSS21", "1234567890", "ac_power")
-        assert entity_id == "sensor.flexboss21_1234567890_ac_power"
-
-    def test_with_suffix(self):
-        """Test entity ID with suffix."""
-        entity_id = generate_entity_id(
-            "sensor", "FlexBOSS21", "1234567890", "battery", "01"
-        )
-        assert entity_id == "sensor.flexboss21_1234567890_battery_01"
-
-    def test_model_cleaning(self):
-        """Test model name is cleaned."""
-        entity_id = generate_entity_id(
-            "sensor", "Flex-BOSS 21", "1234567890", "voltage"
-        )
-        assert entity_id == "sensor.flexboss21_1234567890_voltage"
 
 
 class TestGenerateUniqueId:


### PR DESCRIPTION
## Summary
- Removes dead `utils.generate_entity_id` and its sole feeder `clean_model_name`, left unused after PR #566 deleted the inert `_attr_entity_id = generate_entity_id(...)` assignments (#550).
- Drops the corresponding unit tests; leaves live `generate_unique_id` call sites untouched.
- Zero behavior change — dead-code cleanup only.

## Test plan
- [x] `uv run ruff check custom_components/ --fix && uv run ruff format custom_components/`
- [x] `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/`
- [x] `uv run pytest tests/ -x --tb=short` (2860 passed, 3 skipped)
- [x] `uv run python tests/validate_silver_tier.py`
- [x] `uv run python tests/validate_gold_tier.py`
- [x] `uv run python tests/validate_platinum_tier.py`
- [x] Confirm `rg generate_entity_id custom_components/eg4_web_monitor/` is empty after

Refs: #550, #566, #558/#569

Made with [Cursor](https://cursor.com)