### PR TITLE
feat: add offline dongle capture sanitizer

### DIFF
--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -647,6 +647,7 @@ class _SessionState:
 def find_frames(data: bytes) -> list[tuple[int, bytes]]:
     decoder = StreamFrameDecoder()
     frames = decoder.feed(data, captured_at=0.0)
+    decoder.close(captured_at=0.0)
     result: list[tuple[int, bytes]] = []
     offset = 0
     for frame in frames:

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -991,11 +991,20 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
     if isinstance(data, module.ip.IP):
         return cast(_IPPacket, data)
     if isinstance(data, module.ip6.IP6):
-        transport_data = cast(_IPPacket, data).data
+        ip_packet = cast(_IPPacket, data)
+        transport_data = ip_packet.data
+        ports: tuple[int, int] | None = None
         if isinstance(transport_data, module.tcp.TCP):
             transport = cast(_TCPPacket, transport_data)
-            if transport.sport == 4346 or transport.dport == 4346:
-                raise CaptureError(FailureReason.IP_VERSION)
+            ports = transport.sport, transport.dport
+        elif ip_packet.p == module.ip.IP_PROTO_TCP and isinstance(
+            transport_data, Buffer
+        ):
+            prefix = memoryview(transport_data)
+            if len(prefix) >= 4:
+                ports = int.from_bytes(prefix[:2]), int.from_bytes(prefix[2:4])
+        if ports is not None and 4346 in ports:
+            raise CaptureError(FailureReason.IP_VERSION)
     return None
 
 

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -1,536 +1,564 @@
 #!/usr/bin/env python3
-"""Decode EG4 cloud protocol frames from a pcap capture.
+"""Create synthetic protocol fixtures from an authorized offline PCAP.
 
-Reads a pcap file containing TCP traffic between a WiFi dongle and
-us2.solarcloudsystem.com:4346, decodes all 0xA1/0x1A frames, and
-produces a human-readable analysis.
+The tool never opens a socket and never emits captured identities, addresses,
+payloads, timestamps, or register values. TCP segments are reassembled before
+frames are parsed; only then is a minimal synthetic representation produced.
 
 Usage:
-    python scripts/decode_cloud_frames.py scratchpad/firmware/dongle_capture.pcap
+    python scripts/decode_cloud_frames.py INPUT.pcap --output sanitized.json \
+        --authorized-offline-input
 
-Requires: dpkt (pip install dpkt)
-
-The script reconstructs TCP streams and identifies:
-- 0xC1 heartbeat frames (timing, format)
-- 0xC2 data frames (register groups, values)
-- 0xC3 GET_PARAM commands (register ranges)
-- 0xC4 SET_PARAM commands (register writes)
-- Server→dongle responses (any direction)
+The output path must not already exist. Optional PCAP support requires ``dpkt``.
+Core stream, parser, and sanitizer tests do not require that package.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import sys
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
+from typing import Any, Final
 
 try:
     import dpkt
-except ImportError:
-    print("ERROR: dpkt is required. Install with: uv pip install dpkt")
-    sys.exit(1)
+except ImportError:  # pragma: no cover - exercised by the CLI environment
+    dpkt = None  # type: ignore[assignment]
 
 
-# Cloud protocol constants
-FRAME_MAGIC = bytes([0xA1, 0x1A])
-FUNC_NAMES = {
-    0xC1: "HEARTBEAT",
-    0xC2: "DATA_TX",
-    0xC3: "GET_PARAM",
-    0xC4: "SET_PARAM",
-}
-MODBUS_FUNC_NAMES = {
-    0x03: "READ_HOLDING",
-    0x04: "READ_INPUT",
-    0x06: "WRITE_SINGLE",
-    0x10: "WRITE_MULTI",
-}
+FRAME_MAGIC: Final = b"\xa1\x1a"
+SYNTHETIC_DONGLE_IDENTITY: Final = "SYNTHDG001"
+SYNTHETIC_INVERTER_IDENTITY: Final = "SYNTHIV001"
+DOCUMENTATION_DONGLE_ADDRESS: Final = "192.0.2.10"
+DOCUMENTATION_CLOUD_ADDRESS: Final = "198.51.100.20"
+SYNTHETIC_REGISTER_WORD: Final = "SYNTHETIC_A55A"
+MAX_SANITIZED_RECORDS: Final = 1024
+
+
+class FailureReason(StrEnum):
+    """Bounded, redacted parser failure classifications."""
+
+    CAPACITY = "capacity"
+    CRC = "crc"
+    FUNCTION = "function"
+    IDENTITY = "identity"
+    MALFORMED = "malformed"
+    OVERSIZE = "oversize"
+    PREFIX = "prefix"
+    RANGE = "range"
+    TIMEOUT = "timeout"
+    TRUNCATED = "truncated"
+
+
+class CaptureError(RuntimeError):
+    """A fail-closed capture error whose message cannot contain capture data."""
+
+    def __init__(self, reason: FailureReason) -> None:
+        self.reason = reason
+        super().__init__(f"capture rejected: {reason.value}")
+
+
+@dataclass(frozen=True, slots=True)
+class ParserPolicy:
+    """Internal parser bounds from the Phase A contract."""
+
+    maximum_frame_bytes: int = 4096
+    prefix_scan_bytes: int = 64
+    overall_frame_deadline: float = 5.0
+
+    def __post_init__(self) -> None:
+        bounds: tuple[tuple[int | float, int | float, int | float], ...] = (
+            (self.maximum_frame_bytes, 512, 65535),
+            (self.prefix_scan_bytes, 2, 1024),
+            (self.overall_frame_deadline, 1.0, 30.0),
+        )
+        if any(
+            value < minimum or value > maximum for value, minimum, maximum in bounds
+        ):
+            raise ValueError("parser policy value outside the internal contract")
+
+    @property
+    def reassembly_capacity(self) -> int:
+        """Bound pending reassembly under the parser memory budget."""
+        return 16 * 1024
+
+
+class StreamFrameDecoder:
+    """Bounded incremental decoder for complete cloud protocol frames."""
+
+    def __init__(self, policy: ParserPolicy | None = None) -> None:
+        self.policy = policy or ParserPolicy()
+        self._buffer = bytearray()
+        self._prefix_scanned = 0
+        self._started_at: float | None = None
+
+    @property
+    def buffered_bytes(self) -> int:
+        """Return retained bytes for resource-bound assertions."""
+        return len(self._buffer)
+
+    def feed(self, data: bytes, *, captured_at: float) -> list[bytes]:
+        """Consume one ordered stream chunk and return every complete frame."""
+        self._check_deadline(captured_at)
+        if data and self._started_at is None:
+            self._started_at = captured_at
+
+        decoded: list[bytes] = []
+        remaining = memoryview(data)
+        storage_limit = self.policy.maximum_frame_bytes + self.policy.prefix_scan_bytes
+
+        while remaining:
+            room = storage_limit - len(self._buffer)
+            if room <= 0:
+                before = len(self._buffer)
+                decoded.extend(self._extract_available(captured_at))
+                if len(self._buffer) >= before:
+                    raise CaptureError(FailureReason.CAPACITY)
+                continue
+
+            take = min(room, len(remaining))
+            self._buffer.extend(remaining[:take])
+            remaining = remaining[take:]
+            decoded.extend(self._extract_available(captured_at))
+
+        decoded.extend(self._extract_available(captured_at))
+        return decoded
+
+    def close(self, *, captured_at: float) -> None:
+        """Finalize at EOF, rejecting any partial prefix, header, or body."""
+        self._check_deadline(captured_at)
+        self._extract_available(captured_at)
+        if self._buffer or self._prefix_scanned:
+            self._discard()
+            raise CaptureError(FailureReason.TRUNCATED)
+
+    def _check_deadline(self, captured_at: float) -> None:
+        if (
+            self._started_at is not None
+            and captured_at - self._started_at > self.policy.overall_frame_deadline
+        ):
+            self._discard()
+            raise CaptureError(FailureReason.TIMEOUT)
+
+    def _extract_available(self, captured_at: float) -> list[bytes]:
+        frames: list[bytes] = []
+        while self._buffer:
+            magic_index = self._buffer.find(FRAME_MAGIC)
+            if magic_index < 0:
+                retained = 1 if self._buffer[-1:] == FRAME_MAGIC[:1] else 0
+                discarded = len(self._buffer) - retained
+                self._prefix_scanned += discarded
+                if self._prefix_scanned > self.policy.prefix_scan_bytes:
+                    self._discard()
+                    raise CaptureError(FailureReason.PREFIX)
+                if discarded:
+                    del self._buffer[:discarded]
+                break
+
+            if magic_index:
+                self._prefix_scanned += magic_index
+                if self._prefix_scanned > self.policy.prefix_scan_bytes:
+                    self._discard()
+                    raise CaptureError(FailureReason.PREFIX)
+                del self._buffer[:magic_index]
+
+            if len(self._buffer) < 6:
+                break
+
+            total_size = 6 + int.from_bytes(self._buffer[4:6], "little")
+            if total_size > self.policy.maximum_frame_bytes:
+                self._discard()
+                raise CaptureError(FailureReason.OVERSIZE)
+            if total_size < 19:
+                self._discard()
+                raise CaptureError(FailureReason.MALFORMED)
+            if len(self._buffer) < total_size:
+                break
+
+            frames.append(bytes(self._buffer[:total_size]))
+            del self._buffer[:total_size]
+            self._prefix_scanned = 0
+            self._started_at = captured_at if self._buffer else None
+
+        return frames
+
+    def _discard(self) -> None:
+        self._buffer.clear()
+        self._prefix_scanned = 0
+        self._started_at = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingSegment:
+    captured_at: float
+    payload: bytes
+
+
+class TCPStreamReassembler:
+    """Sequence-aware, duplicate-safe bounded TCP payload reassembler."""
+
+    def __init__(self, policy: ParserPolicy | None = None) -> None:
+        self.policy = policy or ParserPolicy()
+        self._next_sequence: int | None = None
+        self._pending: dict[int, _PendingSegment] = {}
+        self._pending_bytes = 0
+
+    def push(
+        self, sequence: int, payload: bytes, *, captured_at: float
+    ) -> list[tuple[float, bytes]]:
+        """Add a TCP segment and return newly contiguous stream chunks."""
+        if not payload:
+            return []
+        if sequence < 0:
+            raise CaptureError(FailureReason.MALFORMED)
+        if self._next_sequence is None:
+            self._next_sequence = sequence
+
+        assert self._next_sequence is not None
+        segment_end = sequence + len(payload)
+        if segment_end <= self._next_sequence:
+            return []
+        if sequence < self._next_sequence:
+            payload = payload[self._next_sequence - sequence :]
+            sequence = self._next_sequence
+
+        if sequence > self._next_sequence:
+            existing = self._pending.get(sequence)
+            if existing is not None:
+                if existing.payload != payload:
+                    raise CaptureError(FailureReason.MALFORMED)
+                return []
+            if self._pending_bytes + len(payload) > self.policy.reassembly_capacity:
+                raise CaptureError(FailureReason.CAPACITY)
+            self._pending[sequence] = _PendingSegment(captured_at, payload)
+            self._pending_bytes += len(payload)
+            return []
+
+        chunks = [(captured_at, payload)]
+        self._next_sequence += len(payload)
+        chunks.extend(self._drain_pending(available_at=captured_at))
+        return chunks
+
+    def _drain_pending(self, *, available_at: float) -> list[tuple[float, bytes]]:
+        chunks: list[tuple[float, bytes]] = []
+        assert self._next_sequence is not None
+        while self._pending:
+            sequence = min(self._pending)
+            segment = self._pending[sequence]
+            segment_end = sequence + len(segment.payload)
+            if sequence > self._next_sequence:
+                break
+            del self._pending[sequence]
+            self._pending_bytes -= len(segment.payload)
+            if segment_end <= self._next_sequence:
+                continue
+            overlap = self._next_sequence - sequence
+            payload = segment.payload[overlap:]
+            chunks.append((max(available_at, segment.captured_at), payload))
+            self._next_sequence += len(payload)
+        return chunks
+
+    def close(self) -> None:
+        """Reject a stream ending with an unresolved sequence gap."""
+        if self._pending:
+            self._pending.clear()
+            self._pending_bytes = 0
+            raise CaptureError(FailureReason.TRUNCATED)
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedSegment:
+    """One offline TCP payload with only in-memory capture metadata."""
+
+    direction: str
+    sequence: int
+    captured_at: float
+    payload: bytes
+    stream_id: int = 0
+
+
+@dataclass(slots=True)
+class _DirectionState:
+    reassembler: TCPStreamReassembler
+    decoder: StreamFrameDecoder
+    source_identity: bytes | None = None
 
 
 def compute_crc16(data: bytes) -> int:
-    """CRC-16/Modbus."""
+    """Return CRC-16/Modbus for an inner frame."""
     crc = 0xFFFF
     for byte in data:
         crc ^= byte
         for _ in range(8):
-            if crc & 1:
-                crc = (crc >> 1) ^ 0xA001
-            else:
-                crc >>= 1
+            crc = (crc >> 1) ^ 0xA001 if crc & 1 else crc >> 1
     return crc & 0xFFFF
 
 
-@dataclass
-class DecodedFrame:
-    """A decoded cloud protocol frame."""
-
-    timestamp: float
-    direction: str  # "dongle→cloud" or "cloud→dongle"
-    func: int
-    func_name: str
-    serial: str
-    payload: bytes
-    raw_size: int
-    details: str = ""
-
-
-@dataclass
-class StreamState:
-    """TCP stream reassembly state."""
-
-    buffer: bytearray = field(default_factory=bytearray)
-
-
 def find_frames(data: bytes) -> list[tuple[int, bytes]]:
-    """Find all 0xA1 0x1A frames in a byte buffer.
-
-    Returns list of (offset, frame_bytes) tuples.
-    """
-    frames = []
-    i = 0
-    while i < len(data) - 6:
-        if data[i] == 0xA1 and data[i + 1] == 0x1A:
-            # Read frame length
-            frame_len = int.from_bytes(data[i + 4 : i + 6], "little")
-            total = 6 + frame_len
-            if i + total <= len(data):
-                frames.append((i, data[i : i + total]))
-                i += total
-                continue
-        i += 1
-    return frames
+    """Compatibility helper using the same bounded streaming decoder."""
+    decoder = StreamFrameDecoder()
+    frames = decoder.feed(data, captured_at=0.0)
+    result: list[tuple[int, bytes]] = []
+    offset = 0
+    for frame in frames:
+        offset = data.find(frame, offset)
+        result.append((offset, frame))
+        offset += len(frame)
+    return result
 
 
-def decode_frame(
-    frame_bytes: bytes, timestamp: float, direction: str
-) -> DecodedFrame | None:
-    """Decode a single cloud protocol frame.
-
-    Cloud TCP frames do NOT have trailing CRC-16. The frame format is:
-    [A1 1A][ver 2B][frame_len 2B LE][addr][func][serial 10B][payload...]
-    Total size = 6 + frame_length = 18 + payload_len
-    """
-    if len(frame_bytes) < 19:  # Minimum: 18 preamble + 1 payload (heartbeat)
-        return None
-
-    func = frame_bytes[7]
-    serial = frame_bytes[8:18].decode("ascii", errors="replace").rstrip("\x00")
-
-    # No CRC on TCP cloud frames (confirmed via firmware decompilation).
-    # CRC-16/Modbus is only used on RS485 Modbus RTU frames within 0xC2 payloads.
-    payload = frame_bytes[18:]
-
-    details_parts: list[str] = []
-    func_name = FUNC_NAMES.get(func, f"UNKNOWN(0x{func:02X})")
-
-    # Decode payload based on function
-    if func == 0xC1:
-        if payload:
-            details_parts.append(f"status=0x{payload[0]:02X}")
-    elif func == 0xC2 and len(payload) >= 2:
-        # 0xC2 payload structure (from firmware decompilation + pcap validation):
-        # [0:2] = modbus_data_length (uint16 LE)
-        # [2:]  = extended Modbus frame (NOT standard Modbus RTU)
-        #
-        # Extended Modbus format (shared by requests and responses):
-        # [0]=slave_addr [1]=func_code [2:12]=inverter_serial (10 ASCII bytes)
-        # [12:14]=start_register (uint16 LE)
-        #
-        # REQUEST (18 bytes total, modbus_len=18):
-        #   For READ (0x03/0x04): [14:16]=register_count (uint16 LE)
-        #   For WRITE_SINGLE (0x06): [14:16]=value (uint16 BE)
-        #   [16:18]=CRC-16/Modbus
-        #
-        # RESPONSE (variable, modbus_len=271 for full block):
-        #   For READ: [14]=byte_count [15:15+byte_count]=register_data [last 2]=CRC
-        #   For WRITE_SINGLE: [14:16]=value (uint16 BE) [16:18]=CRC (echo of request)
-        #   For EXCEPTION (0x83): [14]=exception_code [15:17]=CRC
-        modbus_len = int.from_bytes(payload[0:2], "little")
-        details_parts.append(f"modbus_len={modbus_len}")
-
-        modbus_data = payload[2:]
-        if len(modbus_data) >= 15:
-            slave = modbus_data[0]
-            modbus_func = modbus_data[1]
-            inv_serial = (
-                modbus_data[2:12].decode("ascii", errors="replace").rstrip("\x00")
-            )
-            start_reg = int.from_bytes(modbus_data[12:14], "little")
-            is_request = modbus_len == 18
-
-            if modbus_func == 0x83:
-                # Exception response: [14]=exception_code
-                exception_code = modbus_data[14]
-                details_parts.append(
-                    f"slave={slave} inv={inv_serial} EXCEPTION"
-                    f" reg={start_reg} code={exception_code}"
-                )
-                # CRC check on exception frame
-                if len(modbus_data) >= 17:
-                    crc_data = modbus_data[:15]
-                    crc_actual = int.from_bytes(modbus_data[15:17], "little")
-                    crc_expected = compute_crc16(crc_data)
-                    details_parts.append(
-                        "CRC OK"
-                        if crc_actual == crc_expected
-                        else f"BAD CRC (0x{crc_actual:04X} vs 0x{crc_expected:04X})"
-                    )
-
-            elif modbus_func == 0x06:
-                # WRITE_SINGLE: [14:16]=value (little-endian, like all extended Modbus fields)
-                value = int.from_bytes(modbus_data[14:16], "little")
-                details_parts.append(
-                    f"slave={slave} inv={inv_serial} WRITE_SINGLE"
-                    f" reg={start_reg} value={value} (0x{value:04X})"
-                )
-                if len(modbus_data) >= 18:
-                    crc_data = modbus_data[:16]
-                    crc_actual = int.from_bytes(modbus_data[16:18], "little")
-                    crc_expected = compute_crc16(crc_data)
-                    details_parts.append(
-                        "CRC OK"
-                        if crc_actual == crc_expected
-                        else f"BAD CRC (0x{crc_actual:04X} vs 0x{crc_expected:04X})"
-                    )
-
-            elif is_request and modbus_func in (0x03, 0x04):
-                # READ request: [14:16]=register_count (uint16 LE)
-                reg_count = int.from_bytes(modbus_data[14:16], "little")
-                end_reg = start_reg + reg_count - 1
-                func_name_inner = MODBUS_FUNC_NAMES.get(
-                    modbus_func, f"0x{modbus_func:02X}"
-                )
-                details_parts.append(
-                    f"slave={slave} inv={inv_serial} {func_name_inner}"
-                    f" READ regs {start_reg}-{end_reg} ({reg_count} regs)"
-                )
-                if len(modbus_data) >= 18:
-                    crc_data = modbus_data[:16]
-                    crc_actual = int.from_bytes(modbus_data[16:18], "little")
-                    crc_expected = compute_crc16(crc_data)
-                    details_parts.append(
-                        "CRC OK"
-                        if crc_actual == crc_expected
-                        else f"BAD CRC (0x{crc_actual:04X} vs 0x{crc_expected:04X})"
-                    )
-
-            else:
-                # READ response: [14]=byte_count [15:]=register_data
-                byte_count = modbus_data[14]
-                data_start = 15
-                data_end = 15 + byte_count
-                reg_count = byte_count // 2
-                end_reg = start_reg + reg_count - 1
-                func_name_inner = MODBUS_FUNC_NAMES.get(
-                    modbus_func, f"0x{modbus_func:02X}"
-                )
-                details_parts.append(
-                    f"slave={slave} inv={inv_serial} {func_name_inner}"
-                    f" regs {start_reg}-{end_reg} ({reg_count} regs)"
-                )
-
-                # Verify Modbus CRC within extended response
-                if len(modbus_data) >= data_end + 2:
-                    crc_data = modbus_data[:data_end]
-                    crc_actual = int.from_bytes(
-                        modbus_data[data_end : data_end + 2], "little"
-                    )
-                    crc_expected = compute_crc16(crc_data)
-                    details_parts.append(
-                        "CRC OK"
-                        if crc_actual == crc_expected
-                        else f"BAD CRC (0x{crc_actual:04X} vs 0x{crc_expected:04X})"
-                    )
-
-                # Extract a few sample register values (little-endian in extended Modbus)
-                if len(modbus_data) >= data_start + 10:
-                    sample_values = []
-                    for j in range(0, min(byte_count, 10), 2):
-                        val = int.from_bytes(
-                            modbus_data[data_start + j : data_start + j + 2], "little"
-                        )
-                        sample_values.append(str(val))
-                    details_parts.append(f"first_regs=[{', '.join(sample_values)}]")
-        elif len(modbus_data) > 0:
-            details_parts.append(f"raw={modbus_data.hex()}")
-    elif func == 0xC3 and len(payload) >= 4:
-        start = int.from_bytes(payload[0:2], "little")
-        end = int.from_bytes(payload[2:4], "little")
-        details_parts.append(f"GET regs {start}-{end} ({end - start + 1} regs)")
-    elif func == 0xC4 and len(payload) >= 4:
-        param_code = int.from_bytes(payload[0:2], "little")
-        data_len = int.from_bytes(payload[2:4], "little")
-        details_parts.append(f"SET param_code={param_code} data_len={data_len}")
-        if len(payload) > 4:
-            hex_data = payload[4:].hex()
-            details_parts.append(f"data={hex_data}")
-
-    return DecodedFrame(
-        timestamp=timestamp,
-        direction=direction,
-        func=func,
-        func_name=func_name,
-        serial=serial,
-        payload=payload,
-        raw_size=len(frame_bytes),
-        details=", ".join(details_parts),
-    )
-
-
-def _decode_modbus_rtu(payload: bytes) -> list[str]:
-    """Decode standard Modbus RTU response (unused — kept for reference).
-
-    Note: EG4 inverters use EXTENDED Modbus (with 10-byte serial), not standard RTU.
-    The main decode_frame() function handles the extended format directly.
-    """
-    parts = []
-    if len(payload) < 3:
-        return ["(truncated Modbus RTU)"]
-
-    slave_addr = payload[0]
-    modbus_func = payload[1]
-    func_name = MODBUS_FUNC_NAMES.get(modbus_func, f"0x{modbus_func:02X}")
-    parts.append(f"slave={slave_addr} func={func_name}")
-
-    if modbus_func in (0x03, 0x04):
-        byte_count = payload[2]
-        reg_count = byte_count // 2
-        parts.append(f"byte_count={byte_count} ({reg_count} regs)")
-
-        # Decode register values (big-endian per Modbus convention)
-        if len(payload) >= 3 + byte_count:
-            values = []
-            for j in range(0, byte_count, 2):
-                val = int.from_bytes(payload[3 + j : 3 + j + 2], "big")
-                values.append(val)
-            # Show first 5 and last 2 values for brevity
-            if len(values) > 7:
-                shown = (
-                    [str(v) for v in values[:5]]
-                    + ["..."]
-                    + [str(v) for v in values[-2:]]
-                )
-            else:
-                shown = [str(v) for v in values]
-            parts.append(f"values=[{', '.join(shown)}]")
-
-        # Verify Modbus CRC
-        if len(payload) >= 3 + byte_count + 2:
-            modbus_data = payload[: 3 + byte_count]
-            modbus_crc = int.from_bytes(
-                payload[3 + byte_count : 3 + byte_count + 2], "little"
-            )
-            expected_crc = compute_crc16(modbus_data)
-            if modbus_crc != expected_crc:
-                parts.append(
-                    f"BAD MODBUS CRC (0x{modbus_crc:04X} vs 0x{expected_crc:04X})"
-                )
-    else:
-        parts.append(f"payload={payload[2:].hex()}")
-
-    return parts
-
-
-def _extract_ip_from_buf(buf: bytes, link_type: int) -> dpkt.ip.IP | None:
-    """Extract IP packet from a raw pcap buffer, handling different link types.
-
-    Link types:
-    - 1 (EN10MB): Standard Ethernet
-    - 113 (LINUX_SLL): Linux cooked capture (tcpdump -i any)
-    - 276 (LINUX_SLL2): Linux cooked capture v2
-    """
+def _validated_identity(raw: bytes) -> bytes:
+    if len(raw) != 10:
+        raise CaptureError(FailureReason.IDENTITY)
     try:
-        if link_type == 1:  # Ethernet
-            eth = dpkt.ethernet.Ethernet(buf)
-            if isinstance(eth.data, dpkt.ip.IP):
-                return eth.data
-        elif link_type == 113:  # Linux cooked capture (SLL)
-            # SLL header: 16 bytes [pkt_type(2) arphrd(2) ll_addr_len(2) ll_addr(8) proto(2)]
-            if len(buf) < 16:
-                return None
-            proto = int.from_bytes(buf[14:16], "big")
-            if proto == 0x0800:  # IPv4
-                return dpkt.ip.IP(buf[16:])
-        elif link_type == 276:  # Linux cooked capture v2 (SLL2)
-            # SLL2 header: 20 bytes [proto(2) reserved(2) iface_idx(4) arphrd(2) pkt_type(1) ll_addr_len(1) ll_addr(8)]
-            if len(buf) < 20:
-                return None
-            proto = int.from_bytes(buf[0:2], "big")
-            if proto == 0x0800:  # IPv4
-                return dpkt.ip.IP(buf[20:])
-        else:
-            # Unknown link type — try Ethernet as fallback
-            eth = dpkt.ethernet.Ethernet(buf)
-            if isinstance(eth.data, dpkt.ip.IP):
-                return eth.data
+        text = raw.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise CaptureError(FailureReason.IDENTITY) from error
+    if not all(character.isalnum() for character in text):
+        raise CaptureError(FailureReason.IDENTITY)
+    return raw
+
+
+def _validate_crc(frame: bytes) -> None:
+    if len(frame) < 3:
+        raise CaptureError(FailureReason.MALFORMED)
+    actual = int.from_bytes(frame[-2:], "little")
+    if actual != compute_crc16(frame[:-2]):
+        raise CaptureError(FailureReason.CRC)
+
+
+def _sanitize_frame(
+    frame: bytes, direction: str, state: _DirectionState
+) -> dict[str, Any]:
+    if len(frame) < 19 or 6 + int.from_bytes(frame[4:6], "little") != len(frame):
+        raise CaptureError(FailureReason.MALFORMED)
+
+    outer_identity = _validated_identity(frame[8:18])
+    if state.source_identity is None:
+        state.source_identity = outer_identity
+    elif state.source_identity != outer_identity:
+        raise CaptureError(FailureReason.IDENTITY)
+
+    function = frame[7]
+    payload = frame[18:]
+    base: dict[str, Any] = {
+        "direction": direction,
+        "identity": SYNTHETIC_DONGLE_IDENTITY,
+    }
+    if function == 0xC1:
+        if not payload:
+            raise CaptureError(FailureReason.MALFORMED)
+        return base | {"function": "heartbeat", "payload": "SYNTHETIC_STATUS"}
+    if function != 0xC2:
+        raise CaptureError(FailureReason.FUNCTION)
+    if len(payload) < 2:
+        raise CaptureError(FailureReason.MALFORMED)
+
+    inner_size = int.from_bytes(payload[:2], "little")
+    inner = payload[2:]
+    if inner_size != len(inner) or len(inner) < 17:
+        raise CaptureError(FailureReason.MALFORMED)
+    inner_function = inner[1]
+    if inner_function not in (0x03, 0x04):
+        raise CaptureError(FailureReason.FUNCTION)
+    if inner[0] != frame[6]:
+        raise CaptureError(FailureReason.IDENTITY)
+    _validated_identity(inner[2:12])
+    start_register = int.from_bytes(inner[12:14], "little")
+
+    if len(inner) == 18:
+        register_count = int.from_bytes(inner[14:16], "little")
+        if register_count < 1 or start_register + register_count > 65536:
+            raise CaptureError(FailureReason.RANGE)
+        _validate_crc(inner)
+        return base | {
+            "function": "data_read_request",
+            "inner_identity": SYNTHETIC_INVERTER_IDENTITY,
+            "inner_function": _inner_function_name(inner_function),
+            "start_register": start_register,
+            "register_count": register_count,
+            "register_words": [],
+        }
+
+    byte_count = inner[14]
+    if byte_count < 2 or byte_count % 2 or len(inner) != 15 + byte_count + 2:
+        raise CaptureError(FailureReason.RANGE)
+    register_count = byte_count // 2
+    if start_register + register_count > 65536:
+        raise CaptureError(FailureReason.RANGE)
+    _validate_crc(inner)
+    return base | {
+        "function": "data_read_response",
+        "inner_identity": SYNTHETIC_INVERTER_IDENTITY,
+        "inner_function": _inner_function_name(inner_function),
+        "start_register": start_register,
+        "register_count": register_count,
+        "register_words": [SYNTHETIC_REGISTER_WORD],
+    }
+
+
+def _inner_function_name(function: int) -> str:
+    return "read_holding" if function == 0x03 else "read_input"
+
+
+def sanitize_segments(
+    segments: Iterable[CapturedSegment], policy: ParserPolicy | None = None
+) -> dict[str, Any]:
+    """Reassemble, parse, and sanitize authorized offline TCP payloads."""
+    active_policy = policy or ParserPolicy()
+    states: dict[tuple[int, str], _DirectionState] = {}
+    records: list[dict[str, Any]] = []
+    record_keys: set[str] = set()
+    last_timestamp: dict[tuple[int, str], float] = {}
+
+    for segment in segments:
+        if segment.direction not in ("dongle_to_cloud", "cloud_to_dongle"):
+            raise CaptureError(FailureReason.MALFORMED)
+        state_key = (segment.stream_id, segment.direction)
+        state = states.setdefault(
+            state_key,
+            _DirectionState(
+                TCPStreamReassembler(active_policy), StreamFrameDecoder(active_policy)
+            ),
+        )
+        last_timestamp[state_key] = segment.captured_at
+        for captured_at, chunk in state.reassembler.push(
+            segment.sequence, segment.payload, captured_at=segment.captured_at
+        ):
+            for frame in state.decoder.feed(chunk, captured_at=captured_at):
+                record = _sanitize_frame(frame, segment.direction, state)
+                record_key = json.dumps(record, sort_keys=True, separators=(",", ":"))
+                if record_key in record_keys:
+                    continue
+                if len(records) >= MAX_SANITIZED_RECORDS:
+                    raise CaptureError(FailureReason.CAPACITY)
+                record_keys.add(record_key)
+                records.append(record)
+
+    for state_key, state in states.items():
+        state.reassembler.close()
+        state.decoder.close(captured_at=last_timestamp[state_key])
+
+    return {
+        "schema_version": 1,
+        "capture": {
+            "source": "authorized_offline_input",
+            "dongle_address": DOCUMENTATION_DONGLE_ADDRESS,
+            "cloud_address": DOCUMENTATION_CLOUD_ADDRESS,
+        },
+        "frames": records,
+    }
+
+
+def _extract_ip_from_buf(buf: bytes, link_type: int) -> Any | None:
+    """Extract IPv4 data from supported offline PCAP link layers."""
+    if dpkt is None:
+        raise RuntimeError("optional PCAP dependency unavailable")
+    try:
+        if link_type == 1:
+            ethernet = dpkt.ethernet.Ethernet(buf)
+            return ethernet.data if isinstance(ethernet.data, dpkt.ip.IP) else None
+        if link_type == 113 and len(buf) >= 16:
+            return dpkt.ip.IP(buf[16:]) if buf[14:16] == b"\x08\x00" else None
+        if link_type == 276 and len(buf) >= 20:
+            return dpkt.ip.IP(buf[20:]) if buf[:2] == b"\x08\x00" else None
     except (dpkt.dpkt.NeedData, dpkt.dpkt.UnpackError):
-        pass
+        return None
     return None
 
 
-def process_pcap(pcap_path: str) -> list[DecodedFrame]:
-    """Process a pcap file and extract all cloud protocol frames."""
-    frames: list[DecodedFrame] = []
-    seen: set[tuple[float, str, int]] = set()  # Dedup (timestamp, direction, size)
-
-    f = open(pcap_path, "rb")  # noqa: SIM115 — kept open for lazy pcap iteration
+def _pcap_segments(pcap_path: Path) -> Iterable[CapturedSegment]:
+    if dpkt is None:
+        raise RuntimeError("optional PCAP dependency unavailable")
     try:
-        try:
-            pcap = dpkt.pcap.Reader(f)
-        except ValueError:
-            f.seek(0)
-            pcap = dpkt.pcapng.Reader(f)
-
-        link_type = pcap.datalink()
-        cloud_port = 4346
-
-        for timestamp, buf in pcap:
-            ip = _extract_ip_from_buf(buf, link_type)
-            if ip is None:
-                continue
-
-            if not isinstance(ip.data, dpkt.tcp.TCP):
-                continue
-            tcp = ip.data
-
-            if not tcp.data:
-                continue
-
-            # Determine direction
-            if tcp.dport == cloud_port:
-                direction = "dongle->cloud"
-            elif tcp.sport == cloud_port:
-                direction = "cloud->dongle"
-            else:
-                continue
-
-            # Dedup: -i any captures each packet twice (ingress + egress).
-            # Use direction + TCP seq + payload length. The NAT changes IP src
-            # between ingress/egress, so we can't use IP addresses.
-            seg_key = (direction, tcp.seq, len(tcp.data))
-            if seg_key in seen:
-                continue
-            seen.add(seg_key)
-
-            # Find frames in TCP payload
-            for _offset, frame_bytes in find_frames(tcp.data):
-                decoded = decode_frame(frame_bytes, timestamp, direction)
-                if decoded:
-                    frames.append(decoded)
-    finally:
-        f.close()
-
-    return frames
-
-
-def print_analysis(frames: list[DecodedFrame]) -> None:
-    """Print a human-readable analysis of decoded frames."""
-    if not frames:
-        print("No frames found in capture.")
-        return
-
-    print(f"\n{'=' * 80}")
-    print("EG4 Cloud Protocol Traffic Analysis")
-    print(f"{'=' * 80}")
-    print(f"Total frames: {len(frames)}")
-
-    # Count by direction and type
-    dongle_frames = [f for f in frames if f.direction == "dongle->cloud"]
-    cloud_frames = [f for f in frames if f.direction == "cloud->dongle"]
-    print(f"Dongle → Cloud: {len(dongle_frames)}")
-    print(f"Cloud → Dongle: {len(cloud_frames)}")
-
-    # Count by function
-    func_counts: dict[str, int] = {}
-    for f in frames:
-        func_counts[f.func_name] = func_counts.get(f.func_name, 0) + 1
-    print("\nFrame types:")
-    for name, count in sorted(func_counts.items()):
-        print(f"  {name}: {count}")
-
-    # Serials seen
-    serials = {f.serial for f in frames}
-    print(f"\nDongle serials: {', '.join(sorted(serials))}")
-
-    # Heartbeat timing
-    heartbeats = [
-        f for f in frames if f.func == 0xC1 and f.direction == "dongle->cloud"
-    ]
-    if len(heartbeats) >= 2:
-        intervals = []
-        for i in range(1, len(heartbeats)):
-            intervals.append(heartbeats[i].timestamp - heartbeats[i - 1].timestamp)
-        avg_interval = sum(intervals) / len(intervals)
-        print("\nHeartbeat timing:")
-        print(f"  Count: {len(heartbeats)}")
-        print(f"  Avg interval: {avg_interval:.1f}s")
-        print(f"  Min interval: {min(intervals):.1f}s")
-        print(f"  Max interval: {max(intervals):.1f}s")
-
-    # Data frame timing
-    data_frames = [
-        f for f in frames if f.func == 0xC2 and f.direction == "dongle->cloud"
-    ]
-    if len(data_frames) >= 2:
-        # Group by poll cycle (frames within 5s of each other = same cycle)
-        cycles: list[list[DecodedFrame]] = []
-        current_cycle: list[DecodedFrame] = [data_frames[0]]
-        for i in range(1, len(data_frames)):
-            if data_frames[i].timestamp - data_frames[i - 1].timestamp < 5.0:
-                current_cycle.append(data_frames[i])
-            else:
-                cycles.append(current_cycle)
-                current_cycle = [data_frames[i]]
-        cycles.append(current_cycle)
-
-        print(f"\nData transmission cycles: {len(cycles)}")
-        print(f"  Frames per cycle: {[len(c) for c in cycles]}")
-        if len(cycles) >= 2:
-            cycle_intervals = []
-            for i in range(1, len(cycles)):
-                cycle_intervals.append(
-                    cycles[i][0].timestamp - cycles[i - 1][0].timestamp
+        with pcap_path.open("rb") as capture_file:
+            try:
+                reader = dpkt.pcap.Reader(capture_file)
+            except ValueError:
+                capture_file.seek(0)
+                reader = dpkt.pcapng.Reader(capture_file)
+            link_type = reader.datalink()
+            stream_ids: dict[tuple[bytes, int, bytes, int], int] = {}
+            next_stream_id = 0
+            for timestamp, packet_buffer in reader:
+                ip_packet = _extract_ip_from_buf(packet_buffer, link_type)
+                if ip_packet is None or not isinstance(ip_packet.data, dpkt.tcp.TCP):
+                    continue
+                tcp = ip_packet.data
+                if tcp.dport == 4346:
+                    direction = "dongle_to_cloud"
+                elif tcp.sport == 4346:
+                    direction = "cloud_to_dongle"
+                else:
+                    continue
+                flow_key = (ip_packet.src, tcp.sport, ip_packet.dst, tcp.dport)
+                if tcp.flags & dpkt.tcp.TH_SYN or flow_key not in stream_ids:
+                    stream_ids[flow_key] = next_stream_id
+                    next_stream_id += 1
+                if not tcp.data:
+                    continue
+                yield CapturedSegment(
+                    direction,
+                    tcp.seq,
+                    float(timestamp),
+                    bytes(tcp.data),
+                    stream_ids[flow_key],
                 )
-            avg_cycle = sum(cycle_intervals) / len(cycle_intervals)
-            print(f"  Avg cycle interval: {avg_cycle:.1f}s")
-
-    # Detailed frame log
-    print(f"\n{'=' * 80}")
-    print("Detailed Frame Log")
-    print(f"{'=' * 80}")
-
-    t0 = frames[0].timestamp if frames else 0
-    for f in frames:
-        ts = f.timestamp - t0
-        dt = datetime.fromtimestamp(f.timestamp, tz=timezone.utc).strftime(
-            "%H:%M:%S.%f"
-        )[:-3]
-        print(
-            f"[{ts:8.3f}s] [{dt}] {f.direction:15s} "
-            f"{f.func_name:12s} serial={f.serial} "
-            f"size={f.raw_size:4d}  {f.details}"
-        )
+    except (OSError, ValueError, dpkt.dpkt.Error) as error:
+        raise CaptureError(FailureReason.MALFORMED) from error
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <pcap_file>")
-        print("\nCapture traffic first:")
-        print(
-            "  sudo tcpdump -i any host us2.solarcloudsystem.com and port 4346 -w capture.pcap"
-        )
-        sys.exit(1)
+def process_pcap(
+    pcap_path: str | Path, policy: ParserPolicy | None = None
+) -> dict[str, Any]:
+    """Sanitize one authorized capture without retaining raw capture data."""
+    return sanitize_segments(_pcap_segments(Path(pcap_path)), policy)
 
-    pcap_path = sys.argv[1]
-    if not Path(pcap_path).exists():
-        print(f"ERROR: File not found: {pcap_path}")
-        sys.exit(1)
 
-    print(f"Reading: {pcap_path}")
-    frames = process_pcap(pcap_path)
-    print_analysis(frames)
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a synthetic fixture from an authorized offline capture."
+    )
+    parser.add_argument("input", type=Path, help="authorized offline PCAP or PCAPNG")
+    parser.add_argument(
+        "--output", required=True, type=Path, help="new JSON output path"
+    )
+    parser.add_argument(
+        "--authorized-offline-input",
+        action="store_true",
+        required=True,
+        help="confirm authorization and offline-only handling",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the offline-only sanitizer with redacted status output."""
+    arguments = _parse_args(argv)
+    try:
+        sanitized = process_pcap(arguments.input)
+        with arguments.output.open("x", encoding="utf-8") as output_file:
+            json.dump(sanitized, output_file, indent=2)
+            output_file.write("\n")
+    except FileExistsError:
+        print("capture rejected: output_exists", file=sys.stderr)
+        return 2
+    except (CaptureError, OSError, RuntimeError) as error:
+        if isinstance(error, CaptureError):
+            message = str(error)
+        elif isinstance(error, RuntimeError):
+            message = "capture rejected: dependency"
+        else:
+            message = "capture rejected: input"
+        print(message, file=sys.stderr)
+        return 2
+    print(f"synthetic fixture written: {len(sanitized['frames'])} frame classes")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -13,6 +13,7 @@ import secrets
 import stat
 import sys
 from collections.abc import Buffer, Iterable, Iterator
+from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
 from importlib import import_module
@@ -125,6 +126,14 @@ _ATOMIC_DIR_FD_SUPPORTED: Final = all(
 )
 _DONGLE_ALIAS = re.compile(r"SYNTHDG[0-9]{3}\Z")
 _INVERTER_ALIAS = re.compile(r"SYNTHIV[0-9]{3}\Z")
+
+
+def _is_finite_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
 
 
 def compute_crc16(data: Buffer) -> int:
@@ -251,12 +260,8 @@ class StreamFrameDecoder:
         normalized = bytes(data)
         observation = captured_at if observed_at is None else observed_at
         if (
-            isinstance(captured_at, bool)
-            or not isinstance(captured_at, (int, float))
-            or not math.isfinite(captured_at)
-            or isinstance(observation, bool)
-            or not isinstance(observation, (int, float))
-            or not math.isfinite(observation)
+            not _is_finite_number(captured_at)
+            or not _is_finite_number(observation)
             or captured_at > observation
         ):
             raise CaptureError(FailureReason.MALFORMED)
@@ -300,14 +305,8 @@ class StreamFrameDecoder:
             raise CaptureError(FailureReason.TIMEOUT)
 
     def _validate_timestamp(self, captured_at: float) -> None:
-        if (
-            isinstance(captured_at, bool)
-            or not isinstance(captured_at, (int, float))
-            or not math.isfinite(captured_at)
-            or (
-                self._last_captured_at is not None
-                and captured_at < self._last_captured_at
-            )
+        if not _is_finite_number(captured_at) or (
+            self._last_captured_at is not None and captured_at < self._last_captured_at
         ):
             raise CaptureError(FailureReason.MALFORMED)
         self._last_captured_at = captured_at
@@ -515,14 +514,8 @@ class TCPStreamReassembler:
             raise CaptureError(FailureReason.TRUNCATED)
 
     def _validate_timestamp(self, captured_at: float) -> None:
-        if (
-            isinstance(captured_at, bool)
-            or not isinstance(captured_at, (int, float))
-            or not math.isfinite(captured_at)
-            or (
-                self._last_captured_at is not None
-                and captured_at < self._last_captured_at
-            )
+        if not _is_finite_number(captured_at) or (
+            self._last_captured_at is not None and captured_at < self._last_captured_at
         ):
             raise CaptureError(FailureReason.MALFORMED)
         self._last_captured_at = captured_at
@@ -688,14 +681,8 @@ def sanitize_segments(
     last_timestamp: dict[tuple[int, str], float] = {}
     capture_timestamp: float | None = None
     for segment in segments:
-        if (
-            isinstance(segment.captured_at, bool)
-            or not isinstance(segment.captured_at, (int, float))
-            or not math.isfinite(segment.captured_at)
-            or (
-                capture_timestamp is not None
-                and segment.captured_at < capture_timestamp
-            )
+        if not _is_finite_number(segment.captured_at) or (
+            capture_timestamp is not None and segment.captured_at < capture_timestamp
         ):
             raise CaptureError(FailureReason.MALFORMED)
         capture_timestamp = segment.captured_at
@@ -846,10 +833,8 @@ def _stat_signature(file_stat: os.stat_result) -> tuple[int, int, int, int, int,
 def _read_stable_capture(path: Path, policy: ParserPolicy) -> bytes:
     flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0)
     descriptor: int | None = None
-    try:
+    with suppress(OSError):
         descriptor = os.open(path, flags)
-    except OSError:
-        pass
     if descriptor is None:
         raise CaptureError(FailureReason.INPUT_KIND)
     failure: FailureReason | None = None
@@ -907,10 +892,8 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
     if factory is None:
         raise CaptureError(FailureReason.UNSUPPORTED_LINK)
     link_packet: _LinkPacket | None = None
-    try:
+    with suppress(Exception):
         link_packet = factory(packet)
-    except Exception:
-        pass
     if link_packet is None:
         raise CaptureError(FailureReason.MALFORMED)
     data = link_packet.data
@@ -1023,9 +1006,9 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
                 session.server_handshake = handshake
                 starts_stream = True
                 sequence = (sequence + 1) % _SEQUENCE_MODULUS
-            elif session is None:
-                raise CaptureError(FailureReason.TRUNCATED)
-            elif not client_side and session.server_initial_sequence is None:
+            elif session is None or (
+                not client_side and session.server_initial_sequence is None
+            ):
                 raise CaptureError(FailureReason.TRUNCATED)
             assert session is not None
             if payload:
@@ -1100,6 +1083,21 @@ def _open_temporary(directory_descriptor: int) -> tuple[int, str]:
     raise CaptureError(FailureReason.CAPACITY)
 
 
+def _unlink_if_same(
+    directory_descriptor: int,
+    name: str,
+    identity: tuple[int, int],
+) -> None:
+    with suppress(OSError):
+        current = os.stat(
+            name,
+            dir_fd=directory_descriptor,
+            follow_symlinks=False,
+        )
+        if (current.st_dev, current.st_ino) == identity:
+            os.unlink(name, dir_fd=directory_descriptor)
+
+
 def _write_exclusive(path: Path, content: bytes) -> None:
     descriptor: int | None = None
     directory_descriptor: int | None = None
@@ -1172,36 +1170,16 @@ def _write_exclusive(path: Path, content: bytes) -> None:
             and temporary_identity is not None
             and directory_descriptor is not None
         ):
-            try:
-                current = os.stat(
-                    path.name,
-                    dir_fd=directory_descriptor,
-                    follow_symlinks=False,
-                )
-                if (current.st_dev, current.st_ino) == temporary_identity:
-                    os.unlink(path.name, dir_fd=directory_descriptor)
-            except OSError:
-                pass
+            _unlink_if_same(directory_descriptor, path.name, temporary_identity)
         if (
             temporary_name is not None
             and temporary_identity is not None
             and directory_descriptor is not None
         ):
-            try:
-                current = os.stat(
-                    temporary_name,
-                    dir_fd=directory_descriptor,
-                    follow_symlinks=False,
-                )
-                if (current.st_dev, current.st_ino) == temporary_identity:
-                    os.unlink(temporary_name, dir_fd=directory_descriptor)
-            except OSError:
-                pass
+            _unlink_if_same(directory_descriptor, temporary_name, temporary_identity)
         if directory_descriptor is not None:
-            try:
+            with suppress(OSError):
                 os.fsync(directory_descriptor)
-            except OSError:
-                pass
     if directory_descriptor is not None:
         try:
             os.close(directory_descriptor)

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import math
 import os
 import re
+import secrets
 import stat
 import sys
 from collections.abc import Buffer, Iterable, Iterator
@@ -17,8 +19,6 @@ from importlib import import_module
 from pathlib import Path
 from types import ModuleType
 from typing import Any, BinaryIO, Final, Protocol, cast
-
-from pymodbus.framer import FramerRTU
 
 
 class _CaptureReader(Protocol):
@@ -51,6 +51,7 @@ class _TCPPacket(Protocol):
     dport: int
     seq: int
     flags: int
+    opts: Buffer
     data: Buffer
 
 
@@ -81,6 +82,8 @@ class _IPNamespace(Protocol):
 class _TCPNamespace(Protocol):
     TCP: type
     TH_ACK: int
+    TH_FIN: int
+    TH_RST: int
     TH_SYN: int
 
 
@@ -112,14 +115,26 @@ SYNTHETIC_REGISTER_WORD: Final = "SYNTHETIC_A55A"
 MAX_SANITIZED_RECORDS: Final = 1024
 _SEQUENCE_MODULUS: Final = 1 << 32
 _SEQUENCE_HALF: Final = 1 << 31
+_PENDING_BYTE_MEMORY_CHARGE: Final = max(
+    1,
+    sys.getsizeof({0: 0}) - sys.getsizeof({}) + sys.getsizeof(0),
+)
+_ATOMIC_DIR_FD_SUPPORTED: Final = all(
+    function in os.supports_dir_fd
+    for function in (os.open, os.link, os.stat, os.unlink)
+)
 _DONGLE_ALIAS = re.compile(r"SYNTHDG[0-9]{3}\Z")
 _INVERTER_ALIAS = re.compile(r"SYNTHIV[0-9]{3}\Z")
 
 
 def compute_crc16(data: Buffer) -> int:
     """Return the Modbus CRC in the byte order used by captured frames."""
-    network_order = FramerRTU.compute_CRC(bytes(data))
-    return int.from_bytes(network_order.to_bytes(2, "big"), "little")
+    crc = 0xFFFF
+    for byte in bytes(data):
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ (0xA001 if crc & 1 else 0)
+    return crc
 
 
 class FailureReason(StrEnum):
@@ -136,6 +151,7 @@ class FailureReason(StrEnum):
     INPUT_SIZE = "input_size"
     MALFORMED = "malformed"
     OUTPUT = "output"
+    OUTPUT_EXISTS = "output_exists"
     OVERSIZE = "oversize"
     PREFIX = "prefix"
     RANGE = "range"
@@ -179,7 +195,10 @@ class ParserPolicy:
             (self.maximum_reassembled_bytes_per_flow, 1, 64 * 1024 * 1024),
             (self.maximum_aggregate_memory_bytes, 1, 64 * 1024 * 1024),
         )
-        if any(value < low or value > high for value, low, high in bounded):
+        if any(
+            not math.isfinite(value) or value < low or value > high
+            for value, low, high in bounded
+        ):
             raise ValueError("parser policy value outside the internal contract")
 
     @property
@@ -213,17 +232,36 @@ class StreamFrameDecoder:
         self._budget = budget or _MemoryBudget(
             self.policy.maximum_aggregate_memory_bytes
         )
-        self._buffer = bytearray()
+        self._buffer = b""
         self._prefix_scanned = 0
         self._started_at: float | None = None
+        self._last_captured_at: float | None = None
 
     @property
     def buffered_bytes(self) -> int:
         return len(self._buffer)
 
-    def feed(self, data: Buffer, *, captured_at: float) -> list[bytes]:
+    def feed(
+        self,
+        data: Buffer,
+        *,
+        captured_at: float,
+        observed_at: float | None = None,
+    ) -> list[bytes]:
         normalized = bytes(data)
-        self._check_deadline(captured_at)
+        observation = captured_at if observed_at is None else observed_at
+        if (
+            isinstance(captured_at, bool)
+            or not isinstance(captured_at, (int, float))
+            or not math.isfinite(captured_at)
+            or isinstance(observation, bool)
+            or not isinstance(observation, (int, float))
+            or not math.isfinite(observation)
+            or captured_at > observation
+        ):
+            raise CaptureError(FailureReason.MALFORMED)
+        self._validate_timestamp(observation)
+        self._check_deadline(observation)
         if normalized and self._started_at is None:
             self._started_at = captured_at
         decoded: list[bytes] = []
@@ -239,13 +277,14 @@ class StreamFrameDecoder:
                 continue
             take = min(room, len(normalized) - offset)
             self._budget.reserve(take)
-            self._buffer.extend(normalized[offset : offset + take])
+            self._buffer += normalized[offset : offset + take]
             offset += take
             decoded.extend(self._extract_available(captured_at))
         decoded.extend(self._extract_available(captured_at))
         return decoded
 
     def close(self, *, captured_at: float) -> None:
+        self._validate_timestamp(captured_at)
         self._check_deadline(captured_at)
         self._extract_available(captured_at)
         if self._buffer or self._prefix_scanned:
@@ -260,9 +299,22 @@ class StreamFrameDecoder:
             self._discard()
             raise CaptureError(FailureReason.TIMEOUT)
 
+    def _validate_timestamp(self, captured_at: float) -> None:
+        if (
+            isinstance(captured_at, bool)
+            or not isinstance(captured_at, (int, float))
+            or not math.isfinite(captured_at)
+            or (
+                self._last_captured_at is not None
+                and captured_at < self._last_captured_at
+            )
+        ):
+            raise CaptureError(FailureReason.MALFORMED)
+        self._last_captured_at = captured_at
+
     def _remove_prefix(self, count: int) -> None:
         if count:
-            del self._buffer[:count]
+            self._buffer = self._buffer[count:]
             self._budget.release(count)
 
     def _extract_available(self, captured_at: float) -> list[bytes]:
@@ -303,7 +355,7 @@ class StreamFrameDecoder:
 
     def _discard(self) -> None:
         self._budget.release(len(self._buffer))
-        self._buffer.clear()
+        self._buffer = b""
         self._prefix_scanned = 0
         self._started_at = None
 
@@ -321,24 +373,30 @@ class TCPStreamReassembler:
             self.policy.maximum_aggregate_memory_bytes
         )
         self._origin: int | None = None
-        self._history = bytearray()
-        self._window_size = self.policy.maximum_pending_bytes_per_flow + 1
-        self._pending_values = bytearray(self._window_size)
-        self._pending_present = bytearray(self._window_size)
-        self._pending_count = 0
+        self._assembled_bytes = 0
+        self._history_start = 0
+        self._history = b""
+        self._pending: dict[int, int] | None = None
         self._segment_count = 0
+        self._started_at: float | None = None
+        self._emitted_started_at: float | None = None
+        self._last_captured_at: float | None = None
 
     @property
     def pending_bytes(self) -> int:
-        return self._pending_count
+        return len(self._pending) if self._pending is not None else 0
 
     @property
     def retained_bytes(self) -> int:
-        return len(self._history) + self._pending_count
+        return len(self._history) + self.pending_bytes
 
     @property
     def segment_count(self) -> int:
         return self._segment_count
+
+    @property
+    def emitted_started_at(self) -> float | None:
+        return self._emitted_started_at
 
     def start(self, sequence: int) -> None:
         if self._origin is not None or not 0 <= sequence < _SEQUENCE_MODULUS:
@@ -356,70 +414,127 @@ class TCPStreamReassembler:
     def push(
         self, sequence: int, payload: Buffer, *, captured_at: float
     ) -> list[tuple[float, bytes]]:
+        self._validate_timestamp(captured_at)
+        self._emitted_started_at = None
         normalized = bytes(payload)
         if not normalized:
             return []
+        if self._started_at is None:
+            self._started_at = captured_at
+        elif captured_at - self._started_at > self.policy.overall_frame_deadline:
+            self._clear()
+            raise CaptureError(FailureReason.TIMEOUT)
         self._segment_count += 1
         if self._segment_count > self.policy.maximum_segments_per_flow:
             raise CaptureError(FailureReason.CAPACITY)
         start = self._offset(sequence)
-        if start < 0:
+        end = start + len(normalized)
+        if start < self._history_start:
             raise CaptureError(FailureReason.MALFORMED)
-        contiguous = bytearray()
+        if end > self.policy.maximum_reassembled_bytes_per_flow:
+            raise CaptureError(FailureReason.CAPACITY)
+        pending = self._pending
+        new_bytes = 0
         for index, byte in enumerate(normalized):
             offset = start + index
-            if offset < len(self._history):
-                if self._history[offset] != byte:
+            if offset < self._assembled_bytes:
+                if self._history[offset - self._history_start] != byte:
                     raise CaptureError(FailureReason.MALFORMED)
                 continue
-            if offset == len(self._history):
-                if len(self._history) >= self.policy.maximum_reassembled_bytes_per_flow:
-                    raise CaptureError(FailureReason.CAPACITY)
-                self._budget.reserve(1)
-                self._history.append(byte)
+            existing = pending.get(offset) if pending is not None else None
+            if existing is not None:
+                if existing != byte:
+                    raise CaptureError(FailureReason.MALFORMED)
+                continue
+            new_bytes += 1
+        if start > self._assembled_bytes and (
+            start - self._assembled_bytes > self.policy.maximum_pending_bytes_per_flow
+            or self.pending_bytes + new_bytes
+            > self.policy.maximum_pending_bytes_per_flow
+        ):
+            raise CaptureError(FailureReason.CAPACITY)
+        contiguous = bytearray()
+        if start > self._assembled_bytes:
+            self._budget.reserve(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
+            if new_bytes:
+                if pending is None:
+                    pending = {}
+                for index, byte in enumerate(normalized):
+                    offset = start + index
+                    if offset not in pending:
+                        pending[offset] = byte
+                self._pending = pending
+        else:
+            self._budget.reserve(new_bytes)
+            while self._assembled_bytes < end:
+                pending_byte = (
+                    pending.pop(self._assembled_bytes)
+                    if pending is not None and self._assembled_bytes in pending
+                    else None
+                )
+                if pending_byte is None:
+                    byte = normalized[self._assembled_bytes - start]
+                else:
+                    byte = pending_byte
+                    self._budget.release(_PENDING_BYTE_MEMORY_CHARGE - 1)
                 contiguous.append(byte)
-                while self._pending_present[len(self._history) % self._window_size]:
-                    if (
-                        len(self._history)
-                        >= self.policy.maximum_reassembled_bytes_per_flow
-                    ):
-                        raise CaptureError(FailureReason.CAPACITY)
-                    slot = len(self._history) % self._window_size
-                    pending_byte = self._pending_values[slot]
-                    self._pending_present[slot] = 0
-                    self._pending_count -= 1
-                    self._history.append(pending_byte)
-                    contiguous.append(pending_byte)
-                continue
-            distance = offset - len(self._history)
-            if distance > self.policy.maximum_pending_bytes_per_flow:
-                raise CaptureError(FailureReason.CAPACITY)
-            slot = offset % self._window_size
-            if self._pending_present[slot]:
-                if self._pending_values[slot] != byte:
-                    raise CaptureError(FailureReason.MALFORMED)
-                continue
-            if self._pending_count >= self.policy.maximum_pending_bytes_per_flow:
-                raise CaptureError(FailureReason.CAPACITY)
-            self._budget.reserve(1)
-            self._pending_values[slot] = byte
-            self._pending_present[slot] = 1
-            self._pending_count += 1
+                self._assembled_bytes += 1
+            while pending is not None and self._assembled_bytes in pending:
+                byte = pending.pop(self._assembled_bytes)
+                self._budget.release(_PENDING_BYTE_MEMORY_CHARGE - 1)
+                contiguous.append(byte)
+                self._assembled_bytes += 1
+            if pending is not None and not pending:
+                self._pending = None
+                pending = None
+        overlap_limit = min(
+            self.policy.maximum_packet_bytes,
+            self.policy.maximum_reassembled_bytes_per_flow,
+        )
+        combined_history = self._history + bytes(contiguous)
+        expired = len(combined_history) - overlap_limit
+        if expired > 0:
+            self._history = combined_history[expired:]
+            self._history_start += expired
+            self._budget.release(expired)
+        else:
+            self._history = combined_history
         chunks: list[tuple[float, bytes]] = []
         if contiguous:
+            assert self._started_at is not None
+            self._emitted_started_at = self._started_at
             chunks.append((captured_at, bytes(contiguous)))
+        if self._pending is None:
+            self._started_at = None
         return chunks
 
     def close(self) -> None:
-        retained = self.retained_bytes
-        has_gap = bool(self._pending_count)
-        self._pending_present.clear()
-        self._pending_values.clear()
-        self._pending_count = 0
-        self._history.clear()
-        self._budget.release(retained)
+        has_gap = self._pending is not None
+        self._clear()
         if has_gap:
             raise CaptureError(FailureReason.TRUNCATED)
+
+    def _validate_timestamp(self, captured_at: float) -> None:
+        if (
+            isinstance(captured_at, bool)
+            or not isinstance(captured_at, (int, float))
+            or not math.isfinite(captured_at)
+            or (
+                self._last_captured_at is not None
+                and captured_at < self._last_captured_at
+            )
+        ):
+            raise CaptureError(FailureReason.MALFORMED)
+        self._last_captured_at = captured_at
+
+    def _clear(self) -> None:
+        retained = len(self._history) + (
+            self.pending_bytes * _PENDING_BYTE_MEMORY_CHARGE
+        )
+        self._pending = None
+        self._history = b""
+        self._budget.release(retained)
+        self._started_at = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -458,13 +573,9 @@ def find_frames(data: bytes) -> list[tuple[int, bytes]]:
 
 
 def _validated_identity(raw: bytes) -> bytes:
-    if len(raw) != 10:
-        raise CaptureError(FailureReason.IDENTITY)
-    try:
-        text = raw.decode("ascii")
-    except UnicodeDecodeError as error:
-        raise CaptureError(FailureReason.IDENTITY) from error
-    if not text.isalnum():
+    if len(raw) != 10 or not all(
+        48 <= byte <= 57 or 65 <= byte <= 90 or 97 <= byte <= 122 for byte in raw
+    ):
         raise CaptureError(FailureReason.IDENTITY)
     return raw
 
@@ -575,7 +686,19 @@ def sanitize_segments(
     dongle_identities: dict[bytes, str] = {}
     inverter_identities: dict[bytes, str] = {}
     last_timestamp: dict[tuple[int, str], float] = {}
+    capture_timestamp: float | None = None
     for segment in segments:
+        if (
+            isinstance(segment.captured_at, bool)
+            or not isinstance(segment.captured_at, (int, float))
+            or not math.isfinite(segment.captured_at)
+            or (
+                capture_timestamp is not None
+                and segment.captured_at < capture_timestamp
+            )
+        ):
+            raise CaptureError(FailureReason.MALFORMED)
+        capture_timestamp = segment.captured_at
         if segment.direction not in ("dongle_to_cloud", "cloud_to_dongle"):
             raise CaptureError(FailureReason.MALFORMED)
         session = sessions.get(segment.stream_id)
@@ -594,10 +717,16 @@ def sanitize_segments(
         if segment.starts_stream:
             state.reassembler.start(segment.sequence)
         last_timestamp[(segment.stream_id, segment.direction)] = segment.captured_at
-        for captured_at, chunk in state.reassembler.push(
+        for _captured_at, chunk in state.reassembler.push(
             segment.sequence, segment.payload, captured_at=segment.captured_at
         ):
-            for frame in state.decoder.feed(chunk, captured_at=captured_at):
+            decoder_timestamp = state.reassembler.emitted_started_at
+            assert decoder_timestamp is not None
+            for frame in state.decoder.feed(
+                chunk,
+                captured_at=decoder_timestamp,
+                observed_at=segment.captured_at,
+            ):
                 record = _sanitize_frame(
                     frame,
                     segment.direction,
@@ -716,10 +845,15 @@ def _stat_signature(file_stat: os.stat_result) -> tuple[int, int, int, int, int,
 
 def _read_stable_capture(path: Path, policy: ParserPolicy) -> bytes:
     flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
     try:
         descriptor = os.open(path, flags)
-    except OSError as error:
-        raise CaptureError(FailureReason.INPUT_KIND) from error
+    except OSError:
+        pass
+    if descriptor is None:
+        raise CaptureError(FailureReason.INPUT_KIND)
+    failure: FailureReason | None = None
+    capture: bytes | None = None
     try:
         before = os.fstat(descriptor)
         if not stat.S_ISREG(before.st_mode):
@@ -736,10 +870,7 @@ def _read_stable_capture(path: Path, policy: ParserPolicy) -> bytes:
             remaining -= len(chunk)
         capture = b"".join(chunks)
         after = os.fstat(descriptor)
-        try:
-            by_name = os.stat(path, follow_symlinks=False)
-        except OSError as error:
-            raise CaptureError(FailureReason.INPUT_CHANGED) from error
+        by_name = os.stat(path, follow_symlinks=False)
         if len(capture) > policy.maximum_capture_bytes:
             raise CaptureError(FailureReason.INPUT_SIZE)
         if (
@@ -748,14 +879,19 @@ def _read_stable_capture(path: Path, policy: ParserPolicy) -> bytes:
             or _stat_signature(after) != _stat_signature(by_name)
         ):
             raise CaptureError(FailureReason.INPUT_CHANGED)
-        return capture
-    except OSError as error:
-        raise CaptureError(FailureReason.INPUT_CHANGED) from error
-    finally:
-        try:
-            os.close(descriptor)
-        except OSError as error:
-            raise CaptureError(FailureReason.INPUT_CHANGED) from error
+    except CaptureError as error:
+        failure = error.reason
+    except OSError:
+        failure = FailureReason.INPUT_CHANGED
+    try:
+        os.close(descriptor)
+    except OSError:
+        if failure is None:
+            failure = FailureReason.INPUT_CHANGED
+    if failure is not None:
+        raise CaptureError(failure)
+    assert capture is not None
+    return capture
 
 
 def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
@@ -770,10 +906,13 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
     factory = factories.get(link_type)
     if factory is None:
         raise CaptureError(FailureReason.UNSUPPORTED_LINK)
+    link_packet: _LinkPacket | None = None
     try:
         link_packet = factory(packet)
-    except Exception as error:
-        raise CaptureError(FailureReason.MALFORMED) from error
+    except Exception:
+        pass
+    if link_packet is None:
+        raise CaptureError(FailureReason.MALFORMED)
     data = link_packet.data
     if isinstance(data, module.ip.IP):
         return cast(_IPPacket, data)
@@ -783,18 +922,26 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
 @dataclass(slots=True)
 class _ObservedSession:
     stream_id: int
-    server_started: bool = False
+    client_initial_sequence: int
+    client_handshake: tuple[int, bytes, bytes]
+    server_initial_sequence: int | None = None
+    server_handshake: tuple[int, bytes, bytes] | None = None
+    application_started: bool = False
 
 
 def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSegment]:
     module = dpkt
     if module is None:
         raise CaptureError(FailureReason.DEPENDENCY)
+    reader: _CaptureReader | None = None
+    link_type: int | None = None
     try:
         reader = module.pcap.UniversalReader(io.BytesIO(capture))
         link_type = reader.datalink()
-    except Exception as error:
-        raise CaptureError(FailureReason.MALFORMED) from error
+    except Exception:
+        pass
+    if reader is None or link_type is None:
+        raise CaptureError(FailureReason.MALFORMED)
     supported = {
         module.pcap.DLT_EN10MB,
         module.pcap.DLT_LINUX_SLL,
@@ -805,8 +952,16 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
     sessions: dict[tuple[bytes, int, bytes, int], _ObservedSession] = {}
     next_stream_id = 0
     packet_count = 0
+    last_timestamp: float | None = None
+    raw_failure = False
     try:
         for timestamp, raw_packet in reader:
+            captured_at = float(timestamp)
+            if not math.isfinite(captured_at) or (
+                last_timestamp is not None and captured_at < last_timestamp
+            ):
+                raise CaptureError(FailureReason.MALFORMED)
+            last_timestamp = captured_at
             packet_count += 1
             if packet_count > policy.maximum_packets:
                 raise CaptureError(FailureReason.CAPACITY)
@@ -836,37 +991,60 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
             session = sessions.get(key)
             starts_stream = False
             sequence = tcp.seq
+            payload = bytes(tcp.data)
+            handshake = (tcp.flags, bytes(tcp.opts), payload)
+            has_terminal_flag = bool(
+                tcp.flags & (module.tcp.TH_FIN | module.tcp.TH_RST)
+            )
             if client_side and syn and not ack:
-                session = _ObservedSession(next_stream_id)
+                if session is not None and sequence == session.client_initial_sequence:
+                    if handshake != session.client_handshake:
+                        raise CaptureError(FailureReason.MALFORMED)
+                    continue
+                if has_terminal_flag:
+                    raise CaptureError(FailureReason.MALFORMED)
+                if session is not None and not session.application_started:
+                    raise CaptureError(FailureReason.MALFORMED)
+                session = _ObservedSession(next_stream_id, sequence, handshake)
                 sessions[key] = session
                 next_stream_id += 1
                 starts_stream = True
                 sequence = (sequence + 1) % _SEQUENCE_MODULUS
             elif not client_side and syn and ack and session is not None:
-                if session.server_started:
+                if session.server_initial_sequence == sequence:
+                    if handshake != session.server_handshake:
+                        raise CaptureError(FailureReason.MALFORMED)
+                    continue
+                if has_terminal_flag:
                     raise CaptureError(FailureReason.MALFORMED)
-                session.server_started = True
+                if session.server_initial_sequence is not None:
+                    raise CaptureError(FailureReason.MALFORMED)
+                session.server_initial_sequence = sequence
+                session.server_handshake = handshake
                 starts_stream = True
                 sequence = (sequence + 1) % _SEQUENCE_MODULUS
             elif session is None:
                 raise CaptureError(FailureReason.TRUNCATED)
-            elif not client_side and not session.server_started:
+            elif not client_side and session.server_initial_sequence is None:
                 raise CaptureError(FailureReason.TRUNCATED)
             assert session is not None
-            payload = bytes(tcp.data)
+            if payload:
+                session.application_started = True
             if starts_stream or payload:
                 yield CapturedSegment(
                     direction,
                     sequence,
-                    float(timestamp),
+                    captured_at,
                     payload,
                     session.stream_id,
                     starts_stream,
                 )
     except CaptureError:
         raise
-    except Exception as error:
-        raise CaptureError(FailureReason.MALFORMED) from error
+    except Exception:
+        raw_failure = True
+    if raw_failure:
+        raise CaptureError(FailureReason.MALFORMED)
 
 
 def process_pcap(
@@ -899,7 +1077,7 @@ def _serialize_output(value: object) -> bytes:
     return (json.dumps(value, indent=2) + "\n").encode()
 
 
-def _write_exclusive(path: Path, content: bytes) -> None:
+def _open_temporary(directory_descriptor: int) -> tuple[int, str]:
     flags = (
         os.O_WRONLY
         | os.O_CREAT
@@ -907,34 +1085,131 @@ def _write_exclusive(path: Path, content: bytes) -> None:
         | os.O_CLOEXEC
         | getattr(os, "O_NOFOLLOW", 0)
     )
+    failed = False
+    for _ in range(16):
+        name = f".decode-cloud-frames-{secrets.token_hex(16)}.tmp"
+        try:
+            return os.open(name, flags, 0o600, dir_fd=directory_descriptor), name
+        except FileExistsError:
+            continue
+        except OSError:
+            failed = True
+            break
+    if failed:
+        raise CaptureError(FailureReason.OUTPUT)
+    raise CaptureError(FailureReason.CAPACITY)
+
+
+def _write_exclusive(path: Path, content: bytes) -> None:
     descriptor: int | None = None
-    created: tuple[int, int] | None = None
+    directory_descriptor: int | None = None
+    temporary_name: str | None = None
+    temporary_identity: tuple[int, int] | None = None
+    published = False
+    failure: FailureReason | None = None
     try:
-        descriptor = os.open(path, flags, 0o600)
-        opened = os.fstat(descriptor)
-        created = (opened.st_dev, opened.st_ino)
-        if os.write(descriptor, content) != len(content):
+        if (
+            not path.name
+            or not _ATOMIC_DIR_FD_SUPPORTED
+            or not hasattr(os, "O_DIRECTORY")
+        ):
             raise CaptureError(FailureReason.OUTPUT)
+        directory_flags = (
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+        )
+        directory_descriptor = os.open(path.parent, directory_flags)
+        directory_stat = os.fstat(directory_descriptor)
+        # Cleanup uses inode validation followed by unlink relative to this fd.
+        # Exclude directories writable by other principals so that validation
+        # and cleanup cannot race an untrusted replacement entry.
+        if not stat.S_ISDIR(directory_stat.st_mode) or directory_stat.st_mode & (
+            stat.S_IWGRP | stat.S_IWOTH
+        ):
+            raise CaptureError(FailureReason.OUTPUT)
+        descriptor, temporary_name = _open_temporary(directory_descriptor)
+        opened = os.fstat(descriptor)
+        temporary_identity = (opened.st_dev, opened.st_ino)
+        if stat.S_IMODE(opened.st_mode) != 0o600:
+            raise CaptureError(FailureReason.OUTPUT)
+        written = 0
+        while written < len(content):
+            count = os.write(descriptor, memoryview(content)[written:])
+            if count <= 0:
+                raise CaptureError(FailureReason.OUTPUT)
+            written += count
         os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.link(
+            temporary_name,
+            path.name,
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+            follow_symlinks=False,
+        )
+        published = True
+        os.unlink(temporary_name, dir_fd=directory_descriptor)
+        temporary_name = None
+        os.fsync(directory_descriptor)
+        os.close(directory_descriptor)
+        directory_descriptor = None
     except FileExistsError:
-        raise
-    except (CaptureError, OSError) as error:
-        if descriptor is not None:
+        failure = FailureReason.OUTPUT_EXISTS
+    except CaptureError as error:
+        failure = error.reason
+    except OSError:
+        failure = FailureReason.OUTPUT
+
+    if descriptor is not None:
+        try:
             os.close(descriptor)
-            descriptor = None
-        if created is not None:
+        except OSError:
+            if failure is None:
+                failure = FailureReason.OUTPUT
+    if failure is not None:
+        if (
+            published
+            and temporary_identity is not None
+            and directory_descriptor is not None
+        ):
             try:
-                current = os.stat(path, follow_symlinks=False)
-                if (current.st_dev, current.st_ino) == created:
-                    path.unlink()
+                current = os.stat(
+                    path.name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (current.st_dev, current.st_ino) == temporary_identity:
+                    os.unlink(path.name, dir_fd=directory_descriptor)
             except OSError:
                 pass
-        if isinstance(error, CaptureError):
-            raise
-        raise CaptureError(FailureReason.OUTPUT) from error
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
+        if (
+            temporary_name is not None
+            and temporary_identity is not None
+            and directory_descriptor is not None
+        ):
+            try:
+                current = os.stat(
+                    temporary_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (current.st_dev, current.st_ino) == temporary_identity:
+                    os.unlink(temporary_name, dir_fd=directory_descriptor)
+            except OSError:
+                pass
+        if directory_descriptor is not None:
+            try:
+                os.fsync(directory_descriptor)
+            except OSError:
+                pass
+    if directory_descriptor is not None:
+        try:
+            os.close(directory_descriptor)
+        except OSError:
+            if failure is None:
+                failure = FailureReason.OUTPUT
+    if failure is not None:
+        raise CaptureError(failure)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -943,9 +1218,6 @@ def main(argv: list[str] | None = None) -> int:
         sanitized = process_pcap(arguments.input)
         serialized = _serialize_output(sanitized)
         _write_exclusive(arguments.output, serialized)
-    except FileExistsError:
-        print("capture rejected: output_exists", file=sys.stderr)
-        return 2
     except CaptureError as error:
         print(str(error), file=sys.stderr)
         return 2

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Final
 
+from pylxpweb.transports.dongle import compute_crc16
+
 try:
     dpkt: ModuleType | None = import_module("dpkt")
 except ImportError:  # pragma: no cover - exercised by the CLI environment
@@ -290,16 +292,6 @@ class _DirectionState:
     source_identity: bytes | None = None
 
 
-def compute_crc16(data: bytes) -> int:
-    """Return CRC-16/Modbus for an inner frame."""
-    crc = 0xFFFF
-    for byte in data:
-        crc ^= byte
-        for _ in range(8):
-            crc = (crc >> 1) ^ 0xA001 if crc & 1 else crc >> 1
-    return crc & 0xFFFF
-
-
 def find_frames(data: bytes) -> list[tuple[int, bytes]]:
     """Compatibility helper using the same bounded streaming decoder."""
     decoder = StreamFrameDecoder()
@@ -461,16 +453,17 @@ def _extract_ip_from_buf(buf: bytes, link_type: int) -> Any | None:
     if dpkt is None:
         raise RuntimeError("optional PCAP dependency unavailable")
     try:
-        if link_type == 1:
-            ethernet = dpkt.ethernet.Ethernet(buf)
-            return ethernet.data if isinstance(ethernet.data, dpkt.ip.IP) else None
-        if link_type == 113 and len(buf) >= 16:
-            return dpkt.ip.IP(buf[16:]) if buf[14:16] == b"\x08\x00" else None
-        if link_type == 276 and len(buf) >= 20:
-            return dpkt.ip.IP(buf[20:]) if buf[:2] == b"\x08\x00" else None
+        if link_type == dpkt.pcap.DLT_EN10MB:
+            link_packet = dpkt.ethernet.Ethernet(buf)
+        elif link_type == dpkt.pcap.DLT_LINUX_SLL:
+            link_packet = dpkt.sll.SLL(buf)
+        elif link_type == dpkt.pcap.DLT_LINUX_SLL2:
+            link_packet = dpkt.sll2.SLL2(buf)
+        else:
+            return None
+        return link_packet.data if isinstance(link_packet.data, dpkt.ip.IP) else None
     except (dpkt.dpkt.NeedData, dpkt.dpkt.UnpackError):
         return None
-    return None
 
 
 def _pcap_segments(pcap_path: Path) -> Iterable[CapturedSegment]:
@@ -478,11 +471,7 @@ def _pcap_segments(pcap_path: Path) -> Iterable[CapturedSegment]:
         raise RuntimeError("optional PCAP dependency unavailable")
     try:
         with pcap_path.open("rb") as capture_file:
-            try:
-                reader = dpkt.pcap.Reader(capture_file)
-            except ValueError:
-                capture_file.seek(0)
-                reader = dpkt.pcapng.Reader(capture_file)
+            reader = dpkt.pcap.UniversalReader(capture_file)
             link_type = reader.datalink()
             stream_ids: dict[tuple[bytes, int, bytes, int], int] = {}
             next_stream_id = 0

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -1,38 +1,107 @@
 #!/usr/bin/env python3
-"""Create synthetic protocol fixtures from an authorized offline PCAP.
-
-The tool never opens a socket and never emits captured identities, addresses,
-payloads, timestamps, or register values. TCP segments are reassembled before
-frames are parsed; only then is a minimal synthetic representation produced.
-
-Usage:
-    python scripts/decode_cloud_frames.py INPUT.pcap --output sanitized.json \
-        --authorized-offline-input
-
-The output path must not already exist. Optional PCAP support requires ``dpkt``.
-Core stream, parser, and sanitizer tests do not require that package.
-"""
+"""Create a synthetic protocol fixture from an authorized offline capture."""
 
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import os
+import re
+import stat
 import sys
-from collections.abc import Iterable
-from dataclasses import dataclass
+from collections.abc import Buffer, Iterable, Iterator
+from dataclasses import dataclass, field
 from enum import StrEnum
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Final
+from typing import Any, BinaryIO, Final, Protocol, cast
 
-from pylxpweb.transports.dongle import compute_crc16
+from pymodbus.framer import FramerRTU
 
-try:
-    dpkt: ModuleType | None = import_module("dpkt")
-except ImportError:  # pragma: no cover - exercised by the CLI environment
-    dpkt = None
 
+class _CaptureReader(Protocol):
+    def __iter__(self) -> Iterator[tuple[float, Buffer]]: ...
+
+    def datalink(self) -> int: ...
+
+
+class _ReaderFactory(Protocol):
+    def __call__(self, capture: BinaryIO) -> _CaptureReader: ...
+
+
+class _PacketFactory(Protocol):
+    def __call__(self, packet: bytes) -> _LinkPacket: ...
+
+
+class _LinkPacket(Protocol):
+    data: object
+
+
+class _IPPacket(Protocol):
+    src: Buffer
+    dst: Buffer
+    p: int
+    data: object
+
+
+class _TCPPacket(Protocol):
+    sport: int
+    dport: int
+    seq: int
+    flags: int
+    data: Buffer
+
+
+class _PcapNamespace(Protocol):
+    DLT_EN10MB: int
+    DLT_LINUX_SLL: int
+    DLT_LINUX_SLL2: int
+    UniversalReader: _ReaderFactory
+
+
+class _PacketNamespace(Protocol):
+    Ethernet: _PacketFactory
+
+
+class _SLLNamespace(Protocol):
+    SLL: _PacketFactory
+
+
+class _SLL2Namespace(Protocol):
+    SLL2: _PacketFactory
+
+
+class _IPNamespace(Protocol):
+    IP: type
+    IP_PROTO_TCP: int
+
+
+class _TCPNamespace(Protocol):
+    TCP: type
+    TH_ACK: int
+    TH_SYN: int
+
+
+class _DPKT(Protocol):
+    pcap: _PcapNamespace
+    ethernet: _PacketNamespace
+    sll: _SLLNamespace
+    sll2: _SLL2Namespace
+    ip: _IPNamespace
+    tcp: _TCPNamespace
+
+
+def _load_dpkt() -> _DPKT | None:
+    try:
+        module = import_module("dpkt")
+    except ImportError:
+        return None
+    return cast(_DPKT, cast(ModuleType, module))
+
+
+dpkt = _load_dpkt()
 
 FRAME_MAGIC: Final = b"\xa1\x1a"
 SYNTHETIC_DONGLE_IDENTITY: Final = "SYNTHDG001"
@@ -41,26 +110,42 @@ DOCUMENTATION_DONGLE_ADDRESS: Final = "192.0.2.10"
 DOCUMENTATION_CLOUD_ADDRESS: Final = "198.51.100.20"
 SYNTHETIC_REGISTER_WORD: Final = "SYNTHETIC_A55A"
 MAX_SANITIZED_RECORDS: Final = 1024
+_SEQUENCE_MODULUS: Final = 1 << 32
+_SEQUENCE_HALF: Final = 1 << 31
+_DONGLE_ALIAS = re.compile(r"SYNTHDG[0-9]{3}\Z")
+_INVERTER_ALIAS = re.compile(r"SYNTHIV[0-9]{3}\Z")
+
+
+def compute_crc16(data: Buffer) -> int:
+    """Return the Modbus CRC in the byte order used by captured frames."""
+    network_order = FramerRTU.compute_CRC(bytes(data))
+    return int.from_bytes(network_order.to_bytes(2, "big"), "little")
 
 
 class FailureReason(StrEnum):
-    """Bounded, redacted parser failure classifications."""
+    """Bounded failure categories that never contain captured values."""
 
     CAPACITY = "capacity"
     CRC = "crc"
+    DEPENDENCY = "dependency"
+    EMPTY = "empty"
     FUNCTION = "function"
     IDENTITY = "identity"
+    INPUT_CHANGED = "input_changed"
+    INPUT_KIND = "input_kind"
+    INPUT_SIZE = "input_size"
     MALFORMED = "malformed"
+    OUTPUT = "output"
     OVERSIZE = "oversize"
     PREFIX = "prefix"
     RANGE = "range"
+    SCHEMA = "schema"
     TIMEOUT = "timeout"
     TRUNCATED = "truncated"
+    UNSUPPORTED_LINK = "unsupported_link"
 
 
 class CaptureError(RuntimeError):
-    """A fail-closed capture error whose message cannot contain capture data."""
-
     def __init__(self, reason: FailureReason) -> None:
         self.reason = reason
         super().__init__(f"capture rejected: {reason.value}")
@@ -68,54 +153,83 @@ class CaptureError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class ParserPolicy:
-    """Internal parser bounds from the Phase A contract."""
-
     maximum_frame_bytes: int = 4096
     prefix_scan_bytes: int = 64
     overall_frame_deadline: float = 5.0
+    maximum_capture_bytes: int = 16 * 1024 * 1024
+    maximum_packet_bytes: int = 1024 * 1024
+    maximum_packets: int = 100_000
+    maximum_flows: int = 128
+    maximum_segments_per_flow: int = 4096
+    maximum_pending_bytes_per_flow: int = 16 * 1024
+    maximum_reassembled_bytes_per_flow: int = 4 * 1024 * 1024
+    maximum_aggregate_memory_bytes: int = 8 * 1024 * 1024
 
     def __post_init__(self) -> None:
-        bounds: tuple[tuple[int | float, int | float, int | float], ...] = (
+        bounded: tuple[tuple[int | float, int | float, int | float], ...] = (
             (self.maximum_frame_bytes, 512, 65535),
             (self.prefix_scan_bytes, 2, 1024),
             (self.overall_frame_deadline, 1.0, 30.0),
+            (self.maximum_capture_bytes, 1, 64 * 1024 * 1024),
+            (self.maximum_packet_bytes, 1, 4 * 1024 * 1024),
+            (self.maximum_packets, 1, 1_000_000),
+            (self.maximum_flows, 1, 4096),
+            (self.maximum_segments_per_flow, 1, 100_000),
+            (self.maximum_pending_bytes_per_flow, 1, 1024 * 1024),
+            (self.maximum_reassembled_bytes_per_flow, 1, 64 * 1024 * 1024),
+            (self.maximum_aggregate_memory_bytes, 1, 64 * 1024 * 1024),
         )
-        if any(
-            value < minimum or value > maximum for value, minimum, maximum in bounds
-        ):
+        if any(value < low or value > high for value, low, high in bounded):
             raise ValueError("parser policy value outside the internal contract")
 
     @property
     def reassembly_capacity(self) -> int:
-        """Bound pending reassembly under the parser memory budget."""
-        return 16 * 1024
+        return self.maximum_pending_bytes_per_flow
+
+
+@dataclass(slots=True)
+class _MemoryBudget:
+    limit: int
+    retained: int = 0
+
+    def reserve(self, count: int) -> None:
+        if count < 0 or self.retained + count > self.limit:
+            raise CaptureError(FailureReason.CAPACITY)
+        self.retained += count
+
+    def release(self, count: int) -> None:
+        self.retained -= count
+        if self.retained < 0:
+            raise CaptureError(FailureReason.MALFORMED)
 
 
 class StreamFrameDecoder:
-    """Bounded incremental decoder for complete cloud protocol frames."""
-
-    def __init__(self, policy: ParserPolicy | None = None) -> None:
+    def __init__(
+        self,
+        policy: ParserPolicy | None = None,
+        budget: _MemoryBudget | None = None,
+    ) -> None:
         self.policy = policy or ParserPolicy()
+        self._budget = budget or _MemoryBudget(
+            self.policy.maximum_aggregate_memory_bytes
+        )
         self._buffer = bytearray()
         self._prefix_scanned = 0
         self._started_at: float | None = None
 
     @property
     def buffered_bytes(self) -> int:
-        """Return retained bytes for resource-bound assertions."""
         return len(self._buffer)
 
-    def feed(self, data: bytes, *, captured_at: float) -> list[bytes]:
-        """Consume one ordered stream chunk and return every complete frame."""
+    def feed(self, data: Buffer, *, captured_at: float) -> list[bytes]:
+        normalized = bytes(data)
         self._check_deadline(captured_at)
-        if data and self._started_at is None:
+        if normalized and self._started_at is None:
             self._started_at = captured_at
-
         decoded: list[bytes] = []
-        remaining = memoryview(data)
+        offset = 0
         storage_limit = self.policy.maximum_frame_bytes + self.policy.prefix_scan_bytes
-
-        while remaining:
+        while offset < len(normalized):
             room = storage_limit - len(self._buffer)
             if room <= 0:
                 before = len(self._buffer)
@@ -123,17 +237,15 @@ class StreamFrameDecoder:
                 if len(self._buffer) >= before:
                     raise CaptureError(FailureReason.CAPACITY)
                 continue
-
-            take = min(room, len(remaining))
-            self._buffer.extend(remaining[:take])
-            remaining = remaining[take:]
+            take = min(room, len(normalized) - offset)
+            self._budget.reserve(take)
+            self._buffer.extend(normalized[offset : offset + take])
+            offset += take
             decoded.extend(self._extract_available(captured_at))
-
         decoded.extend(self._extract_available(captured_at))
         return decoded
 
     def close(self, *, captured_at: float) -> None:
-        """Finalize at EOF, rejecting any partial prefix, header, or body."""
         self._check_deadline(captured_at)
         self._extract_available(captured_at)
         if self._buffer or self._prefix_scanned:
@@ -148,31 +260,32 @@ class StreamFrameDecoder:
             self._discard()
             raise CaptureError(FailureReason.TIMEOUT)
 
+    def _remove_prefix(self, count: int) -> None:
+        if count:
+            del self._buffer[:count]
+            self._budget.release(count)
+
     def _extract_available(self, captured_at: float) -> list[bytes]:
         frames: list[bytes] = []
         while self._buffer:
             magic_index = self._buffer.find(FRAME_MAGIC)
             if magic_index < 0:
-                retained = 1 if self._buffer[-1:] == FRAME_MAGIC[:1] else 0
+                retained = int(self._buffer[-1:] == FRAME_MAGIC[:1])
                 discarded = len(self._buffer) - retained
                 self._prefix_scanned += discarded
                 if self._prefix_scanned > self.policy.prefix_scan_bytes:
                     self._discard()
                     raise CaptureError(FailureReason.PREFIX)
-                if discarded:
-                    del self._buffer[:discarded]
+                self._remove_prefix(discarded)
                 break
-
             if magic_index:
                 self._prefix_scanned += magic_index
                 if self._prefix_scanned > self.policy.prefix_scan_bytes:
                     self._discard()
                     raise CaptureError(FailureReason.PREFIX)
-                del self._buffer[:magic_index]
-
+                self._remove_prefix(magic_index)
             if len(self._buffer) < 6:
                 break
-
             total_size = 6 + int.from_bytes(self._buffer[4:6], "little")
             if total_size > self.policy.maximum_frame_bytes:
                 self._discard()
@@ -182,118 +295,157 @@ class StreamFrameDecoder:
                 raise CaptureError(FailureReason.MALFORMED)
             if len(self._buffer) < total_size:
                 break
-
             frames.append(bytes(self._buffer[:total_size]))
-            del self._buffer[:total_size]
+            self._remove_prefix(total_size)
             self._prefix_scanned = 0
             self._started_at = captured_at if self._buffer else None
-
         return frames
 
     def _discard(self) -> None:
+        self._budget.release(len(self._buffer))
         self._buffer.clear()
         self._prefix_scanned = 0
         self._started_at = None
 
 
-@dataclass(frozen=True, slots=True)
-class _PendingSegment:
-    captured_at: float
-    payload: bytes
-
-
 class TCPStreamReassembler:
-    """Sequence-aware, duplicate-safe bounded TCP payload reassembler."""
+    """Bounded sequence window with complete byte-overlap validation."""
 
-    def __init__(self, policy: ParserPolicy | None = None) -> None:
+    def __init__(
+        self,
+        policy: ParserPolicy | None = None,
+        budget: _MemoryBudget | None = None,
+    ) -> None:
         self.policy = policy or ParserPolicy()
-        self._next_sequence: int | None = None
-        self._pending: dict[int, _PendingSegment] = {}
-        self._pending_bytes = 0
+        self._budget = budget or _MemoryBudget(
+            self.policy.maximum_aggregate_memory_bytes
+        )
+        self._origin: int | None = None
+        self._history = bytearray()
+        self._window_size = self.policy.maximum_pending_bytes_per_flow + 1
+        self._pending_values = bytearray(self._window_size)
+        self._pending_present = bytearray(self._window_size)
+        self._pending_count = 0
+        self._segment_count = 0
+
+    @property
+    def pending_bytes(self) -> int:
+        return self._pending_count
+
+    @property
+    def retained_bytes(self) -> int:
+        return len(self._history) + self._pending_count
+
+    @property
+    def segment_count(self) -> int:
+        return self._segment_count
+
+    def start(self, sequence: int) -> None:
+        if self._origin is not None or not 0 <= sequence < _SEQUENCE_MODULUS:
+            raise CaptureError(FailureReason.MALFORMED)
+        self._origin = sequence
+
+    def _offset(self, sequence: int) -> int:
+        if self._origin is None:
+            raise CaptureError(FailureReason.TRUNCATED)
+        if not 0 <= sequence < _SEQUENCE_MODULUS:
+            raise CaptureError(FailureReason.MALFORMED)
+        delta = (sequence - self._origin) % _SEQUENCE_MODULUS
+        return delta - _SEQUENCE_MODULUS if delta >= _SEQUENCE_HALF else delta
 
     def push(
-        self, sequence: int, payload: bytes, *, captured_at: float
+        self, sequence: int, payload: Buffer, *, captured_at: float
     ) -> list[tuple[float, bytes]]:
-        """Add a TCP segment and return newly contiguous stream chunks."""
-        if not payload:
+        normalized = bytes(payload)
+        if not normalized:
             return []
-        if sequence < 0:
+        self._segment_count += 1
+        if self._segment_count > self.policy.maximum_segments_per_flow:
+            raise CaptureError(FailureReason.CAPACITY)
+        start = self._offset(sequence)
+        if start < 0:
             raise CaptureError(FailureReason.MALFORMED)
-        if self._next_sequence is None:
-            self._next_sequence = sequence
-
-        assert self._next_sequence is not None
-        segment_end = sequence + len(payload)
-        if segment_end <= self._next_sequence:
-            return []
-        if sequence < self._next_sequence:
-            payload = payload[self._next_sequence - sequence :]
-            sequence = self._next_sequence
-
-        if sequence > self._next_sequence:
-            existing = self._pending.get(sequence)
-            if existing is not None:
-                if existing.payload != payload:
+        contiguous = bytearray()
+        for index, byte in enumerate(normalized):
+            offset = start + index
+            if offset < len(self._history):
+                if self._history[offset] != byte:
                     raise CaptureError(FailureReason.MALFORMED)
-                return []
-            if self._pending_bytes + len(payload) > self.policy.reassembly_capacity:
-                raise CaptureError(FailureReason.CAPACITY)
-            self._pending[sequence] = _PendingSegment(captured_at, payload)
-            self._pending_bytes += len(payload)
-            return []
-
-        chunks = [(captured_at, payload)]
-        self._next_sequence += len(payload)
-        chunks.extend(self._drain_pending(available_at=captured_at))
-        return chunks
-
-    def _drain_pending(self, *, available_at: float) -> list[tuple[float, bytes]]:
-        chunks: list[tuple[float, bytes]] = []
-        assert self._next_sequence is not None
-        while self._pending:
-            sequence = min(self._pending)
-            segment = self._pending[sequence]
-            segment_end = sequence + len(segment.payload)
-            if sequence > self._next_sequence:
-                break
-            del self._pending[sequence]
-            self._pending_bytes -= len(segment.payload)
-            if segment_end <= self._next_sequence:
                 continue
-            overlap = self._next_sequence - sequence
-            payload = segment.payload[overlap:]
-            chunks.append((max(available_at, segment.captured_at), payload))
-            self._next_sequence += len(payload)
+            if offset == len(self._history):
+                if len(self._history) >= self.policy.maximum_reassembled_bytes_per_flow:
+                    raise CaptureError(FailureReason.CAPACITY)
+                self._budget.reserve(1)
+                self._history.append(byte)
+                contiguous.append(byte)
+                while self._pending_present[len(self._history) % self._window_size]:
+                    if (
+                        len(self._history)
+                        >= self.policy.maximum_reassembled_bytes_per_flow
+                    ):
+                        raise CaptureError(FailureReason.CAPACITY)
+                    slot = len(self._history) % self._window_size
+                    pending_byte = self._pending_values[slot]
+                    self._pending_present[slot] = 0
+                    self._pending_count -= 1
+                    self._history.append(pending_byte)
+                    contiguous.append(pending_byte)
+                continue
+            distance = offset - len(self._history)
+            if distance > self.policy.maximum_pending_bytes_per_flow:
+                raise CaptureError(FailureReason.CAPACITY)
+            slot = offset % self._window_size
+            if self._pending_present[slot]:
+                if self._pending_values[slot] != byte:
+                    raise CaptureError(FailureReason.MALFORMED)
+                continue
+            if self._pending_count >= self.policy.maximum_pending_bytes_per_flow:
+                raise CaptureError(FailureReason.CAPACITY)
+            self._budget.reserve(1)
+            self._pending_values[slot] = byte
+            self._pending_present[slot] = 1
+            self._pending_count += 1
+        chunks: list[tuple[float, bytes]] = []
+        if contiguous:
+            chunks.append((captured_at, bytes(contiguous)))
         return chunks
 
     def close(self) -> None:
-        """Reject a stream ending with an unresolved sequence gap."""
-        if self._pending:
-            self._pending.clear()
-            self._pending_bytes = 0
+        retained = self.retained_bytes
+        has_gap = bool(self._pending_count)
+        self._pending_present.clear()
+        self._pending_values.clear()
+        self._pending_count = 0
+        self._history.clear()
+        self._budget.release(retained)
+        if has_gap:
             raise CaptureError(FailureReason.TRUNCATED)
 
 
 @dataclass(frozen=True, slots=True)
 class CapturedSegment:
-    """One offline TCP payload with only in-memory capture metadata."""
-
     direction: str
     sequence: int
     captured_at: float
     payload: bytes
     stream_id: int = 0
+    starts_stream: bool = False
 
 
 @dataclass(slots=True)
 class _DirectionState:
     reassembler: TCPStreamReassembler
     decoder: StreamFrameDecoder
-    source_identity: bytes | None = None
+
+
+@dataclass(slots=True)
+class _SessionState:
+    directions: dict[str, _DirectionState] = field(default_factory=dict)
+    outer_identity: bytes | None = None
+    inner_identity: bytes | None = None
 
 
 def find_frames(data: bytes) -> list[tuple[int, bytes]]:
-    """Compatibility helper using the same bounded streaming decoder."""
     decoder = StreamFrameDecoder()
     frames = decoder.feed(data, captured_at=0.0)
     result: list[tuple[int, bytes]] = []
@@ -312,46 +464,64 @@ def _validated_identity(raw: bytes) -> bytes:
         text = raw.decode("ascii")
     except UnicodeDecodeError as error:
         raise CaptureError(FailureReason.IDENTITY) from error
-    if not all(character.isalnum() for character in text):
+    if not text.isalnum():
         raise CaptureError(FailureReason.IDENTITY)
     return raw
+
+
+def _bind_identity(current: bytes | None, candidate: bytes) -> bytes:
+    validated = _validated_identity(candidate)
+    if current is not None and current != validated:
+        raise CaptureError(FailureReason.IDENTITY)
+    return validated
 
 
 def _validate_crc(frame: bytes) -> None:
     if len(frame) < 3:
         raise CaptureError(FailureReason.MALFORMED)
-    actual = int.from_bytes(frame[-2:], "little")
-    if actual != compute_crc16(frame[:-2]):
+    if int.from_bytes(frame[-2:], "little") != compute_crc16(frame[:-2]):
         raise CaptureError(FailureReason.CRC)
 
 
+def _alias(identity: bytes, identities: dict[bytes, str], prefix: str) -> str:
+    existing = identities.get(identity)
+    if existing is not None:
+        return existing
+    if len(identities) >= 999:
+        raise CaptureError(FailureReason.CAPACITY)
+    alias = f"{prefix}{len(identities) + 1:03d}"
+    identities[identity] = alias
+    return alias
+
+
+def _inner_function_name(function: int) -> str:
+    return "read_holding" if function == 0x03 else "read_input"
+
+
 def _sanitize_frame(
-    frame: bytes, direction: str, state: _DirectionState
+    frame: bytes,
+    direction: str,
+    session: _SessionState,
+    dongle_identities: dict[bytes, str],
+    inverter_identities: dict[bytes, str],
 ) -> dict[str, Any]:
     if len(frame) < 19 or 6 + int.from_bytes(frame[4:6], "little") != len(frame):
         raise CaptureError(FailureReason.MALFORMED)
-
-    outer_identity = _validated_identity(frame[8:18])
-    if state.source_identity is None:
-        state.source_identity = outer_identity
-    elif state.source_identity != outer_identity:
-        raise CaptureError(FailureReason.IDENTITY)
-
-    function = frame[7]
-    payload = frame[18:]
+    session.outer_identity = _bind_identity(session.outer_identity, frame[8:18])
     base: dict[str, Any] = {
         "direction": direction,
-        "identity": SYNTHETIC_DONGLE_IDENTITY,
+        "identity": _alias(session.outer_identity, dongle_identities, "SYNTHDG"),
     }
+    function = frame[7]
+    payload = frame[18:]
     if function == 0xC1:
         if not payload:
             raise CaptureError(FailureReason.MALFORMED)
         return base | {"function": "heartbeat", "payload": "SYNTHETIC_STATUS"}
-    if function != 0xC2:
-        raise CaptureError(FailureReason.FUNCTION)
-    if len(payload) < 2:
-        raise CaptureError(FailureReason.MALFORMED)
-
+    if function != 0xC2 or len(payload) < 2:
+        raise CaptureError(
+            FailureReason.FUNCTION if function != 0xC2 else FailureReason.MALFORMED
+        )
     inner_size = int.from_bytes(payload[:2], "little")
     inner = payload[2:]
     if inner_size != len(inner) or len(inner) < 17:
@@ -361,9 +531,9 @@ def _sanitize_frame(
         raise CaptureError(FailureReason.FUNCTION)
     if inner[0] != frame[6]:
         raise CaptureError(FailureReason.IDENTITY)
-    _validated_identity(inner[2:12])
+    session.inner_identity = _bind_identity(session.inner_identity, inner[2:12])
+    inner_alias = _alias(session.inner_identity, inverter_identities, "SYNTHIV")
     start_register = int.from_bytes(inner[12:14], "little")
-
     if len(inner) == 18:
         register_count = int.from_bytes(inner[14:16], "little")
         if register_count < 1 or start_register + register_count > 65536:
@@ -371,15 +541,14 @@ def _sanitize_frame(
         _validate_crc(inner)
         return base | {
             "function": "data_read_request",
-            "inner_identity": SYNTHETIC_INVERTER_IDENTITY,
+            "inner_identity": inner_alias,
             "inner_function": _inner_function_name(inner_function),
             "start_register": start_register,
             "register_count": register_count,
             "register_words": [],
         }
-
     byte_count = inner[14]
-    if byte_count < 2 or byte_count % 2 or len(inner) != 15 + byte_count + 2:
+    if byte_count < 2 or byte_count % 2 or len(inner) != 17 + byte_count:
         raise CaptureError(FailureReason.RANGE)
     register_count = byte_count // 2
     if start_register + register_count > 65536:
@@ -387,7 +556,7 @@ def _sanitize_frame(
     _validate_crc(inner)
     return base | {
         "function": "data_read_response",
-        "inner_identity": SYNTHETIC_INVERTER_IDENTITY,
+        "inner_identity": inner_alias,
         "inner_function": _inner_function_name(inner_function),
         "start_register": start_register,
         "register_count": register_count,
@@ -395,49 +564,64 @@ def _sanitize_frame(
     }
 
 
-def _inner_function_name(function: int) -> str:
-    return "read_holding" if function == 0x03 else "read_input"
+def _new_direction(policy: ParserPolicy, budget: _MemoryBudget) -> _DirectionState:
+    return _DirectionState(
+        TCPStreamReassembler(policy, budget), StreamFrameDecoder(policy, budget)
+    )
 
 
 def sanitize_segments(
     segments: Iterable[CapturedSegment], policy: ParserPolicy | None = None
 ) -> dict[str, Any]:
-    """Reassemble, parse, and sanitize authorized offline TCP payloads."""
     active_policy = policy or ParserPolicy()
-    states: dict[tuple[int, str], _DirectionState] = {}
+    budget = _MemoryBudget(active_policy.maximum_aggregate_memory_bytes)
+    sessions: dict[int, _SessionState] = {}
     records: list[dict[str, Any]] = []
     record_keys: set[str] = set()
+    dongle_identities: dict[bytes, str] = {}
+    inverter_identities: dict[bytes, str] = {}
     last_timestamp: dict[tuple[int, str], float] = {}
-
     for segment in segments:
         if segment.direction not in ("dongle_to_cloud", "cloud_to_dongle"):
             raise CaptureError(FailureReason.MALFORMED)
-        state_key = (segment.stream_id, segment.direction)
-        state = states.setdefault(
-            state_key,
-            _DirectionState(
-                TCPStreamReassembler(active_policy), StreamFrameDecoder(active_policy)
-            ),
-        )
-        last_timestamp[state_key] = segment.captured_at
+        session = sessions.get(segment.stream_id)
+        if session is None:
+            if len(sessions) >= active_policy.maximum_flows:
+                raise CaptureError(FailureReason.CAPACITY)
+            session = _SessionState()
+            sessions[segment.stream_id] = session
+        state = session.directions.get(segment.direction)
+        if state is None:
+            state = _new_direction(active_policy, budget)
+            session.directions[segment.direction] = state
+        if segment.starts_stream:
+            state.reassembler.start(segment.sequence)
+        last_timestamp[(segment.stream_id, segment.direction)] = segment.captured_at
         for captured_at, chunk in state.reassembler.push(
             segment.sequence, segment.payload, captured_at=segment.captured_at
         ):
             for frame in state.decoder.feed(chunk, captured_at=captured_at):
-                record = _sanitize_frame(frame, segment.direction, state)
-                record_key = json.dumps(record, sort_keys=True, separators=(",", ":"))
-                if record_key in record_keys:
+                record = _sanitize_frame(
+                    frame,
+                    segment.direction,
+                    session,
+                    dongle_identities,
+                    inverter_identities,
+                )
+                key = json.dumps(record, sort_keys=True, separators=(",", ":"))
+                if key in record_keys:
                     continue
                 if len(records) >= MAX_SANITIZED_RECORDS:
                     raise CaptureError(FailureReason.CAPACITY)
-                record_keys.add(record_key)
+                record_keys.add(key)
                 records.append(record)
-
-    for state_key, state in states.items():
-        state.reassembler.close()
-        state.decoder.close(captured_at=last_timestamp[state_key])
-
-    return {
+    for stream_id, session in sessions.items():
+        for direction, state in session.directions.items():
+            state.reassembler.close()
+            state.decoder.close(captured_at=last_timestamp[(stream_id, direction)])
+    if not records:
+        raise CaptureError(FailureReason.EMPTY)
+    result: dict[str, Any] = {
         "schema_version": 1,
         "capture": {
             "source": "authorized_offline_input",
@@ -446,68 +630,257 @@ def sanitize_segments(
         },
         "frames": records,
     }
+    _validate_synthetic_output(result)
+    return result
 
 
-def _extract_ip_from_buf(buf: bytes, link_type: int) -> Any | None:
-    """Extract IPv4 data from supported offline PCAP link layers."""
-    if dpkt is None:
-        raise RuntimeError("optional PCAP dependency unavailable")
+def _exact_keys(value: object, expected: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise CaptureError(FailureReason.SCHEMA)
+    return cast(dict[str, Any], value)
+
+
+def _validate_synthetic_output(value: object) -> None:
+    root = _exact_keys(value, {"schema_version", "capture", "frames"})
+    if root["schema_version"] != 1 or not isinstance(root["frames"], list):
+        raise CaptureError(FailureReason.SCHEMA)
+    capture = _exact_keys(
+        root["capture"], {"source", "dongle_address", "cloud_address"}
+    )
+    if capture != {
+        "source": "authorized_offline_input",
+        "dongle_address": DOCUMENTATION_DONGLE_ADDRESS,
+        "cloud_address": DOCUMENTATION_CLOUD_ADDRESS,
+    }:
+        raise CaptureError(FailureReason.SCHEMA)
+    for raw_frame in root["frames"]:
+        frame = cast(dict[str, Any], raw_frame) if isinstance(raw_frame, dict) else {}
+        function = frame.get("function")
+        common = {"direction", "identity", "function"}
+        expected = common | (
+            {"payload"}
+            if function == "heartbeat"
+            else {
+                "inner_identity",
+                "inner_function",
+                "start_register",
+                "register_count",
+                "register_words",
+            }
+        )
+        frame = _exact_keys(raw_frame, expected)
+        if frame["direction"] not in ("dongle_to_cloud", "cloud_to_dongle"):
+            raise CaptureError(FailureReason.SCHEMA)
+        identity = frame["identity"]
+        if not isinstance(identity, str) or _DONGLE_ALIAS.fullmatch(identity) is None:
+            raise CaptureError(FailureReason.SCHEMA)
+        if function == "heartbeat":
+            if frame["payload"] != "SYNTHETIC_STATUS":
+                raise CaptureError(FailureReason.SCHEMA)
+            continue
+        if function not in ("data_read_request", "data_read_response"):
+            raise CaptureError(FailureReason.SCHEMA)
+        inner_identity = frame["inner_identity"]
+        if (
+            not isinstance(inner_identity, str)
+            or _INVERTER_ALIAS.fullmatch(inner_identity) is None
+            or frame["inner_function"] not in ("read_holding", "read_input")
+        ):
+            raise CaptureError(FailureReason.SCHEMA)
+        start = frame["start_register"]
+        count = frame["register_count"]
+        words = frame["register_words"]
+        if (
+            not isinstance(start, int)
+            or isinstance(start, bool)
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count < 1
+            or start < 0
+            or start + count > 65536
+            or not isinstance(words, list)
+            or words not in ([], [SYNTHETIC_REGISTER_WORD])
+            or (function == "data_read_request" and words)
+            or (function == "data_read_response" and not words)
+        ):
+            raise CaptureError(FailureReason.SCHEMA)
+
+
+def _stat_signature(file_stat: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_mode,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+    )
+
+
+def _read_stable_capture(path: Path, policy: ParserPolicy) -> bytes:
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0)
     try:
-        if link_type == dpkt.pcap.DLT_EN10MB:
-            link_packet = dpkt.ethernet.Ethernet(buf)
-        elif link_type == dpkt.pcap.DLT_LINUX_SLL:
-            link_packet = dpkt.sll.SLL(buf)
-        elif link_type == dpkt.pcap.DLT_LINUX_SLL2:
-            link_packet = dpkt.sll2.SLL2(buf)
-        else:
-            return None
-        return link_packet.data if isinstance(link_packet.data, dpkt.ip.IP) else None
-    except (dpkt.dpkt.NeedData, dpkt.dpkt.UnpackError):
-        return None
-
-
-def _pcap_segments(pcap_path: Path) -> Iterable[CapturedSegment]:
-    if dpkt is None:
-        raise RuntimeError("optional PCAP dependency unavailable")
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise CaptureError(FailureReason.INPUT_KIND) from error
     try:
-        with pcap_path.open("rb") as capture_file:
-            reader = dpkt.pcap.UniversalReader(capture_file)
-            link_type = reader.datalink()
-            stream_ids: dict[tuple[bytes, int, bytes, int], int] = {}
-            next_stream_id = 0
-            for timestamp, packet_buffer in reader:
-                ip_packet = _extract_ip_from_buf(packet_buffer, link_type)
-                if ip_packet is None or not isinstance(ip_packet.data, dpkt.tcp.TCP):
-                    continue
-                tcp = ip_packet.data
-                if tcp.dport == 4346:
-                    direction = "dongle_to_cloud"
-                elif tcp.sport == 4346:
-                    direction = "cloud_to_dongle"
-                else:
-                    continue
-                flow_key = (ip_packet.src, tcp.sport, ip_packet.dst, tcp.dport)
-                if tcp.flags & dpkt.tcp.TH_SYN or flow_key not in stream_ids:
-                    stream_ids[flow_key] = next_stream_id
-                    next_stream_id += 1
-                if not tcp.data:
-                    continue
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise CaptureError(FailureReason.INPUT_KIND)
+        if before.st_size > policy.maximum_capture_bytes:
+            raise CaptureError(FailureReason.INPUT_SIZE)
+        chunks: list[bytes] = []
+        remaining = policy.maximum_capture_bytes + 1
+        while remaining:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        capture = b"".join(chunks)
+        after = os.fstat(descriptor)
+        try:
+            by_name = os.stat(path, follow_symlinks=False)
+        except OSError as error:
+            raise CaptureError(FailureReason.INPUT_CHANGED) from error
+        if len(capture) > policy.maximum_capture_bytes:
+            raise CaptureError(FailureReason.INPUT_SIZE)
+        if (
+            len(capture) != before.st_size
+            or _stat_signature(before) != _stat_signature(after)
+            or _stat_signature(after) != _stat_signature(by_name)
+        ):
+            raise CaptureError(FailureReason.INPUT_CHANGED)
+        return capture
+    except OSError as error:
+        raise CaptureError(FailureReason.INPUT_CHANGED) from error
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as error:
+            raise CaptureError(FailureReason.INPUT_CHANGED) from error
+
+
+def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
+    module = dpkt
+    if module is None:
+        raise CaptureError(FailureReason.DEPENDENCY)
+    factories: dict[int, _PacketFactory] = {
+        module.pcap.DLT_EN10MB: module.ethernet.Ethernet,
+        module.pcap.DLT_LINUX_SLL: module.sll.SLL,
+        module.pcap.DLT_LINUX_SLL2: module.sll2.SLL2,
+    }
+    factory = factories.get(link_type)
+    if factory is None:
+        raise CaptureError(FailureReason.UNSUPPORTED_LINK)
+    try:
+        link_packet = factory(packet)
+    except Exception as error:
+        raise CaptureError(FailureReason.MALFORMED) from error
+    data = link_packet.data
+    if isinstance(data, module.ip.IP):
+        return cast(_IPPacket, data)
+    return None
+
+
+@dataclass(slots=True)
+class _ObservedSession:
+    stream_id: int
+    client_started: bool = True
+    server_started: bool = False
+
+
+def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSegment]:
+    module = dpkt
+    if module is None:
+        raise CaptureError(FailureReason.DEPENDENCY)
+    try:
+        reader = module.pcap.UniversalReader(io.BytesIO(capture))
+        link_type = reader.datalink()
+    except Exception as error:
+        raise CaptureError(FailureReason.MALFORMED) from error
+    supported = {
+        module.pcap.DLT_EN10MB,
+        module.pcap.DLT_LINUX_SLL,
+        module.pcap.DLT_LINUX_SLL2,
+    }
+    if link_type not in supported:
+        raise CaptureError(FailureReason.UNSUPPORTED_LINK)
+    sessions: dict[tuple[bytes, int, bytes, int], _ObservedSession] = {}
+    next_stream_id = 0
+    packet_count = 0
+    try:
+        for timestamp, raw_packet in reader:
+            packet_count += 1
+            if packet_count > policy.maximum_packets:
+                raise CaptureError(FailureReason.CAPACITY)
+            packet = bytes(raw_packet)
+            if len(packet) > policy.maximum_packet_bytes:
+                raise CaptureError(FailureReason.CAPACITY)
+            ip_packet = _decode_link_packet(packet, link_type)
+            if ip_packet is None:
+                continue
+            if ip_packet.p != module.ip.IP_PROTO_TCP:
+                continue
+            if not isinstance(ip_packet.data, module.tcp.TCP):
+                raise CaptureError(FailureReason.MALFORMED)
+            tcp = cast(_TCPPacket, ip_packet.data)
+            if tcp.dport == 4346:
+                direction = "dongle_to_cloud"
+                key = (bytes(ip_packet.src), tcp.sport, bytes(ip_packet.dst), tcp.dport)
+                client_side = True
+            elif tcp.sport == 4346:
+                direction = "cloud_to_dongle"
+                key = (bytes(ip_packet.dst), tcp.dport, bytes(ip_packet.src), tcp.sport)
+                client_side = False
+            else:
+                continue
+            syn = bool(tcp.flags & module.tcp.TH_SYN)
+            ack = bool(tcp.flags & module.tcp.TH_ACK)
+            session = sessions.get(key)
+            starts_stream = False
+            sequence = tcp.seq
+            if client_side and syn and not ack:
+                session = _ObservedSession(next_stream_id)
+                sessions[key] = session
+                next_stream_id += 1
+                starts_stream = True
+                sequence = (sequence + 1) % _SEQUENCE_MODULUS
+            elif not client_side and syn and ack and session is not None:
+                if session.server_started:
+                    raise CaptureError(FailureReason.MALFORMED)
+                session.server_started = True
+                starts_stream = True
+                sequence = (sequence + 1) % _SEQUENCE_MODULUS
+            elif session is None:
+                raise CaptureError(FailureReason.TRUNCATED)
+            elif client_side and not session.client_started:
+                raise CaptureError(FailureReason.TRUNCATED)
+            elif not client_side and not session.server_started:
+                raise CaptureError(FailureReason.TRUNCATED)
+            assert session is not None
+            payload = bytes(tcp.data)
+            if starts_stream or payload:
                 yield CapturedSegment(
                     direction,
-                    tcp.seq,
+                    sequence,
                     float(timestamp),
-                    bytes(tcp.data),
-                    stream_ids[flow_key],
+                    payload,
+                    session.stream_id,
+                    starts_stream,
                 )
-    except (OSError, ValueError, dpkt.dpkt.Error) as error:
+    except CaptureError:
+        raise
+    except Exception as error:
         raise CaptureError(FailureReason.MALFORMED) from error
 
 
 def process_pcap(
     pcap_path: str | Path, policy: ParserPolicy | None = None
 ) -> dict[str, Any]:
-    """Sanitize one authorized capture without retaining raw capture data."""
-    return sanitize_segments(_pcap_segments(Path(pcap_path)), policy)
+    active_policy = policy or ParserPolicy()
+    capture = _read_stable_capture(Path(pcap_path), active_policy)
+    return sanitize_segments(_pcap_segments(capture, active_policy), active_policy)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -527,25 +900,60 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _serialize_output(value: object) -> bytes:
+    _validate_synthetic_output(value)
+    return (json.dumps(value, indent=2) + "\n").encode()
+
+
+def _write_exclusive(path: Path, content: bytes) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | os.O_CLOEXEC
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor: int | None = None
+    created: tuple[int, int] | None = None
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        opened = os.fstat(descriptor)
+        created = (opened.st_dev, opened.st_ino)
+        if os.write(descriptor, content) != len(content):
+            raise CaptureError(FailureReason.OUTPUT)
+        os.fsync(descriptor)
+    except FileExistsError:
+        raise
+    except (CaptureError, OSError) as error:
+        if descriptor is not None:
+            os.close(descriptor)
+            descriptor = None
+        if created is not None:
+            try:
+                current = os.stat(path, follow_symlinks=False)
+                if (current.st_dev, current.st_ino) == created:
+                    path.unlink()
+            except OSError:
+                pass
+        if isinstance(error, CaptureError):
+            raise
+        raise CaptureError(FailureReason.OUTPUT) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Run the offline-only sanitizer with redacted status output."""
     arguments = _parse_args(argv)
     try:
         sanitized = process_pcap(arguments.input)
-        with arguments.output.open("x", encoding="utf-8") as output_file:
-            json.dump(sanitized, output_file, indent=2)
-            output_file.write("\n")
+        serialized = _serialize_output(sanitized)
+        _write_exclusive(arguments.output, serialized)
     except FileExistsError:
         print("capture rejected: output_exists", file=sys.stderr)
         return 2
-    except (CaptureError, OSError, RuntimeError) as error:
-        if isinstance(error, CaptureError):
-            message = str(error)
-        elif isinstance(error, RuntimeError):
-            message = "capture rejected: dependency"
-        else:
-            message = "capture rejected: input"
-        print(message, file=sys.stderr)
+    except CaptureError as error:
+        print(str(error), file=sys.stderr)
         return 2
     print(f"synthetic fixture written: {len(sanitized['frames'])} frame classes")
     return 0

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -18,8 +18,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from importlib import import_module
 from pathlib import Path
-from types import ModuleType
-from typing import Any, BinaryIO, Final, Protocol, cast
+from typing import Any, BinaryIO, Final, Never, Protocol, cast
 
 
 class _CaptureReader(Protocol):
@@ -51,6 +50,7 @@ class _TCPPacket(Protocol):
     sport: int
     dport: int
     seq: int
+    ack: int
     flags: int
     opts: Buffer
     data: Buffer
@@ -80,6 +80,10 @@ class _IPNamespace(Protocol):
     IP_PROTO_TCP: int
 
 
+class _IP6Namespace(Protocol):
+    IP6: type
+
+
 class _TCPNamespace(Protocol):
     TCP: type
     TH_ACK: int
@@ -94,6 +98,7 @@ class _DPKT(Protocol):
     sll: _SLLNamespace
     sll2: _SLL2Namespace
     ip: _IPNamespace
+    ip6: _IP6Namespace
     tcp: _TCPNamespace
 
 
@@ -102,7 +107,7 @@ def _load_dpkt() -> _DPKT | None:
         module = import_module("dpkt")
     except ImportError:
         return None
-    return cast(_DPKT, cast(ModuleType, module))
+    return cast(_DPKT, module)
 
 
 dpkt = _load_dpkt()
@@ -150,6 +155,7 @@ class FailureReason(StrEnum):
     """Bounded failure categories that never contain captured values."""
 
     CAPACITY = "capacity"
+    CLI = "cli"
     CRC = "crc"
     DEPENDENCY = "dependency"
     EMPTY = "empty"
@@ -158,6 +164,7 @@ class FailureReason(StrEnum):
     INPUT_CHANGED = "input_changed"
     INPUT_KIND = "input_kind"
     INPUT_SIZE = "input_size"
+    IP_VERSION = "ip_version"
     MALFORMED = "malformed"
     OUTPUT = "output"
     OUTPUT_EXISTS = "output_exists"
@@ -220,6 +227,10 @@ class _MemoryBudget:
     limit: int
     retained: int = 0
 
+    @property
+    def available(self) -> int:
+        return self.limit - self.retained
+
     def reserve(self, count: int) -> None:
         if count < 0 or self.retained + count > self.limit:
             raise CaptureError(FailureReason.CAPACITY)
@@ -229,6 +240,86 @@ class _MemoryBudget:
         self.retained -= count
         if self.retained < 0:
             raise CaptureError(FailureReason.MALFORMED)
+
+
+class _ChargedRingBuffer:
+    """Lazy fixed-capacity ring whose whole allocation is budgeted up front."""
+
+    def __init__(self, capacity: int, budget: _MemoryBudget) -> None:
+        self._capacity = capacity
+        self._budget = budget
+        self._data: bytearray | None = None
+        self._head = 0
+        self._size = 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    @property
+    def allocated_bytes(self) -> int:
+        return self._capacity if self._data is not None else 0
+
+    def _ensure_allocated(self) -> bytearray:
+        if self._data is None:
+            self._budget.reserve(self._capacity)
+            try:
+                self._data = bytearray(self._capacity)
+            except MemoryError:
+                self._budget.release(self._capacity)
+                raise CaptureError(FailureReason.CAPACITY) from None
+        return self._data
+
+    def byte_at(self, index: int) -> int:
+        if not 0 <= index < self._size or self._data is None:
+            raise CaptureError(FailureReason.MALFORMED)
+        return self._data[(self._head + index) % self._capacity]
+
+    def append(self, value: Buffer) -> None:
+        view = memoryview(value).cast("B")
+        if len(view) > self._capacity - self._size:
+            raise CaptureError(FailureReason.CAPACITY)
+        if not view:
+            return
+        data = self._ensure_allocated()
+        tail = (self._head + self._size) % self._capacity
+        first = min(len(view), self._capacity - tail)
+        data[tail : tail + first] = view[:first]
+        data[: len(view) - first] = view[first:]
+        self._size += len(view)
+
+    def find(self, value: bytes) -> int:
+        if not value:
+            return 0
+        limit = self._size - len(value) + 1
+        for index in range(max(0, limit)):
+            if all(
+                self.byte_at(index + offset) == byte
+                for offset, byte in enumerate(value)
+            ):
+                return index
+        return -1
+
+    def to_bytes(self, start: int = 0, count: int | None = None) -> bytes:
+        length = self._size - start if count is None else count
+        if start < 0 or length < 0 or start + length > self._size:
+            raise CaptureError(FailureReason.MALFORMED)
+        return bytes(self.byte_at(start + offset) for offset in range(length))
+
+    def discard(self, count: int) -> None:
+        if not 0 <= count <= self._size:
+            raise CaptureError(FailureReason.MALFORMED)
+        if self._capacity:
+            self._head = (self._head + count) % self._capacity
+        self._size -= count
+        if not self._size:
+            self._head = 0
+
+    def release(self) -> None:
+        if self._data is not None:
+            self._data = None
+            self._budget.release(self._capacity)
+        self._head = 0
+        self._size = 0
 
 
 class StreamFrameDecoder:
@@ -241,7 +332,10 @@ class StreamFrameDecoder:
         self._budget = budget or _MemoryBudget(
             self.policy.maximum_aggregate_memory_bytes
         )
-        self._buffer = b""
+        self._buffer = _ChargedRingBuffer(
+            self.policy.maximum_frame_bytes + self.policy.prefix_scan_bytes,
+            self._budget,
+        )
         self._prefix_scanned = 0
         self._started_at: float | None = None
         self._last_captured_at: float | None = None
@@ -281,8 +375,7 @@ class StreamFrameDecoder:
                     raise CaptureError(FailureReason.CAPACITY)
                 continue
             take = min(room, len(normalized) - offset)
-            self._budget.reserve(take)
-            self._buffer += normalized[offset : offset + take]
+            self._buffer.append(normalized[offset : offset + take])
             offset += take
             decoded.extend(self._extract_available(captured_at))
         decoded.extend(self._extract_available(captured_at))
@@ -292,9 +385,10 @@ class StreamFrameDecoder:
         self._validate_timestamp(captured_at)
         self._check_deadline(captured_at)
         self._extract_available(captured_at)
-        if self._buffer or self._prefix_scanned:
+        if len(self._buffer) or self._prefix_scanned:
             self._discard()
             raise CaptureError(FailureReason.TRUNCATED)
+        self._buffer.release()
 
     def _check_deadline(self, captured_at: float) -> None:
         if (
@@ -313,15 +407,17 @@ class StreamFrameDecoder:
 
     def _remove_prefix(self, count: int) -> None:
         if count:
-            self._buffer = self._buffer[count:]
-            self._budget.release(count)
+            self._buffer.discard(count)
 
     def _extract_available(self, captured_at: float) -> list[bytes]:
         frames: list[bytes] = []
-        while self._buffer:
+        while len(self._buffer):
             magic_index = self._buffer.find(FRAME_MAGIC)
             if magic_index < 0:
-                retained = int(self._buffer[-1:] == FRAME_MAGIC[:1])
+                retained = int(
+                    len(self._buffer) > 0
+                    and self._buffer.byte_at(len(self._buffer) - 1) == FRAME_MAGIC[0]
+                )
                 discarded = len(self._buffer) - retained
                 self._prefix_scanned += discarded
                 if self._prefix_scanned > self.policy.prefix_scan_bytes:
@@ -337,7 +433,7 @@ class StreamFrameDecoder:
                 self._remove_prefix(magic_index)
             if len(self._buffer) < 6:
                 break
-            total_size = 6 + int.from_bytes(self._buffer[4:6], "little")
+            total_size = 6 + int.from_bytes(self._buffer.to_bytes(4, 2), "little")
             if total_size > self.policy.maximum_frame_bytes:
                 self._discard()
                 raise CaptureError(FailureReason.OVERSIZE)
@@ -346,15 +442,14 @@ class StreamFrameDecoder:
                 raise CaptureError(FailureReason.MALFORMED)
             if len(self._buffer) < total_size:
                 break
-            frames.append(bytes(self._buffer[:total_size]))
+            frames.append(self._buffer.to_bytes(0, total_size))
             self._remove_prefix(total_size)
             self._prefix_scanned = 0
-            self._started_at = captured_at if self._buffer else None
+            self._started_at = captured_at if len(self._buffer) else None
         return frames
 
     def _discard(self) -> None:
-        self._budget.release(len(self._buffer))
-        self._buffer = b""
+        self._buffer.release()
         self._prefix_scanned = 0
         self._started_at = None
 
@@ -374,7 +469,12 @@ class TCPStreamReassembler:
         self._origin: int | None = None
         self._assembled_bytes = 0
         self._history_start = 0
-        self._history = b""
+        history_capacity = min(
+            self.policy.maximum_packet_bytes,
+            self.policy.maximum_reassembled_bytes_per_flow,
+            16 * 1024,
+        )
+        self._history = _ChargedRingBuffer(history_capacity, self._budget)
         self._pending: dict[int, int] | None = None
         self._segment_count = 0
         self._started_at: float | None = None
@@ -387,7 +487,7 @@ class TCPStreamReassembler:
 
     @property
     def retained_bytes(self) -> int:
-        return len(self._history) + self.pending_bytes
+        return self._history.allocated_bytes + self.pending_bytes
 
     @property
     def segment_count(self) -> int:
@@ -418,6 +518,8 @@ class TCPStreamReassembler:
         normalized = bytes(payload)
         if not normalized:
             return []
+        if len(normalized) > self._budget.available:
+            raise CaptureError(FailureReason.CAPACITY)
         if self._started_at is None:
             self._started_at = captured_at
         elif captured_at - self._started_at > self.policy.overall_frame_deadline:
@@ -437,7 +539,7 @@ class TCPStreamReassembler:
         for index, byte in enumerate(normalized):
             offset = start + index
             if offset < self._assembled_bytes:
-                if self._history[offset - self._history_start] != byte:
+                if self._history.byte_at(offset - self._history_start) != byte:
                     raise CaptureError(FailureReason.MALFORMED)
                 continue
             existing = pending.get(offset) if pending is not None else None
@@ -464,7 +566,6 @@ class TCPStreamReassembler:
                         pending[offset] = byte
                 self._pending = pending
         else:
-            self._budget.reserve(new_bytes)
             while self._assembled_bytes < end:
                 pending_byte = (
                     pending.pop(self._assembled_bytes)
@@ -489,15 +590,17 @@ class TCPStreamReassembler:
         overlap_limit = min(
             self.policy.maximum_packet_bytes,
             self.policy.maximum_reassembled_bytes_per_flow,
+            16 * 1024,
         )
-        combined_history = self._history + bytes(contiguous)
-        expired = len(combined_history) - overlap_limit
+        expired = max(0, len(self._history) + len(contiguous) - overlap_limit)
+        contiguous_history_start = 0
         if expired > 0:
-            self._history = combined_history[expired:]
+            from_history = min(expired, len(self._history))
+            self._history.discard(from_history)
+            if expired > from_history:
+                contiguous_history_start = expired - from_history
             self._history_start += expired
-            self._budget.release(expired)
-        else:
-            self._history = combined_history
+        self._history.append(memoryview(contiguous)[contiguous_history_start:])
         chunks: list[tuple[float, bytes]] = []
         if contiguous:
             assert self._started_at is not None
@@ -521,11 +624,9 @@ class TCPStreamReassembler:
         self._last_captured_at = captured_at
 
     def _clear(self) -> None:
-        retained = len(self._history) + (
-            self.pending_bytes * _PENDING_BYTE_MEMORY_CHARGE
-        )
+        retained = self.pending_bytes * _PENDING_BYTE_MEMORY_CHARGE
         self._pending = None
-        self._history = b""
+        self._history.release()
         self._budget.release(retained)
         self._started_at = None
 
@@ -899,6 +1000,17 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
     data = link_packet.data
     if isinstance(data, module.ip.IP):
         return cast(_IPPacket, data)
+    if isinstance(data, module.ip6.IP6):
+        ip6_packet = cast(_IPPacket, data)
+        transport_data = ip6_packet.data
+        if isinstance(transport_data, module.tcp.TCP):
+            transport = cast(_TCPPacket, transport_data)
+        else:
+            transport = None
+        if transport is not None and (
+            transport.sport == 4346 or transport.dport == 4346
+        ):
+            raise CaptureError(FailureReason.IP_VERSION)
     return None
 
 
@@ -906,10 +1018,13 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
 class _ObservedSession:
     stream_id: int
     client_initial_sequence: int
-    client_handshake: tuple[int, bytes, bytes]
+    client_handshake: tuple[int, int, bytes, bytes]
     server_initial_sequence: int | None = None
-    server_handshake: tuple[int, bytes, bytes] | None = None
+    server_handshake: tuple[int, int, bytes, bytes] | None = None
     application_started: bool = False
+    client_terminal: tuple[int, int, int, bytes, bytes] | None = None
+    server_terminal: tuple[int, int, int, bytes, bytes] | None = None
+    reset_terminal: tuple[bool, int, int, int, bytes, bytes] | None = None
 
 
 def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSegment]:
@@ -975,7 +1090,8 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
             starts_stream = False
             sequence = tcp.seq
             payload = bytes(tcp.data)
-            handshake = (tcp.flags, bytes(tcp.opts), payload)
+            options = bytes(tcp.opts)
+            handshake = (tcp.flags, tcp.ack, options, payload)
             has_terminal_flag = bool(
                 tcp.flags & (module.tcp.TH_FIN | module.tcp.TH_RST)
             )
@@ -984,7 +1100,7 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
                     if handshake != session.client_handshake:
                         raise CaptureError(FailureReason.MALFORMED)
                     continue
-                if has_terminal_flag:
+                if tcp.ack or payload or has_terminal_flag:
                     raise CaptureError(FailureReason.MALFORMED)
                 if session is not None and not session.application_started:
                     raise CaptureError(FailureReason.MALFORMED)
@@ -998,7 +1114,11 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
                     if handshake != session.server_handshake:
                         raise CaptureError(FailureReason.MALFORMED)
                     continue
-                if has_terminal_flag:
+                if (
+                    tcp.ack != (session.client_initial_sequence + 1) % _SEQUENCE_MODULUS
+                    or payload
+                    or has_terminal_flag
+                ):
                     raise CaptureError(FailureReason.MALFORMED)
                 if session.server_initial_sequence is not None:
                     raise CaptureError(FailureReason.MALFORMED)
@@ -1011,6 +1131,34 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
             ):
                 raise CaptureError(FailureReason.TRUNCATED)
             assert session is not None
+            if syn and not starts_stream:
+                raise CaptureError(FailureReason.MALFORMED)
+            terminal = (sequence, tcp.ack, tcp.flags, options, payload)
+            reset_terminal = (client_side, *terminal)
+            if session.reset_terminal is not None:
+                if reset_terminal == session.reset_terminal:
+                    continue
+                if payload or has_terminal_flag:
+                    raise CaptureError(FailureReason.MALFORMED)
+                continue
+            direction_terminal = (
+                session.client_terminal if client_side else session.server_terminal
+            )
+            if direction_terminal is not None:
+                if terminal == direction_terminal:
+                    continue
+                if payload or has_terminal_flag:
+                    raise CaptureError(FailureReason.MALFORMED)
+                continue
+            if (payload or has_terminal_flag) and not ack:
+                raise CaptureError(FailureReason.MALFORMED)
+            if tcp.flags & module.tcp.TH_RST:
+                session.reset_terminal = reset_terminal
+            elif tcp.flags & module.tcp.TH_FIN:
+                if client_side:
+                    session.client_terminal = terminal
+                else:
+                    session.server_terminal = terminal
             if payload:
                 session.application_started = True
             if starts_stream or payload:
@@ -1038,8 +1186,22 @@ def process_pcap(
     return sanitize_segments(_pcap_segments(capture, active_policy), active_policy)
 
 
+class _ArgumentParseFailure(Exception):
+    pass
+
+
+class _RedactedArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> Never:
+        raise _ArgumentParseFailure
+
+    def exit(self, status: int = 0, message: str | None = None) -> Never:
+        if status:
+            raise _ArgumentParseFailure
+        super().exit(status, message)
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
+    parser = _RedactedArgumentParser(
         description="Create a synthetic fixture from an authorized offline capture."
     )
     parser.add_argument("input", type=Path, help="authorized offline PCAP or PCAPNG")
@@ -1052,7 +1214,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         required=True,
         help="confirm authorization and offline-only handling",
     )
-    return parser.parse_args(argv)
+    try:
+        return parser.parse_args(argv)
+    except _ArgumentParseFailure:
+        pass
+    raise CaptureError(FailureReason.CLI)
 
 
 def _serialize_output(value: object) -> bytes:
@@ -1136,8 +1302,9 @@ def _write_exclusive(path: Path, content: bytes) -> None:
                 raise CaptureError(FailureReason.OUTPUT)
             written += count
         os.fsync(descriptor)
-        os.close(descriptor)
+        closing_descriptor = descriptor
         descriptor = None
+        os.close(closing_descriptor)
         os.link(
             temporary_name,
             path.name,
@@ -1149,8 +1316,10 @@ def _write_exclusive(path: Path, content: bytes) -> None:
         os.unlink(temporary_name, dir_fd=directory_descriptor)
         temporary_name = None
         os.fsync(directory_descriptor)
-        os.close(directory_descriptor)
+        closing_directory_descriptor = directory_descriptor
         directory_descriptor = None
+        with suppress(OSError):
+            os.close(closing_directory_descriptor)
     except FileExistsError:
         failure = FailureReason.OUTPUT_EXISTS
     except CaptureError as error:
@@ -1159,8 +1328,10 @@ def _write_exclusive(path: Path, content: bytes) -> None:
         failure = FailureReason.OUTPUT
 
     if descriptor is not None:
+        closing_descriptor = descriptor
+        descriptor = None
         try:
-            os.close(descriptor)
+            os.close(closing_descriptor)
         except OSError:
             if failure is None:
                 failure = FailureReason.OUTPUT
@@ -1181,8 +1352,10 @@ def _write_exclusive(path: Path, content: bytes) -> None:
             with suppress(OSError):
                 os.fsync(directory_descriptor)
     if directory_descriptor is not None:
+        closing_directory_descriptor = directory_descriptor
+        directory_descriptor = None
         try:
-            os.close(directory_descriptor)
+            os.close(closing_directory_descriptor)
         except OSError:
             if failure is None:
                 failure = FailureReason.OUTPUT
@@ -1191,8 +1364,8 @@ def _write_exclusive(path: Path, content: bytes) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    arguments = _parse_args(argv)
     try:
+        arguments = _parse_args(argv)
         sanitized = process_pcap(arguments.input)
         serialized = _serialize_output(sanitized)
         _write_exclusive(arguments.output, serialized)

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -564,12 +564,6 @@ def _sanitize_frame(
     }
 
 
-def _new_direction(policy: ParserPolicy, budget: _MemoryBudget) -> _DirectionState:
-    return _DirectionState(
-        TCPStreamReassembler(policy, budget), StreamFrameDecoder(policy, budget)
-    )
-
-
 def sanitize_segments(
     segments: Iterable[CapturedSegment], policy: ParserPolicy | None = None
 ) -> dict[str, Any]:
@@ -592,7 +586,10 @@ def sanitize_segments(
             sessions[segment.stream_id] = session
         state = session.directions.get(segment.direction)
         if state is None:
-            state = _new_direction(active_policy, budget)
+            state = _DirectionState(
+                TCPStreamReassembler(active_policy, budget),
+                StreamFrameDecoder(active_policy, budget),
+            )
             session.directions[segment.direction] = state
         if segment.starts_stream:
             state.reassembler.start(segment.sequence)
@@ -786,7 +783,6 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
 @dataclass(slots=True)
 class _ObservedSession:
     stream_id: int
-    client_started: bool = True
     server_started: bool = False
 
 
@@ -853,8 +849,6 @@ def _pcap_segments(capture: bytes, policy: ParserPolicy) -> Iterable[CapturedSeg
                 starts_stream = True
                 sequence = (sequence + 1) % _SEQUENCE_MODULUS
             elif session is None:
-                raise CaptureError(FailureReason.TRUNCATED)
-            elif client_side and not session.client_started:
                 raise CaptureError(FailureReason.TRUNCATED)
             elif not client_side and not session.server_started:
                 raise CaptureError(FailureReason.TRUNCATED)

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -227,10 +227,6 @@ class _MemoryBudget:
     limit: int
     retained: int = 0
 
-    @property
-    def available(self) -> int:
-        return self.limit - self.retained
-
     def reserve(self, count: int) -> None:
         if count < 0 or self.retained + count > self.limit:
             raise CaptureError(FailureReason.CAPACITY)
@@ -308,8 +304,7 @@ class _ChargedRingBuffer:
     def discard(self, count: int) -> None:
         if not 0 <= count <= self._size:
             raise CaptureError(FailureReason.MALFORMED)
-        if self._capacity:
-            self._head = (self._head + count) % self._capacity
+        self._head = (self._head + count) % self._capacity
         self._size -= count
         if not self._size:
             self._head = 0
@@ -469,12 +464,12 @@ class TCPStreamReassembler:
         self._origin: int | None = None
         self._assembled_bytes = 0
         self._history_start = 0
-        history_capacity = min(
+        self._history_limit = min(
             self.policy.maximum_packet_bytes,
             self.policy.maximum_reassembled_bytes_per_flow,
             16 * 1024,
         )
-        self._history = _ChargedRingBuffer(history_capacity, self._budget)
+        self._history = _ChargedRingBuffer(self._history_limit, self._budget)
         self._pending: dict[int, int] | None = None
         self._segment_count = 0
         self._started_at: float | None = None
@@ -518,7 +513,7 @@ class TCPStreamReassembler:
         normalized = bytes(payload)
         if not normalized:
             return []
-        if len(normalized) > self._budget.available:
+        if len(normalized) > self._budget.limit - self._budget.retained:
             raise CaptureError(FailureReason.CAPACITY)
         if self._started_at is None:
             self._started_at = captured_at
@@ -587,12 +582,7 @@ class TCPStreamReassembler:
             if pending is not None and not pending:
                 self._pending = None
                 pending = None
-        overlap_limit = min(
-            self.policy.maximum_packet_bytes,
-            self.policy.maximum_reassembled_bytes_per_flow,
-            16 * 1024,
-        )
-        expired = max(0, len(self._history) + len(contiguous) - overlap_limit)
+        expired = max(0, len(self._history) + len(contiguous) - self._history_limit)
         contiguous_history_start = 0
         if expired > 0:
             from_history = min(expired, len(self._history))
@@ -1001,16 +991,11 @@ def _decode_link_packet(packet: bytes, link_type: int) -> _IPPacket | None:
     if isinstance(data, module.ip.IP):
         return cast(_IPPacket, data)
     if isinstance(data, module.ip6.IP6):
-        ip6_packet = cast(_IPPacket, data)
-        transport_data = ip6_packet.data
+        transport_data = cast(_IPPacket, data).data
         if isinstance(transport_data, module.tcp.TCP):
             transport = cast(_TCPPacket, transport_data)
-        else:
-            transport = None
-        if transport is not None and (
-            transport.sport == 4346 or transport.dport == 4346
-        ):
-            raise CaptureError(FailureReason.IP_VERSION)
+            if transport.sport == 4346 or transport.dport == 4346:
+                raise CaptureError(FailureReason.IP_VERSION)
     return None
 
 
@@ -1194,11 +1179,6 @@ class _RedactedArgumentParser(argparse.ArgumentParser):
     def error(self, message: str) -> Never:
         raise _ArgumentParseFailure
 
-    def exit(self, status: int = 0, message: str | None = None) -> Never:
-        if status:
-            raise _ArgumentParseFailure
-        super().exit(status, message)
-
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = _RedactedArgumentParser(
@@ -1234,7 +1214,6 @@ def _open_temporary(directory_descriptor: int) -> tuple[int, str]:
         | os.O_CLOEXEC
         | getattr(os, "O_NOFOLLOW", 0)
     )
-    failed = False
     for _ in range(16):
         name = f".decode-cloud-frames-{secrets.token_hex(16)}.tmp"
         try:
@@ -1242,11 +1221,10 @@ def _open_temporary(directory_descriptor: int) -> tuple[int, str]:
         except FileExistsError:
             continue
         except OSError:
-            failed = True
             break
-    if failed:
-        raise CaptureError(FailureReason.OUTPUT)
-    raise CaptureError(FailureReason.CAPACITY)
+    else:
+        raise CaptureError(FailureReason.CAPACITY)
+    raise CaptureError(FailureReason.OUTPUT)
 
 
 def _unlink_if_same(

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -21,13 +21,15 @@ import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Final
 
 try:
-    import dpkt
+    dpkt: ModuleType | None = import_module("dpkt")
 except ImportError:  # pragma: no cover - exercised by the CLI environment
-    dpkt = None  # type: ignore[assignment]
+    dpkt = None
 
 
 FRAME_MAGIC: Final = b"\xa1\x1a"

--- a/tests/fixtures/dongle_emulation/minimal_sanitized.json
+++ b/tests/fixtures/dongle_emulation/minimal_sanitized.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "capture": {
+    "source": "authorized_offline_input",
+    "dongle_address": "192.0.2.10",
+    "cloud_address": "198.51.100.20"
+  },
+  "frames": [
+    {
+      "direction": "dongle_to_cloud",
+      "function": "heartbeat",
+      "identity": "SYNTHDG001",
+      "payload": "SYNTHETIC_STATUS"
+    },
+    {
+      "direction": "dongle_to_cloud",
+      "function": "data_read_response",
+      "identity": "SYNTHDG001",
+      "inner_identity": "SYNTHIV001",
+      "inner_function": "read_input",
+      "start_register": 7,
+      "register_count": 2,
+      "register_words": [
+        "SYNTHETIC_A55A"
+      ]
+    }
+  ]
+}

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -5,6 +5,7 @@ pytest>=8.3.0
 pytest-asyncio>=0.24.0
 pytest-cov>=6.0.0
 pytest-homeassistant-custom-component>=0.13.206
+dpkt>=1.9.8  # offline-only PCAP sanitizer tests (#576)
 
 # Home Assistant core for testing
 homeassistant>=2025.6.0

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -28,6 +28,7 @@ from scripts.decode_cloud_frames import (
     TCPStreamReassembler,
     _validate_synthetic_output,
     compute_crc16,
+    find_frames,
     main,
     process_pcap,
     sanitize_segments,
@@ -120,6 +121,33 @@ def _ipv6_ethernet_packet(payload: bytes, *, sequence: int, flags: int) -> bytes
         type=packet_module.ethernet.ETH_TYPE_IP6,
         data=ip,
     )
+    return bytes(ethernet)
+
+
+def _ipv6_extension_ethernet_packet(
+    *,
+    destination_port: int = 4346,
+    extension_count: int = 1,
+    truncate_tcp: bool = False,
+) -> bytes:
+    packet_module = _dpkt()
+    ethernet = packet_module.ethernet.Ethernet(
+        _ipv6_ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)
+    )
+    ip = ethernet.data
+    ip.data.dport = destination_port
+    transport = bytes(ip.data)
+    if truncate_tcp:
+        transport = transport[:4]
+    for index in reversed(range(extension_count)):
+        next_header = (
+            packet_module.ip.IP_PROTO_TCP
+            if index == extension_count - 1
+            else packet_module.ip.IP_PROTO_HOPOPTS
+        )
+        transport = bytes((next_header, 0)) + bytes(6) + transport
+    ip.nxt = packet_module.ip.IP_PROTO_HOPOPTS
+    ip.data = transport
     return bytes(ethernet)
 
 
@@ -284,6 +312,27 @@ def test_stream_decoder_emits_coalesced_frames() -> None:
         heartbeat,
         request,
     ]
+
+
+def test_find_frames_preserves_offsets_and_incomplete_tail() -> None:
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    request = _c2(_read_request())
+    prefix = b"x"
+    data = prefix + heartbeat + request + heartbeat[:5]
+
+    assert find_frames(data) == [
+        (len(prefix), heartbeat),
+        (len(prefix) + len(heartbeat), request),
+    ]
+
+
+def test_find_frames_preserves_strict_failure_contract() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+
+    with pytest.raises(CaptureError) as caught:
+        find_frames(b"x" * 65 + frame)
+
+    assert caught.value.reason is FailureReason.PREFIX
 
 
 def test_tcp_reassembler_deduplicates_and_orders_segments() -> None:
@@ -1446,6 +1495,36 @@ def test_capture_rejects_ipv6_target_traffic_explicitly(tmp_path: Path) -> None:
         process_pcap(capture_path)
 
     assert caught.value.reason is FailureReason.IP_VERSION
+
+
+def test_capture_classifies_ipv6_extension_header_traffic(tmp_path: Path) -> None:
+    cases = (
+        ("target", _ipv6_extension_ethernet_packet(), FailureReason.IP_VERSION),
+        (
+            "raw-target",
+            _ipv6_extension_ethernet_packet(truncate_tcp=True),
+            FailureReason.IP_VERSION,
+        ),
+        (
+            "long-target",
+            _ipv6_extension_ethernet_packet(extension_count=32),
+            FailureReason.IP_VERSION,
+        ),
+        (
+            "non-target",
+            _ipv6_extension_ethernet_packet(destination_port=4347),
+            FailureReason.EMPTY,
+        ),
+    )
+    observed: list[FailureReason] = []
+    for name, packet, _expected in cases:
+        capture_path = tmp_path / f"ipv6-extension-{name}.pcap"
+        _write_capture(capture_path, [(1.0, packet)])
+        with pytest.raises(CaptureError) as caught:
+            process_pcap(capture_path)
+        observed.append(caught.value.reason)
+
+    assert observed == [expected for _name, _packet, expected in cases]
 
 
 def test_capture_rejects_midstream_payload_without_handshake(tmp_path: Path) -> None:

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+import socket
+import sys
+from collections.abc import Buffer, Callable
+from importlib import util
 from pathlib import Path
+from types import ModuleType
+from typing import Protocol, cast
 
-import dpkt
 import pytest
 
 import scripts.decode_cloud_frames as decoder_module
@@ -16,6 +22,7 @@ from scripts.decode_cloud_frames import (
     ParserPolicy,
     StreamFrameDecoder,
     TCPStreamReassembler,
+    _validate_synthetic_output,
     compute_crc16,
     main,
     process_pcap,
@@ -25,6 +32,81 @@ from scripts.decode_cloud_frames import (
 
 OUTER_IDENTITY = b"CANARYDG01"
 INNER_IDENTITY = b"CANARYIV01"
+PROTECTED_CANARIES = {
+    "serial_identity": OUTER_IDENTITY.decode(),
+    "device_identity": INNER_IDENTITY.decode(),
+    "pin_check_code": "PIN-CHECK-CANARY",
+    "psk": "PSK-CANARY",
+    "cookie": "COOKIE-CANARY",
+    "token": "TOKEN-CANARY",
+    "private_address": "10.23.45.67",
+    "mac": "02:00:5e:10:00:01",
+    "payload_register": "REG!",
+}
+
+
+class _DecoderModule(Protocol):
+    dpkt: ModuleType | None
+    CaptureError: type[Exception]
+
+    def process_pcap(self, pcap_path: str | Path) -> dict[str, object]: ...
+
+    def main(self, argv: list[str] | None = None) -> int: ...
+
+
+def _dpkt() -> ModuleType:
+    return cast(
+        ModuleType,
+        pytest.importorskip("dpkt", reason="offline PCAP adapter dependency"),
+    )
+
+
+def _ethernet_packet(
+    payload: bytes,
+    *,
+    sequence: int,
+    flags: int,
+    cloud_to_dongle: bool = False,
+) -> bytes:
+    packet_module = _dpkt()
+    tcp = packet_module.tcp.TCP(
+        sport=4346 if cloud_to_dongle else 32000,
+        dport=32000 if cloud_to_dongle else 4346,
+        seq=sequence,
+        flags=flags,
+        data=payload,
+    )
+    ip = packet_module.ip.IP(
+        src=b"\xc6\x33\x64\x63" if cloud_to_dongle else b"\xc0\x00\x02\x63",
+        dst=b"\xc0\x00\x02\x63" if cloud_to_dongle else b"\xc6\x33\x64\x63",
+        p=packet_module.ip.IP_PROTO_TCP,
+        data=tcp,
+    )
+    ethernet = packet_module.ethernet.Ethernet(
+        src=b"\x02\x00\x00\x00\x00\x01",
+        dst=b"\x02\x00\x00\x00\x00\x02",
+        type=packet_module.ethernet.ETH_TYPE_IP,
+        data=ip,
+    )
+    return bytes(ethernet)
+
+
+def _write_capture(
+    capture_path: Path,
+    packets: list[tuple[float, bytes]],
+    *,
+    link_type: int = 1,
+    pcapng: bool = False,
+) -> None:
+    packet_module = _dpkt()
+    with capture_path.open("wb") as capture_file:
+        writer_type = (
+            packet_module.pcapng.Writer if pcapng else packet_module.pcap.Writer
+        )
+        writer = writer_type(capture_file, linktype=link_type)
+        for timestamp, packet in packets:
+            writer.writepkt(packet, ts=timestamp)
+        writer.close()
 
 
 def _cloud_frame(
@@ -83,11 +165,19 @@ def _segments(*payloads: bytes) -> list[CapturedSegment]:
                 sequence=sequence,
                 captured_at=captured_at,
                 payload=payload,
+                starts_stream=not result,
             )
         )
         sequence += len(payload)
         captured_at += 0.01
     return result
+
+
+@pytest.mark.parametrize(
+    "value", [b"123456789", bytearray(b"123456789"), memoryview(b"123456789")]
+)
+def test_public_crc_seam_normalizes_bytes_like_inputs(value: Buffer) -> None:
+    assert compute_crc16(value) == 0x4B37
 
 
 @pytest.mark.parametrize(
@@ -111,21 +201,29 @@ def test_parser_policy_accepts_contract_boundaries(
 
 
 @pytest.mark.parametrize(
-    "overrides",
+    "constructor",
     [
-        {"maximum_frame_bytes": 511},
-        {"maximum_frame_bytes": 65536},
-        {"prefix_scan_bytes": 1},
-        {"prefix_scan_bytes": 1025},
-        {"overall_frame_deadline": 0.9},
-        {"overall_frame_deadline": 30.1},
+        lambda: ParserPolicy(maximum_frame_bytes=511),
+        lambda: ParserPolicy(maximum_frame_bytes=65536),
+        lambda: ParserPolicy(prefix_scan_bytes=1),
+        lambda: ParserPolicy(prefix_scan_bytes=1025),
+        lambda: ParserPolicy(overall_frame_deadline=0.9),
+        lambda: ParserPolicy(overall_frame_deadline=30.1),
+        lambda: ParserPolicy(maximum_capture_bytes=0),
+        lambda: ParserPolicy(maximum_packet_bytes=0),
+        lambda: ParserPolicy(maximum_packets=0),
+        lambda: ParserPolicy(maximum_flows=0),
+        lambda: ParserPolicy(maximum_segments_per_flow=0),
+        lambda: ParserPolicy(maximum_pending_bytes_per_flow=0),
+        lambda: ParserPolicy(maximum_reassembled_bytes_per_flow=0),
+        lambda: ParserPolicy(maximum_aggregate_memory_bytes=0),
     ],
 )
 def test_parser_policy_rejects_values_outside_contract(
-    overrides: dict[str, int | float],
+    constructor: Callable[[], ParserPolicy],
 ) -> None:
     with pytest.raises(ValueError, match="outside the internal contract"):
-        ParserPolicy(**overrides)  # type: ignore[arg-type]
+        constructor()
 
 
 def test_stream_decoder_handles_every_split_and_byte_fragmentation() -> None:
@@ -156,18 +254,17 @@ def test_stream_decoder_emits_coalesced_frames() -> None:
 
 def test_tcp_reassembler_deduplicates_and_orders_segments() -> None:
     reassembler = TCPStreamReassembler(ParserPolicy())
+    reassembler.start(100)
 
     assert reassembler.push(100, b"abc", captured_at=1.0) == [(1.0, b"abc")]
     assert reassembler.push(106, b"ghi", captured_at=1.2) == []
     assert reassembler.push(100, b"abc", captured_at=1.3) == []
-    assert reassembler.push(102, b"cdef", captured_at=1.4) == [
-        (1.4, b"def"),
-        (1.4, b"ghi"),
-    ]
+    assert reassembler.push(102, b"cdef", captured_at=1.4) == [(1.4, b"defghi")]
 
 
 def test_tcp_reassembler_fails_closed_on_gap_conflict_and_capacity() -> None:
     gap = TCPStreamReassembler()
+    gap.start(100)
     gap.push(100, b"a", captured_at=1.0)
     gap.push(102, b"c", captured_at=1.1)
     with pytest.raises(CaptureError) as gap_error:
@@ -175,6 +272,7 @@ def test_tcp_reassembler_fails_closed_on_gap_conflict_and_capacity() -> None:
     assert gap_error.value.reason is FailureReason.TRUNCATED
 
     conflict = TCPStreamReassembler()
+    conflict.start(100)
     conflict.push(100, b"a", captured_at=1.0)
     conflict.push(102, b"c", captured_at=1.1)
     with pytest.raises(CaptureError) as conflict_error:
@@ -182,19 +280,27 @@ def test_tcp_reassembler_fails_closed_on_gap_conflict_and_capacity() -> None:
     assert conflict_error.value.reason is FailureReason.MALFORMED
 
     capacity = TCPStreamReassembler()
+    capacity.start(100)
     capacity.push(100, b"a", captured_at=1.0)
     with pytest.raises(CaptureError) as capacity_error:
         capacity.push(102, b"x" * (16 * 1024 + 1), captured_at=1.1)
     assert capacity_error.value.reason is FailureReason.CAPACITY
 
 
-def test_combined_stream_storage_matches_contract_budget() -> None:
-    policy = ParserPolicy()
-    decoder_storage = policy.maximum_frame_bytes + policy.prefix_scan_bytes
+def test_reassembly_pending_storage_accepts_exact_limit_and_rejects_one_over() -> None:
+    policy = ParserPolicy(maximum_pending_bytes_per_flow=4)
+    exact = TCPStreamReassembler(policy)
+    exact.start(100)
+    assert exact.push(101, b"bcde", captured_at=1.0) == []
+    assert exact.pending_bytes == 4
+    assert exact.retained_bytes == 4
 
-    assert decoder_storage + policy.reassembly_capacity == (
-        policy.maximum_frame_bytes + policy.prefix_scan_bytes + 16 * 1024
-    )
+    overflow = TCPStreamReassembler(policy)
+    overflow.start(100)
+    with pytest.raises(CaptureError) as caught:
+        overflow.push(101, b"bcdef", captured_at=1.0)
+    assert caught.value.reason is FailureReason.CAPACITY
+    assert overflow.pending_bytes <= policy.maximum_pending_bytes_per_flow
 
 
 def test_stream_decoder_rejects_truncation_at_eof() -> None:
@@ -208,7 +314,13 @@ def test_stream_decoder_rejects_truncation_at_eof() -> None:
 
 
 def test_stream_decoder_rejects_oversize_before_body_buffering() -> None:
-    decoder = StreamFrameDecoder(ParserPolicy(maximum_frame_bytes=512))
+    policy = ParserPolicy(maximum_frame_bytes=512)
+    exact_frame = _cloud_frame(0xC1, b"x" * (policy.maximum_frame_bytes - 18))
+    exact = StreamFrameDecoder(policy)
+    assert exact.feed(exact_frame, captured_at=1.0) == [exact_frame]
+    exact.close(captured_at=1.0)
+
+    decoder = StreamFrameDecoder(policy)
     advertised_body = (507).to_bytes(2, "little")
 
     with pytest.raises(CaptureError) as caught:
@@ -293,25 +405,14 @@ def test_sanitizer_fails_closed_on_unknown_functions_and_ranges(
 
 
 def test_sanitizer_emits_only_synthetic_minimal_data() -> None:
-    protected_canaries = (
-        b"PIN=7391;PSK=private-canary;cookie=private-cookie;"
-        b"token=private-token;192.0.2.99;02:00:5e:10:00:00"
-    )
-    heartbeat = _cloud_frame(0xC1, b"\x01" + protected_canaries)
-    response = _c2(_read_response())
+    payload = "|".join(PROTECTED_CANARIES.values()).encode()
+    heartbeat = _cloud_frame(0xC1, b"\x01" + payload)
+    response = _c2(_read_response(words=(0x4552, 0x2147)))
 
     sanitized = sanitize_segments(_segments(heartbeat, response))
     serialized = json.dumps(sanitized, sort_keys=True)
 
-    for forbidden in (
-        OUTER_IDENTITY.decode(),
-        INNER_IDENTITY.decode(),
-        protected_canaries.decode(),
-        "192.0.2.99",
-        "02:00:5e:10:00:00",
-        "1234",
-        "5678",
-    ):
+    for forbidden in PROTECTED_CANARIES.values():
         assert forbidden not in serialized
     assert sanitized["capture"] == {
         "source": "authorized_offline_input",
@@ -355,38 +456,34 @@ def test_sanitizer_fails_closed_at_synthetic_record_capacity(
 def test_offline_pcap_adapter_and_cli_never_report_source_metadata(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    heartbeat = _cloud_frame(0xC1, b"\x01")
-    response = _c2(_read_response())
+    heartbeat = _cloud_frame(
+        0xC1, b"\x01" + "|".join(PROTECTED_CANARIES.values()).encode()
+    )
+    response = _c2(_read_response(words=(0x4552, 0x2147)))
     chunks = (heartbeat[:5], heartbeat[5:] + response)
     capture_path = tmp_path / "CANARYDG01-authorized-input.pcap"
     output_path = tmp_path / "sanitized.json"
-
-    with capture_path.open("wb") as capture_file:
-        writer = dpkt.pcap.Writer(capture_file)
-        sequence = 100
-        for index, chunk in enumerate(chunks):
-            tcp = dpkt.tcp.TCP(
-                sport=32000,
-                dport=4346,
-                seq=sequence,
-                flags=dpkt.tcp.TH_ACK,
-                data=chunk,
+    packet_module = _dpkt()
+    sequence = 100
+    packets = [
+        (
+            0.9,
+            _ethernet_packet(
+                b"", sequence=sequence - 1, flags=packet_module.tcp.TH_SYN
+            ),
+        )
+    ]
+    for index, chunk in enumerate(chunks):
+        packets.append(
+            (
+                1.0 + index / 10,
+                _ethernet_packet(
+                    chunk, sequence=sequence, flags=packet_module.tcp.TH_ACK
+                ),
             )
-            ip = dpkt.ip.IP(
-                src=b"\xc0\x00\x02\x63",
-                dst=b"\xc6\x33\x64\x63",
-                p=dpkt.ip.IP_PROTO_TCP,
-                data=tcp,
-            )
-            ethernet = dpkt.ethernet.Ethernet(
-                src=b"\x02\x00\x00\x00\x00\x01",
-                dst=b"\x02\x00\x00\x00\x00\x02",
-                type=dpkt.ethernet.ETH_TYPE_IP,
-                data=ip,
-            )
-            writer.writepkt(ethernet, ts=1.0 + index / 10)
-            sequence += len(chunk)
-        writer.close()
+        )
+        sequence += len(chunk)
+    _write_capture(capture_path, packets)
 
     direct = process_pcap(capture_path)
     assert direct["frames"][0]["identity"] == "SYNTHDG001"
@@ -402,8 +499,13 @@ def test_offline_pcap_adapter_and_cli_never_report_source_metadata(
         == 0
     )
     captured_output = capsys.readouterr()
-    assert "CANARYDG01" not in captured_output.out
-    assert "CANARYDG01" not in captured_output.err
+    recursive_return = json.dumps(direct, sort_keys=True)
+    created_output = output_path.read_text(encoding="utf-8")
+    for canary in PROTECTED_CANARIES.values():
+        assert canary not in recursive_return
+        assert canary not in captured_output.out
+        assert canary not in captured_output.err
+        assert canary not in created_output
     assert str(capture_path) not in captured_output.out
     assert str(capture_path) not in captured_output.err
     assert str(output_path) not in captured_output.out
@@ -415,36 +517,597 @@ def test_pcap_reconnect_on_same_flow_starts_a_new_stream(tmp_path: Path) -> None
     capture_path = tmp_path / "synthetic-reconnect.pcap"
     frames = (_c2(_read_response(start=7)), _c2(_read_response(start=42)))
 
-    with capture_path.open("wb") as capture_file:
-        writer = dpkt.pcap.Writer(capture_file)
-        for timestamp, sequence, flags, payload in (
-            (1.0, 100, dpkt.tcp.TH_SYN, b""),
-            (1.1, 101, dpkt.tcp.TH_ACK, frames[0]),
-            (2.0, 10, dpkt.tcp.TH_SYN, b""),
-            (2.1, 11, dpkt.tcp.TH_ACK, frames[1]),
-        ):
-            tcp = dpkt.tcp.TCP(
-                sport=32000,
-                dport=4346,
-                seq=sequence,
-                flags=flags,
-                data=payload,
+    packet_module = _dpkt()
+    _write_capture(
+        capture_path,
+        [
+            (
+                timestamp,
+                _ethernet_packet(payload, sequence=sequence, flags=flags),
             )
-            ip = dpkt.ip.IP(
-                src=b"\xc0\x00\x02\x63",
-                dst=b"\xc6\x33\x64\x63",
-                p=dpkt.ip.IP_PROTO_TCP,
-                data=tcp,
+            for timestamp, sequence, flags, payload in (
+                (1.0, 100, packet_module.tcp.TH_SYN, b""),
+                (1.1, 101, packet_module.tcp.TH_ACK, frames[0]),
+                (2.0, 10, packet_module.tcp.TH_SYN, b""),
+                (2.1, 11, packet_module.tcp.TH_ACK, frames[1]),
             )
-            ethernet = dpkt.ethernet.Ethernet(
-                src=b"\x02\x00\x00\x00\x00\x01",
-                dst=b"\x02\x00\x00\x00\x00\x02",
-                type=dpkt.ethernet.ETH_TYPE_IP,
-                data=ip,
-            )
-            writer.writepkt(ethernet, ts=timestamp)
-        writer.close()
+        ],
+    )
 
     sanitized = process_pcap(capture_path)
 
     assert [frame["start_register"] for frame in sanitized["frames"]] == [7, 42]
+
+
+def test_tcp_reassembler_requires_explicit_stream_origin() -> None:
+    reassembler = TCPStreamReassembler()
+
+    with pytest.raises(CaptureError) as caught:
+        reassembler.push(100, b"a", captured_at=1.0)
+
+    assert caught.value.reason is FailureReason.TRUNCATED
+
+
+def test_tcp_reassembler_handles_sequence_wrap_and_reverse_one_byte_segments() -> None:
+    policy = ParserPolicy(maximum_segments_per_flow=257)
+    reassembler = TCPStreamReassembler(policy)
+    origin = (1 << 32) - 4
+    reassembler.start(origin)
+
+    for offset in range(256, 0, -1):
+        assert (
+            reassembler.push(
+                (origin + offset) % (1 << 32),
+                bytes((offset % 251,)),
+                captured_at=1.0,
+            )
+            == []
+        )
+    assert reassembler.pending_bytes == 256
+    expected = bytes(offset % 251 for offset in range(257))
+    assert reassembler.push(origin, b"\x00", captured_at=1.1) == [(1.1, expected)]
+    assert reassembler.segment_count == policy.maximum_segments_per_flow
+
+
+def test_tcp_reassembler_rejects_one_segment_over_limit() -> None:
+    reassembler = TCPStreamReassembler(ParserPolicy(maximum_segments_per_flow=1))
+    reassembler.start(10)
+    reassembler.push(10, b"a", captured_at=1.0)
+
+    with pytest.raises(CaptureError) as caught:
+        reassembler.push(11, b"b", captured_at=1.1)
+
+    assert caught.value.reason is FailureReason.CAPACITY
+
+
+@pytest.mark.parametrize(
+    ("first_sequence", "first", "second_sequence", "second", "expected"),
+    [
+        (100, b"abcd", 100, b"abcd", b""),
+        (100, b"abcd", 102, b"cdef", b"ef"),
+        (102, b"cdef", 100, b"abcd", b"abcdef"),
+        (103, b"def", 102, b"cde", b"abcdef"),
+        (102, b"cde", 103, b"def", b"abcdef"),
+    ],
+)
+def test_tcp_reassembler_accepts_every_matching_overlap_shape(
+    first_sequence: int,
+    first: bytes,
+    second_sequence: int,
+    second: bytes,
+    expected: bytes,
+) -> None:
+    reassembler = TCPStreamReassembler()
+    reassembler.start(100)
+    first_chunks = reassembler.push(first_sequence, first, captured_at=1.0)
+    second_chunks = reassembler.push(second_sequence, second, captured_at=1.1)
+    if first_sequence > 100 and second_sequence > 100:
+        second_chunks += reassembler.push(100, b"ab", captured_at=1.2)
+
+    emitted = b"".join(chunk for _, chunk in first_chunks + second_chunks)
+    if first_sequence == 100:
+        assert emitted == first + expected
+    else:
+        assert emitted == expected
+
+
+@pytest.mark.parametrize(
+    ("first_sequence", "first", "second_sequence", "second"),
+    [
+        (100, b"abcd", 100, b"abXd"),
+        (100, b"abcd", 102, b"Xdef"),
+        (102, b"cdef", 100, b"abXd"),
+        (103, b"def", 102, b"cXe"),
+        (102, b"cde", 103, b"dXf"),
+    ],
+)
+def test_tcp_reassembler_rejects_every_conflicting_overlap_shape(
+    first_sequence: int,
+    first: bytes,
+    second_sequence: int,
+    second: bytes,
+) -> None:
+    reassembler = TCPStreamReassembler()
+    reassembler.start(100)
+    reassembler.push(first_sequence, first, captured_at=1.0)
+
+    with pytest.raises(CaptureError) as caught:
+        reassembler.push(second_sequence, second, captured_at=1.1)
+
+    assert caught.value.reason is FailureReason.MALFORMED
+
+
+def test_reassembly_memory_and_stream_limits_accept_exact_and_reject_one_over() -> None:
+    exact_policy = ParserPolicy(
+        maximum_reassembled_bytes_per_flow=4,
+        maximum_aggregate_memory_bytes=4,
+    )
+    exact = TCPStreamReassembler(exact_policy)
+    exact.start(1)
+    assert exact.push(1, b"abcd", captured_at=1.0) == [(1.0, b"abcd")]
+    assert exact.retained_bytes == 4
+
+    aggregate = TCPStreamReassembler(exact_policy)
+    aggregate.start(1)
+    with pytest.raises(CaptureError) as aggregate_error:
+        aggregate.push(1, b"abcde", captured_at=1.0)
+    assert aggregate_error.value.reason is FailureReason.CAPACITY
+    assert aggregate.retained_bytes <= exact_policy.maximum_aggregate_memory_bytes
+
+    stream_policy = ParserPolicy(
+        maximum_reassembled_bytes_per_flow=4,
+        maximum_aggregate_memory_bytes=5,
+    )
+    stream = TCPStreamReassembler(stream_policy)
+    stream.start(1)
+    with pytest.raises(CaptureError) as stream_error:
+        stream.push(1, b"abcde", captured_at=1.0)
+    assert stream_error.value.reason is FailureReason.CAPACITY
+    assert stream.retained_bytes <= stream_policy.maximum_aggregate_memory_bytes
+
+
+def test_sanitizer_flow_limit_accepts_exact_and_rejects_one_over() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    exact = [
+        CapturedSegment(
+            "dongle_to_cloud", 100, float(stream_id), frame, stream_id, True
+        )
+        for stream_id in range(2)
+    ]
+    assert len(sanitize_segments(exact, ParserPolicy(maximum_flows=2))["frames"]) == 1
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(exact, ParserPolicy(maximum_flows=1))
+
+    assert caught.value.reason is FailureReason.CAPACITY
+
+
+def test_sanitizer_aggregate_memory_limit_accepts_peak_and_rejects_one_under() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    segments = [
+        CapturedSegment(
+            "dongle_to_cloud", 100, float(stream_id), frame, stream_id, True
+        )
+        for stream_id in range(2)
+    ]
+    peak_retained = len(frame) * 3
+
+    assert sanitize_segments(
+        segments,
+        ParserPolicy(maximum_aggregate_memory_bytes=peak_retained),
+    )["frames"]
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(
+            segments,
+            ParserPolicy(maximum_aggregate_memory_bytes=peak_retained - 1),
+        )
+
+    assert caught.value.reason is FailureReason.CAPACITY
+
+
+def test_session_binds_outer_identity_across_both_directions() -> None:
+    segments = [
+        CapturedSegment(
+            "dongle_to_cloud", 100, 1.0, _cloud_frame(0xC1, b"\x01"), 0, True
+        ),
+        CapturedSegment(
+            "cloud_to_dongle",
+            200,
+            1.1,
+            _cloud_frame(0xC1, b"\x01", identity=b"CANARYDG02"),
+            0,
+            True,
+        ),
+    ]
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(segments)
+
+    assert caught.value.reason is FailureReason.IDENTITY
+
+
+def test_session_binds_inner_identity_across_both_directions() -> None:
+    segments = [
+        CapturedSegment("dongle_to_cloud", 100, 1.0, _c2(_read_request()), 0, True),
+        CapturedSegment(
+            "cloud_to_dongle",
+            200,
+            1.1,
+            _c2(_read_request(identity=b"CANARYIV02")),
+            0,
+            True,
+        ),
+    ]
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(segments)
+
+    assert caught.value.reason is FailureReason.IDENTITY
+
+
+def test_distinct_valid_identities_receive_distinct_synthetic_aliases() -> None:
+    segments = [
+        CapturedSegment("dongle_to_cloud", 100, 1.0, _c2(_read_request()), 0, True),
+        CapturedSegment(
+            "dongle_to_cloud",
+            200,
+            1.1,
+            _c2(
+                _read_request(identity=b"CANARYIV02"),
+                identity=b"CANARYDG02",
+            ),
+            1,
+            True,
+        ),
+    ]
+
+    frames = sanitize_segments(segments)["frames"]
+
+    assert [frame["identity"] for frame in frames] == ["SYNTHDG001", "SYNTHDG002"]
+    assert [frame["inner_identity"] for frame in frames] == [
+        "SYNTHIV001",
+        "SYNTHIV002",
+    ]
+
+
+def test_recursive_output_schema_rejects_unknown_nested_fields() -> None:
+    sanitized = sanitize_segments(_segments(_cloud_frame(0xC1, b"\x01")))
+    frames = cast(list[dict[str, object]], sanitized["frames"])
+    frames[0]["unexpected"] = "SYNTHETIC_ONLY"
+
+    with pytest.raises(CaptureError) as caught:
+        _validate_synthetic_output(sanitized)
+
+    assert caught.value.reason is FailureReason.SCHEMA
+
+
+@pytest.mark.parametrize("kind", ["directory", "symlink", "fifo", "socket"])
+def test_process_pcap_rejects_non_regular_and_linked_inputs(
+    tmp_path: Path, kind: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = Path("input")
+    peer_socket: socket.socket | None = None
+    if kind == "directory":
+        target.mkdir()
+    elif kind == "symlink":
+        regular = Path("regular")
+        regular.write_bytes(b"safe")
+        target.symlink_to(regular)
+    elif kind == "fifo":
+        os.mkfifo(target)
+    else:
+        peer_socket = socket.socket(socket.AF_UNIX)
+        peer_socket.bind(str(target))
+    try:
+        with pytest.raises(CaptureError) as caught:
+            process_pcap(target)
+    finally:
+        if peer_socket is not None:
+            peer_socket.close()
+
+    assert caught.value.reason is FailureReason.INPUT_KIND
+
+
+def test_capture_size_limit_distinguishes_exact_boundary_and_one_over(
+    tmp_path: Path,
+) -> None:
+    capture_path = tmp_path / "capture"
+    capture_path.write_bytes(b"abcd")
+    with pytest.raises(CaptureError) as exact:
+        process_pcap(capture_path, ParserPolicy(maximum_capture_bytes=4))
+    assert exact.value.reason is FailureReason.MALFORMED
+
+    with pytest.raises(CaptureError) as overflow:
+        process_pcap(capture_path, ParserPolicy(maximum_capture_bytes=3))
+    assert overflow.value.reason is FailureReason.INPUT_SIZE
+
+
+@pytest.mark.parametrize("replacement_content", [b"abcd", b"abcde"])
+def test_process_pcap_rejects_file_identity_or_size_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_content: bytes,
+) -> None:
+    capture_path = tmp_path / "capture"
+    replacement = tmp_path / "replacement"
+    capture_path.write_bytes(b"abcd")
+    replacement.write_bytes(replacement_content)
+    original_stat = os.stat
+
+    def changed_stat(
+        path: os.PathLike[str] | str, *, follow_symlinks: bool = True
+    ) -> os.stat_result:
+        if Path(path) == capture_path and not follow_symlinks:
+            return original_stat(replacement, follow_symlinks=False)
+        return original_stat(path, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "stat", changed_stat)
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.INPUT_CHANGED
+
+
+def test_process_pcap_redacts_read_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = tmp_path / "capture"
+    capture_path.write_bytes(b"synthetic")
+
+    def failed_read(descriptor: int, count: int) -> bytes:
+        raise OSError("synthetic read failure")
+
+    monkeypatch.setattr(os, "read", failed_read)
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.INPUT_CHANGED
+    assert str(caught.value) == "capture rejected: input_changed"
+
+
+def test_capture_rejects_unsupported_link_and_malformed_supported_packet(
+    tmp_path: Path,
+) -> None:
+    unsupported = tmp_path / "unsupported.pcap"
+    malformed = tmp_path / "malformed.pcap"
+    _write_capture(unsupported, [(1.0, b"synthetic")], link_type=147)
+    _write_capture(malformed, [(1.0, b"\x00")])
+
+    with pytest.raises(CaptureError) as unsupported_error:
+        process_pcap(unsupported)
+    with pytest.raises(CaptureError) as malformed_error:
+        process_pcap(malformed)
+
+    assert unsupported_error.value.reason is FailureReason.UNSUPPORTED_LINK
+    assert malformed_error.value.reason is FailureReason.MALFORMED
+
+
+def test_capture_distinguishes_irrelevant_traffic_from_decode_failure(
+    tmp_path: Path,
+) -> None:
+    packet_module = _dpkt()
+    udp = packet_module.udp.UDP(sport=1000, dport=1001, data=b"synthetic")
+    ip = packet_module.ip.IP(
+        src=b"\xc0\x00\x02\x01",
+        dst=b"\xc6\x33\x64\x01",
+        p=packet_module.ip.IP_PROTO_UDP,
+        data=udp,
+    )
+    ethernet = packet_module.ethernet.Ethernet(
+        src=b"\x02\x00\x00\x00\x00\x01",
+        dst=b"\x02\x00\x00\x00\x00\x02",
+        type=packet_module.ethernet.ETH_TYPE_IP,
+        data=ip,
+    )
+    capture_path = tmp_path / "irrelevant.pcap"
+    _write_capture(capture_path, [(1.0, bytes(ethernet))])
+
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.EMPTY
+
+
+def test_capture_rejects_midstream_payload_without_handshake(tmp_path: Path) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "midstream.pcap"
+    _write_capture(
+        capture_path,
+        [
+            (
+                1.0,
+                _ethernet_packet(
+                    _cloud_frame(0xC1, b"\x01"),
+                    sequence=100,
+                    flags=packet_module.tcp.TH_ACK,
+                ),
+            )
+        ],
+    )
+
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.TRUNCATED
+
+
+def test_capture_rejects_reverse_payload_without_syn_ack(tmp_path: Path) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "missing-syn-ack.pcap"
+    _write_capture(
+        capture_path,
+        [
+            (1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)),
+            (
+                1.1,
+                _ethernet_packet(
+                    _cloud_frame(0xC1, b"\x01"),
+                    sequence=200,
+                    flags=packet_module.tcp.TH_ACK,
+                    cloud_to_dongle=True,
+                ),
+            ),
+        ],
+    )
+
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.TRUNCATED
+
+
+def test_capture_packet_count_and_size_limits_have_exact_boundaries(
+    tmp_path: Path,
+) -> None:
+    packet_module = _dpkt()
+    frame = _cloud_frame(0xC1, b"\x01")
+    syn = _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)
+    data = _ethernet_packet(frame, sequence=100, flags=packet_module.tcp.TH_ACK)
+    capture_path = tmp_path / "bounded.pcap"
+    _write_capture(capture_path, [(1.0, syn), (1.1, data)])
+    exact = ParserPolicy(
+        maximum_packets=2, maximum_packet_bytes=max(len(syn), len(data))
+    )
+    assert process_pcap(capture_path, exact)["frames"]
+
+    with pytest.raises(CaptureError) as packet_count:
+        process_pcap(capture_path, ParserPolicy(maximum_packets=1))
+    with pytest.raises(CaptureError) as packet_size:
+        process_pcap(
+            capture_path,
+            ParserPolicy(maximum_packet_bytes=max(len(syn), len(data)) - 1),
+        )
+
+    assert packet_count.value.reason is FailureReason.CAPACITY
+    assert packet_size.value.reason is FailureReason.CAPACITY
+
+
+def test_output_uses_one_exclusive_write_and_removes_short_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    packet_module = _dpkt()
+    frame = _cloud_frame(0xC1, b"\x01")
+    capture_path = tmp_path / "input.pcap"
+    output_path = tmp_path / "output.json"
+    _write_capture(
+        capture_path,
+        [
+            (1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)),
+            (
+                1.1,
+                _ethernet_packet(frame, sequence=100, flags=packet_module.tcp.TH_ACK),
+            ),
+        ],
+    )
+    writes = 0
+
+    def short_write(descriptor: int, content: Buffer) -> int:
+        nonlocal writes
+        writes += 1
+        return max(0, len(memoryview(content)) - 1)
+
+    monkeypatch.setattr(os, "write", short_write)
+    assert (
+        main(
+            [
+                str(capture_path),
+                "--output",
+                str(output_path),
+                "--authorized-offline-input",
+            ]
+        )
+        == 2
+    )
+    output = capsys.readouterr()
+
+    assert writes == 1
+    assert not output_path.exists()
+    assert output.out == ""
+    assert output.err == "capture rejected: output\n"
+
+
+def test_output_success_is_one_write_and_existing_target_is_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "input.pcap"
+    output_path = tmp_path / "output.json"
+    frame = _cloud_frame(0xC1, b"\x01")
+    _write_capture(
+        capture_path,
+        [
+            (1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)),
+            (
+                1.1,
+                _ethernet_packet(frame, sequence=100, flags=packet_module.tcp.TH_ACK),
+            ),
+        ],
+    )
+    original_write = os.write
+    writes = 0
+
+    def counted_write(descriptor: int, content: Buffer) -> int:
+        nonlocal writes
+        writes += 1
+        return original_write(descriptor, content)
+
+    monkeypatch.setattr(os, "write", counted_write)
+    arguments = [
+        str(capture_path),
+        "--output",
+        str(output_path),
+        "--authorized-offline-input",
+    ]
+    assert main(arguments) == 0
+    assert writes == 1
+    first_output = output_path.read_bytes()
+    assert main(arguments) == 2
+    capsys.readouterr()
+
+    assert output_path.read_bytes() == first_output
+    assert set(tmp_path.iterdir()) == {capture_path, output_path}
+
+
+def test_missing_dpkt_fails_closed_in_process_and_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module_name = "decode_cloud_frames_without_optional_dependency"
+    script_path = Path(decoder_module.__file__)
+    spec = util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    loaded = util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, loaded)
+    monkeypatch.setitem(sys.modules, "dpkt", None)
+    spec.loader.exec_module(loaded)
+    isolated = cast(_DecoderModule, loaded)
+    capture_path = tmp_path / "SYNTHETIC_CANARY_INPUT"
+    output_path = tmp_path / "output.json"
+    capture_path.write_bytes(b"synthetic-only")
+
+    with pytest.raises(isolated.CaptureError) as caught:
+        isolated.process_pcap(capture_path)
+    assert str(caught.value) == "capture rejected: dependency"
+    assert (
+        isolated.main(
+            [
+                str(capture_path),
+                "--output",
+                str(output_path),
+                "--authorized-offline-input",
+            ]
+        )
+        == 2
+    )
+    output = capsys.readouterr()
+
+    assert output.out == ""
+    assert output.err == "capture rejected: dependency\n"
+    assert not output_path.exists()
+    assert "SYNTHETIC_CANARY_INPUT" not in output.err

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -1516,15 +1516,12 @@ def test_capture_classifies_ipv6_extension_header_traffic(tmp_path: Path) -> Non
             FailureReason.EMPTY,
         ),
     )
-    observed: list[FailureReason] = []
-    for name, packet, _expected in cases:
+    for name, packet, expected in cases:
         capture_path = tmp_path / f"ipv6-extension-{name}.pcap"
         _write_capture(capture_path, [(1.0, packet)])
         with pytest.raises(CaptureError) as caught:
             process_pcap(capture_path)
-        observed.append(caught.value.reason)
-
-    assert observed == [expected for _name, _packet, expected in cases]
+        assert caught.value.reason is expected
 
 
 def test_capture_rejects_midstream_payload_without_handshake(tmp_path: Path) -> None:

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import gc
 import json
 import os
@@ -11,7 +10,7 @@ import stat
 import sys
 import traceback
 import tracemalloc
-from collections.abc import Buffer, Callable, Mapping, Sequence
+from collections.abc import Buffer, Callable
 from importlib import util
 from pathlib import Path
 from types import ModuleType
@@ -74,12 +73,14 @@ def _ethernet_packet(
     sequence: int,
     flags: int,
     cloud_to_dongle: bool = False,
+    acknowledgement: int = 0,
 ) -> bytes:
     packet_module = _dpkt()
     tcp = packet_module.tcp.TCP(
         sport=4346 if cloud_to_dongle else 32000,
         dport=32000 if cloud_to_dongle else 4346,
         seq=sequence,
+        ack=acknowledgement,
         flags=flags,
         data=payload,
     )
@@ -93,6 +94,30 @@ def _ethernet_packet(
         src=b"\x02\x00\x00\x00\x00\x01",
         dst=b"\x02\x00\x00\x00\x00\x02",
         type=packet_module.ethernet.ETH_TYPE_IP,
+        data=ip,
+    )
+    return bytes(ethernet)
+
+
+def _ipv6_ethernet_packet(payload: bytes, *, sequence: int, flags: int) -> bytes:
+    packet_module = _dpkt()
+    tcp = packet_module.tcp.TCP(
+        sport=32000,
+        dport=4346,
+        seq=sequence,
+        flags=flags,
+        data=payload,
+    )
+    ip = packet_module.ip6.IP6(
+        src=bytes.fromhex("20010db8000000000000000000000001"),
+        dst=bytes.fromhex("20010db8000000000000000000000002"),
+        nxt=packet_module.ip.IP_PROTO_TCP,
+        data=tcp,
+    )
+    ethernet = packet_module.ethernet.Ethernet(
+        src=b"\x02\x00\x00\x00\x00\x01",
+        dst=b"\x02\x00\x00\x00\x00\x02",
+        type=packet_module.ethernet.ETH_TYPE_IP6,
         data=ip,
     )
     return bytes(ethernet)
@@ -185,34 +210,6 @@ def _segments(*payloads: bytes) -> list[CapturedSegment]:
 )
 def test_public_crc_seam_normalizes_bytes_like_inputs(value: Buffer) -> None:
     assert compute_crc16(value) == 0x4B37
-
-
-def test_crc_seam_loads_without_pymodbus(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module_name = "decode_cloud_frames_without_pymodbus"
-    script_path = Path(decoder_module.__file__)
-    spec = util.spec_from_file_location(module_name, script_path)
-    assert spec is not None and spec.loader is not None
-    loaded = util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, module_name, loaded)
-    original_import = builtins.__import__
-
-    def import_without_pymodbus(
-        name: str,
-        globals: Mapping[str, object] | None = None,
-        locals: Mapping[str, object] | None = None,
-        fromlist: Sequence[str] = (),
-        level: int = 0,
-    ) -> object:
-        if name == "pymodbus" or name.startswith("pymodbus."):
-            raise ImportError("optional dependency unavailable")
-        return original_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", import_without_pymodbus)
-    spec.loader.exec_module(loaded)
-
-    assert cast(_DecoderModule, loaded).compute_crc16(b"123456789") == 0x4B37
 
 
 @pytest.mark.parametrize(
@@ -590,6 +587,35 @@ def test_offline_pcap_adapter_and_cli_never_report_source_metadata(
     assert json.loads(output_path.read_text(encoding="utf-8")) == direct
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--unknown-option", "TOKEN-CANARY"],
+        ["SYNTHETIC_CANARY_INPUT", "--output"],
+        ["SYNTHETIC_CANARY_INPUT"],
+    ],
+)
+def test_cli_parse_failures_are_closed_redacted_errors(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(CaptureError) as caught:
+        decoder_module._parse_args(arguments)
+    direct_output = capsys.readouterr()
+
+    assert caught.value.reason is FailureReason.CLI
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert direct_output.out == ""
+    assert direct_output.err == ""
+
+    assert main(arguments) == 2
+    cli_output = capsys.readouterr()
+    diagnostics = cli_output.out + cli_output.err
+    assert cli_output.out == ""
+    assert cli_output.err == "capture rejected: cli\n"
+    assert not any(argument in diagnostics for argument in arguments)
+
+
 def test_pcap_reconnect_on_same_flow_starts_a_new_stream(tmp_path: Path) -> None:
     capture_path = tmp_path / "synthetic-reconnect.pcap"
     frames = (_c2(_read_response(start=7)), _c2(_read_response(start=42)))
@@ -636,7 +662,11 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
             (
                 2.1,
                 _ethernet_packet(
-                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
                 ),
             ),
             (
@@ -648,7 +678,11 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
             (
                 2.3,
                 _ethernet_packet(
-                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
                 ),
             ),
             (
@@ -675,13 +709,44 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
             (
                 4.1,
                 _ethernet_packet(
-                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
                 ),
             ),
             (
                 4.2,
                 _ethernet_packet(
-                    b"", sequence=299, flags=syn_ack, cloud_to_dongle=True
+                    b"",
+                    sequence=299,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
+                ),
+            ),
+        ],
+        "conflicting-server-ack": [
+            (4.5, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (
+                4.6,
+                _ethernet_packet(
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
+                ),
+            ),
+            (
+                4.7,
+                _ethernet_packet(
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=101,
                 ),
             ),
         ],
@@ -700,7 +765,11 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
             (
                 6.1,
                 _ethernet_packet(
-                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                    b"",
+                    sequence=199,
+                    flags=syn_ack,
+                    cloud_to_dongle=True,
+                    acknowledgement=100,
                 ),
             ),
             (
@@ -710,6 +779,7 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
                     sequence=199,
                     flags=syn_ack | packet_module.tcp.TH_RST,
                     cloud_to_dongle=True,
+                    acknowledgement=100,
                 ),
             ),
             (
@@ -724,6 +794,106 @@ def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
         with pytest.raises(CaptureError) as caught:
             process_pcap(capture_path)
         assert caught.value.reason is FailureReason.MALFORMED
+
+
+@pytest.mark.parametrize(
+    "packets",
+    [
+        pytest.param(
+            lambda tcp, frame: [
+                (
+                    1.0,
+                    _ethernet_packet(
+                        b"", sequence=99, flags=tcp.TH_SYN, acknowledgement=1
+                    ),
+                ),
+            ],
+            id="client-syn-acknowledgement",
+        ),
+        pytest.param(
+            lambda tcp, frame: [
+                (1.0, _ethernet_packet(b"", sequence=99, flags=tcp.TH_SYN)),
+                (
+                    1.1,
+                    _ethernet_packet(
+                        b"",
+                        sequence=199,
+                        flags=tcp.TH_SYN | tcp.TH_ACK,
+                        cloud_to_dongle=True,
+                        acknowledgement=101,
+                    ),
+                ),
+            ],
+            id="syn-ack-acknowledgement",
+        ),
+        pytest.param(
+            lambda tcp, frame: [
+                (1.0, _ethernet_packet(b"", sequence=99, flags=tcp.TH_SYN)),
+                (1.1, _ethernet_packet(frame, sequence=100, flags=tcp.TH_ACK)),
+                (
+                    1.2,
+                    _ethernet_packet(
+                        b"", sequence=100 + len(frame), flags=tcp.TH_FIN | tcp.TH_ACK
+                    ),
+                ),
+                (
+                    1.3,
+                    _ethernet_packet(
+                        frame, sequence=101 + len(frame), flags=tcp.TH_ACK
+                    ),
+                ),
+            ],
+            id="payload-after-fin",
+        ),
+        pytest.param(
+            lambda tcp, frame: [
+                (1.0, _ethernet_packet(b"", sequence=99, flags=tcp.TH_SYN)),
+                (
+                    1.1,
+                    _ethernet_packet(
+                        b"",
+                        sequence=199,
+                        flags=tcp.TH_SYN | tcp.TH_ACK,
+                        cloud_to_dongle=True,
+                        acknowledgement=100,
+                    ),
+                ),
+                (1.2, _ethernet_packet(frame, sequence=100, flags=tcp.TH_ACK)),
+                (
+                    1.3,
+                    _ethernet_packet(
+                        b"", sequence=100 + len(frame), flags=tcp.TH_RST | tcp.TH_ACK
+                    ),
+                ),
+                (
+                    1.4,
+                    _ethernet_packet(
+                        frame,
+                        sequence=200,
+                        flags=tcp.TH_ACK,
+                        cloud_to_dongle=True,
+                    ),
+                ),
+            ],
+            id="payload-after-rst-opposite-direction",
+        ),
+    ],
+)
+def test_pcap_rejects_invalid_ack_and_terminal_transitions(
+    tmp_path: Path,
+    packets: Callable[[ModuleType, bytes], list[tuple[float, bytes]]],
+) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "invalid-lifecycle.pcap"
+    _write_capture(
+        capture_path,
+        packets(packet_module.tcp, _cloud_frame(0xC1, b"\x01")),
+    )
+
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.MALFORMED
 
 
 def test_tcp_reassembler_requires_explicit_stream_origin() -> None:
@@ -882,6 +1052,41 @@ def test_reassembly_does_not_eagerly_allocate_per_flow_windows() -> None:
     assert bounded.retained_bytes == 0
 
 
+def test_fragmentation_buffers_have_charged_linear_resource_bounds() -> None:
+    policy = ParserPolicy(
+        maximum_frame_bytes=65535,
+        prefix_scan_bytes=64,
+        maximum_packet_bytes=65535,
+        maximum_segments_per_flow=65535,
+        maximum_reassembled_bytes_per_flow=65535,
+        maximum_aggregate_memory_bytes=256 * 1024,
+    )
+    advertised = bytearray(b"\xa1\x1a\x00\x01\x00\x00")
+    advertised[4:6] = (policy.maximum_frame_bytes - 6).to_bytes(2, "little")
+    incomplete = bytes(advertised) + bytes(policy.maximum_frame_bytes - 7)
+
+    gc.collect()
+    tracemalloc.start()
+    before, _ = tracemalloc.get_traced_memory()
+    decoder = StreamFrameDecoder(policy)
+    for byte in incomplete:
+        assert decoder.feed(bytes((byte,)), captured_at=1.0) == []
+    _, decoder_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    decoder_bound = policy.maximum_frame_bytes + policy.prefix_scan_bytes + 16 * 1024
+    assert decoder.buffered_bytes == len(incomplete)
+    assert decoder_peak - before <= decoder_bound
+
+    reassembler = TCPStreamReassembler(policy)
+    reassembler.start(0)
+    for offset in range(0, policy.maximum_reassembled_bytes_per_flow, 64):
+        payload = bytes(min(64, policy.maximum_reassembled_bytes_per_flow - offset))
+        reassembler.push(offset, payload, captured_at=2.0)
+
+    assert reassembler.retained_bytes <= 16 * 1024
+
+
 def test_sanitizer_flow_limit_accepts_exact_and_rejects_one_over() -> None:
     frame = _cloud_frame(0xC1, b"\x01")
     exact = [
@@ -906,7 +1111,17 @@ def test_sanitizer_aggregate_memory_limit_accepts_peak_and_rejects_one_under() -
         )
         for stream_id in range(2)
     ]
-    peak_retained = len(frame) * 3
+    policy = ParserPolicy()
+    per_flow_retained = (
+        min(
+            policy.maximum_packet_bytes,
+            policy.maximum_reassembled_bytes_per_flow,
+            16 * 1024,
+        )
+        + policy.maximum_frame_bytes
+        + policy.prefix_scan_bytes
+    )
+    peak_retained = per_flow_retained * len(segments)
 
     assert sanitize_segments(
         segments,
@@ -1214,6 +1429,25 @@ def test_capture_distinguishes_irrelevant_traffic_from_decode_failure(
     assert caught.value.reason is FailureReason.EMPTY
 
 
+def test_capture_rejects_ipv6_target_traffic_explicitly(tmp_path: Path) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "ipv6-target.pcap"
+    _write_capture(
+        capture_path,
+        [
+            (
+                1.0,
+                _ipv6_ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN),
+            )
+        ],
+    )
+
+    with pytest.raises(CaptureError) as caught:
+        process_pcap(capture_path)
+
+    assert caught.value.reason is FailureReason.IP_VERSION
+
+
 def test_capture_rejects_midstream_payload_without_handshake(tmp_path: Path) -> None:
     packet_module = _dpkt()
     capture_path = tmp_path / "midstream.pcap"
@@ -1471,6 +1705,38 @@ def test_output_failures_remove_temporary_and_published_files(
         assert list(destination_dir.iterdir()) == []
         if stage == "directory_fsync":
             assert directory_fsync_attempts == 2
+
+
+@pytest.mark.parametrize("close_before_raise", [True, False])
+def test_output_is_committed_after_directory_fsync_despite_close_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    close_before_raise: bool,
+) -> None:
+    output_path = tmp_path / "output.json"
+    original_close = os.close
+    failed_descriptor: int | None = None
+    close_attempts = 0
+
+    def ambiguous_close(descriptor: int) -> None:
+        nonlocal close_attempts, failed_descriptor
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            close_attempts += 1
+            failed_descriptor = descriptor
+            if close_before_raise:
+                original_close(descriptor)
+            raise OSError("CLOSE-CANARY")
+        original_close(descriptor)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(os, "close", ambiguous_close)
+        decoder_module._write_exclusive(output_path, b"synthetic\n")
+
+    assert output_path.read_bytes() == b"synthetic\n"
+    assert close_attempts == 1
+    if not close_before_raise:
+        assert failed_descriptor is not None
+        original_close(failed_descriptor)
 
 
 def test_missing_dpkt_fails_closed_in_process_and_cli(

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -1,0 +1,450 @@
+"""Offline-only tests for the dongle capture sanitizer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import dpkt
+import pytest
+
+import scripts.decode_cloud_frames as decoder_module
+from scripts.decode_cloud_frames import (
+    CaptureError,
+    CapturedSegment,
+    FailureReason,
+    ParserPolicy,
+    StreamFrameDecoder,
+    TCPStreamReassembler,
+    compute_crc16,
+    main,
+    process_pcap,
+    sanitize_segments,
+)
+
+
+OUTER_IDENTITY = b"CANARYDG01"
+INNER_IDENTITY = b"CANARYIV01"
+
+
+def _cloud_frame(
+    function: int,
+    payload: bytes,
+    *,
+    identity: bytes = OUTER_IDENTITY,
+) -> bytes:
+    body = bytes((1, function)) + identity + payload
+    return b"\xa1\x1a\x00\x01" + len(body).to_bytes(2, "little") + body
+
+
+def _read_request(
+    *,
+    start: int = 7,
+    count: int = 2,
+    function: int = 0x03,
+    identity: bytes = INNER_IDENTITY,
+) -> bytes:
+    body = bytes((1, function)) + identity
+    body += start.to_bytes(2, "little") + count.to_bytes(2, "little")
+    return body + compute_crc16(body).to_bytes(2, "little")
+
+
+def _read_response(
+    *,
+    start: int = 7,
+    words: tuple[int, ...] = (0x1234, 0x5678),
+    function: int = 0x04,
+    identity: bytes = INNER_IDENTITY,
+) -> bytes:
+    register_data = b"".join(word.to_bytes(2, "little") for word in words)
+    body = (
+        bytes((1, function))
+        + identity
+        + start.to_bytes(2, "little")
+        + bytes((len(register_data),))
+        + register_data
+    )
+    return body + compute_crc16(body).to_bytes(2, "little")
+
+
+def _c2(modbus_frame: bytes, *, identity: bytes = OUTER_IDENTITY) -> bytes:
+    payload = len(modbus_frame).to_bytes(2, "little") + modbus_frame
+    return _cloud_frame(0xC2, payload, identity=identity)
+
+
+def _segments(*payloads: bytes) -> list[CapturedSegment]:
+    sequence = 100
+    captured_at = 10.0
+    result: list[CapturedSegment] = []
+    for payload in payloads:
+        result.append(
+            CapturedSegment(
+                direction="dongle_to_cloud",
+                sequence=sequence,
+                captured_at=captured_at,
+                payload=payload,
+            )
+        )
+        sequence += len(payload)
+        captured_at += 0.01
+    return result
+
+
+@pytest.mark.parametrize(
+    ("maximum_frame_bytes", "prefix_scan_bytes", "overall_frame_deadline"),
+    [(512, 2, 1.0), (4096, 64, 5.0), (65535, 1024, 30.0)],
+)
+def test_parser_policy_accepts_contract_boundaries(
+    maximum_frame_bytes: int,
+    prefix_scan_bytes: int,
+    overall_frame_deadline: float,
+) -> None:
+    policy = ParserPolicy(
+        maximum_frame_bytes=maximum_frame_bytes,
+        prefix_scan_bytes=prefix_scan_bytes,
+        overall_frame_deadline=overall_frame_deadline,
+    )
+
+    assert policy.maximum_frame_bytes == maximum_frame_bytes
+    assert policy.prefix_scan_bytes == prefix_scan_bytes
+    assert policy.overall_frame_deadline == overall_frame_deadline
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"maximum_frame_bytes": 511},
+        {"maximum_frame_bytes": 65536},
+        {"prefix_scan_bytes": 1},
+        {"prefix_scan_bytes": 1025},
+        {"overall_frame_deadline": 0.9},
+        {"overall_frame_deadline": 30.1},
+    ],
+)
+def test_parser_policy_rejects_values_outside_contract(
+    overrides: dict[str, int | float],
+) -> None:
+    with pytest.raises(ValueError, match="outside the internal contract"):
+        ParserPolicy(**overrides)  # type: ignore[arg-type]
+
+
+def test_stream_decoder_handles_every_split_and_byte_fragmentation() -> None:
+    frame = _c2(_read_request())
+
+    for split in range(1, len(frame)):
+        decoder = StreamFrameDecoder()
+        assert decoder.feed(frame[:split], captured_at=1.0) == []
+        assert decoder.feed(frame[split:], captured_at=1.1) == [frame]
+        decoder.close(captured_at=1.1)
+
+    byte_decoder = StreamFrameDecoder()
+    decoded: list[bytes] = []
+    for index, byte in enumerate(frame):
+        decoded.extend(byte_decoder.feed(bytes((byte,)), captured_at=2 + index / 100))
+    assert decoded == [frame]
+
+
+def test_stream_decoder_emits_coalesced_frames() -> None:
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    request = _c2(_read_request())
+
+    assert StreamFrameDecoder().feed(heartbeat + request, captured_at=1.0) == [
+        heartbeat,
+        request,
+    ]
+
+
+def test_tcp_reassembler_deduplicates_and_orders_segments() -> None:
+    reassembler = TCPStreamReassembler(ParserPolicy())
+
+    assert reassembler.push(100, b"abc", captured_at=1.0) == [(1.0, b"abc")]
+    assert reassembler.push(106, b"ghi", captured_at=1.2) == []
+    assert reassembler.push(100, b"abc", captured_at=1.3) == []
+    assert reassembler.push(102, b"cdef", captured_at=1.4) == [
+        (1.4, b"def"),
+        (1.4, b"ghi"),
+    ]
+
+
+def test_tcp_reassembler_fails_closed_on_gap_conflict_and_capacity() -> None:
+    gap = TCPStreamReassembler()
+    gap.push(100, b"a", captured_at=1.0)
+    gap.push(102, b"c", captured_at=1.1)
+    with pytest.raises(CaptureError) as gap_error:
+        gap.close()
+    assert gap_error.value.reason is FailureReason.TRUNCATED
+
+    conflict = TCPStreamReassembler()
+    conflict.push(100, b"a", captured_at=1.0)
+    conflict.push(102, b"c", captured_at=1.1)
+    with pytest.raises(CaptureError) as conflict_error:
+        conflict.push(102, b"d", captured_at=1.2)
+    assert conflict_error.value.reason is FailureReason.MALFORMED
+
+    capacity = TCPStreamReassembler()
+    capacity.push(100, b"a", captured_at=1.0)
+    with pytest.raises(CaptureError) as capacity_error:
+        capacity.push(102, b"x" * (16 * 1024 + 1), captured_at=1.1)
+    assert capacity_error.value.reason is FailureReason.CAPACITY
+
+
+def test_combined_stream_storage_matches_contract_budget() -> None:
+    policy = ParserPolicy()
+    decoder_storage = policy.maximum_frame_bytes + policy.prefix_scan_bytes
+
+    assert decoder_storage + policy.reassembly_capacity == (
+        policy.maximum_frame_bytes + policy.prefix_scan_bytes + 16 * 1024
+    )
+
+
+def test_stream_decoder_rejects_truncation_at_eof() -> None:
+    decoder = StreamFrameDecoder()
+    decoder.feed(_cloud_frame(0xC1, b"\x01")[:-1], captured_at=1.0)
+
+    with pytest.raises(CaptureError) as caught:
+        decoder.close(captured_at=1.1)
+
+    assert caught.value.reason is FailureReason.TRUNCATED
+
+
+def test_stream_decoder_rejects_oversize_before_body_buffering() -> None:
+    decoder = StreamFrameDecoder(ParserPolicy(maximum_frame_bytes=512))
+    advertised_body = (507).to_bytes(2, "little")
+
+    with pytest.raises(CaptureError) as caught:
+        decoder.feed(b"\xa1\x1a\x00\x01" + advertised_body, captured_at=1.0)
+
+    assert caught.value.reason is FailureReason.OVERSIZE
+    assert decoder.buffered_bytes <= 6
+
+
+def test_stream_decoder_enforces_bounded_prefix_scan() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    decoder = StreamFrameDecoder(ParserPolicy(prefix_scan_bytes=2))
+    assert decoder.feed(b"xy" + frame, captured_at=1.0) == [frame]
+
+    with pytest.raises(CaptureError) as caught:
+        StreamFrameDecoder(ParserPolicy(prefix_scan_bytes=2)).feed(
+            b"xyz" + frame, captured_at=1.0
+        )
+
+    assert caught.value.reason is FailureReason.PREFIX
+
+
+def test_stream_decoder_uses_one_non_resetting_deadline() -> None:
+    decoder = StreamFrameDecoder(ParserPolicy(overall_frame_deadline=1.0))
+    frame = _cloud_frame(0xC1, b"\x01")
+    decoder.feed(frame[:2], captured_at=1.0)
+    decoder.feed(frame[2:3], captured_at=1.9)
+
+    with pytest.raises(CaptureError) as caught:
+        decoder.feed(frame[3:4], captured_at=2.01)
+
+    assert caught.value.reason is FailureReason.TIMEOUT
+
+
+def test_sanitizer_rejects_bad_crc() -> None:
+    bad_request = bytearray(_read_request())
+    bad_request[-1] ^= 0xFF
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(_c2(bytes(bad_request))))
+
+    assert caught.value.reason is FailureReason.CRC
+
+
+def test_sanitizer_rejects_mismatched_identity_on_stream() -> None:
+    first = _cloud_frame(0xC1, b"\x01")
+    second = _cloud_frame(0xC1, b"\x01", identity=b"CANARYDG02")
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(first, second))
+
+    assert caught.value.reason is FailureReason.IDENTITY
+
+
+def test_sanitizer_rejects_mismatched_inner_address() -> None:
+    inner = bytearray(_read_request())
+    inner[0] = 2
+    inner[-2:] = compute_crc16(inner[:-2]).to_bytes(2, "little")
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(_c2(bytes(inner))))
+
+    assert caught.value.reason is FailureReason.IDENTITY
+
+
+@pytest.mark.parametrize(
+    ("frame", "reason"),
+    [
+        (_cloud_frame(0xCF, b"\x01"), FailureReason.FUNCTION),
+        (_c2(_read_request(function=0x06)), FailureReason.FUNCTION),
+        (_c2(_read_request(start=65535, count=2)), FailureReason.RANGE),
+    ],
+)
+def test_sanitizer_fails_closed_on_unknown_functions_and_ranges(
+    frame: bytes,
+    reason: FailureReason,
+) -> None:
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(frame))
+
+    assert caught.value.reason is reason
+
+
+def test_sanitizer_emits_only_synthetic_minimal_data() -> None:
+    protected_canaries = (
+        b"PIN=7391;PSK=private-canary;cookie=private-cookie;"
+        b"token=private-token;192.0.2.99;02:00:5e:10:00:00"
+    )
+    heartbeat = _cloud_frame(0xC1, b"\x01" + protected_canaries)
+    response = _c2(_read_response())
+
+    sanitized = sanitize_segments(_segments(heartbeat, response))
+    serialized = json.dumps(sanitized, sort_keys=True)
+
+    for forbidden in (
+        OUTER_IDENTITY.decode(),
+        INNER_IDENTITY.decode(),
+        protected_canaries.decode(),
+        "192.0.2.99",
+        "02:00:5e:10:00:00",
+        "1234",
+        "5678",
+    ):
+        assert forbidden not in serialized
+    assert sanitized["capture"] == {
+        "source": "authorized_offline_input",
+        "dongle_address": "192.0.2.10",
+        "cloud_address": "198.51.100.20",
+    }
+    assert all(frame["identity"].startswith("SYNTH") for frame in sanitized["frames"])
+    response_record = sanitized["frames"][1]
+    assert response_record["register_count"] == 2
+    assert response_record["register_words"] == ["SYNTHETIC_A55A"]
+
+
+def test_sanitizer_matches_synthetic_minimum_golden_fixture() -> None:
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    response = _c2(_read_response(start=7, words=(0x1234, 0x5678)))
+
+    actual = sanitize_segments(_segments(heartbeat, response))
+    fixture_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "dongle_emulation"
+        / "minimal_sanitized.json"
+    )
+
+    assert actual == json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_sanitizer_fails_closed_at_synthetic_record_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(decoder_module, "MAX_SANITIZED_RECORDS", 1)
+    first = _c2(_read_response(start=7))
+    second = _c2(_read_response(start=42))
+
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(first, second))
+
+    assert caught.value.reason is FailureReason.CAPACITY
+
+
+def test_offline_pcap_adapter_and_cli_never_report_source_metadata(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    response = _c2(_read_response())
+    chunks = (heartbeat[:5], heartbeat[5:] + response)
+    capture_path = tmp_path / "CANARYDG01-authorized-input.pcap"
+    output_path = tmp_path / "sanitized.json"
+
+    with capture_path.open("wb") as capture_file:
+        writer = dpkt.pcap.Writer(capture_file)
+        sequence = 100
+        for index, chunk in enumerate(chunks):
+            tcp = dpkt.tcp.TCP(
+                sport=32000,
+                dport=4346,
+                seq=sequence,
+                flags=dpkt.tcp.TH_ACK,
+                data=chunk,
+            )
+            ip = dpkt.ip.IP(
+                src=b"\xc0\x00\x02\x63",
+                dst=b"\xc6\x33\x64\x63",
+                p=dpkt.ip.IP_PROTO_TCP,
+                data=tcp,
+            )
+            ethernet = dpkt.ethernet.Ethernet(
+                src=b"\x02\x00\x00\x00\x00\x01",
+                dst=b"\x02\x00\x00\x00\x00\x02",
+                type=dpkt.ethernet.ETH_TYPE_IP,
+                data=ip,
+            )
+            writer.writepkt(ethernet, ts=1.0 + index / 10)
+            sequence += len(chunk)
+        writer.close()
+
+    direct = process_pcap(capture_path)
+    assert direct["frames"][0]["identity"] == "SYNTHDG001"
+    assert (
+        main(
+            [
+                str(capture_path),
+                "--output",
+                str(output_path),
+                "--authorized-offline-input",
+            ]
+        )
+        == 0
+    )
+    captured_output = capsys.readouterr()
+    assert "CANARYDG01" not in captured_output.out
+    assert "CANARYDG01" not in captured_output.err
+    assert str(capture_path) not in captured_output.out
+    assert str(capture_path) not in captured_output.err
+    assert str(output_path) not in captured_output.out
+    assert str(output_path) not in captured_output.err
+    assert json.loads(output_path.read_text(encoding="utf-8")) == direct
+
+
+def test_pcap_reconnect_on_same_flow_starts_a_new_stream(tmp_path: Path) -> None:
+    capture_path = tmp_path / "synthetic-reconnect.pcap"
+    frames = (_c2(_read_response(start=7)), _c2(_read_response(start=42)))
+
+    with capture_path.open("wb") as capture_file:
+        writer = dpkt.pcap.Writer(capture_file)
+        for timestamp, sequence, flags, payload in (
+            (1.0, 100, dpkt.tcp.TH_SYN, b""),
+            (1.1, 101, dpkt.tcp.TH_ACK, frames[0]),
+            (2.0, 10, dpkt.tcp.TH_SYN, b""),
+            (2.1, 11, dpkt.tcp.TH_ACK, frames[1]),
+        ):
+            tcp = dpkt.tcp.TCP(
+                sport=32000,
+                dport=4346,
+                seq=sequence,
+                flags=flags,
+                data=payload,
+            )
+            ip = dpkt.ip.IP(
+                src=b"\xc0\x00\x02\x63",
+                dst=b"\xc6\x33\x64\x63",
+                p=dpkt.ip.IP_PROTO_TCP,
+                data=tcp,
+            )
+            ethernet = dpkt.ethernet.Ethernet(
+                src=b"\x02\x00\x00\x00\x00\x01",
+                dst=b"\x02\x00\x00\x00\x00\x02",
+                type=dpkt.ethernet.ETH_TYPE_IP,
+                data=ip,
+            )
+            writer.writepkt(ethernet, ts=timestamp)
+        writer.close()
+
+    sanitized = process_pcap(capture_path)
+
+    assert [frame["start_register"] for frame in sanitized["frames"]] == [7, 42]

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -314,16 +314,33 @@ def test_stream_decoder_emits_coalesced_frames() -> None:
     ]
 
 
-def test_find_frames_preserves_offsets_and_incomplete_tail() -> None:
+def test_find_frames_preserves_offsets_for_complete_input() -> None:
     heartbeat = _cloud_frame(0xC1, b"\x01")
     request = _c2(_read_request())
     prefix = b"x"
-    data = prefix + heartbeat + request + heartbeat[:5]
+    data = prefix + heartbeat + request
 
     assert find_frames(data) == [
         (len(prefix), heartbeat),
         (len(prefix) + len(heartbeat), request),
     ]
+
+
+@pytest.mark.parametrize(
+    "tail_kind", ["partial-prefix", "partial-header", "partial-body"]
+)
+def test_find_frames_rejects_incomplete_eof_tail(tail_kind: str) -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    tails = {
+        "partial-prefix": frame[:1],
+        "partial-header": frame[:5],
+        "partial-body": frame[:-1],
+    }
+
+    with pytest.raises(CaptureError) as caught:
+        find_frames(frame + tails[tail_kind])
+
+    assert caught.value.reason is FailureReason.TRUNCATED
 
 
 def test_find_frames_preserves_strict_failure_contract() -> None:

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import builtins
+import gc
 import json
 import os
 import socket
+import stat
 import sys
-from collections.abc import Buffer, Callable
+import traceback
+import tracemalloc
+from collections.abc import Buffer, Callable, Mapping, Sequence
 from importlib import util
 from pathlib import Path
 from types import ModuleType
@@ -48,6 +53,8 @@ PROTECTED_CANARIES = {
 class _DecoderModule(Protocol):
     dpkt: ModuleType | None
     CaptureError: type[Exception]
+
+    def compute_crc16(self, data: Buffer) -> int: ...
 
     def process_pcap(self, pcap_path: str | Path) -> dict[str, object]: ...
 
@@ -180,6 +187,34 @@ def test_public_crc_seam_normalizes_bytes_like_inputs(value: Buffer) -> None:
     assert compute_crc16(value) == 0x4B37
 
 
+def test_crc_seam_loads_without_pymodbus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "decode_cloud_frames_without_pymodbus"
+    script_path = Path(decoder_module.__file__)
+    spec = util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    loaded = util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, loaded)
+    original_import = builtins.__import__
+
+    def import_without_pymodbus(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "pymodbus" or name.startswith("pymodbus."):
+            raise ImportError("optional dependency unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pymodbus)
+    spec.loader.exec_module(loaded)
+
+    assert cast(_DecoderModule, loaded).compute_crc16(b"123456789") == 0x4B37
+
+
 @pytest.mark.parametrize(
     ("maximum_frame_bytes", "prefix_scan_bytes", "overall_frame_deadline"),
     [(512, 2, 1.0), (4096, 64, 5.0), (65535, 1024, 30.0)],
@@ -209,6 +244,8 @@ def test_parser_policy_accepts_contract_boundaries(
         lambda: ParserPolicy(prefix_scan_bytes=1025),
         lambda: ParserPolicy(overall_frame_deadline=0.9),
         lambda: ParserPolicy(overall_frame_deadline=30.1),
+        lambda: ParserPolicy(overall_frame_deadline=float("nan")),
+        lambda: ParserPolicy(overall_frame_deadline=float("inf")),
         lambda: ParserPolicy(maximum_capture_bytes=0),
         lambda: ParserPolicy(maximum_packet_bytes=0),
         lambda: ParserPolicy(maximum_packets=0),
@@ -353,6 +390,46 @@ def test_stream_decoder_uses_one_non_resetting_deadline() -> None:
         decoder.feed(frame[3:4], captured_at=2.01)
 
     assert caught.value.reason is FailureReason.TIMEOUT
+
+
+def test_capture_timestamps_must_be_finite_and_monotonic() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    invalid_captures = (
+        [CapturedSegment("dongle_to_cloud", 100, value, frame, 0, True)]
+        for value in (float("nan"), float("inf"), float("-inf"))
+    )
+    decreasing = [
+        CapturedSegment("dongle_to_cloud", 100, 2.0, b"", 0, True),
+        CapturedSegment("dongle_to_cloud", 100, 1.0, frame, 0),
+    ]
+
+    for segments in (*invalid_captures, decreasing):
+        with pytest.raises(CaptureError) as caught:
+            sanitize_segments(segments)
+        assert caught.value.reason is FailureReason.MALFORMED
+
+
+def test_reassembly_gap_uses_earliest_fragment_deadline() -> None:
+    frame = _cloud_frame(0xC1, b"\x01")
+    captures = (
+        [
+            CapturedSegment("dongle_to_cloud", 100, 1.0, b"", 0, True),
+            CapturedSegment("dongle_to_cloud", 101, 1.0, frame[1:], 0),
+            CapturedSegment("dongle_to_cloud", 100, 2.01, frame[:1], 0),
+        ],
+        [
+            CapturedSegment("dongle_to_cloud", 100, 1.0, b"", 0, True),
+            CapturedSegment("dongle_to_cloud", 100, 1.0, frame[:3], 0),
+            CapturedSegment("dongle_to_cloud", 104, 1.9, frame[4:], 0),
+            CapturedSegment("dongle_to_cloud", 103, 2.01, frame[3:4], 0),
+        ],
+    )
+
+    for segments in captures:
+        with pytest.raises(CaptureError) as caught:
+            sanitize_segments(segments, ParserPolicy(overall_frame_deadline=1.0))
+
+        assert caught.value.reason is FailureReason.TIMEOUT
 
 
 def test_sanitizer_rejects_bad_crc() -> None:
@@ -539,6 +616,116 @@ def test_pcap_reconnect_on_same_flow_starts_a_new_stream(tmp_path: Path) -> None
     assert [frame["start_register"] for frame in sanitized["frames"]] == [7, 42]
 
 
+def test_pcap_handshake_retransmissions_are_exact_in_both_directions(
+    tmp_path: Path,
+) -> None:
+    packet_module = _dpkt()
+    frame = _cloud_frame(0xC1, b"\x01")
+    syn = packet_module.tcp.TH_SYN
+    syn_ack = packet_module.tcp.TH_SYN | packet_module.tcp.TH_ACK
+    ack = packet_module.tcp.TH_ACK
+    captures = {
+        "exact-client": [
+            (1.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (1.1, _ethernet_packet(frame[:5], sequence=100, flags=ack)),
+            (1.2, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (1.3, _ethernet_packet(frame[5:], sequence=105, flags=ack)),
+        ],
+        "exact-server": [
+            (2.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (
+                2.1,
+                _ethernet_packet(
+                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                ),
+            ),
+            (
+                2.2,
+                _ethernet_packet(
+                    frame[:5], sequence=200, flags=ack, cloud_to_dongle=True
+                ),
+            ),
+            (
+                2.3,
+                _ethernet_packet(
+                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                ),
+            ),
+            (
+                2.4,
+                _ethernet_packet(
+                    frame[5:], sequence=205, flags=ack, cloud_to_dongle=True
+                ),
+            ),
+        ],
+    }
+    for name, packets in captures.items():
+        capture_path = tmp_path / f"{name}.pcap"
+        _write_capture(capture_path, packets)
+        assert process_pcap(capture_path)["frames"]
+
+    conflicting = {
+        "conflicting-client": [
+            (3.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (3.1, _ethernet_packet(b"", sequence=199, flags=syn)),
+            (3.2, _ethernet_packet(frame, sequence=200, flags=ack)),
+        ],
+        "conflicting-server": [
+            (4.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (
+                4.1,
+                _ethernet_packet(
+                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                ),
+            ),
+            (
+                4.2,
+                _ethernet_packet(
+                    b"", sequence=299, flags=syn_ack, cloud_to_dongle=True
+                ),
+            ),
+        ],
+        "conflicting-client-flags": [
+            (5.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (
+                5.1,
+                _ethernet_packet(
+                    b"", sequence=99, flags=syn | packet_module.tcp.TH_FIN
+                ),
+            ),
+            (5.2, _ethernet_packet(frame, sequence=100, flags=ack)),
+        ],
+        "conflicting-server-flags": [
+            (6.0, _ethernet_packet(b"", sequence=99, flags=syn)),
+            (
+                6.1,
+                _ethernet_packet(
+                    b"", sequence=199, flags=syn_ack, cloud_to_dongle=True
+                ),
+            ),
+            (
+                6.2,
+                _ethernet_packet(
+                    b"",
+                    sequence=199,
+                    flags=syn_ack | packet_module.tcp.TH_RST,
+                    cloud_to_dongle=True,
+                ),
+            ),
+            (
+                6.3,
+                _ethernet_packet(frame, sequence=200, flags=ack, cloud_to_dongle=True),
+            ),
+        ],
+    }
+    for name, packets in conflicting.items():
+        capture_path = tmp_path / f"{name}.pcap"
+        _write_capture(capture_path, packets)
+        with pytest.raises(CaptureError) as caught:
+            process_pcap(capture_path)
+        assert caught.value.reason is FailureReason.MALFORMED
+
+
 def test_tcp_reassembler_requires_explicit_stream_origin() -> None:
     reassembler = TCPStreamReassembler()
 
@@ -639,20 +826,26 @@ def test_tcp_reassembler_rejects_every_conflicting_overlap_shape(
 
 def test_reassembly_memory_and_stream_limits_accept_exact_and_reject_one_over() -> None:
     exact_policy = ParserPolicy(
-        maximum_reassembled_bytes_per_flow=4,
-        maximum_aggregate_memory_bytes=4,
+        maximum_packet_bytes=2,
+        maximum_reassembled_bytes_per_flow=5,
+        maximum_aggregate_memory_bytes=5,
     )
     exact = TCPStreamReassembler(exact_policy)
     exact.start(1)
-    assert exact.push(1, b"abcd", captured_at=1.0) == [(1.0, b"abcd")]
-    assert exact.retained_bytes == 4
+    assert exact.push(1, b"abcde", captured_at=1.0) == [(1.0, b"abcde")]
+    assert exact.retained_bytes == 2
 
-    aggregate = TCPStreamReassembler(exact_policy)
+    aggregate_policy = ParserPolicy(
+        maximum_packet_bytes=4,
+        maximum_reassembled_bytes_per_flow=5,
+        maximum_aggregate_memory_bytes=4,
+    )
+    aggregate = TCPStreamReassembler(aggregate_policy)
     aggregate.start(1)
     with pytest.raises(CaptureError) as aggregate_error:
         aggregate.push(1, b"abcde", captured_at=1.0)
     assert aggregate_error.value.reason is FailureReason.CAPACITY
-    assert aggregate.retained_bytes <= exact_policy.maximum_aggregate_memory_bytes
+    assert aggregate.retained_bytes <= aggregate_policy.maximum_aggregate_memory_bytes
 
     stream_policy = ParserPolicy(
         maximum_reassembled_bytes_per_flow=4,
@@ -664,6 +857,29 @@ def test_reassembly_memory_and_stream_limits_accept_exact_and_reject_one_over() 
         stream.push(1, b"abcde", captured_at=1.0)
     assert stream_error.value.reason is FailureReason.CAPACITY
     assert stream.retained_bytes <= stream_policy.maximum_aggregate_memory_bytes
+
+
+def test_reassembly_does_not_eagerly_allocate_per_flow_windows() -> None:
+    policy = ParserPolicy(
+        maximum_pending_bytes_per_flow=1024 * 1024,
+        maximum_aggregate_memory_bytes=64 * 1024,
+    )
+    gc.collect()
+    tracemalloc.start()
+    before, _ = tracemalloc.get_traced_memory()
+    reassemblers = [TCPStreamReassembler(policy) for _ in range(4)]
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert all(reassembler.retained_bytes == 0 for reassembler in reassemblers)
+    assert peak - before <= policy.maximum_aggregate_memory_bytes
+
+    bounded = TCPStreamReassembler(policy)
+    bounded.start(0)
+    with pytest.raises(CaptureError) as caught:
+        bounded.push(1, b"x" * 1024, captured_at=1.0)
+    assert caught.value.reason is FailureReason.CAPACITY
+    assert bounded.retained_bytes == 0
 
 
 def test_sanitizer_flow_limit_accepts_exact_and_rejects_one_over() -> None:
@@ -866,6 +1082,95 @@ def test_process_pcap_redacts_read_failures(
     assert str(caught.value) == "capture rejected: input_changed"
 
 
+def test_capture_errors_drop_raw_exception_chains_and_diagnostics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet_module = _dpkt()
+    valid_capture = tmp_path / "valid.pcap"
+    _write_capture(
+        valid_capture,
+        [(1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN))],
+    )
+    caught_errors: list[tuple[CaptureError, str]] = []
+
+    invalid_identity = b"\xffUNICODE!!"
+    with pytest.raises(CaptureError) as unicode_error:
+        sanitize_segments(
+            [
+                CapturedSegment(
+                    "dongle_to_cloud",
+                    100,
+                    1.0,
+                    _cloud_frame(0xC1, b"\x01", identity=invalid_identity),
+                    0,
+                    True,
+                )
+            ]
+        )
+    caught_errors.append((unicode_error.value, "UNICODE!!"))
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            os,
+            "read",
+            lambda descriptor, count: (_ for _ in ()).throw(
+                OSError("FILESYSTEM-CANARY")
+            ),
+        )
+        with pytest.raises(CaptureError) as filesystem_error:
+            process_pcap(valid_capture)
+    caught_errors.append((filesystem_error.value, "FILESYSTEM-CANARY"))
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            decoder_module,
+            "_decode_link_packet",
+            lambda packet, link_type: (_ for _ in ()).throw(
+                ValueError("PACKET-CANARY")
+            ),
+        )
+        with pytest.raises(CaptureError) as packet_error:
+            process_pcap(valid_capture)
+    caught_errors.append((packet_error.value, "PACKET-CANARY"))
+
+    with monkeypatch.context() as scoped:
+        real_close = os.close
+        failed = False
+
+        def failed_close(descriptor: int) -> None:
+            nonlocal failed
+            if not failed:
+                failed = True
+                real_close(descriptor)
+                raise OSError("CLOSE-CANARY")
+            real_close(descriptor)
+
+        scoped.setattr(os, "close", failed_close)
+        with pytest.raises(CaptureError) as close_error:
+            process_pcap(valid_capture)
+    caught_errors.append((close_error.value, "CLOSE-CANARY"))
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            os,
+            "link",
+            lambda source, destination, **kwargs: (_ for _ in ()).throw(
+                OSError("PUBLISH-CANARY")
+            ),
+        )
+        with pytest.raises(CaptureError) as publish_error:
+            decoder_module._write_exclusive(tmp_path / "output.json", b"{}\n")
+    caught_errors.append((publish_error.value, "PUBLISH-CANARY"))
+
+    for error, canary in caught_errors:
+        diagnostics = "".join(traceback.format_exception(error))
+        diagnostics += repr((error, error.args, error.__dict__))
+        assert error.__cause__ is None
+        assert error.__context__ is None
+        assert canary not in diagnostics
+
+
 def test_capture_rejects_unsupported_link_and_malformed_supported_packet(
     tmp_path: Path,
 ) -> None:
@@ -983,61 +1288,14 @@ def test_capture_packet_count_and_size_limits_have_exact_boundaries(
     assert packet_size.value.reason is FailureReason.CAPACITY
 
 
-def test_output_uses_one_exclusive_write_and_removes_short_write(
+def test_output_is_hidden_until_complete_and_handles_partial_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     packet_module = _dpkt()
     frame = _cloud_frame(0xC1, b"\x01")
     capture_path = tmp_path / "input.pcap"
     output_path = tmp_path / "output.json"
-    _write_capture(
-        capture_path,
-        [
-            (1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)),
-            (
-                1.1,
-                _ethernet_packet(frame, sequence=100, flags=packet_module.tcp.TH_ACK),
-            ),
-        ],
-    )
-    writes = 0
-
-    def short_write(descriptor: int, content: Buffer) -> int:
-        nonlocal writes
-        writes += 1
-        return max(0, len(memoryview(content)) - 1)
-
-    monkeypatch.setattr(os, "write", short_write)
-    assert (
-        main(
-            [
-                str(capture_path),
-                "--output",
-                str(output_path),
-                "--authorized-offline-input",
-            ]
-        )
-        == 2
-    )
-    output = capsys.readouterr()
-
-    assert writes == 1
-    assert not output_path.exists()
-    assert output.out == ""
-    assert output.err == "capture rejected: output\n"
-
-
-def test_output_success_is_one_write_and_existing_target_is_preserved(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    packet_module = _dpkt()
-    capture_path = tmp_path / "input.pcap"
-    output_path = tmp_path / "output.json"
-    frame = _cloud_frame(0xC1, b"\x01")
     _write_capture(
         capture_path,
         [
@@ -1049,14 +1307,83 @@ def test_output_success_is_one_write_and_existing_target_is_preserved(
         ],
     )
     original_write = os.write
-    writes = 0
+    original_fsync = os.fsync
+    target_visible_during_write: list[bool] = []
+    fsync_kinds: list[str] = []
 
-    def counted_write(descriptor: int, content: Buffer) -> int:
-        nonlocal writes
-        writes += 1
-        return original_write(descriptor, content)
+    def short_write(descriptor: int, content: Buffer) -> int:
+        target_visible_during_write.append(output_path.exists())
+        view = memoryview(content)
+        return original_write(descriptor, view[: max(1, len(view) // 2)])
 
-    monkeypatch.setattr(os, "write", counted_write)
+    def tracked_fsync(descriptor: int) -> None:
+        mode = os.fstat(descriptor).st_mode
+        fsync_kinds.append("directory" if stat.S_ISDIR(mode) else "file")
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "write", short_write)
+    monkeypatch.setattr(os, "fsync", tracked_fsync)
+    assert (
+        main(
+            [
+                str(capture_path),
+                "--output",
+                str(output_path),
+                "--authorized-offline-input",
+            ]
+        )
+        == 0
+    )
+
+    assert len(target_visible_during_write) > 1
+    assert not any(target_visible_during_write)
+    assert output_path.exists()
+    assert fsync_kinds == ["file", "directory"]
+
+
+def test_output_publication_is_mode_0600_and_never_replaces_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    packet_module = _dpkt()
+    capture_path = tmp_path / "input.pcap"
+    output_path = tmp_path / "output.json"
+    frame = _cloud_frame(0xC1, b"\x01")
+    _write_capture(
+        capture_path,
+        [
+            (1.0, _ethernet_packet(b"", sequence=99, flags=packet_module.tcp.TH_SYN)),
+            (
+                1.1,
+                _ethernet_packet(frame, sequence=100, flags=packet_module.tcp.TH_ACK),
+            ),
+        ],
+    )
+    original_link = os.link
+    publications = 0
+    publication_coordinates: list[tuple[str, str, int | None, int | None]] = []
+
+    def counted_link(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal publications
+        publications += 1
+        publication_coordinates.append((source, destination, src_dir_fd, dst_dir_fd))
+        original_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(os, "link", counted_link)
     arguments = [
         str(capture_path),
         "--output",
@@ -1064,13 +1391,86 @@ def test_output_success_is_one_write_and_existing_target_is_preserved(
         "--authorized-offline-input",
     ]
     assert main(arguments) == 0
-    assert writes == 1
+    assert publications == 1
+    assert len(publication_coordinates) == 1
+    source, destination, source_directory, destination_directory = (
+        publication_coordinates[0]
+    )
+    assert "/" not in source
+    assert destination == output_path.name
+    assert source_directory is not None
+    assert source_directory == destination_directory
     first_output = output_path.read_bytes()
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
     assert main(arguments) == 2
-    capsys.readouterr()
+    output = capsys.readouterr()
 
     assert output_path.read_bytes() == first_output
     assert set(tmp_path.iterdir()) == {capture_path, output_path}
+    assert output.err == "capture rejected: output_exists\n"
+
+
+def test_output_failures_remove_temporary_and_published_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_fsync = os.fsync
+    original_close = os.close
+
+    for stage in ("write", "file_fsync", "close", "link", "directory_fsync"):
+        destination_dir = tmp_path / stage
+        destination_dir.mkdir()
+        output_path = destination_dir / "output.json"
+        directory_fsync_attempts = 0
+        with monkeypatch.context() as scoped:
+            if stage == "write":
+                scoped.setattr(
+                    os,
+                    "write",
+                    lambda descriptor, content: (_ for _ in ()).throw(
+                        OSError("WRITE-CANARY")
+                    ),
+                )
+            elif stage in ("file_fsync", "directory_fsync"):
+
+                def failed_fsync(descriptor: int, *, expected: str = stage) -> None:
+                    nonlocal directory_fsync_attempts
+                    is_directory = stat.S_ISDIR(os.fstat(descriptor).st_mode)
+                    if is_directory:
+                        directory_fsync_attempts += 1
+                    if is_directory == (expected == "directory_fsync"):
+                        raise OSError("FSYNC-CANARY")
+                    original_fsync(descriptor)
+
+                scoped.setattr(os, "fsync", failed_fsync)
+            elif stage == "close":
+                failed = False
+
+                def failed_close(descriptor: int) -> None:
+                    nonlocal failed
+                    mode = os.fstat(descriptor).st_mode
+                    original_close(descriptor)
+                    if not failed and stat.S_ISREG(mode):
+                        failed = True
+                        raise OSError("CLOSE-CANARY")
+
+                scoped.setattr(os, "close", failed_close)
+            else:
+                scoped.setattr(
+                    os,
+                    "link",
+                    lambda source, destination, **kwargs: (_ for _ in ()).throw(
+                        OSError("LINK-CANARY")
+                    ),
+                )
+
+            with pytest.raises(CaptureError) as caught:
+                decoder_module._write_exclusive(output_path, b"synthetic\n")
+
+        assert caught.value.reason is FailureReason.OUTPUT
+        assert list(destination_dir.iterdir()) == []
+        if stage == "directory_fsync":
+            assert directory_fsync_attempts == 2
 
 
 def test_missing_dpkt_fails_closed_in_process_and_cli(


### PR DESCRIPTION
Implements Phase A1 from the canonical contract in `llmwiki/40-hardware/dongle-emulation.md`.

Closes #576.
Bead: `eg4-11ac`.

## Summary

- replaces per-segment capture decoding with bounded TCP sequence reassembly before frame parsing and redaction
- adds a named parser policy for frame size, prefix scan, overall deadline, and the combined memory budget
- fails closed on truncation, sequence gaps, conflicting retransmits, oversize frames, malformed lengths, CRC failures, identity/function/range mismatches, timeouts, and capacity limits
- emits only minimal synthetic fixture records with RFC 5737 documentation addresses
- handles same-flow reconnect epochs without silently coalescing sessions
- removes raw identity, register-value, timestamp, capture-path, and endpoint output from the CLI

## Security and scope

- offline authorized input only; the CLI requires an explicit acknowledgement
- no live capture and no vendor-cloud contact
- no production identity, raw capture, private address, MAC, token, secret, or register value in the diff or this report
- no runtime integration, bus-owner, listener, write, control, or OTA changes
- output refuses overwrite and errors/logs use bounded redacted classifications
- no PCAP/PCAPNG artifact is tracked

## Red/green evidence

- initial legacy state: focused collection failed because the decoder exited when the optional PCAP dependency was absent
- 22 temporary fix-reverted mutation runs covered every one of the 20 new test functions and all 29 collected cases
- mutations covered policy min/max/outside bounds, split/coalesced emission, overlap/dedup, EOF, oversize, prefix, deadline, CRC, outer/inner identity, outer/inner function, range, redaction, golden/CLI output, gap/conflict/pending capacity, combined memory, record capacity, and reconnect epochs
- every mutation run exited non-zero; all mutations were restored
- restored focused suite: 29 passed

## Gates

- Ruff lint and format: pass (137 files)
- strict mypy: pass (46 source files)
- full pytest: 2,953 passed, 3 skipped
- coverage command: pass, 91% repository coverage
- Silver, Gold, Platinum validators: pass
- Bandit under CI Python 3.12: pass, zero medium/high findings and zero skipped files
- commit-range and changed-path Gitleaks: pass, zero findings
- full-tree Gitleaks: one pre-existing redacted generic-key false positive outside this diff; no changed-path finding
- duplicate-code review: pass, 10.00/10
- compileall and diff hygiene: pass
- pre-commit hooks: pass

## Review routing

- Kimi K3 advisory review found one blocker: payload-less SYNs were filtered before stream epoch assignment, allowing a same-four-tuple reconnect to be silently omitted
- that blocker was fixed, mutation-tested, and the Kimi recheck returned PASS with no blockers
- the complete requested tribunal is not claimed: `grok-5.6` is absent from the installed model catalog, and the Claude Fable seat is not authenticated in this harness

## Tribunal — Round 3 escalation

Status: **NOT MERGEABLE — human ruling required.**

- Reviewed artifact target: `157a2ed16b74f19ab62c5ba85f8fe9939a9ee61e` (4 files).
- Local gates: 85 focused tests passed; Ruff lint and format passed; configured strict mypy passed across 46 files.
- Current-head CI: 35 successful, 0 failed, 0 pending.
- Codex (blocking): engine failure. The initial full-diff payload was stripped; its single compressed-payload retry was delivered as an invalid placeholder, so no code verdict was produced.
- Claude Fable (blocking): engine failure. The initial full-diff payload was stripped; its single compressed-payload retry could not be reconstructed byte-exactly, so no code verdict was produced.
- Advisory: unseated; Kimi was retired after its earlier silent exit.

The branch is green, but tribunal did not attain CLEAN. The three-round safety valve prohibits another automatic remediation/review loop. No merge may occur until the human explicitly rules on whether to authorize an exceptional transport-only re-review using chunked plain-text artifact delivery.


## Tribunal round 4

Artifact `157a2ed1` was successfully delivered and reviewed by both blocking engines. Verdict: **findings; not mergeable**. Codex reported four blockers covering diagnostic redaction, amortized resource bounds, TCP lifecycle invariants, and post-publication failure handling. Claude Fable reported four low findings covering a vacuous dependency test, dead/untested helper surface, post-publication failure semantics, and silent IPv6 skipping. Remediation is in progress; no sensitive literals are included here.


## Tribunal round 5

Artifact `24269355` used the hash-verified neutral review bundle. Codex (`gpt-5.6-sol`, BLOCKING) returned **CLEAN**. Claude Fable exhausted usage credits; with explicit human approval, the blocking seat was recreated on `claude-opus-4-8`. Opus returned three LOW findings: retained-helper contract coverage, IPv6 extension-header rejection, and complexity/maintenance cost. Therefore the round has **findings and is not mergeable**; remediation and evidence-backed triage are in progress.



## Tribunal round 6

Artifact `9f687e5d` used the hash-verified neutral bundle. Claude Opus 4.8 (BLOCKING, human-approved fallback) returned **CLEAN**. Codex (BLOCKING) reported one blocker: `find_frames` omits incomplete EOF tails instead of enforcing the Phase A1 truncation contract. Verdict: **findings; not mergeable**.


## Tribunal round 7

Artifact `cb6f249f` used the hash-verified neutral bundle. Codex (`gpt-5.6-sol`, BLOCKING) returned **CLEAN**. Claude (`claude-opus-4-8`, BLOCKING, human-approved fallback) returned **CLEAN**. Tribunal status: **CLEAN on current bytes**, pending final post-CLEAN DRY attestation and current-head CI.


## Final gate

Head `cb6f249f`: round 7 dual-CLEAN, post-CLEAN DRY no-op, four-file scope verified, and all 35 CI checks green. Cleanup attestation confirmed the PR head is fully persisted; destructive local cleanup was intentionally skipped because unrelated pre-existing stashes and a clean stale local branch must be preserved.


## Tribunal round 8

Synchronized head `eb4a26fc` preserves the exact round-7 deliverable artifact (`4c0b7523…0e29`). Codex (`gpt-5.6-sol`, BLOCKING) returned **CLEAN**. Claude (`claude-opus-4-8`, BLOCKING, human-approved fallback) returned **CLEAN**. Post-CLEAN DRY was already completed as a no-op before the byte-identical base sync.
