### PR TITLE
feat: dismiss duplicate cloud identity Repair on successful migration (eg4-06er.12)

### DIFF
--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -549,6 +549,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 DOMAIN,
                 f"duplicate_cloud_entry_{config_entry.entry_id}",
                 is_fixable=False,
+                is_persistent=True,
                 severity=ir.IssueSeverity.ERROR,
                 translation_key="duplicate_cloud_entry",
                 translation_placeholders={
@@ -1593,3 +1594,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: EG4ConfigEntry) -> None
         PV_STRING_LIFETIME_STORAGE_VERSION,
         f"{PV_STRING_LIFETIME_STORAGE_KEY}_{entry.entry_id}",
     ).async_remove()
+
+    # Removing the losing entry is the recovery this entry's duplicate Repair
+    # asks the user to perform, so clear that Repair here (no-op when none exists).
+    ir.async_delete_issue(hass, DOMAIN, f"duplicate_cloud_entry_{entry.entry_id}")

--- a/custom_components/eg4_web_monitor/__init__.py
+++ b/custom_components/eg4_web_monitor/__init__.py
@@ -562,6 +562,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_data[CONF_PLANT_ID] = str(new_data[CONF_PLANT_ID])
         new_unique_id = canonical_unique_id
 
+    # Reaching this point means ownership resolved in this entry's favour, so any
+    # conflict that previously blocked it is gone. Clear a stale duplicate Repair
+    # (no-op when none exists) so a resolved conflict dismisses its own issue.
+    ir.async_delete_issue(
+        hass, DOMAIN, f"duplicate_cloud_entry_{config_entry.entry_id}"
+    )
+
     hass.config_entries.async_update_entry(
         config_entry,
         data=new_data,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import MockConfigEntry, flush_store
 
 from custom_components.eg4_web_monitor import (
     PLATFORMS,
@@ -1665,3 +1665,38 @@ class TestAsyncMigrateEntry:
         assert duplicate.version == 3
         assert duplicate.unique_id == "user@example.com_12345"
         assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+
+    async def test_removing_losing_entry_dismisses_repair(self, hass: HomeAssistant):
+        """Removing the losing entry — the Repair's advised recovery — clears it."""
+        _owner, duplicate = self._cloud_conflict_pair(hass)
+        issue_id = f"duplicate_cloud_entry_{duplicate.entry_id}"
+
+        assert await async_migrate_entry(hass, duplicate) is False
+        assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+
+        # Delete the losing entry through the real Home Assistant removal path.
+        await hass.config_entries.async_remove(duplicate.entry_id)
+
+        assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+
+    async def test_duplicate_repair_survives_registry_reload(
+        self, hass: HomeAssistant, hass_storage
+    ):
+        """The actionable Repair persists across a registry reload (restart)."""
+        _owner, duplicate = self._cloud_conflict_pair(hass)
+        issue_id = f"duplicate_cloud_entry_{duplicate.entry_id}"
+
+        assert await async_migrate_entry(hass, duplicate) is False
+
+        registry = ir.async_get(hass)
+        await flush_store(registry._store)
+
+        # Simulate a restart: a fresh registry restores issues from storage.
+        reloaded = ir.IssueRegistry(hass)
+        await reloaded.async_load()
+
+        issue = reloaded.async_get_issue(DOMAIN, issue_id)
+        assert issue is not None
+        assert issue.active is True
+        assert issue.severity == ir.IssueSeverity.ERROR
+        assert issue.translation_key == "duplicate_cloud_entry"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
+import homeassistant.helpers.issue_registry as ir
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ServiceValidationError
@@ -1555,3 +1556,113 @@ class TestAsyncMigrateEntry:
         result = await async_migrate_entry(hass, entry)
 
         assert result is False
+
+    def _cloud_conflict_pair(
+        self, hass: HomeAssistant
+    ) -> tuple[MockConfigEntry, MockConfigEntry]:
+        """Build an established canonical owner and a losing duplicate (both v2)."""
+        owner = MockConfigEntry(
+            domain=DOMAIN,
+            version=2,
+            title="Owner Cloud Plant",
+            data={
+                "connection_type": "http",
+                CONF_USERNAME: "user@example.com",
+                CONF_PASSWORD: "owner-secret",
+                CONF_PLANT_ID: "12345",
+                "local_transports": [],
+            },
+            entry_id="canonical_owner",
+            unique_id="user@example.com_12345",
+        )
+        duplicate = MockConfigEntry(
+            domain=DOMAIN,
+            version=2,
+            title="Duplicate Cloud Plant",
+            data={
+                "connection_type": "hybrid",
+                CONF_USERNAME: "user@example.com",
+                CONF_PASSWORD: "duplicate-secret",
+                CONF_PLANT_ID: "12345",
+                "local_transports": [{"serial": "1234567890"}],
+            },
+            entry_id="legacy_duplicate",
+            unique_id="hybrid_user@example.com_12345",
+        )
+        owner.add_to_hass(hass)
+        duplicate.add_to_hass(hass)
+        return owner, duplicate
+
+    async def test_duplicate_conflict_creates_repair_issue(self, hass: HomeAssistant):
+        """A blocked duplicate migration raises a stable, non-fixable ERROR Repair."""
+        owner, duplicate = self._cloud_conflict_pair(hass)
+
+        assert await async_migrate_entry(hass, duplicate) is False
+
+        issue = ir.async_get(hass).async_get_issue(
+            DOMAIN, f"duplicate_cloud_entry_{duplicate.entry_id}"
+        )
+        assert issue is not None
+        assert issue.is_fixable is False
+        assert issue.severity == ir.IssueSeverity.ERROR
+        assert issue.translation_key == "duplicate_cloud_entry"
+        # The guidance names both entries and the canonical cloud identity.
+        assert issue.translation_placeholders == {
+            "entry_title": "Duplicate Cloud Plant",
+            "owner_title": "Owner Cloud Plant",
+            "unique_id": "user@example.com_12345",
+        }
+
+    async def test_duplicate_repair_leaves_losing_entry_unchanged(
+        self, hass: HomeAssistant
+    ):
+        """Raising the Repair must not mutate the losing entry (non-destructive)."""
+        _owner, duplicate = self._cloud_conflict_pair(hass)
+        before = dict(duplicate.data)
+
+        assert await async_migrate_entry(hass, duplicate) is False
+
+        assert duplicate.version == 2
+        assert duplicate.unique_id == "hybrid_user@example.com_12345"
+        assert dict(duplicate.data) == before
+        assert duplicate.options == {}
+        # The user-visible Repair still exists despite the entry being untouched.
+        assert (
+            ir.async_get(hass).async_get_issue(
+                DOMAIN, f"duplicate_cloud_entry_{duplicate.entry_id}"
+            )
+            is not None
+        )
+
+    async def test_duplicate_repair_persists_and_dedupes_on_repeat(
+        self, hass: HomeAssistant
+    ):
+        """Repeated failed migrations keep exactly one persistent Repair."""
+        _owner, duplicate = self._cloud_conflict_pair(hass)
+        issue_id = f"duplicate_cloud_entry_{duplicate.entry_id}"
+
+        assert await async_migrate_entry(hass, duplicate) is False
+        assert await async_migrate_entry(hass, duplicate) is False
+
+        registry = ir.async_get(hass)
+        assert registry.async_get_issue(DOMAIN, issue_id) is not None
+        matching = [key for key in registry.issues if key == (DOMAIN, issue_id)]
+        assert len(matching) == 1
+
+    async def test_successful_migration_after_conflict_removal_dismisses_repair(
+        self, hass: HomeAssistant
+    ):
+        """Removing the conflict lets the entry migrate and clears its Repair."""
+        owner, duplicate = self._cloud_conflict_pair(hass)
+        issue_id = f"duplicate_cloud_entry_{duplicate.entry_id}"
+
+        assert await async_migrate_entry(hass, duplicate) is False
+        assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+
+        # User resolves the conflict by removing the owning duplicate.
+        await hass.config_entries.async_remove(owner.entry_id)
+
+        assert await async_migrate_entry(hass, duplicate) is True
+        assert duplicate.version == 3
+        assert duplicate.unique_id == "user@example.com_12345"
+        assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1645,9 +1645,8 @@ class TestAsyncMigrateEntry:
         assert await async_migrate_entry(hass, duplicate) is False
 
         registry = ir.async_get(hass)
-        assert registry.async_get_issue(DOMAIN, issue_id) is not None
-        matching = [key for key in registry.issues if key == (DOMAIN, issue_id)]
-        assert len(matching) == 1
+        eg4_issues = [key for key in registry.issues if key[0] == DOMAIN]
+        assert eg4_issues == [(DOMAIN, issue_id)]
 
     async def test_successful_migration_after_conflict_removal_dismisses_repair(
         self, hass: HomeAssistant


### PR DESCRIPTION
## Summary

Completes the duplicate-cloud-identity Repair lifecycle for the v2→v3 config-entry migration (`custom_components/eg4_web_monitor/__init__.py`).

When a v2→v3 migration is blocked because another entry already owns the canonical cloud identity, `async_migrate_entry` already:

- raises a **stable, non-fixable ERROR** Repair keyed `duplicate_cloud_entry_<losing entry id>`,
- names **both** the losing entry and the owning entry plus the canonical cloud identity via the existing `duplicate_cloud_entry` translation,
- returns `False` and leaves the losing entry's `version` / `data` / `unique_id` / `options` **entirely unchanged**,
- deduplicates on repeat (Home Assistant keys issues by `issue_id`, so retries persist a single Repair).

The missing half was cleanup: once the user resolves the conflict (e.g. removes the owning entry) and the losing entry finally migrates, the Repair was never dismissed.

This PR adds a single call on the **successful** migration path:

```python
ir.async_delete_issue(hass, DOMAIN, f"duplicate_cloud_entry_{config_entry.entry_id}")
```

`async_delete_issue` is a no-op when no issue exists, so it is safe on every successful migration and clears a previously-raised Repair the moment the conflict is gone — satisfying the acceptance criterion "resolving or removing the conflict dismisses the issue" without weakening the non-destructive migration policy.

## Bead

Implements **eg4-06er.12** — *Surface duplicate cloud identity migration conflicts as Repairs* (parent eg4-06er).

## Changes

- `custom_components/eg4_web_monitor/__init__.py` — delete the entry's `duplicate_cloud_entry_<id>` Repair on the successful migration path (+7 lines, comment included).
- `tests/test_init.py` — 4 new mutation-checked tests + a small `_cloud_conflict_pair` helper.

No translation changes were required — the `duplicate_cloud_entry` strings entry already carries the `entry_title` / `owner_title` / `unique_id` placeholders used here.

## Tests

New tests under `TestAsyncMigrateEntry`:

| Test | Covers |
|---|---|
| `test_duplicate_conflict_creates_repair_issue` | Repair creation: non-fixable, ERROR, correct translation key, names both entries + canonical identity |
| `test_duplicate_repair_leaves_losing_entry_unchanged` | Non-destructive: version/unique_id/data/options untouched while Repair exists |
| `test_duplicate_repair_persists_and_dedupes_on_repeat` | Persistence/dedup: repeated failures keep exactly one Repair |
| `test_successful_migration_after_conflict_removal_dismisses_repair` | Cleanup: removing the conflict lets the entry migrate and clears the Repair |

### Mutation-check (fix reverted → red, restored → green)

- Reverting the new `async_delete_issue` line → `test_successful_migration_after_conflict_removal_dismisses_repair` **fails**; the other three stay green (they gate on the pre-existing creation behavior).
- Independently reverting the `async_create_issue` block → the three creation/persistence/non-destructive tests **fail**, proving they are non-vacuous.
- With both restored: all migration tests pass.

## Gates

- `uv run pytest tests/test_init.py -q` → **PASS** (all migration + init tests green)
- `uv run ruff check` (scoped) → PASS
- `uv run ruff format` (scoped) → applied (wrapped the new call)
- `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` → **Success: no issues found**
- pre-commit hooks (ruff / ruff-format / mypy) → PASS on commit
- Diff audit → only the two in-scope files changed; no unrelated reformatting

## Scope

Limited to `custom_components/eg4_web_monitor/__init__.py` and `tests/test_init.py`. Draft — do not merge.

---

## Tribunal round-1 fixes (head d706c56)

1. **Removal path now dismisses the Repair.** The Repair advises removing the losing entry, but `async_remove_entry` never cleared `duplicate_cloud_entry_<losing id>`. Added the HA-native `ir.async_delete_issue` on entry removal (no-op when absent), mirroring the existing successful-migration cleanup.
2. **Repair persists across restart/reload.** `async_create_issue` relied on the `is_persistent=False` default, which reloads the issue inactive with severity/translation stripped. Set `is_persistent=True` so the actionable ERROR Repair survives a registry reload even when migration is not retried.

Preserved: successful-migration cleanup, non-destructive failure semantics, stable issue key, dedup behavior, existing translation, scope.

New tests (both mutation-checked RED with their fix reverted, GREEN restored):
- `test_removing_losing_entry_dismisses_repair` — removes the losing entry via the real `hass.config_entries.async_remove` path; asserts the Repair is gone.
- `test_duplicate_repair_survives_registry_reload` — `flush_store` + fresh `IssueRegistry.async_load`; asserts the reloaded issue is `active`, `severity == ERROR`, `translation_key == "duplicate_cloud_entry"`.

Gates: `pytest tests/test_init.py` → 46 passed; scoped ruff → clean; ruff format → clean; `mypy --config-file tests/mypy.ini` → no issues.
