### PR TITLE
fix: bound TCP reassembly overlap work

### DIFF
--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -299,7 +299,15 @@ class _ChargedRingBuffer:
         length = self._size - start if count is None else count
         if start < 0 or length < 0 or start + length > self._size:
             raise CaptureError(FailureReason.MALFORMED)
-        return bytes(self.byte_at(start + offset) for offset in range(length))
+        if not length:
+            return b""
+        if self._data is None:
+            raise CaptureError(FailureReason.MALFORMED)
+        physical_start = (self._head + start) % self._capacity
+        first = min(length, self._capacity - physical_start)
+        return bytes(self._data[physical_start : physical_start + first]) + bytes(
+            self._data[: length - first]
+        )
 
     def discard(self, count: int) -> None:
         if not 0 <= count <= self._size:
@@ -449,6 +457,16 @@ class StreamFrameDecoder:
         self._started_at = None
 
 
+@dataclass(frozen=True, slots=True)
+class _PendingRun:
+    start: int
+    data: bytes
+
+    @property
+    def end(self) -> int:
+        return self.start + len(self.data)
+
+
 class TCPStreamReassembler:
     """Bounded sequence window with complete byte-overlap validation."""
 
@@ -470,7 +488,8 @@ class TCPStreamReassembler:
             16 * 1024,
         )
         self._history = _ChargedRingBuffer(self._history_limit, self._budget)
-        self._pending: dict[int, int] | None = None
+        self._pending: list[_PendingRun] | None = None
+        self._pending_bytes = 0
         self._segment_count = 0
         self._started_at: float | None = None
         self._emitted_started_at: float | None = None
@@ -478,7 +497,7 @@ class TCPStreamReassembler:
 
     @property
     def pending_bytes(self) -> int:
-        return len(self._pending) if self._pending is not None else 0
+        return self._pending_bytes
 
     @property
     def retained_bytes(self) -> int:
@@ -529,20 +548,44 @@ class TCPStreamReassembler:
             raise CaptureError(FailureReason.MALFORMED)
         if end > self.policy.maximum_reassembled_bytes_per_flow:
             raise CaptureError(FailureReason.CAPACITY)
+        assembled_overlap_end = min(end, self._assembled_bytes)
+        if (
+            start < assembled_overlap_end
+            and self._history.to_bytes(
+                start - self._history_start, assembled_overlap_end - start
+            )
+            != normalized[: assembled_overlap_end - start]
+        ):
+            raise CaptureError(FailureReason.MALFORMED)
+
+        unassembled_start = max(start, self._assembled_bytes)
+        unassembled = normalized[unassembled_start - start :]
         pending = self._pending
-        new_bytes = 0
-        for index, byte in enumerate(normalized):
-            offset = start + index
-            if offset < self._assembled_bytes:
-                if self._history.byte_at(offset - self._history_start) != byte:
+        first_run = 0
+        while pending is not None and first_run < len(pending):
+            if pending[first_run].end >= unassembled_start:
+                break
+            first_run += 1
+        last_run = first_run
+        overlap_bytes = 0
+        while pending is not None and last_run < len(pending):
+            run = pending[last_run]
+            if run.start > end:
+                break
+            overlap_start = max(unassembled_start, run.start)
+            overlap_end = min(end, run.end)
+            if overlap_start < overlap_end:
+                run_overlap = run.data[
+                    overlap_start - run.start : overlap_end - run.start
+                ]
+                segment_overlap = unassembled[
+                    overlap_start - unassembled_start : overlap_end - unassembled_start
+                ]
+                if run_overlap != segment_overlap:
                     raise CaptureError(FailureReason.MALFORMED)
-                continue
-            existing = pending.get(offset) if pending is not None else None
-            if existing is not None:
-                if existing != byte:
-                    raise CaptureError(FailureReason.MALFORMED)
-                continue
-            new_bytes += 1
+                overlap_bytes += overlap_end - overlap_start
+            last_run += 1
+        new_bytes = len(unassembled) - overlap_bytes
         if start > self._assembled_bytes and (
             start - self._assembled_bytes > self.policy.maximum_pending_bytes_per_flow
             or self.pending_bytes + new_bytes
@@ -551,37 +594,55 @@ class TCPStreamReassembler:
             raise CaptureError(FailureReason.CAPACITY)
         contiguous = bytearray()
         if start > self._assembled_bytes:
-            self._budget.reserve(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
             if new_bytes:
+                self._budget.reserve(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
+                merged_start = unassembled_start
+                merged_end = end
+                if pending is not None and first_run < last_run:
+                    merged_start = min(merged_start, pending[first_run].start)
+                    merged_end = max(merged_end, pending[last_run - 1].end)
+                try:
+                    merged = bytearray(merged_end - merged_start)
+                    if pending is not None:
+                        for run in pending[first_run:last_run]:
+                            run_start = run.start - merged_start
+                            merged[run_start : run_start + len(run.data)] = run.data
+                    segment_start = unassembled_start - merged_start
+                    merged[segment_start : segment_start + len(unassembled)] = (
+                        unassembled
+                    )
+                    merged_run = _PendingRun(merged_start, bytes(merged))
+                except MemoryError:
+                    self._budget.release(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
+                    raise CaptureError(FailureReason.CAPACITY) from None
                 if pending is None:
-                    pending = {}
-                for index, byte in enumerate(normalized):
-                    offset = start + index
-                    if offset not in pending:
-                        pending[offset] = byte
+                    pending = []
+                pending[first_run:last_run] = [merged_run]
                 self._pending = pending
+                self._pending_bytes += new_bytes
         else:
-            while self._assembled_bytes < end:
-                pending_byte = (
-                    pending.pop(self._assembled_bytes)
-                    if pending is not None and self._assembled_bytes in pending
-                    else None
-                )
-                if pending_byte is None:
-                    byte = normalized[self._assembled_bytes - start]
-                else:
-                    byte = pending_byte
-                    self._budget.release(_PENDING_BYTE_MEMORY_CHARGE - 1)
-                contiguous.append(byte)
-                self._assembled_bytes += 1
-            while pending is not None and self._assembled_bytes in pending:
-                byte = pending.pop(self._assembled_bytes)
-                self._budget.release(_PENDING_BYTE_MEMORY_CHARGE - 1)
-                contiguous.append(byte)
-                self._assembled_bytes += 1
-            if pending is not None and not pending:
-                self._pending = None
-                pending = None
+            contiguous.extend(unassembled)
+            contiguous_end = self._assembled_bytes + len(contiguous)
+            consumed_runs = 0
+            consumed_bytes = 0
+            while pending is not None and consumed_runs < len(pending):
+                run = pending[consumed_runs]
+                if run.start > contiguous_end:
+                    break
+                suffix_start = min(len(run.data), max(0, contiguous_end - run.start))
+                contiguous.extend(run.data[suffix_start:])
+                contiguous_end += len(run.data) - suffix_start
+                consumed_bytes += len(run.data)
+                consumed_runs += 1
+            self._assembled_bytes = contiguous_end
+            if consumed_runs:
+                assert pending is not None
+                del pending[:consumed_runs]
+                self._pending_bytes -= consumed_bytes
+                self._budget.release(consumed_bytes * (_PENDING_BYTE_MEMORY_CHARGE - 1))
+                if not pending:
+                    self._pending = None
+                    pending = None
         expired = max(0, len(self._history) + len(contiguous) - self._history_limit)
         contiguous_history_start = 0
         if expired > 0:
@@ -616,6 +677,7 @@ class TCPStreamReassembler:
     def _clear(self) -> None:
         retained = self.pending_bytes * _PENDING_BYTE_MEMORY_CHARGE
         self._pending = None
+        self._pending_bytes = 0
         self._history.release()
         self._budget.release(retained)
         self._started_at = None

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import bisect
 import io
 import json
 import math
@@ -457,14 +458,59 @@ class StreamFrameDecoder:
         self._started_at = None
 
 
-@dataclass(frozen=True, slots=True)
 class _PendingRun:
-    start: int
-    data: bytes
+    """A coalesced run of pending stream bytes, growable at either edge.
+
+    Bytes live in a single ``bytearray`` with tracked front slack (``_head``) so a
+    reverse-adjacent fragment prepends without recopying the whole run on every
+    insert, while forward growth uses ``bytearray``'s amortized append. Both edges
+    are therefore amortized O(1); transient slack is bounded by the run length, so
+    pending memory stays within the charged budget.
+    """
+
+    __slots__ = ("start", "_buffer", "_head")
+
+    def __init__(self, start: int, data: Buffer) -> None:
+        self.start = start
+        self._buffer = bytearray(data)
+        self._head = 0
+
+    def __len__(self) -> int:
+        return len(self._buffer) - self._head
 
     @property
     def end(self) -> int:
-        return self.start + len(self.data)
+        return self.start + len(self)
+
+    def to_bytes(self, begin: int = 0, stop: int | None = None) -> bytes:
+        length = len(self)
+        stop = length if stop is None else stop
+        return bytes(self._buffer[self._head + begin : self._head + stop])
+
+    def append(self, data: Buffer) -> None:
+        self._buffer += bytes(data)
+
+    def prepend(self, start: int, data: Buffer) -> None:
+        chunk = bytes(data)
+        need = len(chunk)
+        if self._head < need:
+            length = len(self)
+            reserve = need + length
+            grown = bytearray(reserve + length)
+            grown[reserve:] = self._buffer[self._head :]
+            self._buffer = grown
+            self._head = reserve
+        self._head -= need
+        self._buffer[self._head : self._head + need] = chunk
+        self.start = start
+
+
+def _pending_run_start(run: _PendingRun) -> int:
+    return run.start
+
+
+def _pending_run_end(run: _PendingRun) -> int:
+    return run.end
 
 
 class TCPStreamReassembler:
@@ -560,31 +606,33 @@ class TCPStreamReassembler:
 
         unassembled_start = max(start, self._assembled_bytes)
         unassembled = normalized[unassembled_start - start :]
+        # Runs are sorted and non-overlapping, so both ``start`` and ``end`` rise
+        # monotonically; bisect the touched window instead of scanning from zero so
+        # sparse out-of-order fragments cost O(log runs), not O(runs), per insert.
         pending = self._pending
-        first_run = 0
-        while pending is not None and first_run < len(pending):
-            if pending[first_run].end >= unassembled_start:
-                break
-            first_run += 1
-        last_run = first_run
+        if pending is None:
+            first_run = last_run = 0
+            touched: list[_PendingRun] = []
+        else:
+            first_run = bisect.bisect_left(
+                pending, unassembled_start, key=_pending_run_end
+            )
+            last_run = bisect.bisect_right(pending, end, key=_pending_run_start)
+            touched = pending[first_run:last_run]
         overlap_bytes = 0
-        while pending is not None and last_run < len(pending):
-            run = pending[last_run]
-            if run.start > end:
-                break
+        for run in touched:
             overlap_start = max(unassembled_start, run.start)
             overlap_end = min(end, run.end)
             if overlap_start < overlap_end:
-                run_overlap = run.data[
-                    overlap_start - run.start : overlap_end - run.start
-                ]
+                run_overlap = run.to_bytes(
+                    overlap_start - run.start, overlap_end - run.start
+                )
                 segment_overlap = unassembled[
                     overlap_start - unassembled_start : overlap_end - unassembled_start
                 ]
                 if run_overlap != segment_overlap:
                     raise CaptureError(FailureReason.MALFORMED)
                 overlap_bytes += overlap_end - overlap_start
-            last_run += 1
         new_bytes = len(unassembled) - overlap_bytes
         if start > self._assembled_bytes and (
             start - self._assembled_bytes > self.policy.maximum_pending_bytes_per_flow
@@ -596,28 +644,46 @@ class TCPStreamReassembler:
         if start > self._assembled_bytes:
             if new_bytes:
                 self._budget.reserve(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
-                merged_start = unassembled_start
-                merged_end = end
-                if pending is not None and first_run < last_run:
-                    merged_start = min(merged_start, pending[first_run].start)
-                    merged_end = max(merged_end, pending[last_run - 1].end)
+                if pending is None:
+                    pending = []
                 try:
-                    merged = bytearray(merged_end - merged_start)
-                    if pending is not None:
+                    if first_run == last_run:
+                        # Isolated gap fragment: a brand-new run.
+                        pending.insert(
+                            first_run, _PendingRun(unassembled_start, unassembled)
+                        )
+                    elif last_run - first_run == 1:
+                        # One adjacent/overlapping run: grow it at the edge(s) that
+                        # extended, in place, so reverse-adjacent inserts never
+                        # recopy the whole run.
+                        run = pending[first_run]
+                        run_start = run.start
+                        run_end = run.end
+                        if end > run_end:
+                            run.append(unassembled[run_end - unassembled_start :])
+                        if unassembled_start < run_start:
+                            run.prepend(
+                                unassembled_start,
+                                unassembled[: run_start - unassembled_start],
+                            )
+                    else:
+                        # Bridge several runs into one: a single coalescing copy.
+                        merged_start = min(unassembled_start, pending[first_run].start)
+                        merged_end = max(end, pending[last_run - 1].end)
+                        merged = bytearray(merged_end - merged_start)
                         for run in pending[first_run:last_run]:
-                            run_start = run.start - merged_start
-                            merged[run_start : run_start + len(run.data)] = run.data
-                    segment_start = unassembled_start - merged_start
-                    merged[segment_start : segment_start + len(unassembled)] = (
-                        unassembled
-                    )
-                    merged_run = _PendingRun(merged_start, bytes(merged))
+                            offset = run.start - merged_start
+                            merged[offset : offset + len(run)] = run.to_bytes()
+                        segment_start = unassembled_start - merged_start
+                        merged[segment_start : segment_start + len(unassembled)] = (
+                            unassembled
+                        )
+                        pending[first_run:last_run] = [
+                            _PendingRun(merged_start, bytes(merged))
+                        ]
                 except MemoryError:
                     self._budget.release(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
                     raise CaptureError(FailureReason.CAPACITY) from None
-                if pending is None:
-                    pending = []
-                pending[first_run:last_run] = [merged_run]
                 self._pending = pending
                 self._pending_bytes += new_bytes
         else:
@@ -629,10 +695,10 @@ class TCPStreamReassembler:
                 run = pending[consumed_runs]
                 if run.start > contiguous_end:
                     break
-                suffix_start = min(len(run.data), max(0, contiguous_end - run.start))
-                contiguous.extend(run.data[suffix_start:])
-                contiguous_end += len(run.data) - suffix_start
-                consumed_bytes += len(run.data)
+                suffix_start = min(len(run), max(0, contiguous_end - run.start))
+                contiguous.extend(run.to_bytes(suffix_start))
+                contiguous_end += len(run) - suffix_start
+                consumed_bytes += len(run)
                 consumed_runs += 1
             self._assembled_bytes = contiguous_end
             if consumed_runs:

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -650,6 +650,7 @@ class TCPStreamReassembler:
                 self._budget.reserve(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
                 if pending is None:
                     pending = []
+                run_snapshot: tuple[_PendingRun, bytearray, int, int] | None = None
                 try:
                     if first_run == last_run:
                         # Isolated gap fragment: a brand-new run.
@@ -664,6 +665,7 @@ class TCPStreamReassembler:
                         run = pending[first_run]
                         run_start = run.start
                         run_end = run.end
+                        run_snapshot = (run, run._buffer, run._head, run_start)
                         prefix = unassembled[: max(0, run_start - unassembled_start)]
                         if last_run - first_run == 1:
                             suffix = unassembled[max(0, run_end - unassembled_start) :]
@@ -693,6 +695,8 @@ class TCPStreamReassembler:
                             run.prepend(unassembled_start, prefix)
                         del pending[first_run + 1 : last_run]
                 except MemoryError:
+                    if run_snapshot is not None:
+                        run, run._buffer, run._head, run.start = run_snapshot
                     self._budget.release(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
                     raise CaptureError(FailureReason.CAPACITY) from None
                 self._pending = pending

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -642,7 +642,6 @@ class TCPStreamReassembler:
                 self._budget.release(consumed_bytes * (_PENDING_BYTE_MEMORY_CHARGE - 1))
                 if not pending:
                     self._pending = None
-                    pending = None
         expired = max(0, len(self._history) + len(contiguous) - self._history_limit)
         contiguous_history_start = 0
         if expired > 0:

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -490,16 +490,20 @@ class _PendingRun:
     def append(self, data: Buffer) -> None:
         self._buffer += bytes(data)
 
+    def reserve_prepend(self, need: int) -> None:
+        if self._head >= need:
+            return
+        length = len(self)
+        reserve = need + length
+        grown = bytearray(reserve + length)
+        grown[reserve:] = self._buffer[self._head :]
+        self._buffer = grown
+        self._head = reserve
+
     def prepend(self, start: int, data: Buffer) -> None:
         chunk = bytes(data)
         need = len(chunk)
-        if self._head < need:
-            length = len(self)
-            reserve = need + length
-            grown = bytearray(reserve + length)
-            grown[reserve:] = self._buffer[self._head :]
-            self._buffer = grown
-            self._head = reserve
+        self.reserve_prepend(need)
         self._head -= need
         self._buffer[self._head : self._head + need] = chunk
         self.start = start
@@ -652,35 +656,42 @@ class TCPStreamReassembler:
                         pending.insert(
                             first_run, _PendingRun(unassembled_start, unassembled)
                         )
-                    elif last_run - first_run == 1:
-                        # One adjacent/overlapping run: grow it at the edge(s) that
-                        # extended, in place, so reverse-adjacent inserts never
-                        # recopy the whole run.
+                    else:
+                        # Retain the leftmost touched run and append only bytes not
+                        # already stored there. Preflight front growth before the
+                        # append so a failed prepend allocation cannot leave an
+                        # uncharged suffix behind.
                         run = pending[first_run]
                         run_start = run.start
                         run_end = run.end
-                        if end > run_end:
-                            run.append(unassembled[run_end - unassembled_start :])
+                        prefix = unassembled[: max(0, run_start - unassembled_start)]
+                        if last_run - first_run == 1:
+                            suffix = unassembled[max(0, run_end - unassembled_start) :]
+                        else:
+                            tail = bytearray()
+                            cursor = run_end
+                            for subsequent in pending[first_run + 1 : last_run]:
+                                segment_end = min(subsequent.start, end)
+                                if cursor < segment_end:
+                                    tail += unassembled[
+                                        cursor - unassembled_start : segment_end
+                                        - unassembled_start
+                                    ]
+                                    cursor = segment_end
+                                if cursor < subsequent.end:
+                                    tail += subsequent.to_bytes(
+                                        max(0, cursor - subsequent.start)
+                                    )
+                                    cursor = subsequent.end
+                            if cursor < end:
+                                tail += unassembled[cursor - unassembled_start :]
+                            suffix = bytes(tail)
+                        run.reserve_prepend(len(prefix))
+                        if suffix:
+                            run.append(suffix)
                         if unassembled_start < run_start:
-                            run.prepend(
-                                unassembled_start,
-                                unassembled[: run_start - unassembled_start],
-                            )
-                    else:
-                        # Bridge several runs into one: a single coalescing copy.
-                        merged_start = min(unassembled_start, pending[first_run].start)
-                        merged_end = max(end, pending[last_run - 1].end)
-                        merged = bytearray(merged_end - merged_start)
-                        for run in pending[first_run:last_run]:
-                            offset = run.start - merged_start
-                            merged[offset : offset + len(run)] = run.to_bytes()
-                        segment_start = unassembled_start - merged_start
-                        merged[segment_start : segment_start + len(unassembled)] = (
-                            unassembled
-                        )
-                        pending[first_run:last_run] = [
-                            _PendingRun(merged_start, bytes(merged))
-                        ]
+                            run.prepend(unassembled_start, prefix)
+                        del pending[first_run + 1 : last_run]
                 except MemoryError:
                     self._budget.release(new_bytes * _PENDING_BYTE_MEMORY_CHARGE)
                     raise CaptureError(FailureReason.CAPACITY) from None

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -1082,6 +1082,84 @@ def test_tcp_reassembler_reverse_adjacent_grows_run_without_rebuild(
     assert reassembler.push(0, expected[:1], captured_at=1.1) == [(1.1, expected)]
 
 
+def test_tcp_reassembler_bridges_runs_with_linear_copy_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = ParserPolicy(maximum_segments_per_flow=4096)
+    reassembler = TCPStreamReassembler(policy)
+    reassembler.start(0)
+    length = 512
+    expected = bytes(index % 251 for index in range(length))
+
+    copied_bytes = 0
+    original_to_bytes = decoder_module._PendingRun.to_bytes
+
+    def counting_to_bytes(
+        self: decoder_module._PendingRun,
+        begin: int = 0,
+        stop: int | None = None,
+    ) -> bytes:
+        nonlocal copied_bytes
+        copied_bytes += len(self) - begin if stop is None else stop - begin
+        return original_to_bytes(self, begin, stop)
+
+    monkeypatch.setattr(decoder_module._PendingRun, "to_bytes", counting_to_bytes)
+
+    assert reassembler.push(1, expected[1:2], captured_at=1.0) == []
+    for bridge in range(2, length, 2):
+        assert (
+            reassembler.push(
+                bridge + 1, expected[bridge + 1 : bridge + 2], captured_at=1.0
+            )
+            == []
+        )
+        assert (
+            reassembler.push(bridge, expected[bridge : bridge + 1], captured_at=1.0)
+            == []
+        )
+
+    assert reassembler.push(0, expected[:1], captured_at=1.1) == [(1.1, expected)]
+    assert copied_bytes <= 2 * length
+
+
+def test_tcp_reassembler_two_sided_growth_is_atomic_on_memory_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reassembler = TCPStreamReassembler()
+    reassembler.start(0)
+    assert reassembler.push(2, b"cd", captured_at=1.0) == []
+    assert reassembler._pending is not None
+    retained_before = reassembler._budget.retained
+
+    allocation_calls = 0
+    native_bytearray = bytearray
+
+    def fail_second_allocation(source: object = 0) -> bytearray:
+        nonlocal allocation_calls
+        allocation_calls += 1
+        if allocation_calls == 2:
+            raise MemoryError
+        return native_bytearray(source)
+
+    monkeypatch.setattr(
+        decoder_module, "bytearray", fail_second_allocation, raising=False
+    )
+    with pytest.raises(CaptureError) as caught:
+        reassembler.push(1, b"bcde", captured_at=1.1)
+    monkeypatch.delattr(decoder_module, "bytearray")
+
+    assert caught.value.reason is FailureReason.CAPACITY
+    assert reassembler.pending_bytes == 2
+    assert reassembler._budget.retained == retained_before
+    assert len(reassembler._pending) == 1
+    assert reassembler._pending[0].start == 2
+    assert reassembler._pending[0].to_bytes() == b"cd"
+
+    assert reassembler.push(1, b"bcde", captured_at=1.2) == []
+    assert reassembler.push(0, b"a", captured_at=1.3) == [(1.3, b"abcde")]
+    assert reassembler.pending_bytes == 0
+
+
 def test_tcp_reassembler_validates_duplicate_with_bounded_history_slices(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -992,6 +992,42 @@ def test_tcp_reassembler_handles_sequence_wrap_and_reverse_one_byte_segments() -
     assert reassembler.segment_count == policy.maximum_segments_per_flow
 
 
+def test_tcp_reassembler_coalesces_pathological_reverse_fragmentation() -> None:
+    policy = ParserPolicy(maximum_segments_per_flow=4096)
+    reassembler = TCPStreamReassembler(policy)
+    reassembler.start(0)
+    expected = bytes(offset % 251 for offset in range(4096))
+
+    for offset in range(4095, 0, -1):
+        assert (
+            reassembler.push(offset, expected[offset : offset + 1], captured_at=1.0)
+            == []
+        )
+
+    assert reassembler.pending_bytes == 4095
+    assert reassembler._pending is not None
+    assert len(reassembler._pending) == 1
+    assert reassembler.push(0, expected[:1], captured_at=1.1) == [(1.1, expected)]
+    assert reassembler.segment_count == policy.maximum_segments_per_flow
+
+
+def test_tcp_reassembler_validates_duplicate_with_bounded_history_slices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reassembler = TCPStreamReassembler()
+    reassembler.start(0)
+    payload = bytes(index % 251 for index in range(16 * 1024))
+    assert reassembler.push(0, payload, captured_at=1.0) == [(1.0, payload)]
+
+    def reject_per_byte_access(_buffer: object, _index: int) -> int:
+        raise AssertionError("history overlap used per-byte validation")
+
+    monkeypatch.setattr(
+        decoder_module._ChargedRingBuffer, "byte_at", reject_per_byte_access
+    )
+    assert reassembler.push(0, payload, captured_at=1.1) == []
+
+
 def test_tcp_reassembler_rejects_one_segment_over_limit() -> None:
     reassembler = TCPStreamReassembler(ParserPolicy(maximum_segments_per_flow=1))
     reassembler.start(10)

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -14,7 +14,7 @@ from collections.abc import Buffer, Callable
 from importlib import util
 from pathlib import Path
 from types import ModuleType
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import pytest
 
@@ -1009,6 +1009,77 @@ def test_tcp_reassembler_coalesces_pathological_reverse_fragmentation() -> None:
     assert len(reassembler._pending) == 1
     assert reassembler.push(0, expected[:1], captured_at=1.1) == [(1.1, expected)]
     assert reassembler.segment_count == policy.maximum_segments_per_flow
+
+
+def test_tcp_reassembler_sparse_fragments_inspect_sublinear_runs() -> None:
+    # Sparse ascending out-of-order fragments stay as separate runs. A new insert
+    # must locate its window by binary search, touching O(log runs) entries, not by
+    # scanning the whole sorted list (which made S inserts theta(S^2)).
+    policy = ParserPolicy(
+        maximum_segments_per_flow=100_000,
+        maximum_pending_bytes_per_flow=1024 * 1024,
+    )
+    reassembler = TCPStreamReassembler(policy)
+    reassembler.start(0)
+    run_count = 2048
+    # Leave offset 0 unfilled so nothing assembles and every fragment stays pending.
+    for index in range(run_count):
+        assert reassembler.push(2 * index + 2, b"x", captured_at=1.0) == []
+    assert reassembler._pending is not None
+    assert len(reassembler._pending) == run_count
+
+    class _CountingList(list[decoder_module._PendingRun]):
+        def __init__(self, items: list[decoder_module._PendingRun]) -> None:
+            super().__init__(items)
+            self.access_count = 0
+
+        def __getitem__(self, item: Any) -> Any:
+            self.access_count += 1
+            return super().__getitem__(item)
+
+    counting = _CountingList(reassembler._pending)
+    reassembler._pending = counting
+    assert reassembler.push(2 * run_count + 2, b"x", captured_at=1.1) == []
+    # Two bisects plus one window slice; strictly sub-linear in run_count.
+    assert counting.access_count <= 4 * run_count.bit_length()
+    assert len(reassembler._pending) == run_count + 1
+
+
+def test_tcp_reassembler_reverse_adjacent_grows_run_without_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Reverse-adjacent one-byte fragments coalesce into a single run. The buggy
+    # rebuild constructed a fresh run per fragment (theta(n) constructions, each
+    # recopying the whole growing run -> theta(n^2) copied bytes). The run must be
+    # created once and grown in place thereafter.
+    policy = ParserPolicy(maximum_segments_per_flow=100_000)
+    reassembler = TCPStreamReassembler(policy)
+    reassembler.start(0)
+    length = 4096
+    expected = bytes(index % 251 for index in range(length))
+
+    constructions = 0
+    original_init = decoder_module._PendingRun.__init__
+
+    def counting_init(
+        self: decoder_module._PendingRun, start: int, data: Buffer
+    ) -> None:
+        nonlocal constructions
+        constructions += 1
+        original_init(self, start, data)
+
+    monkeypatch.setattr(decoder_module._PendingRun, "__init__", counting_init)
+
+    for offset in range(length - 1, 0, -1):
+        assert (
+            reassembler.push(offset, expected[offset : offset + 1], captured_at=1.0)
+            == []
+        )
+
+    assert reassembler._pending is not None
+    assert len(reassembler._pending) == 1
+    assert constructions == 1
+    assert reassembler.push(0, expected[:1], captured_at=1.1) == [(1.1, expected)]
 
 
 def test_tcp_reassembler_validates_duplicate_with_bounded_history_slices(

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -1129,31 +1129,41 @@ def test_tcp_reassembler_two_sided_growth_is_atomic_on_memory_error(
     reassembler.start(0)
     assert reassembler.push(2, b"cd", captured_at=1.0) == []
     assert reassembler._pending is not None
+    run = reassembler._pending[0]
+    storage_before = run._buffer
+    storage_size_before = len(storage_before)
+    head_before = run._head
+    start_before = run.start
+    end_before = run.end
+    logical_before = run.to_bytes()
+    pending_before = reassembler.pending_bytes
     retained_before = reassembler._budget.retained
 
-    allocation_calls = 0
-    native_bytearray = bytearray
+    original_append = decoder_module._PendingRun.append
 
-    def fail_second_allocation(source: object = 0) -> bytearray:
-        nonlocal allocation_calls
-        allocation_calls += 1
-        if allocation_calls == 2:
-            raise MemoryError
-        return native_bytearray(source)
+    def fail_after_preflight(self: decoder_module._PendingRun, _data: Buffer) -> None:
+        assert self is run
+        assert self._buffer is not storage_before
+        assert len(self._buffer) > storage_size_before
+        assert self._head > head_before
+        raise MemoryError
 
-    monkeypatch.setattr(
-        decoder_module, "bytearray", fail_second_allocation, raising=False
-    )
+    monkeypatch.setattr(decoder_module._PendingRun, "append", fail_after_preflight)
     with pytest.raises(CaptureError) as caught:
         reassembler.push(1, b"bcde", captured_at=1.1)
-    monkeypatch.delattr(decoder_module, "bytearray")
+    monkeypatch.setattr(decoder_module._PendingRun, "append", original_append)
 
     assert caught.value.reason is FailureReason.CAPACITY
-    assert reassembler.pending_bytes == 2
+    assert run._buffer is storage_before
+    assert len(run._buffer) == storage_size_before
+    assert run._head == head_before
+    assert run.start == start_before
+    assert run.end == end_before
+    assert run.to_bytes() == logical_before
+    assert reassembler.pending_bytes == pending_before
     assert reassembler._budget.retained == retained_before
     assert len(reassembler._pending) == 1
-    assert reassembler._pending[0].start == 2
-    assert reassembler._pending[0].to_bytes() == b"cd"
+    assert reassembler._pending[0] is run
 
     assert reassembler.push(1, b"bcde", captured_at=1.2) == []
     assert reassembler.push(0, b"a", captured_at=1.3) == [(1.3, b"abcde")]


### PR DESCRIPTION
Closes #580.
Bead: `eg4-n72v`.

## Summary

Bound the offline TCP reassembler's overlap work without changing its accepted/rejected capture semantics.

## What changed

- compare assembled overlap with native ring-buffer slices instead of Python byte loops
- retain out-of-order payload as offset-sorted, coalesced byte runs instead of a per-byte dictionary
- validate pending overlap run-by-run with slice equality before mutation
- drain contiguous pending data run-by-run while preserving timestamps, sequence wrap, retransmission, conflict, capacity, and failure behavior
- preserve the existing conservative aggregate-memory accounting boundary
- add deterministic regressions for maximum reverse one-byte fragmentation and large duplicate history overlap, with no wall-clock thresholds

## Declared write scope

- `scripts/decode_cloud_frames.py`
- `tests/test_decode_cloud_frames.py`

No other files are changed.

## Semantics audit

A deterministic differential harness executed the staged reassembler and the exact `origin/main` implementation side by side for 500 seeded traces of 100 operations. It compared emitted chunks, failure reasons, pending-byte counts, and segment counts across overlaps, conflicts, gaps, duplicates, and out-of-order delivery.

Result: all 500 traces matched `origin/main` semantics.

## Mutation RED/GREEN evidence

Both added regressions were run with `scripts/decode_cloud_frames.py` restored to `origin/main` while the tests remained staged:

```bash
uv run --with-requirements tests/requirements-test.txt pytest -q tests/test_decode_cloud_frames.py::test_tcp_reassembler_coalesces_pathological_reverse_fragmentation tests/test_decode_cloud_frames.py::test_tcp_reassembler_validates_duplicate_with_bounded_history_slices
```

RED: 2 failed. The fragmentation regression observed 4,095 pending dictionary entries instead of one coalesced run; the duplicate-overlap regression triggered the per-byte history-access sentinel.

After restoring the staged production fix, the exact same command was rerun.

GREEN: 2 passed.

## Gates

- baseline: `uv run --with-requirements tests/requirements-test.txt pytest -q tests/test_decode_cloud_frames.py` — 101 passed
- focused final: `uv run --with-requirements tests/requirements-test.txt pytest -q tests/test_decode_cloud_frames.py` — 103 passed
- full: `uv run --with-requirements tests/requirements-test.txt pytest tests/ -q --tb=short` — 3,097 passed, 9 skipped
- Ruff lint: `uv run --with-requirements tests/requirements-test.txt ruff check scripts/decode_cloud_frames.py tests/test_decode_cloud_frames.py` — pass
- Ruff format: `uv run --with-requirements tests/requirements-test.txt ruff format --check scripts/decode_cloud_frames.py tests/test_decode_cloud_frames.py` — pass
- strict mypy: `uv run --with-requirements tests/requirements-test.txt mypy --strict --explicit-package-bases scripts/decode_cloud_frames.py` — pass
- commit hooks: end-of-file, trailing whitespace, large-file, Ruff, format, and repository mypy hooks — pass
- `git diff --cached --check` — pass
- exact scope audit — only the two declared files
