### PR TITLE
chore: bump pylxpweb to 0.10.0b3

### DIFF
--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b1", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb==0.10.0b3", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.5.1-beta.11"
 }

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b1  # keep in sync with manifest.json
+pylxpweb==0.10.0b3  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -647,9 +647,10 @@ class TestCoordinatorCleanup:
     ):
         """A transport shared between a cache entry and the station walk closes once.
 
-        The station walk's seen-set is seeded from both caches; without it the
-        same transport object would be terminally closed twice (mock transports
-        never flip is_connected, so this asserts the de-dup, not luck).
+        Devices are de-duplicated by identity across caches and the station
+        walk; without it the same transport object would be terminally closed
+        twice (mock transports never flip is_connected, so this asserts the
+        de-dup, not luck).
         """
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -583,12 +583,14 @@ class TestCoordinatorCleanup:
     async def test_async_shutdown_disconnects_cached_transports(
         self, hass, mock_config_entry
     ):
-        """Test async_shutdown disconnects transports on cached inverters/MID devices.
+        """Test async_shutdown closes transports on cached inverters/MID devices.
 
         In LOCAL/HYBRID mode, transports are attached to inverter objects
         in _inverter_cache and MID devices in _mid_device_cache.  These
-        must be disconnected during shutdown so that any in-flight
-        asyncio.gather() on transport I/O unblocks quickly.
+        must be closed during shutdown so that any in-flight
+        asyncio.gather() on transport I/O unblocks quickly.  pylxpweb>=0.10.0b3
+        closes a ``TerminalTransport`` via ``async_shutdown()`` (which does not
+        wait on the operation lock) in preference to legacy ``disconnect()``.
         """
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
@@ -596,22 +598,22 @@ class TestCoordinatorCleanup:
         # public ``.transport`` accessor returns the assigned transport (a bare
         # MagicMock's ``.transport`` would return an unrelated auto-child mock).
         mock_transport_1 = make_transport_spec(is_connected=True)
-        mock_transport_1.disconnect = AsyncMock()
+        mock_transport_1.async_shutdown = AsyncMock()
         mock_inv = make_real_inverter("INV001", "FlexBOSS21")
         mock_inv._transport = mock_transport_1
         coordinator._inverter_cache["INV001"] = mock_inv
 
         # Simulate cached MID device with an open transport
         mock_transport_2 = make_transport_spec(is_connected=True)
-        mock_transport_2.disconnect = AsyncMock()
+        mock_transport_2.async_shutdown = AsyncMock()
         mock_mid = make_real_mid("MID001", "GridBOSS")
         mock_mid._transport = mock_transport_2
         coordinator._mid_device_cache["MID001"] = mock_mid
 
         await coordinator.async_shutdown()
 
-        mock_transport_1.disconnect.assert_awaited_once()
-        mock_transport_2.disconnect.assert_awaited_once()
+        mock_transport_1.async_shutdown.assert_awaited_once()
+        mock_transport_2.async_shutdown.assert_awaited_once()
 
     async def test_async_shutdown_disconnects_station_only_transports(
         self, hass, mock_config_entry
@@ -627,7 +629,7 @@ class TestCoordinatorCleanup:
         assert not coordinator._mid_device_cache
 
         serial_transport = make_transport_spec(is_connected=True)
-        serial_transport.disconnect = AsyncMock()
+        serial_transport.async_shutdown = AsyncMock()
         mock_mid = make_real_mid("MID001", "GridBOSS")
         mock_mid._transport = serial_transport
 
@@ -638,7 +640,7 @@ class TestCoordinatorCleanup:
 
         await coordinator.async_shutdown()
 
-        serial_transport.disconnect.assert_awaited_once()
+        serial_transport.async_shutdown.assert_awaited_once()
 
     async def test_async_shutdown_dedups_station_and_cache_transports(
         self, hass, mock_config_entry
@@ -646,13 +648,13 @@ class TestCoordinatorCleanup:
         """A transport shared between a cache entry and the station walk closes once.
 
         The station walk's seen-set is seeded from both caches; without it the
-        same transport object would get a second disconnect() (mock transports
+        same transport object would be terminally closed twice (mock transports
         never flip is_connected, so this asserts the de-dup, not luck).
         """
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
 
         shared_transport = make_transport_spec(is_connected=True)
-        shared_transport.disconnect = AsyncMock()
+        shared_transport.async_shutdown = AsyncMock()
         mock_inv = make_real_inverter("INV001", "FlexBOSS21")
         mock_inv._transport = shared_transport
         coordinator._inverter_cache["INV001"] = mock_inv
@@ -664,7 +666,7 @@ class TestCoordinatorCleanup:
 
         await coordinator.async_shutdown()
 
-        shared_transport.disconnect.assert_awaited_once()
+        shared_transport.async_shutdown.assert_awaited_once()
 
 
 class TestDeviceInfo:


### PR DESCRIPTION
## Summary

Bumps the pylxpweb pin from `==0.10.0b1` to `==0.10.0b3` in `manifest.json` and `tests/requirements-test.txt` (kept in sync).

**Note on pin style:** the dispatch for this task assumed the manifest carried `pylxpweb>=0.9.39b11`, but `main` moved on — #582 already raised it to an exact `==0.10.0b1` pin to adopt the caller-owned transport-factory seam. This PR follows the current convention (exact pin, both files in lockstep) rather than reverting to `>=`.

## Compatibility audit (0.9.39b11 → 0.10.0b3)

Audited the pylxpweb CHANGELOG and the full `src/` diff `v0.9.39b11..v0.10.0b3`, then grepped the integration for every affected symbol:

- **`Station.attach_local_transports(..., transport_factory=...)`** (0.10.0b1) — additive keyword-only parameter; the integration already uses it (`coordinator_local.py`).
- **`register_observer` on local transport constructors/factories** (0.10.0b2) and **`RegisterObserverControl` / `set_register_observer`** (0.10.0b3) — additive, unused by the integration.
- **`device.transport` accessor** — moved from `BaseInverter`/`MIDDevice` up to `BaseDevice`, same semantics (`_local_transport`); all integration reads unaffected.
- **`BaseTransport.disconnect()`** — retained; no call-site breakage.
- **Register bound data fixes** (`ac_charge_power` max 15000→10000, `ac_charge_start_soc` min 0→1) — library-side data corrections; the integration reads bounds dynamically.
- **`ModbusTransport(session_max_age=3600)`** (0.10.0b3, pylxpweb#288/#290) — new opt-out parameter; aging TCP sessions are now proactively recycled. Behavior improvement, no API break.

## One intentional behavior change requiring test updates

0.10.0b3 adds `async_shutdown()` to `ModbusTransport`, so real local transports now satisfy the runtime-checkable `TerminalTransport` protocol. `BaseDevice` detachment therefore terminally closes them via `async_shutdown()` — which closes *without* waiting on the operation lock — in preference to legacy `disconnect()`. That is exactly what coordinator shutdown wants (unblocks in-flight `asyncio.gather` on transport I/O immediately).

Three `TestCoordinatorCleanup` tests asserted the old `disconnect()` mechanism via shape-faithful autospec mocks (specced on the real `ModbusTransport`, which now exposes `async_shutdown`). They now assert `async_shutdown()`. No production code changed.

**Mutation check:** with the pin reverted to `0.10.0b1`, the three updated tests fail (red); with `0.10.0b3`, they pass (green).

## Gates (all green, uv)

- `ruff check custom_components/ --fix` + `ruff format custom_components/` — clean
- `mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — no issues, 47 files
- `pytest tests/ -x --tb=short` — **3107 passed, 9 skipped** with `pylxpweb==0.10.0b3` installed
- `tests/validate_silver_tier.py`, `validate_gold_tier.py`, `validate_platinum_tier.py` — all pass

## Follow-up (not in scope here)

- `llmwiki/20-pylxpweb/release-and-pinning.md` and `llmwiki/50-operations/release-process.md` still describe the pin as `pylxpweb>=0.9.39b10` — already stale since #582 (which moved to exact `==` pins); worth a wiki update under the llmwiki freshness discipline.
- Integration version intentionally not bumped (release-cut work).