### PR TITLE
chore: bump pylxpweb to 0.10.0b4

### DIFF
--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b3", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb==0.10.0b4", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.5.1-beta.11"
 }

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b3  # keep in sync with manifest.json
+pylxpweb==0.10.0b4  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml


### PR DESCRIPTION
Bumps `pylxpweb` 0.10.0b3 → [0.10.0b4](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b4), carrying the **bounded dead-link probe cost** fix ([pylxpweb#310](https://github.com/joyfulhouse/pylxpweb/pull/310)) — the remaining mechanism behind #587:

When a local endpoint goes deaf (dongle accepts TCP but never answers), every coordinator refresh paid the transport's full read timeout chain (10s dongle / up to ~30s Modbus retry chain) as its link-down probe; HA schedules `next poll = refresh_duration + interval`, so the effective poll interval degraded to ~15–35s (measured live in production: 7–25s gaps on a 5s interval). Now the probe is a single-attempt 2s `check_link()` with an exponentially backed-off window (4s → 60s, reset on any success), and the HTTP fallback keeps data flowing meanwhile.

Also in 0.10.0b4: restored the hermetic `uv_build` release pin ([pylxpweb#311](https://github.com/joyfulhouse/pylxpweb/pull/311)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)