### PR TITLE
fix: skip parallel-config read on GridBOSS during Modbus discovery

### DIFF
--- a/custom_components/eg4_web_monitor/_config_flow/discovery.py
+++ b/custom_components/eg4_web_monitor/_config_flow/discovery.py
@@ -157,26 +157,31 @@ async def _read_device_info_from_transport(
         except Exception as err:
             _LOGGER.debug("Could not read runtime data: %s", err)
 
-    # Read parallel group configuration from input register 113
+    # Read parallel group configuration from input register 113 (skip for
+    # GridBOSS: on MID devices input registers 112-113 hold the
+    # ac_couple3_energy_total_l1 lifetime energy counter, not parallel
+    # config, so decoding it would fabricate a parallel role/phase/group
+    # once the counter crosses 6553.6 kWh — issue #596).
     parallel_number = 0
     parallel_master_slave = 0
     parallel_phase = 0
-    try:
-        reg113_raw = await transport.read_parallel_config()
-        if reg113_raw > 0:
-            parallel_master_slave = reg113_raw & 0x03
-            parallel_phase = (reg113_raw >> 2) & 0x03
-            parallel_number = (reg113_raw >> 8) & 0xFF
-            _LOGGER.debug(
-                "Parallel config for %s: raw=0x%04X, role=%d, phase=%d, group=%d",
-                serial,
-                reg113_raw,
-                parallel_master_slave,
-                parallel_phase,
-                parallel_number,
-            )
-    except Exception as err:
-        _LOGGER.debug("Could not read parallel config: %s", err)
+    if not is_gridboss:
+        try:
+            reg113_raw = await transport.read_parallel_config()
+            if reg113_raw > 0:
+                parallel_master_slave = reg113_raw & 0x03
+                parallel_phase = (reg113_raw >> 2) & 0x03
+                parallel_number = (reg113_raw >> 8) & 0xFF
+                _LOGGER.debug(
+                    "Parallel config for %s: raw=0x%04X, role=%d, phase=%d, group=%d",
+                    serial,
+                    reg113_raw,
+                    parallel_master_slave,
+                    parallel_phase,
+                    parallel_number,
+                )
+        except Exception as err:
+            _LOGGER.debug("Could not read parallel config: %s", err)
 
     return DiscoveredDevice(
         serial=serial,

--- a/tests/test_config_flow_scan.py
+++ b/tests/test_config_flow_scan.py
@@ -342,3 +342,40 @@ class TestDiscoveryModelInfo:
 
         assert device.model == "GridBOSS"
         assert device.is_gridboss is True
+
+    async def test_gridboss_skips_parallel_config_read(self):
+        """Discovery never reads input register 113 on GridBOSS (issue #596).
+
+        On MID devices input registers 112-113 hold the
+        ac_couple3_energy_total_l1 lifetime counter; decoding it as
+        parallel config fabricates a slave role once the counter
+        exceeds 6553.6 kWh. GridBOSS must report standalone defaults.
+        """
+        from custom_components.eg4_web_monitor._config_flow.discovery import (
+            _read_device_info_from_transport,
+        )
+
+        transport = self._make_transport(device_type_code=50, power_rating=0)
+        # Energy counter high word nonzero — would decode as role=slave.
+        transport.read_parallel_config = AsyncMock(return_value=0x0001)
+        device = await _read_device_info_from_transport(transport, "5012345678")
+
+        transport.read_parallel_config.assert_not_called()
+        assert device.parallel_number == 0
+        assert device.parallel_master_slave == 0
+        assert device.parallel_phase == 0
+
+    async def test_inverter_reads_parallel_config(self):
+        """Discovery still reads and decodes parallel config for inverters."""
+        from custom_components.eg4_web_monitor._config_flow.discovery import (
+            _read_device_info_from_transport,
+        )
+
+        transport = self._make_transport(device_type_code=10284, power_rating=8)
+        transport.read_parallel_config = AsyncMock(return_value=0x0205)
+        device = await _read_device_info_from_transport(transport, "SYNTH10000")
+
+        transport.read_parallel_config.assert_awaited_once()
+        assert device.parallel_number == 2
+        assert device.parallel_master_slave == 1  # master
+        assert device.parallel_phase == 1

--- a/tests/test_config_flow_scan.py
+++ b/tests/test_config_flow_scan.py
@@ -348,7 +348,7 @@ class TestDiscoveryModelInfo:
 
         On MID devices input registers 112-113 hold the
         ac_couple3_energy_total_l1 lifetime counter; decoding it as
-        parallel config fabricates a slave role once the counter
+        parallel config fabricates a parallel role once the counter
         exceeds 6553.6 kWh. GridBOSS must report standalone defaults.
         """
         from custom_components.eg4_web_monitor._config_flow.discovery import (
@@ -356,7 +356,8 @@ class TestDiscoveryModelInfo:
         )
 
         transport = self._make_transport(device_type_code=50, power_rating=0)
-        # Energy counter high word nonzero — would decode as role=slave.
+        # Energy counter high word nonzero — would decode as role=master
+        # (0x0001 & 0x03 = 1).
         transport.read_parallel_config = AsyncMock(return_value=0x0001)
         device = await _read_device_info_from_transport(transport, "5012345678")
 


### PR DESCRIPTION
## Summary

`_read_device_info_from_transport()` in `_config_flow/discovery.py` called `transport.read_parallel_config()` (input register 113) unconditionally, including for GridBOSS devices. On MID/GridBOSS, input registers 112–113 are `ac_couple3_energy_total_l1` — a 32-bit lifetime kWh counter, not parallel config. Once that counter crosses 6553.6 kWh the high word goes nonzero and discovery decodes a bogus parallel role/phase/group (e.g. raw `0x0001` → "slave") onto the `DiscoveredDevice`, which then persists into the stored device config.

## Fix

Gate the parallel-config block on `not is_gridboss` — the device type code is read from holding register 19 before the parallel block, so `is_gridboss` is already known. GridBOSS devices now always report standalone defaults (`parallel_number=0`, `parallel_master_slave=0`, `parallel_phase=0`); inverter discovery is unchanged.

## Tests

- `test_gridboss_skips_parallel_config_read` — GridBOSS discovery never calls `read_parallel_config` (mock returns a would-be-bogus `0x0001`) and reports standalone defaults.
- `test_inverter_reads_parallel_config` — inverter (FlexBOSS) discovery still calls it and decodes role/phase/group from `0x0205`.

## Validation

- `ruff check` / `ruff format --check` (pinned 0.15.5): clean
- `mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/`: no issues in 47 files
- `pytest tests/ -x`: 3109 passed, 9 skipped
- Silver / Gold / Platinum tier validators: all pass

Fixes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)