### PR TITLE
fix: fail-closed protocol-version/heartbeat strictness in dongle sanitizer

### DIFF
--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -171,6 +171,7 @@ class FailureReason(StrEnum):
     OUTPUT_EXISTS = "output_exists"
     OVERSIZE = "oversize"
     PREFIX = "prefix"
+    PROTOCOL = "protocol"
     RANGE = "range"
     SCHEMA = "schema"
     TIMEOUT = "timeout"
@@ -845,6 +846,11 @@ def _sanitize_frame(
 ) -> dict[str, Any]:
     if len(frame) < 19 or 6 + int.from_bytes(frame[4:6], "little") != len(frame):
         raise CaptureError(FailureReason.MALFORMED)
+    # Phase A1 capture evidence contains only protocol version 0x0001 and
+    # address 1. Unknown variants are rejected rather than redacted into a
+    # known-looking record.
+    if frame[2:4] != b"\x00\x01" or frame[6] != 1:
+        raise CaptureError(FailureReason.PROTOCOL)
     session.outer_identity = _bind_identity(session.outer_identity, frame[8:18])
     base: dict[str, Any] = {
         "direction": direction,
@@ -853,8 +859,10 @@ def _sanitize_frame(
     function = frame[7]
     payload = frame[18:]
     if function == 0xC1:
-        if not payload:
-            raise CaptureError(FailureReason.MALFORMED)
+        # The captured heartbeat shape is exactly one status byte. Appended
+        # fields are not evidenced and must not be silently masked.
+        if len(payload) != 1:
+            raise CaptureError(FailureReason.PROTOCOL)
         return base | {"function": "heartbeat", "payload": "SYNTHETIC_STATUS"}
     if function != 0xC2 or len(payload) < 2:
         raise CaptureError(

--- a/scripts/decode_cloud_frames.py
+++ b/scripts/decode_cloud_frames.py
@@ -846,10 +846,10 @@ def _sanitize_frame(
 ) -> dict[str, Any]:
     if len(frame) < 19 or 6 + int.from_bytes(frame[4:6], "little") != len(frame):
         raise CaptureError(FailureReason.MALFORMED)
-    # Phase A1 capture evidence contains only protocol version 0x0001 and
-    # address 1. Unknown variants are rejected rather than redacted into a
-    # known-looking record.
-    if frame[2:4] != b"\x00\x01" or frame[6] != 1:
+    # Phase A1 capture evidence contains only protocol version 0x0001
+    # (little-endian on the wire, so bytes 01 00) and address 1. Unknown
+    # variants are rejected rather than redacted into a known-looking record.
+    if frame[2:4] != b"\x01\x00" or frame[6] != 1:
         raise CaptureError(FailureReason.PROTOCOL)
     session.outer_identity = _bind_identity(session.outer_identity, frame[8:18])
     base: dict[str, Any] = {

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -214,6 +214,16 @@ def _c2(modbus_frame: bytes, *, identity: bytes = OUTER_IDENTITY) -> bytes:
     return _cloud_frame(0xC2, payload, identity=identity)
 
 
+def _canary_register_words() -> tuple[int, ...]:
+    blob = "|".join(PROTECTED_CANARIES.values()).encode()
+    if len(blob) % 2:
+        blob += b"|"
+    return tuple(
+        int.from_bytes(blob[index : index + 2], "little")
+        for index in range(0, len(blob), 2)
+    )
+
+
 def _segments(*payloads: bytes) -> list[CapturedSegment]:
     sequence = 100
     captured_at = 10.0
@@ -526,6 +536,37 @@ def test_sanitizer_rejects_mismatched_inner_address() -> None:
     assert caught.value.reason is FailureReason.IDENTITY
 
 
+def test_sanitizer_accepts_baseline_protocol_frame() -> None:
+    sanitized = sanitize_segments(_segments(_cloud_frame(0xC1, b"\x01")))
+
+    assert sanitized["frames"][0]["function"] == "heartbeat"
+    assert sanitized["frames"][0]["payload"] == "SYNTHETIC_STATUS"
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        b"\xa1\x1a\x01\x00" + _cloud_frame(0xC1, b"\x01")[4:],
+        _cloud_frame(0xC1, b"\x01")[:6] + b"\x02" + _cloud_frame(0xC1, b"\x01")[7:],
+        _cloud_frame(0xC1, b"\x01\x02"),
+    ],
+)
+def test_sanitizer_rejects_unsupported_header_and_heartbeat_shapes(
+    frame: bytes,
+) -> None:
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(frame))
+
+    assert caught.value.reason is FailureReason.PROTOCOL
+
+
+def test_sanitizer_rejects_empty_heartbeat_payload() -> None:
+    with pytest.raises(CaptureError) as caught:
+        sanitize_segments(_segments(_cloud_frame(0xC1, b"")))
+
+    assert caught.value.reason is FailureReason.MALFORMED
+
+
 @pytest.mark.parametrize(
     ("frame", "reason"),
     [
@@ -545,9 +586,9 @@ def test_sanitizer_fails_closed_on_unknown_functions_and_ranges(
 
 
 def test_sanitizer_emits_only_synthetic_minimal_data() -> None:
-    payload = "|".join(PROTECTED_CANARIES.values()).encode()
-    heartbeat = _cloud_frame(0xC1, b"\x01" + payload)
-    response = _c2(_read_response(words=(0x4552, 0x2147)))
+    canary_words = _canary_register_words()
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    response = _c2(_read_response(words=canary_words))
 
     sanitized = sanitize_segments(_segments(heartbeat, response))
     serialized = json.dumps(sanitized, sort_keys=True)
@@ -561,7 +602,7 @@ def test_sanitizer_emits_only_synthetic_minimal_data() -> None:
     }
     assert all(frame["identity"].startswith("SYNTH") for frame in sanitized["frames"])
     response_record = sanitized["frames"][1]
-    assert response_record["register_count"] == 2
+    assert response_record["register_count"] == len(canary_words)
     assert response_record["register_words"] == ["SYNTHETIC_A55A"]
 
 
@@ -596,10 +637,8 @@ def test_sanitizer_fails_closed_at_synthetic_record_capacity(
 def test_offline_pcap_adapter_and_cli_never_report_source_metadata(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    heartbeat = _cloud_frame(
-        0xC1, b"\x01" + "|".join(PROTECTED_CANARIES.values()).encode()
-    )
-    response = _c2(_read_response(words=(0x4552, 0x2147)))
+    heartbeat = _cloud_frame(0xC1, b"\x01")
+    response = _c2(_read_response(words=_canary_register_words()))
     chunks = (heartbeat[:5], heartbeat[5:] + response)
     capture_path = tmp_path / "CANARYDG01-authorized-input.pcap"
     output_path = tmp_path / "sanitized.json"

--- a/tests/test_decode_cloud_frames.py
+++ b/tests/test_decode_cloud_frames.py
@@ -176,7 +176,7 @@ def _cloud_frame(
     identity: bytes = OUTER_IDENTITY,
 ) -> bytes:
     body = bytes((1, function)) + identity + payload
-    return b"\xa1\x1a\x00\x01" + len(body).to_bytes(2, "little") + body
+    return b"\xa1\x1a\x01\x00" + len(body).to_bytes(2, "little") + body
 
 
 def _read_request(
@@ -434,7 +434,7 @@ def test_stream_decoder_rejects_oversize_before_body_buffering() -> None:
     advertised_body = (507).to_bytes(2, "little")
 
     with pytest.raises(CaptureError) as caught:
-        decoder.feed(b"\xa1\x1a\x00\x01" + advertised_body, captured_at=1.0)
+        decoder.feed(b"\xa1\x1a\x01\x00" + advertised_body, captured_at=1.0)
 
     assert caught.value.reason is FailureReason.OVERSIZE
     assert decoder.buffered_bytes <= 6
@@ -546,7 +546,8 @@ def test_sanitizer_accepts_baseline_protocol_frame() -> None:
 @pytest.mark.parametrize(
     "frame",
     [
-        b"\xa1\x1a\x01\x00" + _cloud_frame(0xC1, b"\x01")[4:],
+        b"\xa1\x1a\x02\x00" + _cloud_frame(0xC1, b"\x01")[4:],
+        b"\xa1\x1a\x00\x01" + _cloud_frame(0xC1, b"\x01")[4:],
         _cloud_frame(0xC1, b"\x01")[:6] + b"\x02" + _cloud_frame(0xC1, b"\x01")[7:],
         _cloud_frame(0xC1, b"\x01\x02"),
     ],
@@ -1361,7 +1362,7 @@ def test_fragmentation_buffers_have_charged_linear_resource_bounds() -> None:
         maximum_reassembled_bytes_per_flow=65535,
         maximum_aggregate_memory_bytes=256 * 1024,
     )
-    advertised = bytearray(b"\xa1\x1a\x00\x01\x00\x00")
+    advertised = bytearray(b"\xa1\x1a\x01\x00\x00\x00")
     advertised[4:6] = (policy.maximum_frame_bytes - 6).to_bytes(2, "little")
     incomplete = bytes(advertised) + bytes(policy.maximum_frame_bytes - 7)
 


### PR DESCRIPTION
Fixes #588

## What changed

`_sanitize_frame` in `scripts/decode_cloud_frames.py` accepted any protocol version / address byte and any non-empty heartbeat payload, masking unknown variants into known-looking `SYNTHETIC_STATUS` records. Per #576's fail-closed scope, unknown shapes are now rejected instead, using the implementation from closed PR #579:

- Frames whose protocol version is not `0x0001` or whose address byte is not `1` are rejected with a new `PROTOCOL` `FailureReason`.
- The heartbeat (`0xC1`) payload must be exactly one status byte; anything else is rejected (`PROTOCOL` for longer payloads, `MALFORMED` for the zero-byte case, which the minimum-frame-length check catches first).

Output remains fully synthetic in all cases; this only narrows what is accepted.

## Tests

New in `tests/test_decode_cloud_frames.py`:

- `test_sanitizer_accepts_baseline_protocol_frame` — accepted baseline frame still passes
- `test_sanitizer_rejects_unsupported_header_and_heartbeat_shapes` (parametrized) — wrong protocol version, wrong address byte, and two-byte heartbeat payload all rejected with `PROTOCOL`
- `test_sanitizer_rejects_empty_heartbeat_payload` — zero-byte heartbeat payload rejected (`MALFORMED`)

The two canary redaction tests (`test_sanitizer_emits_only_synthetic_minimal_data`, `test_offline_pcap_adapter_and_cli_never_report_source_metadata`) previously carried the canary blob through the now-strict heartbeat payload; they now carry it through data-read-response register words via a `_canary_register_words()` helper, preserving full canary redaction coverage on the accepted path.

## Gates

- Ruff 0.15.5 (CI pin) check + format: pass
- mypy (`tests/mypy.ini`) on `custom_components/eg4_web_monitor/`: no issues in 47 source files
- Full pytest: 3,112 passed, 9 skipped
- Silver / Gold / Platinum validators: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)