### PR TITLE
fix: expire stale active firmware_update_info after bounded refresh-failure window

### DIFF
--- a/custom_components/eg4_web_monitor/coordinator.py
+++ b/custom_components/eg4_web_monitor/coordinator.py
@@ -542,6 +542,10 @@ class EG4DataUpdateCoordinator(
         self._firmware_status_owner: object | None = None
         self._firmware_status_released = True
         self._firmware_prefetched_device_ids: set[int] = set()
+        # Per-serial anchor of the firmware carry-forward window (#573):
+        # last successful refresh, or the first failure when none ever
+        # succeeded. Missing key = never polled (the None sentinel).
+        self._firmware_poll_fresh_at: dict[str, float] = {}
 
         # Track availability state for Silver tier logging requirement
         self._last_available_state: bool = True

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -96,6 +96,18 @@ FIRMWARE_UPDATE_CLOUD_TIMEOUT = 10.0
 BATTERY_BACKUP_CLOUD_TIMEOUT = 10.0
 BATTERY_BACKUP_FETCH_INTERVAL = 30.0
 
+# Carry-forward bound for a cached ACTIVE firmware row (#573). A transient
+# refresh failure must keep serving the device's cached in-progress state so
+# an active update does not flicker to idle (#353) — but that carry-forward
+# must not be indefinite: a stale ``in_progress=True`` row surviving
+# persistent refresh failures wedges the update entity busy forever and HA
+# rejects new installs from that flag. Firmware polls piggyback on the cloud
+# refresh cycle (``_http_polling_interval``), so the window allows roughly
+# three missed polls with a floor so a short configured interval cannot make
+# a brief cloud blip expire a genuinely active update.
+FIRMWARE_POLL_STALENESS_MISSED_POLLS = 3
+FIRMWARE_POLL_STALENESS_FLOOR = 600.0
+
 # Portal event-log poll throttle (#327).  Events are pushed to the cloud
 # out-of-band by the device (some never surface in registers), so the Last
 # Event sensor polls /WManage/api/analyze/event/list — but events are rare,
@@ -802,6 +814,7 @@ if TYPE_CHECKING:
         _firmware_status_owner: object | None
         _firmware_status_released: bool
         _firmware_prefetched_device_ids: set[int]
+        _firmware_poll_fresh_at: dict[str, float]
         _background_scheduling_stopped: bool
         _http_polling_interval: int
         _local_transport_configs: list[dict[str, Any]]
@@ -915,6 +928,10 @@ if TYPE_CHECKING:
         # ── FirmwareUpdateMixin methods ──
         def _extract_firmware_update_info(
             self, device: "BaseInverter | MIDDevice"
+        ) -> dict[str, Any] | None: ...
+        def _note_firmware_poll_result(self, device: Any, *, success: bool) -> None: ...
+        def _expire_stale_firmware_activity(
+            self, device: Any, info: dict[str, Any] | None
         ) -> dict[str, Any] | None: ...
 
         # ── ParameterManagementMixin methods ──
@@ -2345,11 +2362,20 @@ class DeviceProcessingMixin(_MixinBase):
         the device object caches its last firmware state, so we extract from it
         even when the refresh calls above raise. Otherwise an active firmware
         update would flicker to idle on any poll error (issue #353).
+
+        That carry-forward is freshness-bounded (#573): each refresh outcome is
+        recorded via _note_firmware_poll_result, and once failures persist past
+        the staleness window a cached ACTIVE row is expired by
+        _expire_stale_firmware_activity instead of wedging the update entity
+        busy forever.
         """
         if not hasattr(device, "check_firmware_updates"):
             return None
         if id(device) in self._firmware_prefetched_device_ids:
-            return self._extract_firmware_update_info(device)
+            # Refresh outcome was already recorded by the prefetch batch.
+            return self._expire_stale_firmware_activity(
+                device, self._extract_firmware_update_info(device)
+            )
         try:
             await self._breakered_cloud_call(
                 lambda: device.check_firmware_updates(),
@@ -2361,13 +2387,19 @@ class DeviceProcessingMixin(_MixinBase):
                     timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
                 )
         except Exception as e:
+            self._note_firmware_poll_result(device, success=False)
             _LOGGER.debug(
                 "Could not refresh firmware updates for %s (using last cached state): %s",
                 device.serial_number,
                 e,
             )
-        # Extract from the device's cached state regardless of refresh outcome.
-        return self._extract_firmware_update_info(device)
+        else:
+            self._note_firmware_poll_result(device, success=True)
+        # Extract from the device's cached state regardless of refresh outcome,
+        # expiring a stale active row once the carry-forward window is spent.
+        return self._expire_stale_firmware_activity(
+            device, self._extract_firmware_update_info(device)
+        )
 
     async def _fetch_battery_backup_status(
         self,
@@ -2483,12 +2515,19 @@ class DeviceProcessingMixin(_MixinBase):
                         timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
                     )
             except Exception as err:
+                self._note_firmware_poll_result(device, success=False)
                 _LOGGER.debug(
                     "Could not refresh firmware availability for %s "
                     "(using last cached state): %s",
                     getattr(device, "serial_number", "?"),
                     err,
                 )
+            else:
+                # For progress-capable devices the progress call below is the
+                # authoritative freshness signal for in_progress; only stamp
+                # success here when no progress poll will follow.
+                if not hasattr(device, "get_firmware_update_progress"):
+                    self._note_firmware_poll_result(device, success=True)
 
         await asyncio.gather(*(_check(device) for device in firmware_devices))
 
@@ -2506,12 +2545,15 @@ class DeviceProcessingMixin(_MixinBase):
                         timeout=FIRMWARE_UPDATE_CLOUD_TIMEOUT,
                     )
             except Exception as err:
+                self._note_firmware_poll_result(device, success=False)
                 _LOGGER.debug(
                     "Could not refresh firmware progress for %s "
                     "(using last cached state): %s",
                     getattr(device, "serial_number", "?"),
                     err,
                 )
+            else:
+                self._note_firmware_poll_result(device, success=True)
 
         flight = self._firmware_status_flight
         if flight is not None:
@@ -4806,3 +4848,68 @@ class FirmwareUpdateMixin(_MixinBase):
             update_info["update_percentage"] = device.firmware_update_percentage
 
         return update_info
+
+    def _firmware_poll_staleness_window(self) -> float:
+        """Seconds a cached ACTIVE firmware row may be carried forward (#573)."""
+        return max(
+            FIRMWARE_POLL_STALENESS_MISSED_POLLS * float(self._http_polling_interval),
+            FIRMWARE_POLL_STALENESS_FLOOR,
+        )
+
+    def _note_firmware_poll_result(self, device: Any, *, success: bool) -> None:
+        """Record the freshness of a device's firmware refresh outcome (#573).
+
+        A success re-anchors the carry-forward window at now. A failure only
+        seeds the anchor when none exists yet (missing key = the None "never
+        ran" sentinel): monotonic() is host uptime on Linux, so a 0.0 default
+        would make the first-ever failure on a freshly booted host look
+        window-expired and blank cached state immediately (the d66cc92
+        fresh-boot class). Anchoring the first failure at now instead starts
+        the outage clock there, preserving #353's flicker protection.
+        """
+        serial = getattr(device, "serial_number", None)
+        if serial is None:
+            return
+        key = str(serial)
+        now = time.monotonic()
+        if success:
+            self._firmware_poll_fresh_at[key] = now
+        else:
+            self._firmware_poll_fresh_at.setdefault(key, now)
+
+    def _expire_stale_firmware_activity(
+        self, device: Any, info: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Expire a cached ACTIVE firmware row past the staleness window (#573).
+
+        Carry-forward on refresh failure (#353) must be bounded: a stale
+        ``in_progress=True`` row that survives persistent failures wedges the
+        update entity busy indefinitely — HA rejects new installs from that
+        flag — and renders a permanent indeterminate spinner. Once the last
+        refresh success (or the first failure, if none ever succeeded) is
+        older than the window, the row is exposed as not-installing with an
+        unknown percentage rather than actively installing. Availability and
+        version fields are untouched; a later successful poll that still
+        reports an active update re-publishes it fresh.
+        """
+        if not info or not info.get("in_progress"):
+            return info
+        serial = getattr(device, "serial_number", None)
+        if serial is None:
+            return info
+        fresh_at = self._firmware_poll_fresh_at.get(str(serial))
+        if fresh_at is None:
+            # No recorded refresh outcome for this serial: nothing proves the
+            # row stale, so leave it alone.
+            return info
+        if time.monotonic() - fresh_at < self._firmware_poll_staleness_window():
+            return info
+        _LOGGER.debug(
+            "Firmware progress for %s has not refreshed within %.0f s; "
+            "expiring stale active update state (#573)",
+            serial,
+            self._firmware_poll_staleness_window(),
+        )
+        info["in_progress"] = False
+        info["update_percentage"] = None
+        return info

--- a/custom_components/eg4_web_monitor/coordinator_mixins.py
+++ b/custom_components/eg4_web_monitor/coordinator_mixins.py
@@ -4861,11 +4861,16 @@ class FirmwareUpdateMixin(_MixinBase):
 
         A success re-anchors the carry-forward window at now. A failure only
         seeds the anchor when none exists yet (missing key = the None "never
-        ran" sentinel): monotonic() is host uptime on Linux, so a 0.0 default
-        would make the first-ever failure on a freshly booted host look
-        window-expired and blank cached state immediately (the d66cc92
-        fresh-boot class). Anchoring the first failure at now instead starts
-        the outage clock there, preserving #353's flicker protection.
+        ran" sentinel). Do not "simplify" the sentinel to a 0.0 default:
+        monotonic() is host uptime on Linux, so on any host up LONGER than
+        the staleness window a first-ever failure would read
+        ``now - 0.0 >= window`` and instantly expire an active row that was
+        never successfully polled. (This is the mirror image of the d66cc92
+        fresh-boot class, where a 0.0 default makes the first run look
+        THROTTLED on a freshly booted host.) Anchoring the first failure at
+        now instead starts the outage clock there, preserving #353's flicker
+        protection; pinned by
+        test_long_uptime_first_failure_carries_forward_then_expires.
         """
         serial = getattr(device, "serial_number", None)
         if serial is None:

--- a/custom_components/eg4_web_monitor/update.py
+++ b/custom_components/eg4_web_monitor/update.py
@@ -191,12 +191,12 @@ class EG4FirmwareUpdateEntity(
         ``FirmwareUpdateMixin.start_firmware_update``), and an active 100%
         was observed on a 6000XP (asserted-unverified: issues #353/#512).
 
-        Known limitation (pre-existing): a cached ``in_progress=True`` row at
-        0/100 that survives persistent refresh failures keeps this entity
-        busy (``in_progress`` True) and Home Assistant rejects new installs.
-        This PR only changes how that wedged state renders (was Installing
-        100%; now indeterminate). Freshness-bounded clearing of stale active
-        rows is out of scope for #512.
+        A cached ``in_progress=True`` row cannot survive persistent refresh
+        failures indefinitely: the coordinator bounds that carry-forward
+        (#573, ``_expire_stale_firmware_activity``) and republishes the row
+        as not-installing with an unknown percentage once the staleness
+        window is spent, so this entity releases ``in_progress`` and Home
+        Assistant accepts new installs again.
         """
         # HA-initiated chain: never publish current-row percentages as chain progress.
         if self._install_lock.locked():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10102,3 +10102,123 @@ class TestFirmwarePollCarryForward:
         assert result["in_progress"] is True
         assert result["update_percentage"] == 42
         assert result["latest_version"] == "ccaa-1E1515"
+
+    async def test_stale_active_100_expires_after_staleness_window(
+        self, hass, mock_config_entry
+    ):
+        """#573 transition: active-100 row -> repeated refresh failures -> expires.
+
+        Carry-forward of a cached ACTIVE row (#353) is freshness-bounded:
+        within the window failures keep serving the cached state; once the
+        last successful refresh is older than the window, the row is
+        republished as not-installing with an unknown percentage so the
+        update entity releases in_progress and HA accepts new installs.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        device = self._cached_updating_device()
+        device.firmware_update_percentage = 100
+        window = coordinator._firmware_poll_staleness_window()
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_mixins.time.monotonic"
+        ) as monotonic:
+            # t0: a successful poll observes the active-100 row (anchors
+            # the freshness window).
+            monotonic.return_value = 1000.0
+            device.check_firmware_updates = AsyncMock()
+            device.get_firmware_update_progress = AsyncMock()
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+            assert result["update_percentage"] == 100
+
+            # Refresh calls start failing persistently.
+            device.check_firmware_updates = AsyncMock(side_effect=RuntimeError("down"))
+            device.get_firmware_update_progress = AsyncMock(
+                side_effect=RuntimeError("down")
+            )
+
+            # Within the window: cached active state carries forward (#353).
+            monotonic.return_value = 1000.0 + window - 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+            assert result["update_percentage"] == 100
+
+            # Past the window: the stale active row expires (#573). Version
+            # and availability fields survive so the entity stays meaningful.
+            monotonic.return_value = 1000.0 + window + 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is False
+            assert result["update_percentage"] is None
+            assert result["latest_version"] == "ccaa-1E1515"
+
+            # Recovery: a later successful poll that still reports an active
+            # update re-anchors the window and republishes it fresh.
+            device.check_firmware_updates = AsyncMock()
+            device.get_firmware_update_progress = AsyncMock()
+            monotonic.return_value = 1000.0 + window + 10.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+
+    async def test_stale_active_row_expires_even_when_coordinator_succeeds(
+        self, hass, mock_config_entry
+    ):
+        """#573 tribunal case: side-poll fails, coordinator update SUCCEEDS.
+
+        _poll_firmware_update_info swallows its refresh exceptions, so the
+        overall coordinator update keeps succeeding (last_update_success
+        stays True) and the entity stays AVAILABLE — the wedge renders as a
+        permanently visible indeterminate spinner, not as unavailability.
+        The stale active row must still expire after the window.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        assert coordinator.last_update_success is True
+        device = self._cached_updating_device()  # refresh raises; cache active
+        window = coordinator._firmware_poll_staleness_window()
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_mixins.time.monotonic"
+        ) as monotonic:
+            # First observed failure anchors the outage window; the cached
+            # active row still carries forward (no successful poll ever ran).
+            monotonic.return_value = 5000.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+
+            # Failures persist past the window: the row expires even though
+            # every poll cycle "succeeded" from the coordinator's viewpoint.
+            monotonic.return_value = 5000.0 + window + 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is False
+            assert result["update_percentage"] is None
+
+        # The swallowed exceptions never marked the coordinator failed.
+        assert coordinator.last_update_success is True
+
+    async def test_first_failure_on_fresh_boot_carries_forward(
+        self, hass, mock_config_entry
+    ):
+        """d66cc92 fresh-boot class: monotonic is host uptime on Linux.
+
+        With monotonic barely past boot, the first-ever failed poll must
+        anchor the window at that failure and carry the cached active row
+        forward — a 0.0 "never ran" default would read as window-expired
+        and blank the cached state immediately, regressing #353.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        device = self._cached_updating_device()
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_mixins.time.monotonic"
+        ) as monotonic:
+            monotonic.return_value = 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+
+        assert result is not None
+        assert result["in_progress"] is True
+        assert result["update_percentage"] == 42

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10248,3 +10248,45 @@ class TestFirmwarePollCarryForward:
             assert result is not None
             assert result["in_progress"] is False
             assert result["update_percentage"] is None
+
+    async def test_prefetch_path_failures_anchor_the_window_and_expire(
+        self, hass, mock_config_entry
+    ):
+        """#573 via the PRODUCTION prefetch path (Codex round-2 LOW).
+
+        On HTTP/hybrid refresh cycles the firmware refresh calls run inside
+        _prefetch_firmware_update_info()'s _check/_progress closures, and
+        _poll_firmware_update_info() short-circuits straight to extraction
+        for prefetched devices — so if only the direct poll path stamped
+        freshness, persistent prefetch failures would provide no anchor and
+        the stale spinner would persist. This drives the prefetch batch with
+        failing devices and asserts expiry still occurs after the window;
+        it goes RED (verified by mutation) if the prefetch closures stop
+        recording results via _note_firmware_poll_result.
+        """
+        coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
+        device = self._cached_updating_device()
+        window = coordinator._firmware_poll_staleness_window()
+
+        with patch(
+            "custom_components.eg4_web_monitor.coordinator_mixins.time.monotonic"
+        ) as monotonic:
+            # First failing prefetch batch anchors the window; the cached
+            # active row still carries forward through the prefetched
+            # short-circuit (#353).
+            monotonic.return_value = 2000.0
+            await coordinator._prefetch_firmware_update_info([device])
+            assert id(device) in coordinator._firmware_prefetched_device_ids
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+            assert result["update_percentage"] == 42
+
+            # Prefetch batches keep failing past the window: the stale
+            # active row must expire on the prefetched path too.
+            monotonic.return_value = 2000.0 + window + 1.0
+            await coordinator._prefetch_firmware_update_info([device])
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is False
+            assert result["update_percentage"] is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10200,25 +10200,51 @@ class TestFirmwarePollCarryForward:
         # The swallowed exceptions never marked the coordinator failed.
         assert coordinator.last_update_success is True
 
-    async def test_first_failure_on_fresh_boot_carries_forward(
+    async def test_long_uptime_first_failure_carries_forward_then_expires(
         self, hass, mock_config_entry
     ):
-        """d66cc92 fresh-boot class: monotonic is host uptime on Linux.
+        """#573's 0.0 never-ran hazard, pinned at LONG uptime (d66cc92 class).
 
-        With monotonic barely past boot, the first-ever failed poll must
-        anchor the window at that failure and carry the cached active row
-        forward — a 0.0 "never ran" default would read as window-expired
-        and blank the cached state immediately, regressing #353.
+        monotonic() is host uptime on Linux. If the None "never ran"
+        sentinel (missing dict key in ``_firmware_poll_fresh_at``) were
+        swapped for a 0.0 default, a long-running host (monotonic ~ 1e6)
+        whose FIRST-EVER firmware poll fails would compute
+        ``now - 0.0 >> window`` and instantly expire an active cached row
+        that was never successfully polled — regressing #353. Adjudicated
+        behavior: a failure with no recorded stamp anchors the window AT
+        that failure and carries the cached row forward.
+
+        A fresh-boot monotonic (e.g. 1.0) cannot pin this — ``1.0 - 0.0``
+        is inside the window, so a 0.0-default implementation passes it.
+        The large uptime below goes RED under a 0.0 default (verified by
+        mutation), and the final step goes RED if freshness-bounded expiry
+        is reverted entirely; this test subsumes the fresh-boot case.
         """
         coordinator = EG4DataUpdateCoordinator(hass, mock_config_entry)
         device = self._cached_updating_device()
+        window = coordinator._firmware_poll_staleness_window()
 
         with patch(
             "custom_components.eg4_web_monitor.coordinator_mixins.time.monotonic"
         ) as monotonic:
-            monotonic.return_value = 1.0
+            # First-ever poll fails at large uptime: must carry forward,
+            # not instantly expire.
+            monotonic.return_value = 1_000_000.0
             result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+            assert result["update_percentage"] == 42
 
-        assert result is not None
-        assert result["in_progress"] is True
-        assert result["update_percentage"] == 42
+            # Still inside the window measured from that first failure.
+            monotonic.return_value = 1_000_000.0 + window - 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is True
+            assert result["update_percentage"] == 42
+
+            # The first failure was the anchor: past the window it expires.
+            monotonic.return_value = 1_000_000.0 + window + 1.0
+            result = await coordinator._poll_firmware_update_info(device)
+            assert result is not None
+            assert result["in_progress"] is False
+            assert result["update_percentage"] is None

--- a/tests/test_update_entities.py
+++ b/tests/test_update_entities.py
@@ -481,28 +481,30 @@ class TestProperties:
         entity = EG4FirmwareUpdateEntity(coordinator, "SN1")
         assert entity.update_percentage == expected
 
-    def test_stale_active_100_survives_refresh_failures_characterization(self):
-        """CHARACTERIZATION: stale active-100 row + refresh failures (#512 wedge).
+    def test_stale_active_100_expires_after_refresh_failure_window(self):
+        """#573: a stale active-100 row no longer wedges the entity busy.
 
-        Sequence: cached firmware_update_info stays in_progress=True at 100%,
-        then last_update_success flips False (persistent refresh failures)
-        without replacing the device row.
+        Replaces the #512 characterization test that pinned the wedge: a
+        cached ``in_progress=True`` row surviving persistent refresh failures
+        kept ``in_progress`` True forever, so HA rejected new installs.
 
-        Pre-#512 rendering: update_percentage=100 (Installing 100%).
-        Post-#512 rendering: update_percentage=None (indeterminate).
-        in_progress remains True either way — Home Assistant rejects new
-        installs from that busy flag. The wedge WHEN is coordinator
-        carry-forward of the firmware_update_info row across failed refreshes
-        (pre-existing; in_progress property unchanged by this PR).
-        Freshness-bounded clearing of stale active rows is a follow-up,
-        out of #512 scope.
+        The coordinator now bounds that carry-forward
+        (``_expire_stale_firmware_activity``, covered by
+        ``TestFirmwarePollCarryForward`` in test_coordinator.py): past the
+        staleness window it republishes the row as not-installing with an
+        unknown percentage. This test asserts the entity's rendering of that
+        expired row — idle, no percentage, installs accepted again — while
+        version fields survive.
         """
+        # While the row is still within the window the entity renders the
+        # #512 indeterminate-active state.
         coordinator = _mock_coordinator(
             devices={
                 "SN1": {
                     "type": "inverter",
                     "model": "X",
                     "firmware_update_info": {
+                        "latest_version": "2.0.0",
                         "in_progress": True,
                         "update_percentage": 100,
                     },
@@ -514,11 +516,17 @@ class TestProperties:
         assert entity.in_progress is True
         assert entity.update_percentage is None
 
-        # Repeated refresh failures: availability drops, cached row unchanged.
-        coordinator.last_update_success = False
-        assert entity.available is False
-        assert entity.in_progress is True
+        # Past the window the coordinator republishes the row expired.
+        coordinator.data["devices"]["SN1"]["firmware_update_info"] = {
+            "latest_version": "2.0.0",
+            "in_progress": False,
+            "update_percentage": None,
+        }
+        assert entity.in_progress is False
         assert entity.update_percentage is None
+        assert entity.latest_version == "2.0.0"
+        # The busy flag is released, so HA no longer rejects new installs.
+        assert entity.available is True
 
     def test_available_true(self):
         """Entity is available when coordinator succeeds and serial is in data."""


### PR DESCRIPTION
## Problem

A cached `firmware_update_info` row with `in_progress=True` survived persistent refresh failures indefinitely: `_poll_firmware_update_info()` preserves cached device state on failure (deliberate — #353 flicker protection), and the update entity trusts that cache. The device stayed busy forever — pre-#567 a stuck "Installing 100%", post-#567 a permanent indeterminate spinner — and HA rejected new installs via `in_progress`. Adjudicated pre-existing in PR #567's tribunal (finding M1); a characterization test pinning the wedge shipped in #567.

## Fix

The #353 carry-forward is now freshness-bounded (coordinator-side, so every consumer of the row benefits):

- **`_note_firmware_poll_result`** (FirmwareUpdateMixin) records each firmware refresh outcome per serial with `time.monotonic()` — from the direct poll path and from both prefetch-batch closures. A success re-anchors the carry-forward window at now; a failure only seeds the anchor when none exists yet (missing key = the None "never ran" sentinel — a `0.0` default would make the first-ever failure on a freshly booted host look window-expired, the d66cc92 class).
- **`_expire_stale_firmware_activity`** gates every row `_poll_firmware_update_info()` returns: once the anchor is older than the staleness window, an `in_progress=True` row is republished as **not-installing with an unknown percentage** (`in_progress=False`, `update_percentage=None`). Version/availability fields survive, and a later successful poll that still reports an active update re-publishes it fresh.
- **Window**: `_firmware_poll_staleness_window()` = `max(FIRMWARE_POLL_STALENESS_MISSED_POLLS * _http_polling_interval, FIRMWARE_POLL_STALENESS_FLOOR)` — roughly **3 missed cloud poll cycles with a 600 s floor** (default config: 600 s). Firmware polls piggyback on the cloud refresh cycle, so the window derives from `_http_polling_interval`; the floor keeps a short configured interval from letting a brief cloud blip expire a genuinely active update.

The entity's install-lock behavior is untouched: an HA-initiated install still reports busy from the per-serial lock for the whole chain.

## Tests

- Replaced the #512 characterization test (which pinned the wedge) with `test_stale_active_100_expires_after_refresh_failure_window` asserting the new rendering (`tests/test_update_entities.py`).
- `test_stale_active_100_expires_after_staleness_window` — transition test: active-100 row → repeated refresh failures → carry-forward within the window → expiry past it → recovery re-publishes fresh (monotonic patched).
- `test_stale_active_row_expires_even_when_coordinator_succeeds` — the tribunal-flagged visible-spinner case: the firmware side-poll fails (exception swallowed) while the overall coordinator update keeps succeeding (`last_update_success` stays True); the stale active row still expires.
- `test_first_failure_on_fresh_boot_carries_forward` — monotonic patched small: the first-ever failed poll anchors the window instead of expiring immediately (#353 regression guard).

## Quality gates

- `ruff check` / `ruff format` — clean
- `mypy --config-file tests/mypy.ini` — Success: no issues found in 47 source files
- `pytest tests/` — 3110 passed, 9 skipped
- Silver / Gold / Platinum tier validators — all pass

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)