### PR TITLE
chore(release): v3.5.1-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1-beta.13] - 2026-08-30
+
+Requires **[pylxpweb==0.10.0b5](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b5)**.
+
+### Fixed
+
+- **Stale firmware-update activity now expires** ([#573](https://github.com/joyfulhouse/eg4_web_monitor/issues/573), PR [#599](https://github.com/joyfulhouse/eg4_web_monitor/pull/599)): a cached `in_progress` firmware row no longer survives persistent refresh failures as a permanent spinner. Per-serial poll freshness (monotonic, `None` never-ran sentinel) expires stale activity after `max(3 × cloud poll interval, 600 s)` — including when the overall coordinator update succeeds while the firmware side-poll fails — and recovery re-publishes fresh state.
+- **GridBOSS Modbus discovery no longer misreads the AC-couple energy counter as parallel config** ([#596](https://github.com/joyfulhouse/eg4_web_monitor/issues/596), PR [#597](https://github.com/joyfulhouse/eg4_web_monitor/pull/597)): input registers 112–113 on MID/GridBOSS are `ac_couple3_energy_total_l1`, so once lifetime energy crossed 6553.6 kWh discovery would have fabricated a parallel role. The read is skipped for GridBOSS (companion library-side fix in pylxpweb 0.10.0b5).
+- **Dongle sanitizer is fail-closed on protocol shape** ([#588](https://github.com/joyfulhouse/eg4_web_monitor/issues/588), PR [#598](https://github.com/joyfulhouse/eg4_web_monitor/pull/598)): frames with a protocol version other than little-endian 0x0001 or an address byte other than 1 are rejected with a new `PROTOCOL` failure reason, and heartbeat payloads must be exactly one byte. Review caught and fixed an inverted-endianness check inherited from the earlier #579 draft.
+- **Unreported battery state of health shows as unknown, not 100%** (pylxpweb [#309](https://github.com/joyfulhouse/pylxpweb/issues/309), based on pylxpweb [#286](https://github.com/joyfulhouse/pylxpweb/pull/286)): a silent BMS was indistinguishable from a perfectly healthy pack. All decode paths (local Modbus, master/slave battery protocols, cloud) now surface unreported SoH as `None`; bank min-SoH/SoH-delta exclude unreported batteries.
+- **GridBOSS serial-number discovery falls back to holding registers** (eg4 [#593](https://github.com/joyfulhouse/eg4_web_monitor/issues/593), pylxpweb [#315](https://github.com/joyfulhouse/pylxpweb/pull/315)): units whose input-register serial area serves energy counters now read `HOLD_SERIAL_NUM`, gated by a strict 10-char alphanumeric plausibility check on both paths, with dongle-safe inter-register delay and graceful degradation on restricted register maps.
+
+### Changed
+
+- **Off-grid write-evidence audit — every off-grid-writable control derived and fail-closed** ([#570](https://github.com/joyfulhouse/eg4_web_monitor/issues/570), PR [#600](https://github.com/joyfulhouse/eg4_web_monitor/pull/600)): the #558 protected set is now *derived*, not spot-checked. All writable scalars, the quick-charge switch/status path, schedule time entities, and Grid Peak-Shaving Power route cloud-only on EG4_OFFGRID **and unresolved** families (fail-closed, verified against the pinned pylxpweb wheel); resolved non-off-grid families keep local-first behavior. Entity ranges now respect firmware-proven off-grid limits (H66 ≤ 10 kW, H158 39–57 V, H159 48–59 V, H160 ≥ 1 %, H161 ≥ 20 %, H105 10–90 %) with family-scoped bounds. Cloud-routed writes converge cleanly via per-key write-seed settle windows with a one-shot settle-expiry recheck. The llmwiki register ledger carries per-register write-evidence grades from the firmware RE + live hardware sweep, including the H161 write anomaly and the H233 CEAA/CCAA split.
+- **Immutable raw-register snapshot store (Phase A3)** ([#583](https://github.com/joyfulhouse/eg4_web_monitor/issues/583), PR [#586](https://github.com/joyfulhouse/eg4_web_monitor/pull/586)): eligible LOCAL/HYBRID owners publish exactly one immutable latest-complete raw frame per (endpoint, unit) — atomic publication only when every invoked read contributed and coverage held, O(1) storage, monotonic freshness policy, zero additional Modbus reads, redacted metrics only, and clean teardown (shared-owner-safe forced release on unload).
+
 ## [3.5.1-beta.12] - 2026-08-28
 
 Requires **[pylxpweb==0.10.0b4](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b4)** — the first release on the 0.10.x library line, carrying both halves of the #587 fix.

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b4", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.12"
+  "requirements": ["pylxpweb==0.10.0b5", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.5.1-beta.13"
 }

--- a/llmwiki/10-integration/controls-and-writes.md
+++ b/llmwiki/10-integration/controls-and-writes.md
@@ -32,12 +32,12 @@ verified-against:
   # e146d91. Claims describing the PR #600 change set itself (the
   # local_write_blocked_reason protected-set row in §1, the §1.3/§2.4/§6
   # family gates) are licensed PER CLAIM by their inline PR #600 / issue
-  # #570 citations — the pin itself stays commit-only per _conventions.md.
-  # REQUIRED POST-MERGE ACTION (recorded in log.md): re-pin to the
-  # mainline merge SHA at the release cut (#559 precedent).
-  eg4_web_monitor: e146d91
+  # #570 citations. Re-pinned at the 2026-08-30 release cut (#559
+  # precedent): PR #600 merged as d8e2027; the whole page now verifies at
+  # the mainline pin below.
+  eg4_web_monitor: d8e2027
   pylxpweb: ab87902
-last-verified: 2026-08-29
+last-verified: 2026-08-30
 see-also:
   - ../40-hardware/registers.md
   - ../60-history/open-contradictions.md

--- a/llmwiki/10-integration/data-semantics.md
+++ b/llmwiki/10-integration/data-semantics.md
@@ -41,12 +41,12 @@ verified-against:
   # protected set, the quick-charge fail-closed predicates, the schedule
   # and QuickChargeDuration family gates) are licensed PER CLAIM by their
   # inline PR #600 / issue #570 citations — the pin itself stays
-  # commit-only per _conventions.md. REQUIRED POST-MERGE ACTION (recorded
-  # in log.md): re-pin to the mainline merge SHA at the release cut
-  # (#559 precedent).
-  eg4_web_monitor: 9f6d6e2
+  # commit-only per _conventions.md. Re-pinned at the 2026-08-30 release
+  # cut (#559 precedent): PR #600 merged as d8e2027; the whole page now
+  # verifies at the mainline pin below.
+  eg4_web_monitor: d8e2027
   pylxpweb: 204b95d
-last-verified: 2026-08-29
+last-verified: 2026-08-30
 see-also:
   - ../40-hardware/registers.md
   - ../60-history/open-contradictions.md

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -41,13 +41,14 @@ verified-against:
   # schedule-write routing rows) are licensed PER CLAIM by their inline
   # PR #600 / issue #570 citations (the durable artifact — the PR diff
   # survives branch deletion; embedded SHAs staled twice in review).
-  # REQUIRED POST-MERGE ACTION (recorded in log.md): re-pin these claims
-  # to the mainline merge SHA at the release cut. pylxpweb stays
+  # Re-pinned at the 2026-08-30 release cut: PR #600 merged as d8e2027, so
+  # the sweep-extended rows now verify at the mainline pin below (inline
+  # PR #600 / issue #570 citations remain as provenance). pylxpweb stays
   # ab87902 (0.9.39b11); the #271/#272 range fixes merged after it and are
   # cited by PR number (pylxpweb #273), not by pin.
-  eg4_web_monitor: e9853eb
+  eg4_web_monitor: d8e2027
   pylxpweb: ab87902
-last-verified: 2026-08-29
+last-verified: 2026-08-30
 ---
 
 # Register ground truth

--- a/llmwiki/README.md
+++ b/llmwiki/README.md
@@ -12,15 +12,14 @@ sources:
   - issue #549
   - memory/issue-476-green-mode-bit14.md
   - https://github.com/joyfulhouse/eg4_web_monitor/issues/570
-verified-against: 9f6d6e2
+verified-against: d8e2027
 # The hand-maintained keeper cache in "Registers the keeper marks unresolved"
-# was reconciled 2026-08-29 for the #570 sweep; the derivation/legend sections
-# stand at the 9f6d6e2 verification pass. Cache cells describing the #570
-# routing are licensed per claim by their inline PR #600 / issue #570
-# citations — the pin above stays commit-only per _conventions.md.
-# REQUIRED POST-MERGE ACTION, recorded in log.md: re-pin to the mainline
-# merge SHA at the release cut. The keeper stays authoritative.
-last-verified: 2026-08-29
+# was reconciled 2026-08-29 for the #570 sweep. Re-pinned at the 2026-08-30
+# release cut: PR #600 merged as d8e2027, so the #570 routing cells and the
+# derivation/legend sections now verify at the mainline pin above (the
+# per-claim inline PR #600 / issue #570 citations remain as provenance).
+# The keeper stays authoritative.
+last-verified: 2026-08-30
 ---
 
 # llmwiki

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -864,3 +864,13 @@ class only pinned the classic (ac_charge) cloud leg; a gen_charge case now pins 
 writeTime leg — no local FC06 to H256, the atomic `write_time_parameter` call, and no
 classic per-field writes — and the class docstring drops the same "classic cloud field
 writes" overstatement r10 corrected elsewhere. Citations: PR #600 (issue #570).
+
+## [2026-08-30] repin | Release-cut re-pin — PR #600 merged as d8e2027
+
+The REQUIRED POST-MERGE ACTION from the #570 sweep rounds is discharged:
+PR #600 squash-merged to mainline as `d8e2027` (closes #570). The four pages
+carrying per-claim PR #600 citations (README keeper cache, registers keeper,
+controls-and-writes, data-semantics) are re-pinned to `d8e2027` with
+`last-verified: 2026-08-30`; the inline PR/issue citations remain as
+provenance. Performed in the v3.5.1-beta.13 release change set (which bumps
+the pylxpweb pin to 0.10.0b5).

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b4  # keep in sync with manifest.json
+pylxpweb==0.10.0b5  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml


### PR DESCRIPTION
Release v3.5.1-beta.13 — pins **pylxpweb==0.10.0b5**.

Closes out this cycle's issue-zeroing wave: #570, #573, #583, #587, #588, #596 (see CHANGELOG). Also discharges the #570 llmwiki release-cut re-pin (four pages re-pinned to `d8e2027`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)