### PR TITLE
fix: expose inverter_family and pv_string_count setters on EndpointBusCapability (#602)

### DIFF
--- a/custom_components/eg4_web_monitor/endpoint_bus.py
+++ b/custom_components/eg4_web_monitor/endpoint_bus.py
@@ -952,6 +952,10 @@ class EndpointBusCapability:
     def inverter_family(self) -> Any:
         return self._owner.get_property(self._token, "inverter_family")
 
+    @inverter_family.setter
+    def inverter_family(self, value: Any) -> None:
+        self._owner.set_property(self._token, "inverter_family", value)
+
     @property
     def split_phase(self) -> bool:
         return bool(self._owner.get_property(self._token, "split_phase"))
@@ -963,6 +967,10 @@ class EndpointBusCapability:
     @property
     def pv_string_count(self) -> int:
         return int(self._owner.get_property(self._token, "pv_string_count"))
+
+    @pv_string_count.setter
+    def pv_string_count(self, value: int) -> None:
+        self._owner.set_property(self._token, "pv_string_count", value)
 
     @property
     def is_midbox_device(self) -> bool:

--- a/tests/test_endpoint_bus_owner.py
+++ b/tests/test_endpoint_bus_owner.py
@@ -1996,3 +1996,26 @@ def test_capability_forwards_pinned_terminal_protocol_surface() -> None:
         if not hasattr(EndpointBusCapability, member)
     }
     assert missing == set()
+
+
+def test_capability_mutable_config_properties_round_trip() -> None:
+    """Feature-detected config the factory propagates must be settable.
+
+    ``BaseInverter.from_modbus_transport`` assigns ``inverter_family`` (when the
+    detected family differs from the configured one) and ``pv_string_count`` onto
+    the transport after detecting the model. A getter-only property passes
+    ``hasattr`` but raises ``AttributeError`` on assignment, which crashed local
+    inverter setup (issue #602: ``pv_string_count`` observed; ``inverter_family``
+    is the same latent class, fired on family auto-correction).
+    """
+    capability = _registry({"gateway.example.invalid": _WireProbe()}).create_capability(
+        _config("SYNTH00001")
+    )
+
+    capability.inverter_family = "EG4_HYBRID"
+    capability.split_phase = True
+    capability.pv_string_count = 6
+
+    assert capability.inverter_family == "EG4_HYBRID"
+    assert capability.split_phase is True
+    assert capability.pv_string_count == 6

--- a/tests/test_endpoint_raw_snapshot.py
+++ b/tests/test_endpoint_raw_snapshot.py
@@ -852,18 +852,18 @@ async def test_capability_exposes_fresh_only_lookup_and_redacted_metrics() -> No
         await capability.read_runtime()
     frame = capability.latest_complete_snapshot
     assert frame is not None
-    metrics = capability.snapshot_metrics(
-        monotonic_now=frame.acquired_monotonic_end + 15.0
-    )
+    # Probe strictly PAST the policy's maximum age, not at it: the frame's
+    # end is a real (large) monotonic reading, and ``(end + 15.0) - end``
+    # can round to 14.999... so an exact-boundary probe flips ``age < max``
+    # true on some hosts (CI flake on PR #604). The stale margin is 1 s.
+    max_age = capability.snapshot_freshness_policy.maximum_age_seconds
+    assert max_age == 15.0
+    stale_now = frame.acquired_monotonic_end + max_age + 1.0
+    metrics = capability.snapshot_metrics(monotonic_now=stale_now)
 
-    assert metrics.age_seconds == pytest.approx(15.0)
+    assert metrics.age_seconds == pytest.approx(max_age + 1.0)
     assert metrics.fresh is False
-    assert (
-        capability.latest_fresh_snapshot(
-            monotonic_now=frame.acquired_monotonic_end + 15.0
-        )
-        is None
-    )
+    assert capability.latest_fresh_snapshot(monotonic_now=stale_now) is None
     assert "owner-" not in repr(metrics)
     assert "11" not in repr(metrics)
 


### PR DESCRIPTION
Fixes #602

## Bug
Upgrading to v3.5.1-beta.13 makes every locally-connected inverter (Modbus TCP, Modbus serial, WiFi dongle, and hybrid's local path) go unavailable with:

```
AttributeError: property 'pv_string_count' of 'EndpointBusCapability' object has no setter
```

## Root cause
`EndpointBusCapability` — the per-endpoint wrapper introduced in 86428c0a (#582) — replaced the raw pylxpweb transport passed to `BaseInverter.from_modbus_transport()`. pylxpweb assigns two config attributes onto the transport after model detection:

- `pv_string_count` — **unconditionally**, guarded only by `hasattr()` (`pylxpweb/devices/inverters/base.py:576`)
- `inverter_family` — whenever the detected family differs from the configured one (`base.py:542`)

The wrapper exposed both as **getter-only** properties. `hasattr()` evaluates the getter and returns True, then the assignment hits the missing setter and raises. The sibling `split_phase` property already had a setter; these two were omitted.

Scope notes (corrected from the initial triage): this is **not** FlexBOSS21- or >3-string-specific — pylxpweb treats FlexBOSS21 as a 3-string model and the assignment fires for every local inverter. GridBOSS is unaffected because it is built via `MIDDevice.from_transport()`. Cloud-only users never touch the wrapper. `inverter_family` is the same latent defect class, masked whenever the configured family already matches.

## Fix
Add delegating setters for `inverter_family` and `pv_string_count`, mirroring `split_phase`. `_owner.set_property()` is a plain `setattr` on the owned raw transport (a local config-field write that selects register maps / PV4-6 reads — not a Modbus/hardware write), and goes through the same open-record/closing checks as every other property.

## Test plan
- [x] New regression test `test_capability_mutable_config_properties_round_trip` round-trips all three mutable config properties through the capability. Mutation-verified: removing either new setter makes it fail.
- [x] `uv run ruff check` / `ruff format` / `mypy --config-file tests/mypy.ini` — clean
- [x] `uv run pytest tests/` — 3257 passed, 9 skipped
- [x] Silver / Gold / Platinum tier validators — pass
- [ ] Reporter confirmation on live FlexBOSS21 Modbus TCP (requested on the issue)

## Review
Tri-vendor adversarial review, all **NO BLOCKING ISSUES**: Claude (code-reviewer agent), Codex GPT-5.6-sol @ xhigh (also independently ran ruff/mypy/tests), Gemini 3.1 Pro (High). An independent Codex RCA additionally audited pylxpweb's factory via AST and confirmed `inverter_family` + `pv_string_count` are the only two attributes it assigns onto a transport. No risk-accepted MEDIUMs; no pre-existing failures.

No pylxpweb change or pin bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)