### PR TITLE
fix: On-Grid SOC Cut-Off accepts 91-100% and reads portal-set values (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Requires **[pylxpweb==0.10.0b7](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b7)**.
+
+### Fixed
+
+- **On-Grid SOC Cut-Off accepts 91–100 % again and no longer reads unknown for portal-set values** ([#603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603)): beta.13 (PR [#600](https://github.com/joyfulhouse/eg4_web_monitor/pull/600) review round 2) matched the entity to pylxpweb's 10–90 bound for register 105, but that 90 was the portal's arrow-button hint, not a firmware limit — the inverter stores a portal-typed 95 and rejects 101 (96–100 are inferred from that pair). The write ceiling is 100 (companion fix in pylxpweb 0.10.0b7), and the read plausibility window is the full 0–100 so a stored value never blanks. Users who keep batteries full ahead of outages can set the cut-off from HA again.
+- **System Charge SOC Limit accepts 0–9 %** — the same class of defect: an evidence-free 10 floor against pylxpweb's 0–101 range would have blanked a portal-set value below 10 to unknown and refused to write one.
+
 ## [3.5.1-beta.13] - 2026-08-30
 
 Requires **[pylxpweb==0.10.0b5](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b5)**.
@@ -19,7 +28,7 @@ Requires **[pylxpweb==0.10.0b5](https://github.com/joyfulhouse/pylxpweb/releases
 
 ### Changed
 
-- **Off-grid write-evidence audit — every off-grid-writable control derived and fail-closed** ([#570](https://github.com/joyfulhouse/eg4_web_monitor/issues/570), PR [#600](https://github.com/joyfulhouse/eg4_web_monitor/pull/600)): the #558 protected set is now *derived*, not spot-checked. All writable scalars, the quick-charge switch/status path, schedule time entities, and Grid Peak-Shaving Power route cloud-only on EG4_OFFGRID **and unresolved** families (fail-closed, verified against the pinned pylxpweb wheel); resolved non-off-grid families keep local-first behavior. Entity ranges now respect firmware-proven off-grid limits (H66 ≤ 10 kW, H158 39–57 V, H159 48–59 V, H160 ≥ 1 %, H161 ≥ 20 %, H105 10–90 %) with family-scoped bounds. Cloud-routed writes converge cleanly via per-key write-seed settle windows with a one-shot settle-expiry recheck. The llmwiki register ledger carries per-register write-evidence grades from the firmware RE + live hardware sweep, including the H161 write anomaly and the H233 CEAA/CCAA split.
+- **Off-grid write-evidence audit — every off-grid-writable control derived and fail-closed** ([#570](https://github.com/joyfulhouse/eg4_web_monitor/issues/570), PR [#600](https://github.com/joyfulhouse/eg4_web_monitor/pull/600)): the #558 protected set is now *derived*, not spot-checked. All writable scalars, the quick-charge switch/status path, schedule time entities, and Grid Peak-Shaving Power route cloud-only on EG4_OFFGRID **and unresolved** families (fail-closed, verified against the pinned pylxpweb wheel); resolved non-off-grid families keep local-first behavior. Entity ranges now respect firmware-proven off-grid limits (H66 ≤ 10 kW, H158 39–57 V, H159 48–59 V, H160 ≥ 1 %, H161 ≥ 20 %, H105 10–90 % — the H105 ceiling was the then-pinned library bound, not firmware-proven; superseded by #603 in the next beta) with family-scoped bounds. Cloud-routed writes converge cleanly via per-key write-seed settle windows with a one-shot settle-expiry recheck. The llmwiki register ledger carries per-register write-evidence grades from the firmware RE + live hardware sweep, including the H161 write anomaly and the H233 CEAA/CCAA split.
 - **Immutable raw-register snapshot store (Phase A3)** ([#583](https://github.com/joyfulhouse/eg4_web_monitor/issues/583), PR [#586](https://github.com/joyfulhouse/eg4_web_monitor/pull/586)): eligible LOCAL/HYBRID owners publish exactly one immutable latest-complete raw frame per (endpoint, unit) — atomic publication only when every invoked read contributed and coverage held, O(1) storage, monotonic freshness policy, zero additional Modbus reads, redacted metrics only, and clean teardown (shared-owner-safe forced release on unload).
 
 ## [3.5.1-beta.12] - 2026-08-28

--- a/custom_components/eg4_web_monitor/const/limits.py
+++ b/custom_components/eg4_web_monitor/const/limits.py
@@ -62,14 +62,19 @@ SOC_LIMIT_MIN = 0
 SOC_LIMIT_MAX = 100
 SOC_LIMIT_STEP = 1
 
-# On-grid discharge cutoff (reg 105). Narrower than the shared SOC_LIMIT_*:
-# the canonical H105 definition (pylxpweb inverter_holding.py, address 105)
-# and the cloud writer set_battery_soc_limits both enforce 10-90%, so the
-# entity must advertise the same range or off-grid cloud-only routes surface
-# a raw ValueError at the boundaries (#570 review round 2). The off-grid
-# cutoff (reg 125) is genuinely 0-100 and keeps SOC_LIMIT_*.
+# On-grid discharge cutoff (reg 105) WRITE bounds. These mirror pylxpweb's
+# canonical H105 definition and set_battery_soc_limits so an off-grid
+# cloud-only route never surfaces a raw ValueError at a boundary (#570
+# review round 2). The 90 ceiling that round copied from the library was the
+# portal's arrow-button hint, not a firmware bound: a portal-typed 95 is
+# stored (reporter diagnostics, LXP-LB-US 10K, #603) and only >100 is
+# rejected by the inverter, so the ceiling is 100. The 10 floor is the same
+# kind of hint — unproven either way — and is kept as shipped. The READ
+# plausibility window is the tolerant SOC_LIMIT_* 0-100 regardless, so a
+# register value the portal stored never blanks to unknown (#603). The
+# off-grid cutoff (reg 125) is genuinely 0-100 and keeps SOC_LIMIT_*.
 ONGRID_SOC_CUTOFF_MIN = 10
-ONGRID_SOC_CUTOFF_MAX = 90
+ONGRID_SOC_CUTOFF_MAX = 100
 
 # AC Charge SOC Limit (reg 67). Separate from the shared SOC_LIMIT_* (used by
 # the on-grid/off-grid discharge cutoffs) because the inverter accepts 101% =
@@ -197,10 +202,14 @@ START_CHARGE_POWER_MAX = 10000
 START_CHARGE_POWER_STEP = 1
 
 # =============================================================================
-# System Charge SOC Limit (%)
+# System Charge SOC Limit (%) — reg 227
 # =============================================================================
+# 0-101: pylxpweb's canonical definition and set_system_charge_soc_limit both
+# accept 0, and the ledger grades 0-101 hardware-toggle-proven on an 18kPV.
+# The former 10 floor had no evidence and blanked a portal-set 0-9 to unknown
+# (same defect class as #603).
 
-SYSTEM_CHARGE_SOC_LIMIT_MIN = 10
+SYSTEM_CHARGE_SOC_LIMIT_MIN = 0
 SYSTEM_CHARGE_SOC_LIMIT_MAX = 101
 SYSTEM_CHARGE_SOC_LIMIT_STEP = 1
 

--- a/custom_components/eg4_web_monitor/const/limits.py
+++ b/custom_components/eg4_web_monitor/const/limits.py
@@ -204,10 +204,12 @@ START_CHARGE_POWER_STEP = 1
 # =============================================================================
 # System Charge SOC Limit (%) — reg 227
 # =============================================================================
-# 0-101: pylxpweb's canonical definition and set_system_charge_soc_limit both
-# accept 0, and the ledger grades 0-101 hardware-toggle-proven on an 18kPV.
-# The former 10 floor had no evidence and blanked a portal-set 0-9 to unknown
-# (same defect class as #603).
+# 0-101 is the pinned LIBRARY contract: pylxpweb's canonical definition and
+# both set_system_charge_soc_limit writers accept 0. The only hardware capture
+# (18kPV, 80 -> 101 -> 80) proves the 101 top-balance end, not the 0 floor —
+# the floor is a library contract, not a hardware claim. The former entity
+# floor of 10 had no evidence either and would have blanked and refused a
+# portal-set 0-9 (same defect class as #603).
 
 SYSTEM_CHARGE_SOC_LIMIT_MIN = 0
 SYSTEM_CHARGE_SOC_LIMIT_MAX = 101

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b5", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "requirements": ["pylxpweb==0.10.0b7", "pymodbus>=3.6.0", "pyserial>=3.5"],
   "version": "3.5.1-beta.13"
 }

--- a/custom_components/eg4_web_monitor/number.py
+++ b/custom_components/eg4_web_monitor/number.py
@@ -935,7 +935,7 @@ async def async_setup_entry(
 class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
     """Number entity for System Charge SOC Limit control (register 227).
 
-    Values 10-100%: stop charging at this SOC.  101%: enable top balancing.
+    Values 0-100%: stop charging at this SOC.  101%: enable top balancing.
     """
 
     _control_key = "system_charge_soc_limit"
@@ -957,8 +957,8 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
         """Return the current System Charge SOC limit (reads params first)."""
         return self._read_param_value(
             param_key="HOLD_SYSTEM_CHARGE_SOC_LIMIT",
-            value_min=10,
-            value_max=101,
+            value_min=SYSTEM_CHARGE_SOC_LIMIT_MIN,
+            value_max=SYSTEM_CHARGE_SOC_LIMIT_MAX,
             inverter_attr="system_charge_soc_limit",
             params_first=True,
         )
@@ -966,9 +966,13 @@ class SystemChargeSOCLimitNumber(EG4BaseNumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the System Charge SOC limit (3-way: local, cloud API, or client)."""
         int_value = int(value)
-        if int_value < 10 or int_value > 101:
+        if (
+            int_value < SYSTEM_CHARGE_SOC_LIMIT_MIN
+            or int_value > SYSTEM_CHARGE_SOC_LIMIT_MAX
+        ):
             raise HomeAssistantError(
-                f"SOC limit must be an integer between 10-101%, got {int_value}"
+                "SOC limit must be an integer between "
+                f"{SYSTEM_CHARGE_SOC_LIMIT_MIN}-{SYSTEM_CHARGE_SOC_LIMIT_MAX}%, got {int_value}"
             )
         if abs(value - int_value) > 0.01:
             raise HomeAssistantError(f"SOC limit must be an integer value, got {value}")
@@ -1658,7 +1662,11 @@ class ACChargeStartBatterySOCNumber(EG4BaseNumberEntity):
 
     Whole percent, SCALE_NONE on both paths; reg 160 is in pylxpweb's
     transport name map, so local named reads/writes work as-is. Writes cap
-    at 90% (pylxpweb's register definition and hybrid setter bound).
+    at 90% (pylxpweb's register definition and hybrid setter bound). That
+    cap is firmware-proven ONLY on the CEAA/CCAA off-grid images (writer
+    rejects >=91); on hybrid families it is portal-correlated, the same
+    evidence tier as the reg-105 cap #603 falsified — revisit if a hybrid
+    ever stores a portal-typed value above 90.
 
     RANGE FLOOR (#570 review round 4): family-scoped because the evidence
     is. The CEAA/CCAA firmware writer rejects 0 with exception 03 —
@@ -2899,13 +2907,17 @@ class StopDischargeVoltageNumber(EG4BaseNumberEntity):
 class OnGridSOCCutoffNumber(EG4BaseNumberEntity):
     """Number entity for On-Grid SOC Cut-Off control.
 
-    Range 10-90%: the canonical H105 definition (pylxpweb
-    ``inverter_holding.py`` address 105, min 10 / max 90) and the cloud
-    writer ``set_battery_soc_limits`` (ValueError outside 10..90) both
+    Write range 10-100%: the canonical H105 definition (pylxpweb
+    ``inverter_holding.py`` address 105, min 10 / max 100) and the cloud
+    writer ``set_battery_soc_limits`` (ValueError outside 10..100) both
     enforce it. The entity previously advertised 0-100, which the #570
     cloud-only routing turned into a user-visible ValueError on off-grid
     entries for 0-9/91-100 (review round 2 MED) — the entity was the
-    outlier, so its advertised range now matches the writers. H125
+    outlier, so its advertised range was matched to the writers. That
+    round copied a 90 ceiling that was only the portal's arrow-button
+    hint: the inverter stores a portal-typed 95 and rejects only >100
+    (#603), so the writers and this entity now cap at 100; the READ window
+    stays the tolerant 0-100 so a stored value never blanks. H125
     (off-grid cutoff) is 0-100 everywhere and keeps SOC_LIMIT_*.
     """
 
@@ -2927,20 +2939,21 @@ class OnGridSOCCutoffNumber(EG4BaseNumberEntity):
     def native_value(self) -> float | None:
         """Return the current on-grid SOC cutoff (reads from battery_soc_limits dict).
 
-        The plausibility window matches the advertised 10-90 range: a value
-        outside it reads as unknown rather than tripping HA's out-of-range
-        state error on the tightened bounds.
+        The plausibility window is the full 0-100 percent range, deliberately
+        wider than the write bounds: the portal can store any value the
+        firmware accepts (a typed 95 on an LXP-LB-US 10K, #603), and a read
+        window tighter than that blanked a legal value to unknown.
         """
         return self._read_param_value(
             param_key="HOLD_DISCHG_CUT_OFF_SOC_EOD",
-            value_min=ONGRID_SOC_CUTOFF_MIN,
-            value_max=ONGRID_SOC_CUTOFF_MAX,
+            value_min=SOC_LIMIT_MIN,
+            value_max=SOC_LIMIT_MAX,
             inverter_dict_attr="battery_soc_limits",
             inverter_dict_key="on_grid_limit",
         )
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the on-grid SOC cutoff (10-90%, the canonical H105 range)."""
+        """Set the on-grid SOC cutoff (10-100%; only >100 is firmware-rejected, #603)."""
         int_value = _coerce_int_in_range(
             value,
             min_v=ONGRID_SOC_CUTOFF_MIN,

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -780,7 +780,7 @@ per boundary). Cloud param names take the window suffix
 |-----|---------------|-------------|------|-------|
 | 101 | `charge_current` | number | A | 0-140 |
 | 102 | `discharge_current` | number | A | 0-140 |
-| 105 | `ongrid_discharge_soc` | number | % | 10-90 |
+| 105 | `ongrid_discharge_soc` | number | % | 10-100 |
 | 125 | `offgrid_discharge_soc` | number | % | 0-100 |
 | 160 | `ac_charge_start_battery_soc` | number | % | 0-90 |
 | 161 | `ac_charge_end_battery_soc` | number | % | 0-100 |
@@ -964,11 +964,11 @@ integration 3.4.0 / pylxpweb 0.9.36b1.
 | Reg | EG4 Param Key | HA Entity Key | Side / Mode | Unit | Range |
 |-----|---------------|---------------|-------------|------|-------|
 | 67  | `HOLD_AC_CHARGE_SOC_LIMIT` | `ac_charge_soc_limit` | charge / SOC | % | 0-100 |
-| 227 | `HOLD_SYSTEM_CHARGE_SOC_LIMIT` | `system_charge_soc_limit` | charge / SOC | % | 10-101 |
+| 227 | `HOLD_SYSTEM_CHARGE_SOC_LIMIT` | `system_charge_soc_limit` | charge / SOC | % | 0-101 |
 | 228 | `HOLD_SYSTEM_CHARGE_VOLT_LIMIT` | `system_charge_volt_limit` | charge / Voltage | V | 40-64 |
 | 158 | `HOLD_AC_CHARGE_START_BATTERY_VOLTAGE` | `ac_charge_start_voltage` | charge / Voltage | V | 38-60 |
 | 159 | `HOLD_AC_CHARGE_END_BATTERY_VOLTAGE` | `ac_charge_end_voltage` | charge / Voltage | V | 38-60 |
-| 105 | `HOLD_DISCHG_CUT_OFF_SOC_EOD` | `on_grid_soc_cutoff` | discharge / SOC | % | 10-90 |
+| 105 | `HOLD_DISCHG_CUT_OFF_SOC_EOD` | `on_grid_soc_cutoff` | discharge / SOC | % | 10-100 |
 | 125 | `HOLD_SOC_LOW_LIMIT_EPS_DISCHG` | `off_grid_soc_cutoff` | discharge / SOC | % | 0-100 |
 | 169 | `HOLD_ON_GRID_EOD_VOLTAGE` | `on_grid_cutoff_voltage` | discharge / Voltage | V | 40-58 |
 | 100 | `HOLD_LEAD_ACID_DISCHARGE_CUT_OFF_VOLT` | `off_grid_cutoff_voltage` | discharge / Voltage | V | 40-58 |

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -3,6 +3,7 @@ canonical-for: inverter-and-gridboss-register-ground-truth
 sources:
   - docs/DATA_MAPPING.md
   - "eg4_web_monitor issue #603 (reporter diagnostics, LXP-LB-US 10K): HOLD_DISCHG_CUT_OFF_SOC_EOD stored 95"
+  - "pylxpweb PR #322 / c78ab7e (0.10.0b7): H105 canonical ceiling 100"
   - docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
   - docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
   - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
@@ -44,11 +45,14 @@ verified-against:
   # survives branch deletion; embedded SHAs staled twice in review).
   # Re-pinned at the 2026-08-30 release cut: PR #600 merged as d8e2027, so
   # the sweep-extended rows now verify at the mainline pin below (inline
-  # PR #600 / issue #570 citations remain as provenance). pylxpweb stays
-  # ab87902 (0.9.39b11); the #271/#272 range fixes merged after it and are
-  # cited by PR number (pylxpweb #273), not by pin.
+  # PR #600 / issue #570 citations remain as provenance). pylxpweb was
+  # ab87902 (0.9.39b11) until the 2026-09-02 #603 ingest moved it to
+  # c78ab7e (0.10.0b7): between the two, the only holding-definition change
+  # is H105's ceiling (PR #322); the #271/#272 range fixes are cited by PR
+  # number (pylxpweb #273). Inline ab87902 blob links on older rows remain
+  # valid historical URLs and were not rewritten.
   eg4_web_monitor: d8e2027
-  pylxpweb: ab87902
+  pylxpweb: c78ab7e
 last-verified: 2026-09-02
 ---
 
@@ -224,7 +228,7 @@ Every row is readable via FC03 but exists in potentially writable configuration 
 | H103 | Maximum grid sell-back power, raw ×100 W / UI kW | grid-tied | `portal-correlated` | current | 1 | `DATA_MAPPING.md` raw/UI correlation; not percent. |
 | H105 | On-grid discharge SOC cutoff | grid-tied | `lineage-inferred` | current | 1 | Canonical holding definition. |
 | H105 | A portal-typed 95 is stored and read back (the 90 was the portal arrow-button hint, copied into pylxpweb and — beta.13, PR #600 round 2 — into the entity) | LXP-LB-US 10K (reporter unit, hybrid) | `portal-correlated` | current on the reported unit | 1 | [#603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603) reporter diagnostics (`HOLD_DISCHG_CUT_OFF_SOC_EOD: 95`) + portal screenshot. Readback proves storage, not semantics. |
-| H105 | Exact write ceiling is 100 (101 rejected per the reporter; 96–100 never individually written) and the 10 floor is a portal hint only | LXP-LB-US 10K; other families unconfirmed | `inferred` | current | 1 | Bound adopted by [pylxpweb `c78ab7e`](https://github.com/joyfulhouse/pylxpweb/commit/c78ab7e) (PR #322, shipped 0.10.0b7) and the entity; this row is verified against that commit, not the page-level pylxpweb pin. The firmware exception stays the authoritative reject path. **Both ends unproven** — a delta-test at 100 and at 9 would settle it. |
+| H105 | Exact write ceiling is 100 (101 rejected per the reporter; 96–100 never individually written) and the 10 floor is a portal hint only | LXP-LB-US 10K; other families unconfirmed | `inferred` | current | 1 | Bound adopted by [pylxpweb `c78ab7e`](https://github.com/joyfulhouse/pylxpweb/commit/c78ab7e) (PR #322, shipped 0.10.0b7) and the entity; the page-level pylxpweb pin is that commit. The firmware exception stays the authoritative reject path. **Both ends unproven** — a delta-test at 100 and at 9 would settle it. |
 | H110 | Shared system-function word; individual meanings below | all | `verified-against-code` | structural-only | 0 | [`constants/registers.py::REGISTER_110_PARAM_KEYS`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L642-L659) and [`REGISTER_TO_PARAM_KEYS[110]`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L777-L782) define the structure. Never inherit a bit’s grade to the whole word or another family. |
 | H116 | Import threshold to start discharge, W | grid-tied; CT required | `portal-correlated` | current | 1 | `DATA_MAPPING.md`; whole watts, not ×100 W. |
 | H117 | Start-charge threshold, signed W | LOCAL/HYBRID | `asserted-unverified` | unresolved | 0 | [`DATA_MAPPING.md` H117 note](../../docs/DATA_MAPPING.md#power-control-registers); no cloud name or validated behavior. |
@@ -251,7 +255,7 @@ Every row is readable via FC03 but exists in potentially writable configuration 
 | H209-H212 | Peak-shaving window 1-2 packed times | `EG4_HYBRID` | `portal-correlated` | current | 4 | `SCHEDULE_TIME_TYPES` records FlexBOSS21 FAAB-2525 01:05 → H211 raw 1281. |
 | H218 | Peak-shaving period-2 SOC, % | `EG4_HYBRID` | `portal-correlated` | current | 1 | Raw/portal correlation in canonical holding map. |
 | H219 | Peak-shaving period-2 voltage, 0.1 V | `EG4_HYBRID` | `portal-correlated` | current | 1 | Raw/portal correlation in canonical holding map. |
-| H227 | System charge SOC limit, 0-101% | tested 18kPV | `hardware-toggle-proven` | current on tested unit; cross-family write risk unresolved | 1 | Named System Charge SOC Limit action and raw 80→101→80 restoration; component firmware version unrecorded — scope limited to the tested unit. `memory/soc-charge-limit-101-top-balance.md`. Shipped-path fact (`verified-against-code`): `_create_number_entities` adds `SystemChargeSOCLimitNumber` to the always-on block for every supported inverter reaching it, with no family gate. Routing since the [#570 audit](https://github.com/joyfulhouse/eg4_web_monitor/issues/570) (this change set): the write passes `local_write_blocked_reason` from `_offgrid_cloud_only_reason`, so EG4_OFFGRID and unresolved/UNKNOWN families route CLOUD-ONLY and pure-LOCAL raises; a positively resolved non-off-grid family keeps the local-first route (HYBRID may fall back to cloud; LOCAL has no fallback). Code anchors: `number.py::SystemChargeSOCLimitNumber.async_set_native_value`, `number.py::_offgrid_cloud_only_reason`, `utils.py::async_write_with_cloud_fallback`. Residual risk (`inferred`): the local-first route on resolved non-off-grid families still exceeds the tested-unit evidence scope — do not assume a local write is established on FlexBOSS21, 12kPV, or another untested target. History: escalated on [issue #558](https://github.com/joyfulhouse/eg4_web_monitor/issues/558#issuecomment-5232409553); pre-#570 the write was local-first with no family gate at all. |
+| H227 | System charge SOC limit; the 101 top-balance end is the proven part (0–101 is the pinned library range — the 0 floor is untested) | tested 18kPV | `hardware-toggle-proven` | current on tested unit; cross-family write risk unresolved | 1 | Named System Charge SOC Limit action and raw 80→101→80 restoration; component firmware version unrecorded — scope limited to the tested unit. `memory/soc-charge-limit-101-top-balance.md`. Shipped-path fact (`verified-against-code`): `_create_number_entities` adds `SystemChargeSOCLimitNumber` to the always-on block for every supported inverter reaching it, with no family gate. Routing since the [#570 audit](https://github.com/joyfulhouse/eg4_web_monitor/issues/570) (this change set): the write passes `local_write_blocked_reason` from `_offgrid_cloud_only_reason`, so EG4_OFFGRID and unresolved/UNKNOWN families route CLOUD-ONLY and pure-LOCAL raises; a positively resolved non-off-grid family keeps the local-first route (HYBRID may fall back to cloud; LOCAL has no fallback). Code anchors: `number.py::SystemChargeSOCLimitNumber.async_set_native_value`, `number.py::_offgrid_cloud_only_reason`, `utils.py::async_write_with_cloud_fallback`. Residual risk (`inferred`): the local-first route on resolved non-off-grid families still exceeds the tested-unit evidence scope — do not assume a local write is established on FlexBOSS21, 12kPV, or another untested target. History: escalated on [issue #558](https://github.com/joyfulhouse/eg4_web_monitor/issues/558#issuecomment-5232409553); pre-#570 the write was local-first with no family gate at all. |
 | H228 | System charge voltage limit, 0.1 V | voltage-control units | `portal-correlated` | current | 1 | The source preserves raw 595 ↔ cloud 59.5 V at baseline, but the 59.5→59.4→59.5 V action/restoration is recorded only as scaled engineering values; integer register words for the changed and restored states were not preserved; target family unrecorded. `memory/voltage-param-scaling-cloud-vs-local.md`; `memory/cloud-raw-register-write-broken.md`. |
 | H231 | Unknown field; historic peak-shaving/high-word label false | tested hybrid | `portal-correlated` | unresolved | 0 | Single-register reads and quantization contradict the old label; no current semantic is counted. |
 | H232 | Peak-shaving period-2 power, 0.1 kW | `EG4_HYBRID` | `portal-correlated` | current | 1 | `memory/live-write-window-findings.md`; not H231’s high word. |

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -2,6 +2,7 @@
 canonical-for: inverter-and-gridboss-register-ground-truth
 sources:
   - docs/DATA_MAPPING.md
+  - "eg4_web_monitor issue #603 (reporter diagnostics, LXP-LB-US 10K): HOLD_DISCHG_CUT_OFF_SOC_EOD stored 95"
   - docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
   - docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
   - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
@@ -48,12 +49,12 @@ verified-against:
   # cited by PR number (pylxpweb #273), not by pin.
   eg4_web_monitor: d8e2027
   pylxpweb: ab87902
-last-verified: 2026-08-30
+last-verified: 2026-09-02
 ---
 
 # Register ground truth
 
-> **Audited result: 41 of 346 counted current register claims are proven: 33 `firmware-proven` + 8 `hardware-toggle-proven` = 41; 33 + 8 + 170 `portal-correlated` + 135 `lineage-inferred` = 346.** The arithmetic and row contributions are reproducible from the audit command below; this accounting assertion is `asserted-unverified`, not a code-behavior claim. Register semantics retain their own row grades.
+> **Audited result: 41 of 348 counted current register claims are proven: 33 `firmware-proven` + 8 `hardware-toggle-proven` = 41; 33 + 8 + 171 `portal-correlated` + 135 `lineage-inferred` + 1 `inferred` = 348.** The arithmetic and row contributions are reproducible from the audit command below; this accounting assertion is `asserted-unverified`, not a code-behavior claim. Register semantics retain their own row grades.
 
 This page is canonical for register semantics and evidence status. **When it conflicts with [`docs/DATA_MAPPING.md`](../../docs/DATA_MAPPING.md), this page wins.** `DATA_MAPPING.md` remains a useful implementation/derivation source, but its names and derivations are subordinate to the family scope, evidence grade, and status recorded here.
 
@@ -66,12 +67,12 @@ The grade vocabulary is owned by the [llmwiki evidence-grade legend](../README.m
 | `firmware-proven` | 33 | yes |
 | `hardware-toggle-proven` | 8 | yes |
 | `app-write-path-proven` | 0 | no |
-| `portal-correlated` | 170 | no |
+| `portal-correlated` | 171 | no |
 | `lineage-inferred` | 135 | no |
-| `inferred` | 0 | no |
+| `inferred` | 1 | no |
 | `verified-against-code` | 0 | no |
 | `asserted-unverified` | 0 | no; candidate rows are excluded |
-| **Current total** | **346** | **41 proven (11.8%)** |
+| **Current total** | **348** | **41 proven (11.8%)** |
 
 The `Claim count` column is the machine-checkable contribution. One separately named semantic is one claim; a U32 low/high pair is one; family-specific meanings are separate; a compound packed-word contract is one claim unless its bits are separately exposed as independent semantics. Structural-only, candidate, unknown, and `asserted-unverified` rows contribute zero. Refuted historic labels are outside the counted ledger. The markers around the ledger allow an `awk -F'|'` sum of column 7 to reproduce every subtotal.
 
@@ -222,6 +223,8 @@ Every row is readable via FC03 but exists in potentially writable configuration 
 | H101/H102 | Charge/discharge current limits, A | all | `lineage-inferred` | current | 2 | Canonical definitions; reviewed source contains no controlled capture. |
 | H103 | Maximum grid sell-back power, raw ×100 W / UI kW | grid-tied | `portal-correlated` | current | 1 | `DATA_MAPPING.md` raw/UI correlation; not percent. |
 | H105 | On-grid discharge SOC cutoff | grid-tied | `lineage-inferred` | current | 1 | Canonical holding definition. |
+| H105 | A portal-typed 95 is stored and read back (the 90 was the portal arrow-button hint, copied into pylxpweb and — beta.13, PR #600 round 2 — into the entity) | LXP-LB-US 10K (reporter unit, hybrid) | `portal-correlated` | current on the reported unit | 1 | [#603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603) reporter diagnostics (`HOLD_DISCHG_CUT_OFF_SOC_EOD: 95`) + portal screenshot. Readback proves storage, not semantics. |
+| H105 | Exact write ceiling is 100 (101 rejected per the reporter; 96–100 never individually written) and the 10 floor is a portal hint only | LXP-LB-US 10K; other families unconfirmed | `inferred` | current | 1 | Bound adopted by [pylxpweb `c78ab7e`](https://github.com/joyfulhouse/pylxpweb/commit/c78ab7e) (PR #322, shipped 0.10.0b7) and the entity; this row is verified against that commit, not the page-level pylxpweb pin. The firmware exception stays the authoritative reject path. **Both ends unproven** — a delta-test at 100 and at 9 would settle it. |
 | H110 | Shared system-function word; individual meanings below | all | `verified-against-code` | structural-only | 0 | [`constants/registers.py::REGISTER_110_PARAM_KEYS`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L642-L659) and [`REGISTER_TO_PARAM_KEYS[110]`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L777-L782) define the structure. Never inherit a bit’s grade to the whole word or another family. |
 | H116 | Import threshold to start discharge, W | grid-tied; CT required | `portal-correlated` | current | 1 | `DATA_MAPPING.md`; whole watts, not ×100 W. |
 | H117 | Start-charge threshold, signed W | LOCAL/HYBRID | `asserted-unverified` | unresolved | 0 | [`DATA_MAPPING.md` H117 note](../../docs/DATA_MAPPING.md#power-control-registers); no cloud name or validated behavior. |
@@ -385,7 +388,7 @@ No raw wire evidence establishes a firmware-level FC16 rejection. The current in
 
 ## Must-not-regress register claims
 
-These historic claims are excluded from the 346-current-claim denominator. `refuted` is a status; **Evidence** grades the disproof.
+These historic claims are excluded from the 348-current-claim denominator. `refuted` is a status; **Evidence** grades the disproof.
 
 | Historic claim | Evidence | Status | Current bounded result | Durable basis |
 |---|---|---|---|---|

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -47,10 +47,12 @@ verified-against:
   # the sweep-extended rows now verify at the mainline pin below (inline
   # PR #600 / issue #570 citations remain as provenance). pylxpweb was
   # ab87902 (0.9.39b11) until the 2026-09-02 #603 ingest moved it to
-  # c78ab7e (0.10.0b7): between the two, the only holding-definition change
-  # is H105's ceiling (PR #322); the #271/#272 range fixes are cited by PR
-  # number (pylxpweb #273). Inline ab87902 blob links on older rows remain
-  # valid historical URLs and were not rewritten.
+  # c78ab7e (0.10.0b7). Holding-definition deltas between the two pins
+  # (git diff ab87902..c78ab7e -- registers/inverter_holding.py): H105
+  # ceiling 90 -> 100 (PR #322, this ingest); H66 max 15000 -> 10000 and
+  # H160 min 0 -> 1 (PR #273 for #271/#272 — already carried per claim by
+  # the H66/H160 rows below and shipped family-scoped in the integration).
+  # Inline ab87902 blob links on older rows remain valid historical URLs.
   eg4_web_monitor: d8e2027
   pylxpweb: c78ab7e
 last-verified: 2026-09-02

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -886,7 +886,7 @@ portal's arrow-button hint copied into pylxpweb's canonical H105 definition and
 `set_battery_soc_limits`; it blanked the stored 95 to unknown and refused writes
 above 90. Filed on [the registers keeper](40-hardware/registers.md) as two H105 rows: the stored-95 observation
 (`portal-correlated`, reporter unit only) and the exact 10–100 bound (`inferred`;
-both ends unproven). Accounting 346 → 348 claims, 41 proven; keeper pylxpweb pin moved ab87902 → c78ab7e (0.10.0b7; the only holding-definition change in between is H105). Library fix widens both
+both ends unproven). Accounting 346 → 348 claims, 41 proven; keeper pylxpweb pin moved ab87902 → c78ab7e (0.10.0b7; holding-definition deltas in between are H105 (this ingest) plus the PR #273 H66/H160 range fixes the keeper already carried per claim). Library fix widens both
 pylxpweb writers and the definition to 100; the entity read window is now the
 tolerant 0–100 while the write bounds track the writers. Same-class audit: reg 227
 (System Charge SOC Limit) carried an evidence-free 10 floor against a 0–101

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -884,9 +884,9 @@ rejected by the inverter (96–100 were never individually written). The 10–90
 On-Grid SOC Cut-Off entity (advertised, write-validated AND read-windowed) was the
 portal's arrow-button hint copied into pylxpweb's canonical H105 definition and
 `set_battery_soc_limits`; it blanked the stored 95 to unknown and refused writes
-above 90. Filed on the keeper as two H105 rows: the stored-95 observation
+above 90. Filed on [the registers keeper](40-hardware/registers.md) as two H105 rows: the stored-95 observation
 (`portal-correlated`, reporter unit only) and the exact 10–100 bound (`inferred`;
-both ends unproven). Accounting 346 → 348 claims, 41 proven. Library fix widens both
+both ends unproven). Accounting 346 → 348 claims, 41 proven; keeper pylxpweb pin moved ab87902 → c78ab7e (0.10.0b7; the only holding-definition change in between is H105). Library fix widens both
 pylxpweb writers and the definition to 100; the entity read window is now the
 tolerant 0–100 while the write bounds track the writers. Same-class audit: reg 227
 (System Charge SOC Limit) carried an evidence-free 10 floor against a 0–101

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -874,3 +874,23 @@ controls-and-writes, data-semantics) are re-pinned to `d8e2027` with
 `last-verified: 2026-08-30`; the inline PR/issue citations remain as
 provenance. Performed in the v3.5.1-beta.13 release change set (which bumps
 the pylxpweb pin to 0.10.0b5).
+
+## [2026-09-01] ingest | #603 — H105 ceiling is 100, not 90; the entity read window must not be tighter than the writers
+
+Source: [#603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603) reporter
+diagnostics (LXP-LB-US 10K, hybrid) showing `HOLD_DISCHG_CUT_OFF_SOC_EOD: 95`
+stored after a portal-typed value, plus the reporter's statement that 101 is
+rejected by the inverter (96–100 were never individually written). The 10–90 range PR #600 round 2 propagated into the
+On-Grid SOC Cut-Off entity (advertised, write-validated AND read-windowed) was the
+portal's arrow-button hint copied into pylxpweb's canonical H105 definition and
+`set_battery_soc_limits`; it blanked the stored 95 to unknown and refused writes
+above 90. Filed on the keeper as two H105 rows: the stored-95 observation
+(`portal-correlated`, reporter unit only) and the exact 10–100 bound (`inferred`;
+both ends unproven). Accounting 346 → 348 claims, 41 proven. Library fix widens both
+pylxpweb writers and the definition to 100; the entity read window is now the
+tolerant 0–100 while the write bounds track the writers. Same-class audit: reg 227
+(System Charge SOC Limit) carried an evidence-free 10 floor against a 0–101
+library/keeper range — floor set to 0; reg 160's hybrid-side 90 write cap is the
+same evidence tier and is now annotated as such in the entity docstring, not
+changed. Rule recorded: a read plausibility window must never be tighter than the
+widest bound any writer accepts.

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b5  # keep in sync with manifest.json
+pylxpweb==0.10.0b7  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml

--- a/tests/test_number_coerce_int.py
+++ b/tests/test_number_coerce_int.py
@@ -56,11 +56,11 @@ ENTITY_CASES: "Sequence[ParameterSet]" = (
         id="forced-discharge-soc-limit",
     ),
     pytest.param(
-        # 10-90: the canonical H105 range enforced by pylxpweb's definition
-        # and set_battery_soc_limits (#570 review round 2).
+        # 10-100: the canonical H105 range enforced by pylxpweb's definition
+        # and set_battery_soc_limits (#570 review round 2; ceiling 100 per #603).
         OnGridSOCCutoffNumber,
         10,
-        90,
+        100,
         "On-grid SOC cutoff",
         id="on-grid-soc-cutoff",
     ),

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -688,9 +688,79 @@ class TestReadParamValueDict:
         entity = OnGridSOCCutoffNumber(coordinator, "1234567890")
         assert entity.native_value == 15
 
+    @pytest.mark.parametrize("stored", [95, 100, 5])
+    def test_reads_portal_stored_value_outside_write_bounds(self, stored):
+        """#603: the read window is 0-100, wider than the 10-100 write bounds.
+
+        The portal stores any value the firmware accepts (a typed 95 on an
+        LXP-LB-US 10K); the entity must display it, never blank to unknown.
+        """
+        coordinator = _mock_coordinator(
+            inverter_attrs={"battery_soc_limits": {"on_grid_limit": stored}},
+        )
+        entity = OnGridSOCCutoffNumber(coordinator, "1234567890")
+        assert entity.native_value == stored
+        assert entity.native_max_value == 100
+
+    def test_rejects_value_above_100_as_implausible(self):
+        """101+ is outside anything the firmware stores (inverter rejects >100)."""
+        coordinator = _mock_coordinator(
+            inverter_attrs={"battery_soc_limits": {"on_grid_limit": 101}},
+        )
+        entity = OnGridSOCCutoffNumber(coordinator, "1234567890")
+        assert entity.native_value is None
+
 
 class TestReadParamValueParamsFirst:
     """Test _read_param_value with params_first=True (via SystemChargeSOCLimitNumber)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", [0.0, 9.0])
+    async def test_writes_below_former_10_floor(self, value):
+        """The WRITE path accepts 0-9 too (reg 227 is 0-101) — the beta.13
+        entity hardcoded a 10 floor in async_set_native_value that the read
+        test alone did not exercise (review on the #603 fix)."""
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        coordinator.is_transport_link_down = MagicMock(return_value=True)
+        result = MagicMock()
+        result.success = True
+        coordinator.client = MagicMock()
+        coordinator.client.api.control.set_system_charge_soc_limit = AsyncMock(
+            return_value=result
+        )
+        entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        await entity.async_set_native_value(value)
+
+        coordinator.client.api.control.set_system_charge_soc_limit.assert_awaited_once()
+        assert (
+            coordinator.client.api.control.set_system_charge_soc_limit.await_args.args[
+                1
+            ]
+            == int(value)
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", [-1.0, 102.0])
+    async def test_rejects_outside_0_101(self, value):
+        coordinator = _mock_coordinator(has_local=True, has_http=True)
+        entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
+        _prep(entity)
+
+        with pytest.raises(HomeAssistantError, match=r"0-101"):
+            await entity.async_set_native_value(value)
+
+    @pytest.mark.parametrize("stored", [0, 5, 9])
+    def test_reads_below_former_10_floor(self, stored):
+        """Reg 227 is 0-101 (library + hardware-proven); a portal-set 0-9 must
+        display and the slider must advertise 0 (same defect class as #603)."""
+        coordinator = _mock_coordinator(
+            parameters={"HOLD_SYSTEM_CHARGE_SOC_LIMIT": stored},
+        )
+        entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
+        assert entity.native_value == stored
+        assert entity.native_min_value == 0
 
     def test_params_first_order(self):
         """With params_first, reads params before inverter."""
@@ -1217,15 +1287,15 @@ class TestSystemChargeSOCWrite:
 
     @pytest.mark.asyncio
     async def test_write_below_range_raises(self):
-        """Below 10% raises HomeAssistantError."""
+        """Below 0% raises HomeAssistantError (the floor is 0, not 10 — #603)."""
         coordinator = _mock_coordinator()
         entity = SystemChargeSOCLimitNumber(coordinator, "1234567890")
         entity.hass = MagicMock()
 
         with pytest.raises(
-            HomeAssistantError, match="must be an integer between 10-101"
+            HomeAssistantError, match="must be an integer between 0-101"
         ):
-            await entity.async_set_native_value(5.0)
+            await entity.async_set_native_value(-1.0)
 
 
 # ── Forced discharge controls (regs 82/83, GH #207 / PR #249) ────────

--- a/tests/test_number_limit_contracts.py
+++ b/tests/test_number_limit_contracts.py
@@ -1,0 +1,192 @@
+"""Entity write bounds must match the pinned pylxpweb writers (#603).
+
+The number entities validate a value BEFORE handing it to a pylxpweb writer,
+and their advertised range is what Home Assistant shows the user. If the
+entity bound and the library bound drift apart, one of two defects appears:
+a value HA accepts crashes the service call with the library's raw
+``ValueError`` (the beta.13 symptom on off-grid routes), or a value the
+library accepts is refused by HA (#603: the entity capped at 90 while the
+inverter stores 95). Both are caught here against the INSTALLED wheel — CI
+installs ``tests/requirements-test.txt`` — and a separate check keeps that file
+and ``manifest.json`` on the same pin so the wheel under test is the one HA
+will install.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pylxpweb import LuxpowerClient
+from pylxpweb.constants import (
+    ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
+)
+from pylxpweb.devices.inverters.hybrid import HybridInverter
+from pylxpweb.endpoints.control import ControlEndpoints
+from pylxpweb.registers.inverter_holding import BY_NAME as HOLDING_BY_NAME
+
+from custom_components.eg4_web_monitor.const.limits import (
+    ONGRID_SOC_CUTOFF_MAX,
+    ONGRID_SOC_CUTOFF_MIN,
+    SOC_LIMIT_MAX,
+    SOC_LIMIT_MIN,
+    SYSTEM_CHARGE_SOC_LIMIT_MAX,
+    SYSTEM_CHARGE_SOC_LIMIT_MIN,
+)
+
+
+def test_ongrid_soc_cutoff_write_bounds_match_pinned_h105_definition() -> None:
+    """#603: the entity write bounds equal the library's shared H105 constants.
+
+    ``ONGRID_DISCHARGE_CUTOFF_SOC_MIN/MAX`` are the ONE source pylxpweb's cloud
+    writer (``set_battery_soc_limits``), its Modbus writer
+    (``set_on_grid_cutoff_soc``) and the canonical H105 definition all read
+    (pylxpweb #322), so matching them here means neither the cloud nor the
+    local path can refuse a value the entity accepts, or vice versa.
+    """
+    assert (ONGRID_SOC_CUTOFF_MIN, ONGRID_SOC_CUTOFF_MAX) == (
+        ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
+        ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+    )
+    definition = HOLDING_BY_NAME["ongrid_discharge_cutoff_soc"]
+    assert definition.address == 105
+    assert (definition.min_value, definition.max_value) == (
+        ONGRID_SOC_CUTOFF_MIN,
+        ONGRID_SOC_CUTOFF_MAX,
+    )
+    assert ONGRID_SOC_CUTOFF_MAX == 100
+
+
+def test_ongrid_soc_cutoff_read_window_is_not_tighter_than_any_writer() -> None:
+    """The read plausibility window (0-100) must contain the write bounds:
+    the portal can store anything the firmware accepts, and a stored value
+    must display rather than blank to unknown (#603)."""
+    assert SOC_LIMIT_MIN <= ONGRID_SOC_CUTOFF_MIN
+    assert ONGRID_SOC_CUTOFF_MAX <= SOC_LIMIT_MAX
+
+
+def test_offgrid_soc_cutoff_bounds_match_pinned_h125_definition() -> None:
+    definition = HOLDING_BY_NAME["offgrid_discharge_cutoff_soc"]
+
+    assert definition.address == 125
+    assert (definition.min_value, definition.max_value) == (
+        SOC_LIMIT_MIN,
+        SOC_LIMIT_MAX,
+    )
+
+
+def test_system_charge_soc_limit_bounds_match_pinned_h227_definition() -> None:
+    """Reg 227 is 0-101 in the pinned library (a library contract, not a
+    hardware claim: the keeper's capture is 80->101->80, which does not
+    exercise the 0 floor); the former entity floor of 10 would have blanked
+    and refused a portal-set 0-9 (same class as #603)."""
+    definition = HOLDING_BY_NAME["system_charge_soc_limit"]
+
+    assert definition.address == 227
+    assert (definition.min_value, definition.max_value) == (
+        SYSTEM_CHARGE_SOC_LIMIT_MIN,
+        SYSTEM_CHARGE_SOC_LIMIT_MAX,
+    )
+
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def test_manifest_and_test_requirements_pin_the_same_pylxpweb() -> None:
+    """The wheel CI tests against must be the wheel HA installs."""
+    manifest = json.loads(
+        (_REPO / "custom_components/eg4_web_monitor/manifest.json").read_text()
+    )
+    manifest_pin = next(
+        r for r in manifest["requirements"] if r.startswith("pylxpweb==")
+    )
+    requirements = (_REPO / "tests/requirements-test.txt").read_text()
+    match = re.search(r"^pylxpweb==([^\s#]+)", requirements, re.M)
+    assert match is not None
+    assert manifest_pin == f"pylxpweb=={match.group(1)}"
+
+
+def _hybrid_inverter() -> tuple[HybridInverter, Mock]:
+    client = Mock(spec=LuxpowerClient)
+    client.api = Mock()
+    ok = Mock()
+    ok.success = True
+    client.api.control.write_parameter = AsyncMock(return_value=ok)
+    inverter = HybridInverter(
+        client=client, serial_number="1234567890", model="18KPV", transport=Mock()
+    )
+    return inverter, client
+
+
+@pytest.mark.asyncio
+async def test_pinned_cloud_writer_accepts_entity_max_and_rejects_next() -> None:
+    """Exercise the REAL pinned cloud writer with only its I/O seam mocked:
+    the entity ceiling passes its validation and ceiling+1 does not."""
+    inverter, client = _hybrid_inverter()
+
+    assert await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MAX)
+    client.api.control.write_parameter.assert_awaited_once_with(
+        "1234567890", "HOLD_DISCHG_CUT_OFF_SOC_EOD", str(ONGRID_SOC_CUTOFF_MAX)
+    )
+    with pytest.raises(ValueError):
+        await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MAX + 1)
+    with pytest.raises(ValueError):
+        await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MIN - 1)
+
+
+@pytest.mark.asyncio
+async def test_pinned_modbus_writer_accepts_entity_max_and_rejects_next() -> None:
+    inverter, _ = _hybrid_inverter()
+
+    with patch.object(
+        inverter, "write_transport_register", AsyncMock(return_value=True)
+    ) as write:
+        assert await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MAX)
+        write.assert_awaited_once_with(105, ONGRID_SOC_CUTOFF_MAX)
+        with pytest.raises(ValueError):
+            await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MAX + 1)
+        with pytest.raises(ValueError):
+            await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MIN - 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value", [SYSTEM_CHARGE_SOC_LIMIT_MIN, SYSTEM_CHARGE_SOC_LIMIT_MAX]
+)
+async def test_pinned_reg227_writers_accept_entity_bounds(value: int) -> None:
+    """Both REAL pinned reg-227 writers (cloud endpoint + Modbus) accept the
+    entity's floor and ceiling and reject one step outside, with only their
+    I/O seams mocked — the entity's former 10 floor would have refused 0."""
+    control = ControlEndpoints(Mock(spec=LuxpowerClient))
+    with patch.object(
+        control, "write_parameter", AsyncMock(return_value=Mock())
+    ) as write:
+        await control.set_system_charge_soc_limit("1234567890", value)
+        write.assert_awaited_once_with(
+            "1234567890", "HOLD_SYSTEM_CHARGE_SOC_LIMIT", str(value)
+        )
+
+    inverter, _ = _hybrid_inverter()
+    with patch.object(
+        inverter, "write_transport_register", AsyncMock(return_value=True)
+    ) as write:
+        assert await inverter.set_system_charge_soc_limit(value)
+        write.assert_awaited_once_with(227, value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value", [SYSTEM_CHARGE_SOC_LIMIT_MIN - 1, SYSTEM_CHARGE_SOC_LIMIT_MAX + 1]
+)
+async def test_pinned_reg227_writers_reject_one_step_outside(value: int) -> None:
+    control = ControlEndpoints(Mock(spec=LuxpowerClient))
+    with pytest.raises(ValueError):
+        await control.set_system_charge_soc_limit("1234567890", value)
+
+    inverter, _ = _hybrid_inverter()
+    with pytest.raises(ValueError):
+        await inverter.set_system_charge_soc_limit(value)

--- a/tests/test_number_limit_contracts.py
+++ b/tests/test_number_limit_contracts.py
@@ -28,7 +28,12 @@ from pylxpweb.constants import (
 from pylxpweb.devices.inverters.hybrid import HybridInverter
 from pylxpweb.endpoints.control import ControlEndpoints
 from pylxpweb.registers.inverter_holding import BY_NAME as HOLDING_BY_NAME
+from pylxpweb.transports.protocol import BaseTransport
 
+from custom_components.eg4_web_monitor.const.modbus import (
+    PARAM_HOLD_ONGRID_DISCHG_SOC,
+    PARAM_HOLD_SYSTEM_CHARGE_SOC_LIMIT,
+)
 from custom_components.eg4_web_monitor.const.limits import (
     ONGRID_SOC_CUTOFF_MAX,
     ONGRID_SOC_CUTOFF_MIN,
@@ -123,34 +128,86 @@ def _hybrid_inverter() -> tuple[HybridInverter, Mock]:
 
 
 @pytest.mark.asyncio
-async def test_pinned_cloud_writer_accepts_entity_max_and_rejects_next() -> None:
-    """Exercise the REAL pinned cloud writer with only its I/O seam mocked:
-    the entity ceiling passes its validation and ceiling+1 does not."""
+@pytest.mark.parametrize("value", [ONGRID_SOC_CUTOFF_MIN, ONGRID_SOC_CUTOFF_MAX])
+async def test_pinned_h105_writers_accept_entity_bounds(value: int) -> None:
+    """Exercise the REAL pinned cloud and Modbus writers with only their I/O
+    seams mocked: both entity bounds pass their validation and reach the
+    write with the exact value."""
     inverter, client = _hybrid_inverter()
-
-    assert await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MAX)
+    assert await inverter.set_battery_soc_limits(on_grid_limit=value)
     client.api.control.write_parameter.assert_awaited_once_with(
-        "1234567890", "HOLD_DISCHG_CUT_OFF_SOC_EOD", str(ONGRID_SOC_CUTOFF_MAX)
+        "1234567890", "HOLD_DISCHG_CUT_OFF_SOC_EOD", str(value)
     )
-    with pytest.raises(ValueError):
-        await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MAX + 1)
-    with pytest.raises(ValueError):
-        await inverter.set_battery_soc_limits(on_grid_limit=ONGRID_SOC_CUTOFF_MIN - 1)
 
-
-@pytest.mark.asyncio
-async def test_pinned_modbus_writer_accepts_entity_max_and_rejects_next() -> None:
     inverter, _ = _hybrid_inverter()
-
     with patch.object(
         inverter, "write_transport_register", AsyncMock(return_value=True)
     ) as write:
-        assert await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MAX)
-        write.assert_awaited_once_with(105, ONGRID_SOC_CUTOFF_MAX)
-        with pytest.raises(ValueError):
-            await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MAX + 1)
-        with pytest.raises(ValueError):
-            await inverter.set_on_grid_cutoff_soc(ONGRID_SOC_CUTOFF_MIN - 1)
+        assert await inverter.set_on_grid_cutoff_soc(value)
+        write.assert_awaited_once_with(105, value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value", [ONGRID_SOC_CUTOFF_MIN - 1, ONGRID_SOC_CUTOFF_MAX + 1]
+)
+async def test_pinned_h105_writers_reject_one_step_outside_without_io(
+    value: int,
+) -> None:
+    inverter, client = _hybrid_inverter()
+    with pytest.raises(ValueError):
+        await inverter.set_battery_soc_limits(on_grid_limit=value)
+    client.api.control.write_parameter.assert_not_awaited()
+
+    inverter, _ = _hybrid_inverter()
+    with (
+        patch.object(
+            inverter, "write_transport_register", AsyncMock(return_value=True)
+        ) as write,
+        pytest.raises(ValueError),
+    ):
+        await inverter.set_on_grid_cutoff_soc(value)
+    write.assert_not_awaited()
+
+
+class _NameMapTransport(BaseTransport):
+    """Minimal concrete transport: only the physical write is stubbed, so the
+    name -> register resolution and serialization are the library's own."""
+
+    def __init__(self, family: str) -> None:
+        super().__init__("1234567890")
+        self._inverter_family = family
+        self._connected = True
+        self.written: list[dict[int, int]] = []
+
+    def _get_inverter_family(self) -> str | None:
+        return self._inverter_family
+
+    async def write_parameters(self, parameters: dict[int, int]) -> bool:
+        self.written.append(dict(parameters))
+        return True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("family", ["EG4_HYBRID", "EG4_OFFGRID"])
+async def test_named_local_writes_land_on_registers_105_and_227(family: str) -> None:
+    """The entities' LOCAL route is coordinator.write_named_parameter ->
+    transport.write_named_parameters; with only the physical write stubbed,
+    the pinned library must serialize the entity's parameter names to raw
+    {105: value} / {227: value} whole-percent writes."""
+    transport = _NameMapTransport(family)
+
+    assert await transport.write_named_parameters(
+        {PARAM_HOLD_ONGRID_DISCHG_SOC: ONGRID_SOC_CUTOFF_MAX}
+    )
+    assert await transport.write_named_parameters(
+        {PARAM_HOLD_SYSTEM_CHARGE_SOC_LIMIT: SYSTEM_CHARGE_SOC_LIMIT_MIN}
+    )
+
+    assert transport.written == [
+        {105: ONGRID_SOC_CUTOFF_MAX},
+        {227: SYSTEM_CHARGE_SOC_LIMIT_MIN},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_offgrid_write_routing.py
+++ b/tests/test_offgrid_write_routing.py
@@ -866,12 +866,14 @@ class TestSweepExtendedProtectedRouting:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("value", [10, 90], ids=["min-10", "max-90"])
+    @pytest.mark.parametrize(
+        "value", [10, 95, 100], ids=["min-10", "portal-95", "max-100"]
+    )
     async def test_offgrid_ongrid_soc_cutoff_boundaries_write_cloud(self, value):
-        """Review round 2 MED: the entity's advertised range now matches the
-        canonical H105 range (10-90) that pylxpweb's set_battery_soc_limits
-        enforces — both boundary values pass validation and land via the
-        cloud writer without a ValueError."""
+        """Review round 2 MED: the entity's advertised range matches the
+        canonical H105 range (10-100, #603) that pylxpweb's
+        set_battery_soc_limits enforces — both boundary values pass
+        validation and land via the cloud writer without a ValueError."""
         coordinator = _mock_coordinator(
             has_local=True, has_http=True, device_data=dict(OFFGRID_FEATURES)
         )
@@ -885,7 +887,7 @@ class TestSweepExtendedProtectedRouting:
         inverter.set_battery_soc_limits.assert_awaited_once_with(on_grid_limit=value)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("value", [9, 91], ids=["below-min", "above-max"])
+    @pytest.mark.parametrize("value", [9, 101], ids=["below-min", "above-max"])
     async def test_offgrid_ongrid_soc_cutoff_out_of_range_raises_clearly(self, value):
         """Out-of-range values fail at the entity with a clear
         HomeAssistantError BEFORE any writer runs — never pylxpweb's raw
@@ -896,7 +898,7 @@ class TestSweepExtendedProtectedRouting:
         entity = OnGridSOCCutoffNumber(coordinator, SERIAL)
         _prep(entity)
 
-        with pytest.raises(HomeAssistantError, match=r"10-90"):
+        with pytest.raises(HomeAssistantError, match=r"10-100"):
             await entity.async_set_native_value(value)
 
         coordinator.write_named_parameter.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #603. Requires **pylxpweb 0.10.0b7** (companion fix [pylxpweb #322](https://github.com/joyfulhouse/pylxpweb/pull/322), on PyPI).

beta.13 (PR #600 review round 2) matched the On-Grid SOC Cut-Off entity to pylxpweb's 10-90 bound for register 105 in the advertised range, the write validation **and** the read plausibility window. That 90 was the portal's arrow-button hint, not a firmware limit: a portal-typed **95 is stored** on the reporter's LXP-LB-US 10K and **101 is rejected** (96-100 inferred). So a stored 95 read *unknown* and writes above 90 were refused — users keeping batteries full ahead of outages lost the control.

## Changes

- **Pin** `pylxpweb==0.10.0b7` (manifest + `tests/requirements-test.txt`).
- **Reg 105 entity**: write bounds 10-100; read window 0-100 so a value the portal stored never blanks. The 10 floor is the same portal hint, unproven either way, kept fail-closed.
- **Same-class audit — reg 227 System Charge SOC Limit**: evidence-free 10 floor on read *and* write against the library's 0-101 → floor 0 (the write path hardcoded 10; caught by review).
- **Reg 160** hybrid 90 cap annotated as same-tier evidence, not changed.
- **`tests/test_number_limit_contracts.py`**: entity bounds == installed library constants; manifest/requirements pin sync; the real pinned cloud + Modbus writers for reg 105 and reg 227 exercised at each bound and one step outside with only I/O seams mocked.
- **Docs/wiki**: DATA_MAPPING rows 105/227; llmwiki registers keeper gets two H105 rows (stored-95 `portal-correlated`; exact bound `inferred`, citing pylxpweb `c78ab7e`), sources + accounting 346→348 + `last-verified`; log entry; CHANGELOG (beta.13 H105 line marked superseded).

## Adjudicated / risk-accepted

- HA core does **not** range-check `native_value` on state reads — only the `set_value` service checks min/max (verified against installed `homeassistant/components/number/__init__.py`). A Gemini "blanks to unknown" BLOCKER on `native_min_value` vs read window was a false positive; same for the reg-160 variant.
- 10 write floor on reg 105 kept.

## Test plan

- [x] ruff / ruff format / mypy (`tests/mypy.ini`) clean
- [x] Full suite 3276 passed against pylxpweb 0.10.0b7; Silver, Gold, Platinum validators pass
- [x] New tests listed above

## Adversarial review

Four rounds on this repo. **Claude Fable** ×4 — clean. **Gemini 3.1 Pro** — r1 BLOCKER (reg 227 write path) fixed; r3 clean; r4 two test-coverage findings applied. **Codex GPT-5.6-sol (ultra)** — r2 findings (accounting, grading, contract-test strength, pin sync) applied; r3/r4 timed out at 18 min on this repo; a final 30-min Codex pass is running against this PR head and any findings will be pushed before merge. **Cursor Grok 4.5 waived** by the maintainer (CLI returns empty output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)