### PR TITLE
chore(release): v3.5.1-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1-beta.14] - 2026-09-02
 
 Requires **[pylxpweb==0.10.0b7](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b7)**.
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
   "requirements": ["pylxpweb==0.10.0b7", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.13"
+  "version": "3.5.1-beta.14"
 }

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -35,6 +35,7 @@ sources:
   - https://github.com/joyfulhouse/pylxpweb/issues/272
   - https://github.com/joyfulhouse/pylxpweb/pull/273
 verified-against:
+  # Re-pinned at the 2026-09-02 beta.14 release cut: PR #605 merged as 041032f.
   # The pin is commit-only per _conventions.md (machine tooling passes it to
   # git show) and covers the pre-existing claims, verified at e9853eb
   # (v3.5.1-beta.12 mainline, contains the PR #569 routing). Rows
@@ -53,7 +54,7 @@ verified-against:
   # H160 min 0 -> 1 (PR #273 for #271/#272 — already carried per claim by
   # the H66/H160 rows below and shipped family-scoped in the integration).
   # Inline ab87902 blob links on older rows remain valid historical URLs.
-  eg4_web_monitor: d8e2027
+  eg4_web_monitor: 041032f
   pylxpweb: c78ab7e
 last-verified: 2026-09-02
 ---

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -894,3 +894,11 @@ library/keeper range — floor set to 0; reg 160's hybrid-side 90 write cap is t
 same evidence tier and is now annotated as such in the entity docstring, not
 changed. Rule recorded: a read plausibility window must never be tighter than the
 widest bound any writer accepts.
+
+## [2026-09-02] repin | Release-cut re-pin — PR #605 merged as 041032f
+
+The #603 fix (two H105 keeper rows, reg 227 floor, contract tests) merged to
+mainline as `041032f`; the [registers keeper](40-hardware/registers.md) is re-pinned
+to it with `last-verified: 2026-09-02` (its pylxpweb pin moved to `c78ab7e` in the
+#603 ingest above). Performed in the v3.5.1-beta.14 release change set (pylxpweb
+pin 0.10.0b7).


### PR DESCRIPTION
Release cut for v3.5.1-beta.14. Requires **pylxpweb==0.10.0b7**.

- #603 On-Grid SOC Cut-Off accepts 91-100 % and reads portal-set values (PR #605)
- Same-class fix: System Charge SOC Limit accepts 0-9 %
- #602 EndpointBusCapability setters (PR #604)

Version bump, changelog dated, registers keeper re-pinned to 041032f, log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)