### PR TITLE
chore(release): v3.5.1-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1-beta.15] - 2026-09-02
+
+Requires **[pylxpweb==0.10.0b8](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b8)**.
 
 ### Added
 
-- **The rest of the daily Grid Peak Shaving parameter set** ([#592](https://github.com/joyfulhouse/eg4_web_monitor/issues/592)): five new number entities on grid-tied inverters — Grid Peak Shaving Power 2 (register 232), SOC 1 / SOC 2 (207 / 218) and Voltage 1 / Voltage 2 (208 / 219) — alongside the existing Power 1 (206), mode switch and four schedule times. They read locally, via the cloud and in hybrid mode, write locally by name on a positively resolved grid-tied family and through the cloud holdParam (with readback) otherwise; units whose family is unidentified / unresolved route these writes cloud-only, while positively identified off-grid units do not create these entities at all (grid-tied branch only). Power 2 shares Power 1's "Peak Shaving mode must be on" pre-check; the SOC / voltage floors follow the discharge battery-control mode (SOC vs Voltage). Local polling now reads registers 206–212 in one frame plus 218–219 and 232 on hybrid families. Register evidence for the five remains portal-correlated.
+- **The rest of the daily Grid Peak Shaving parameter set** ([#592](https://github.com/joyfulhouse/eg4_web_monitor/issues/592), PR [#608](https://github.com/joyfulhouse/eg4_web_monitor/pull/608)): five new number entities on grid-tied inverters — Grid Peak Shaving Power 2 (register 232), SOC 1 / SOC 2 (207 / 218) and Voltage 1 / Voltage 2 (208 / 219) — alongside the existing Power 1 (206), mode switch and four schedule times. They read locally, via the cloud and in hybrid mode, write locally by name on a positively resolved grid-tied family and through the cloud holdParam (with readback) otherwise; units whose family is unidentified / unresolved route these writes cloud-only, while positively identified off-grid units do not create these entities at all (grid-tied branch only). Power 2 shares Power 1's "Peak Shaving mode must be on" pre-check; the SOC / voltage floors follow the discharge battery-control mode (SOC vs Voltage). Local polling now reads registers 206–212 in one frame plus 218–219 and 232 on hybrid families. The pinned library's voltage holding rows now match the integration's 40.0–64.0 V limits. Register evidence for the five remains portal-correlated.
 
 ### Fixed
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b7", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.14"
+  "requirements": ["pylxpweb==0.10.0b8", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.5.1-beta.15"
 }

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -669,8 +669,10 @@ if reg1 & 0x100:
 > equality-checked readback otherwise; off-grid / unresolved families are
 > cloud-only (#558). Only Power 2 pre-checks `FUNC_GRID_PEAK_SHAVING`; whether
 > the firmware NAKs the SOC / voltage rows with the mode off is unverified. The
-> voltage write bounds 40.0-64.0 V are a maintainer decision (pylxpweb's rows
-> carry no min/max); the read window is 20-70 V, so any plausible portal-stored
+> voltage write bounds 40.0–64.0 V are shared with the pinned pylxpweb 0.10.0b8
+> rows ([pylxpweb PR #327](https://github.com/joyfulhouse/pylxpweb/pull/327));
+> both are a maintainer-chosen bracket with no firmware/portal bound captured.
+> The read window is 20-70 V, so any plausible portal-stored
 > value (within that window) is preserved rather than blanked — a value outside
 > it still renders unknown. LOCAL reads: one `(206, 7)` frame (PS1 + period-1 floors + both
 > schedule windows), `(218, 2)` and `(232, 1)`, all `EG4_HYBRID`-gated. Evidence

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -5,6 +5,8 @@ sources:
   - "eg4_web_monitor issue #603 (reporter diagnostics, LXP-LB-US 10K): HOLD_DISCHG_CUT_OFF_SOC_EOD stored 95"
   - "pylxpweb PR #322 / c78ab7e (0.10.0b7): H105 canonical ceiling 100"
   - "pylxpweb PR #327 / 80e8221 (0.10.0b8): H207/H208/H218/H219 constants, five peak-shaving entity keys, and H208/H219 bounds"
+  - "pylxpweb@80e8221:src/pylxpweb/registers/inverter_holding.py H208 row: https://github.com/joyfulhouse/pylxpweb/blob/80e82214f72bdcbf3669ad60cf8826883fe9842d/src/pylxpweb/registers/inverter_holding.py#L1534-L1544"
+  - "pylxpweb@80e8221:src/pylxpweb/registers/inverter_holding.py H219 row: https://github.com/joyfulhouse/pylxpweb/blob/80e82214f72bdcbf3669ad60cf8826883fe9842d/src/pylxpweb/registers/inverter_holding.py#L1572-L1582"
   - docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
   - docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
   - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
@@ -60,7 +62,11 @@ verified-against:
   # the H66/H160 rows below and shipped family-scoped in the integration).
   # The c78ab7e..80e8221 holding-definition delta adds entity keys for
   # H207/H208/H218/H219/H232 and 40.0-64.0 V bounds to H208/H219; register
-  # semantics and their portal-correlated grades are unchanged.
+  # semantics and their portal-correlated grades are unchanged. The H208/H219
+  # rows in src/pylxpweb/registers/inverter_holding.py state that these bounds
+  # are a maintainer-chosen guard with no firmware/portal bound captured, so
+  # `verified-against-code` attests only that the rows carry the bounds, not
+  # that the window is hardware-correct (see the two pinned blob sources).
   # Inline ab87902 blob links on older rows remain valid historical URLs.
   eg4_web_monitor: 5092b5b
   pylxpweb: 80e8221

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -4,6 +4,7 @@ sources:
   - docs/DATA_MAPPING.md
   - "eg4_web_monitor issue #603 (reporter diagnostics, LXP-LB-US 10K): HOLD_DISCHG_CUT_OFF_SOC_EOD stored 95"
   - "pylxpweb PR #322 / c78ab7e (0.10.0b7): H105 canonical ceiling 100"
+  - "pylxpweb PR #327 / 80e8221 (0.10.0b8): H207/H208/H218/H219 constants, five peak-shaving entity keys, and H208/H219 bounds"
   - docs/reference/firmware/OFFGRID_GENERATOR_REGISTERS.md
   - docs/reference/firmware/OFFGRID_EPS_REGISTERS.md
   - docs/reference/firmware/HYBRID_EPS_REGISTERS.md
@@ -35,6 +36,8 @@ sources:
   - https://github.com/joyfulhouse/pylxpweb/issues/272
   - https://github.com/joyfulhouse/pylxpweb/pull/273
 verified-against:
+  # Re-pinned at the 2026-09-02 beta.15 release cut: PR #608 merged as
+  # 5092b5b and pylxpweb PR #327 merged as 80e8221 (released in 0.10.0b8).
   # Re-pinned at the 2026-09-02 beta.14 release cut: PR #605 merged as 041032f.
   # The pin is commit-only per _conventions.md (machine tooling passes it to
   # git show) and covers the pre-existing claims, verified at e9853eb
@@ -48,14 +51,19 @@ verified-against:
   # the sweep-extended rows now verify at the mainline pin below (inline
   # PR #600 / issue #570 citations remain as provenance). pylxpweb was
   # ab87902 (0.9.39b11) until the 2026-09-02 #603 ingest moved it to
-  # c78ab7e (0.10.0b7). Holding-definition deltas between the two pins
-  # (git diff ab87902..c78ab7e -- registers/inverter_holding.py): H105
+  # c78ab7e (0.10.0b7), then to 80e8221 (0.10.0b8) for the complete
+  # Grid Peak Shaving library surface. Holding-definition deltas from
+  # ab87902 to c78ab7e (git diff ab87902..c78ab7e --
+  # registers/inverter_holding.py): H105
   # ceiling 90 -> 100 (PR #322, this ingest); H66 max 15000 -> 10000 and
   # H160 min 0 -> 1 (PR #273 for #271/#272 — already carried per claim by
   # the H66/H160 rows below and shipped family-scoped in the integration).
+  # The c78ab7e..80e8221 holding-definition delta adds entity keys for
+  # H207/H208/H218/H219/H232 and 40.0-64.0 V bounds to H208/H219; register
+  # semantics and their portal-correlated grades are unchanged.
   # Inline ab87902 blob links on older rows remain valid historical URLs.
-  eg4_web_monitor: 041032f
-  pylxpweb: c78ab7e
+  eg4_web_monitor: 5092b5b
+  pylxpweb: 80e8221
 last-verified: 2026-09-02
 ---
 
@@ -231,7 +239,7 @@ Every row is readable via FC03 but exists in potentially writable configuration 
 | H103 | Maximum grid sell-back power, raw ×100 W / UI kW | grid-tied | `portal-correlated` | current | 1 | `DATA_MAPPING.md` raw/UI correlation; not percent. |
 | H105 | On-grid discharge SOC cutoff | grid-tied | `lineage-inferred` | current | 1 | Canonical holding definition. |
 | H105 | A portal-typed 95 is stored and read back (the 90 was the portal arrow-button hint, copied into pylxpweb and — beta.13, PR #600 round 2 — into the entity) | LXP-LB-US 10K (reporter unit, hybrid) | `portal-correlated` | current on the reported unit | 1 | [#603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603) reporter diagnostics (`HOLD_DISCHG_CUT_OFF_SOC_EOD: 95`) + portal screenshot. Readback proves storage, not semantics. |
-| H105 | Exact write ceiling is 100 (101 rejected per the reporter; 96–100 never individually written) and the 10 floor is a portal hint only | LXP-LB-US 10K; other families unconfirmed | `inferred` | current | 1 | Bound adopted by [pylxpweb `c78ab7e`](https://github.com/joyfulhouse/pylxpweb/commit/c78ab7e) (PR #322, shipped 0.10.0b7) and the entity; the page-level pylxpweb pin is that commit. The firmware exception stays the authoritative reject path. **Both ends unproven** — a delta-test at 100 and at 9 would settle it. |
+| H105 | Exact write ceiling is 100 (101 rejected per the reporter; 96–100 never individually written) and the 10 floor is a portal hint only | LXP-LB-US 10K; other families unconfirmed | `inferred` | current | 1 | Bound adopted by [pylxpweb `c78ab7e`](https://github.com/joyfulhouse/pylxpweb/commit/c78ab7e) (PR #322, shipped 0.10.0b7) and the entity, and retained at the page-level pylxpweb pin. The firmware exception stays the authoritative reject path. **Both ends unproven** — a delta-test at 100 and at 9 would settle it. |
 | H110 | Shared system-function word; individual meanings below | all | `verified-against-code` | structural-only | 0 | [`constants/registers.py::REGISTER_110_PARAM_KEYS`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L642-L659) and [`REGISTER_TO_PARAM_KEYS[110]`](https://github.com/joyfulhouse/pylxpweb/blob/204b95d/src/pylxpweb/constants/registers.py#L777-L782) define the structure. Never inherit a bit’s grade to the whole word or another family. |
 | H116 | Import threshold to start discharge, W | grid-tied; CT required | `portal-correlated` | current | 1 | `DATA_MAPPING.md`; whole watts, not ×100 W. |
 | H117 | Start-charge threshold, signed W | LOCAL/HYBRID | `asserted-unverified` | unresolved | 0 | [`DATA_MAPPING.md` H117 note](../../docs/DATA_MAPPING.md#power-control-registers); no cloud name or validated behavior. |

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -933,5 +933,10 @@ PR [#608](https://github.com/joyfulhouse/eg4_web_monitor/pull/608) merged as
 merged as `80e8221` and shipped in 0.10.0b8. The
 [registers keeper](40-hardware/registers.md) is re-pinned to both commits. The
 library delta gives H208/H219 the same 40.0–64.0 V bounds as the integration
-(`verified-against-code`); the peak-shaving register semantics remain
-`portal-correlated`, and no evidence grade changed.
+(`verified-against-code` at the pinned
+[`src/pylxpweb/registers/inverter_holding.py` H208 row](https://github.com/joyfulhouse/pylxpweb/blob/80e82214f72bdcbf3669ad60cf8826883fe9842d/src/pylxpweb/registers/inverter_holding.py#L1534-L1544)
+and [H219 row](https://github.com/joyfulhouse/pylxpweb/blob/80e82214f72bdcbf3669ad60cf8826883fe9842d/src/pylxpweb/registers/inverter_holding.py#L1572-L1582)).
+Those rows themselves state the bounds are a maintainer-chosen guard with no
+firmware/portal bound captured, so the grade attests only that the code carries
+the bounds, not that the window is hardware-correct. The peak-shaving register
+semantics remain `portal-correlated`, and no evidence grade changed.

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -925,3 +925,13 @@ become one `(206, 7)` frame plus `(218, 2)` and `(232, 1)`, hybrid-gated
 keeper is untouched. Also corrected: `docs/DATA_MAPPING.md` claimed register
 231 holds the peak-shaving power (H231 is unknown; PS1 is H206) — that claim
 was already refuted on the keeper and had rotted only in the docs copy.
+
+## [2026-09-02] ingest | v3.5.1-beta.15 release cut — #608 and pylxpweb 0.10.0b8
+
+PR [#608](https://github.com/joyfulhouse/eg4_web_monitor/pull/608) merged as
+`5092b5b`; companion pylxpweb [#327](https://github.com/joyfulhouse/pylxpweb/pull/327)
+merged as `80e8221` and shipped in 0.10.0b8. The
+[registers keeper](40-hardware/registers.md) is re-pinned to both commits. The
+library delta gives H208/H219 the same 40.0–64.0 V bounds as the integration
+(`verified-against-code`); the peak-shaving register semantics remain
+`portal-correlated`, and no evidence grade changed.

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b7  # keep in sync with manifest.json
+pylxpweb==0.10.0b8  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml

--- a/tests/test_number_limit_contracts.py
+++ b/tests/test_number_limit_contracts.py
@@ -289,17 +289,18 @@ def test_grid_peak_shaving_soc_bounds_match_pinned_definitions(
     ("canonical_name", "address"),
     [("grid_peak_shaving_volt", 208), ("grid_peak_shaving_volt_2", 219)],
 )
-def test_grid_peak_shaving_volt_bounds_are_a_maintainer_decision(
+def test_grid_peak_shaving_volt_bounds_match_pinned_definitions(
     canonical_name: str, address: int
 ) -> None:
-    """The pinned VOLT rows carry NO min/max, so the 40.0-64.0 V write window
-    is the maintainer's choice (the SYSTEM_CHARGE_VOLT_LIMIT shape). If the
-    library ever gains bounds this test must be revisited against them."""
+    """The pinned VOLT rows and integration share the 40.0-64.0 V bounds."""
     definition = HOLDING_BY_NAME[canonical_name]
     assert definition.address == address
-    assert definition.min_value is None
-    assert definition.max_value is None
-    assert (GRID_PEAK_SHAVING_VOLT_MIN, GRID_PEAK_SHAVING_VOLT_MAX) == (40.0, 64.0)
+    library_bounds = (definition.min_value, definition.max_value)
+    assert library_bounds == (40.0, 64.0)
+    assert library_bounds == (
+        GRID_PEAK_SHAVING_VOLT_MIN,
+        GRID_PEAK_SHAVING_VOLT_MAX,
+    )
 
 
 def test_grid_peak_shaving_volt_read_window_contains_write_window() -> None:


### PR DESCRIPTION
## Summary

- Cut v3.5.1-beta.15 from PR [#608](https://github.com/joyfulhouse/eg4_web_monitor/pull/608), completing [#592](https://github.com/joyfulhouse/eg4_web_monitor/issues/592): Grid Peak Shaving Power 2, SOC 1/2, and Voltage 1/2 entities; widened local reads; SOC/VOLT regime gating; and the H231 mapping correction.
- Pin the integration and test environment to [pylxpweb 0.10.0b8](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b8), which carries companion [pylxpweb PR #327](https://github.com/joyfulhouse/pylxpweb/pull/327).
- Flip the H208/H219 contract test to require the library's `(40.0, 64.0)` bounds and equality with the integration limits.
- Re-pin the register keeper to eg4_web_monitor `5092b5b` and pylxpweb `80e8221`; peak-shaving evidence remains `portal-correlated`.

## Scope

- `CHANGELOG.md`
- `custom_components/eg4_web_monitor/manifest.json`
- `docs/DATA_MAPPING.md`
- `llmwiki/40-hardware/registers.md`
- `llmwiki/log.md`
- `tests/requirements-test.txt`
- `tests/test_number_limit_contracts.py`

## Verification

- `uv run ruff check custom_components/ --fix && uv run ruff format custom_components/` — pass
- `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — pass
- `uv run pytest tests/ -x --tb=short` — pass
- `uv run python tests/validate_silver_tier.py` — pass
- `uv run python tests/validate_gold_tier.py` — pass
- `uv run python tests/validate_platinum_tier.py` — pass
- Mutation check: changing the expected H208/H219 upper bound to `56.0` fails with `(40.0, 64.0) != (40.0, 56.0)`; restoring `64.0` passes both parameterized cases.

## Deliberately preserved historical references

- `CHANGELOG.md` keeps the beta.14 `pylxpweb==0.10.0b7` requirement and its #603 release narrative.
- `llmwiki/40-hardware/registers.md` keeps the PR #322 / `c78ab7e` / 0.10.0b7 provenance for H105 and the pin-transition history.
- `llmwiki/log.md` is append-only, so its beta.14 and #592-era 0.10.0b7 entries remain unchanged.
- The beta.14 heading in `CHANGELOG.md` and its historical release-cut log mention remain unchanged.

## Follow-ups

- [#609](https://github.com/joyfulhouse/eg4_web_monitor/issues/609) tracks the out-of-scope comment-only update to `const/limits.py`, whose provenance wording still describes the pre-0.10.0b8 rows. No numeric limit or behavior change is needed.
