### PR TITLE
chore(release): v3.5.1-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to the EG4 Web Monitor integration will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1-beta.16] - 2026-09-04
+
+Requires **[pylxpweb==0.10.0b9](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b9)**.
+
+### Changed
+
+- **One serialized TCP socket per physical dongle endpoint** (pylxpweb [#329](https://github.com/joyfulhouse/pylxpweb/issues/329) / PR [#330](https://github.com/joyfulhouse/pylxpweb/pull/330)): the pinned library now shares one serialized TCP socket per physical dongle endpoint across all devices on that dongle, so two devices on one dongle no longer contend for its single TCP slot. This is library-side and needs no integration configuration.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Requires **[pylxpweb==0.10.0b9](https://github.com/joyfulhouse/pylxpweb/releases
 
 ### Changed
 
-- **One serialized TCP socket per physical dongle endpoint** (pylxpweb [#329](https://github.com/joyfulhouse/pylxpweb/issues/329) / PR [#330](https://github.com/joyfulhouse/pylxpweb/pull/330)): the pinned library now shares one serialized TCP socket per physical dongle endpoint across all devices on that dongle, so two devices on one dongle no longer contend for its single TCP slot. This is library-side and needs no integration configuration.
+- **Two devices on one WiFi dongle no longer fight for its single local TCP slot** (pylxpweb [#329](https://github.com/joyfulhouse/pylxpweb/issues/329) / PR [#330](https://github.com/joyfulhouse/pylxpweb/pull/330)): Home Assistant now uses one shared, serialized socket per dongle, so the second device should stop being dropped and replies should stop landing on the wrong device. This affects WiFi-dongle LOCAL and HYBRID setups with two or more devices on one dongle; cloud-only, Modbus TCP, serial RS485, and one-device-per-dongle installs are unchanged. No configuration change is needed. As one watch-for, pointing two different dongle serials at the same host:port now fails at connect with a mismatch error instead of silently colliding.
 
 ### Fixed
 

--- a/custom_components/eg4_web_monitor/manifest.json
+++ b/custom_components/eg4_web_monitor/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/joyfulhouse/eg4_web_monitor/issues",
   "loggers": ["eg4_web_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["pylxpweb==0.10.0b8", "pymodbus>=3.6.0", "pyserial>=3.5"],
-  "version": "3.5.1-beta.15"
+  "requirements": ["pylxpweb==0.10.0b9", "pymodbus>=3.6.0", "pyserial>=3.5"],
+  "version": "3.5.1-beta.16"
 }

--- a/docs/DATA_MAPPING.md
+++ b/docs/DATA_MAPPING.md
@@ -669,7 +669,7 @@ if reg1 & 0x100:
 > equality-checked readback otherwise; off-grid / unresolved families are
 > cloud-only (#558). Only Power 2 pre-checks `FUNC_GRID_PEAK_SHAVING`; whether
 > the firmware NAKs the SOC / voltage rows with the mode off is unverified. The
-> voltage write bounds 40.0–64.0 V are shared with the pinned pylxpweb 0.10.0b8
+> voltage write bounds 40.0–64.0 V are shared with the pinned pylxpweb 0.10.0b9
 > rows ([pylxpweb PR #327](https://github.com/joyfulhouse/pylxpweb/pull/327));
 > both are a maintainer-chosen bracket with no firmware/portal bound captured.
 > The read window is 20-70 V, so any plausible portal-stored

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -40,8 +40,9 @@ sources:
 verified-against:
   # Re-pinned at the 2026-09-04 beta.16 release cut: eg4_web_monitor main
   # is 1d09823 and pylxpweb tag v0.10.0b9 is f3ced1a. The pylxpweb delta
-  # since 80e8221 is transport-only (#329 / PR #330), so register
-  # definitions, semantics, and evidence grades are unchanged.
+  # since 80e8221 touches only transport, CI and release files (#326,
+  # #329 / PR #330), so no register definition, semantic, or evidence
+  # grade changed.
   # Re-pinned at the 2026-09-02 beta.15 release cut: PR #608 merged as
   # 5092b5b and pylxpweb PR #327 merged as 80e8221 (released in 0.10.0b8).
   # Re-pinned at the 2026-09-02 beta.14 release cut: PR #605 merged as 041032f.

--- a/llmwiki/40-hardware/registers.md
+++ b/llmwiki/40-hardware/registers.md
@@ -38,6 +38,10 @@ sources:
   - https://github.com/joyfulhouse/pylxpweb/issues/272
   - https://github.com/joyfulhouse/pylxpweb/pull/273
 verified-against:
+  # Re-pinned at the 2026-09-04 beta.16 release cut: eg4_web_monitor main
+  # is 1d09823 and pylxpweb tag v0.10.0b9 is f3ced1a. The pylxpweb delta
+  # since 80e8221 is transport-only (#329 / PR #330), so register
+  # definitions, semantics, and evidence grades are unchanged.
   # Re-pinned at the 2026-09-02 beta.15 release cut: PR #608 merged as
   # 5092b5b and pylxpweb PR #327 merged as 80e8221 (released in 0.10.0b8).
   # Re-pinned at the 2026-09-02 beta.14 release cut: PR #605 merged as 041032f.
@@ -68,9 +72,9 @@ verified-against:
   # `verified-against-code` attests only that the rows carry the bounds, not
   # that the window is hardware-correct (see the two pinned blob sources).
   # Inline ab87902 blob links on older rows remain valid historical URLs.
-  eg4_web_monitor: 5092b5b
-  pylxpweb: 80e8221
-last-verified: 2026-09-02
+  eg4_web_monitor: 1d09823
+  pylxpweb: f3ced1a
+last-verified: 2026-09-04
 ---
 
 # Register ground truth

--- a/llmwiki/log.md
+++ b/llmwiki/log.md
@@ -952,3 +952,14 @@ pylxpweb's battery protocol classifier. A match now tells the user the device is
 battery and points to #176; a non-match preserves the original error. The integration
 behavior and both flow mappings are `verified-against-code` at `c411499`; the issue's
 hardware observations remain `asserted-unverified` and were not promoted.
+
+## [2026-09-04] ingest | v3.5.1-beta.16 release cut — #574 and pylxpweb 0.10.0b9
+
+The release cut includes the #574 standalone-battery discovery fix from `c411499`
+and its mainline documentation at `1d09823`. The pylxpweb
+[v0.10.0b9](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b9) tag is
+`f3ced1a` and carries [PR #330](https://github.com/joyfulhouse/pylxpweb/pull/330)
+for issue [#329](https://github.com/joyfulhouse/pylxpweb/issues/329). The
+[registers keeper](40-hardware/registers.md) is re-pinned to both release inputs;
+the pylxpweb delta from `80e8221` to `f3ced1a` changes transport and release files
+but no register definitions, so no register claim or evidence grade changed.

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -16,7 +16,7 @@ aiohttp>=3.10.0
 pycares>=4.9.0,<5
 voluptuous>=0.15.0
 # Exact public prerelease required for the caller-owned transport factory seam (#581).
-pylxpweb==0.10.0b8  # keep in sync with manifest.json
+pylxpweb==0.10.0b9  # keep in sync with manifest.json
 
 # Code quality
 mypy==2.3.0  # pinned (#528 review, same rationale as ruff/#482); keep in sync with quality-validation.yml


### PR DESCRIPTION
## Summary

- Cut v3.5.1-beta.16 from the standalone-battery Modbus-discovery fix in [#574](https://github.com/joyfulhouse/eg4_web_monitor/issues/574): holding-only battery devices now produce an actionable unsupported-device error instead of a generic timeout.
- Pin the integration and test environment to [pylxpweb 0.10.0b9](https://github.com/joyfulhouse/pylxpweb/releases/tag/v0.10.0b9), which carries [pylxpweb #329](https://github.com/joyfulhouse/pylxpweb/issues/329) / [PR #330](https://github.com/joyfulhouse/pylxpweb/pull/330): all devices on a physical dongle endpoint share one serialized TCP socket, with no integration configuration required.
- Re-pin the register keeper to eg4_web_monitor `1d09823` and pylxpweb `f3ced1a`; the library delta touches only transport, CI and release files (#326, #329 / PR #330), so no register definition, semantic, or evidence grade changed.

## Scope

- `CHANGELOG.md`
- `custom_components/eg4_web_monitor/manifest.json`
- `llmwiki/40-hardware/registers.md`
- `llmwiki/log.md`
- `tests/requirements-test.txt`

## Verification

- `uv run ruff check custom_components/ --fix && uv run ruff format custom_components/` — pass; no-op (`48 files left unchanged`)
- `uv run mypy --config-file tests/mypy.ini custom_components/eg4_web_monitor/` — pass; 48 source files
- `uv run pytest tests/ -x --tb=short` — pass; 3,421 collected cases (`3,412 passed, 9 skipped`)
- `uv run python tests/validate_silver_tier.py` — pass; 10/10
- `uv run python tests/validate_gold_tier.py` — pass; 6/6
- `uv run python tests/validate_platinum_tier.py` — pass
- `uv run pytest tests/test_number_limit_contracts.py::test_manifest_and_test_requirements_pin_the_same_pylxpweb tests/test_number_limit_contracts.py::test_grid_peak_shaving_volt_bounds_match_pinned_definitions -q --tb=short` — pass; 3/3 collected cases against installed `pylxpweb==0.10.0b9`

## Environment note

This repository has no `pyproject.toml` or `uv.lock`, so `uv sync` exits 2 with `No pyproject.toml found`. The worktree environment was created with `uv venv --python 3.13` and populated from the repository's CI pin file via `uv pip install --python .venv/bin/python -r tests/requirements-test.txt`; only `uv` was used.

## Deliberately preserved historical references

- `CHANGELOG.md` keeps the beta.15 `pylxpweb==0.10.0b8` requirement and its release narrative.
- `llmwiki/40-hardware/registers.md` keeps earlier pin-transition and register provenance.
- `llmwiki/log.md` remains append-only; prior release-cut entries are unchanged.

